### PR TITLE
go.mod: bump a2tea to pick up the shared-component cycle fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -43,7 +43,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/invopop/jsonschema v0.14.0
 	github.com/itchyny/gojq v0.12.19
-	github.com/joestump-agent/a2tea v0.0.0-20260710173942-49cf767209e1
+	github.com/joestump-agent/a2tea v0.0.0-20260710210055-edbbf646b20e
 	github.com/joho/godotenv v1.5.1
 	github.com/jordanella/go-ansi-paintbrush v0.0.0-20240728195301-b7ad996ecf3d
 	github.com/lucasb-eyer/go-colorful v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -258,8 +258,8 @@ github.com/jackmordaunt/icns/v3 v3.0.1 h1:xxot6aNuGrU+lNgxz5I5H0qSeCjNKp8uTXB1j8
 github.com/jackmordaunt/icns/v3 v3.0.1/go.mod h1:5sHL59nqTd2ynTnowxB/MDQFhKNqkK8X687uKNygaSQ=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
-github.com/joestump-agent/a2tea v0.0.0-20260710173942-49cf767209e1 h1:SZlt+LVGy5zzE3VwmU48xvLPSbRlFJDgRD0rV6/h+20=
-github.com/joestump-agent/a2tea v0.0.0-20260710173942-49cf767209e1/go.mod h1:OsU/M9Q6AkDpJStkS5ceVqTfRwo9FN5l31+yKDPkSNU=
+github.com/joestump-agent/a2tea v0.0.0-20260710210055-edbbf646b20e h1:NpJ9q++08MtyrSB79GoHS2PLGrSVhnZvmrlRzWK9VeU=
+github.com/joestump-agent/a2tea v0.0.0-20260710210055-edbbf646b20e/go.mod h1:OsU/M9Q6AkDpJStkS5ceVqTfRwo9FN5l31+yKDPkSNU=
 github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
 github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/jordanella/go-ansi-paintbrush v0.0.0-20240728195301-b7ad996ecf3d h1:on25kP+Sx7sxUMRQiA8gdcToAGet4DK/EIA30mXre+4=


### PR DESCRIPTION
Follow-up to #1.

Bumps `github.com/joestump-agent/a2tea` from `…-49cf767209e1` to `…-edbbf646b20e` to pick up a2tea's path-scoped-`seen` fix (joestump-agent/a2tea#11). Before it, a component referenced by two parents — ordinary A2UI adjacency-list reuse — rendered a false `[a2tea: cycle …]` on its second occurrence; after it, it renders at both sites.

This is the "inherited from a2tea" observation from the review of #1 — no crush code change, just the pin.

Verified the fix reaches crush: an A2UI surface reusing one component across two rows now renders it twice with no cycle marker; `internal/ui/chat` tests pass and the module builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AtvfVcwLAeVKk9SkRjb7GN

---
_Generated by [Claude Code](https://claude.ai/code/session_01AtvfVcwLAeVKk9SkRjb7GN)_