### PR TITLE
docs: add A2UI section to the README; bump a2tea to the styled renderers

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
 - **Session-Based:** maintain multiple work sessions and contexts per project
 - **LSP-Enhanced:** Crush uses LSPs for additional context, just like you do
 - **Extensible:** add capabilities via MCPs (`http`, `stdio`, and `sse`)
+- **UI-Fluent:** models can speak [A2UI](https://a2ui.org) and Crush will draw it — cards, lists, and buttons right in the chat
 - **Works Everywhere:** first-class support in every terminal on macOS, Linux, Windows (PowerShell and WSL), Android, FreeBSD, OpenBSD, and NetBSD
 - **Industrial Grade:** built on the Charm ecosystem, powering 25k+ applications, from leading open source projects to business-critical infrastructure
 
@@ -227,6 +228,39 @@ Is there a provider you’d like to see in Crush? Is there an existing model tha
 Crush’s default model listing is managed in [Catwalk](https://github.com/charmbracelet/catwalk), a community-supported, open source repository of Crush-compatible models, and you’re welcome to contribute.
 
 <a href="https://github.com/charmbracelet/catwalk"><img width="174" height="174" alt="Catwalk Badge" src="https://github.com/user-attachments/assets/95b49515-fe82-4409-b10d-5beb0873787d" /></a>
+
+## A2UI
+
+Sometimes prose isn’t the best answer. When an assistant reply contains an
+[A2UI](https://a2ui.org) message — structured JSON describing UI, wrapped in
+`<a2ui-json>` tags — Crush renders it as an actual element in the chat instead
+of dumping raw JSON:
+
+```text
+<a2ui-json>{"version":"v0.9","updateComponents":{...}}</a2ui-json>
+
+        …becomes…
+
+╭──────────────────────────────╮
+│ Build passed                 │
+│ 142 tests, 0 failures.       │
+│ ──────────────────────────── │
+│ [ Details ]  [ Re-run ]      │
+╰──────────────────────────────╯
+```
+
+Parsing and rendering are handled by
+[a2tea](https://github.com/joestump-agent/a2tea), which speaks the real A2UI
+v0.9 protocol. The core catalog draws with proper styling: text with heading
+variants, bordered cards, columns, rows, lists, dividers, and buttons, plus
+read-only visuals for input components. Chrome is monochrome on purpose, so
+your theme stays yours.
+
+> [!NOTE]
+> Prose around a surface still renders as Markdown, and a block that fails to
+> parse shows an alert rather than silently disappearing. Interactivity
+> (clicking those buttons and sending the result back to the model) is on the
+> roadmap — today surfaces are display-only in the chat.
 
 ## Configuration
 

--- a/go.mod
+++ b/go.mod
@@ -43,7 +43,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/invopop/jsonschema v0.14.0
 	github.com/itchyny/gojq v0.12.19
-	github.com/joestump-agent/a2tea v0.0.0-20260710210055-edbbf646b20e
+	github.com/joestump-agent/a2tea v0.0.0-20260711072407-19a926ebb3b8
 	github.com/joho/godotenv v1.5.1
 	github.com/jordanella/go-ansi-paintbrush v0.0.0-20240728195301-b7ad996ecf3d
 	github.com/lucasb-eyer/go-colorful v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -258,8 +258,8 @@ github.com/jackmordaunt/icns/v3 v3.0.1 h1:xxot6aNuGrU+lNgxz5I5H0qSeCjNKp8uTXB1j8
 github.com/jackmordaunt/icns/v3 v3.0.1/go.mod h1:5sHL59nqTd2ynTnowxB/MDQFhKNqkK8X687uKNygaSQ=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
-github.com/joestump-agent/a2tea v0.0.0-20260710210055-edbbf646b20e h1:NpJ9q++08MtyrSB79GoHS2PLGrSVhnZvmrlRzWK9VeU=
-github.com/joestump-agent/a2tea v0.0.0-20260710210055-edbbf646b20e/go.mod h1:OsU/M9Q6AkDpJStkS5ceVqTfRwo9FN5l31+yKDPkSNU=
+github.com/joestump-agent/a2tea v0.0.0-20260711072407-19a926ebb3b8 h1:9JA81wdBQANTxfvb9KgLP06XJxlHJzRvonTDAxP9qPE=
+github.com/joestump-agent/a2tea v0.0.0-20260711072407-19a926ebb3b8/go.mod h1:OsU/M9Q6AkDpJStkS5ceVqTfRwo9FN5l31+yKDPkSNU=
 github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
 github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/jordanella/go-ansi-paintbrush v0.0.0-20240728195301-b7ad996ecf3d h1:on25kP+Sx7sxUMRQiA8gdcToAGet4DK/EIA30mXre+4=


### PR DESCRIPTION
## What

Two things that belong together:

1. **README: a `## A2UI` section** (between *Getting Started* and *Configuration*, per the README's structure) plus a Features bullet. It documents what ships today: assistant replies carrying `<a2ui-json>` blocks render as real chat elements via [a2tea](https://github.com/joestump-agent/a2tea); prose stays Markdown; unparseable blocks show an alert; interactivity is roadmap. Written in the README's existing voice (GitHub alerts, language-tagged blocks, no per-feature media).

2. **a2tea pin bump** to the real-renderers revision (joestump-agent/a2tea#12) so the documented styling — heading variants, bordered cards, column/row/list layout, dividers, styled buttons, read-only input visuals — is what users actually see. `internal/ui/chat` suite passes against the new renderers.

## Relationship to the prompt PR

The sibling PR (teach-the-model) carries the **identical** a2tea pin, so the two merge cleanly in either order. This PR is accurate standing alone: rendering already works on main; the sibling adds the prompt section that makes models emit A2UI unprompted.

Diff was reviewed inline (docs + dep only); one mock-output inaccuracy fixed (divider width now matches what the renderer draws).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AtvfVcwLAeVKk9SkRjb7GN

---
_Generated by [Claude Code](https://claude.ai/code/session_01AtvfVcwLAeVKk9SkRjb7GN)_