### PR TITLE
agent: teach the coder to emit A2UI surfaces (config-gated)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -43,7 +43,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/invopop/jsonschema v0.14.0
 	github.com/itchyny/gojq v0.12.19
-	github.com/joestump-agent/a2tea v0.0.0-20260710210055-edbbf646b20e
+	github.com/joestump-agent/a2tea v0.0.0-20260711072407-19a926ebb3b8
 	github.com/joho/godotenv v1.5.1
 	github.com/jordanella/go-ansi-paintbrush v0.0.0-20240728195301-b7ad996ecf3d
 	github.com/lucasb-eyer/go-colorful v1.4.0
@@ -64,6 +64,7 @@ require (
 	github.com/swaggo/swag v1.16.6
 	github.com/tidwall/gjson v1.19.0
 	github.com/tidwall/sjson v1.2.5
+	github.com/tmc/a2ui v0.0.0-20260605070129-b42a8925e473
 	github.com/zeebo/xxh3 v1.1.0
 	go.uber.org/goleak v1.3.0
 	golang.design/x/clipboard v0.8.0
@@ -183,7 +184,6 @@ require (
 	github.com/tadvi/systray v0.0.0-20190226123456-11a2b8fa57af // indirect
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.1 // indirect
-	github.com/tmc/a2ui v0.0.0-20260605070129-b42a8925e473 // indirect
 	github.com/u-root/u-root v0.14.1-0.20250807200646-5e7721023dc7 // indirect
 	github.com/u-root/uio v0.0.0-20240224005618-d2acac8f3701 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect

--- a/go.sum
+++ b/go.sum
@@ -258,8 +258,8 @@ github.com/jackmordaunt/icns/v3 v3.0.1 h1:xxot6aNuGrU+lNgxz5I5H0qSeCjNKp8uTXB1j8
 github.com/jackmordaunt/icns/v3 v3.0.1/go.mod h1:5sHL59nqTd2ynTnowxB/MDQFhKNqkK8X687uKNygaSQ=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
-github.com/joestump-agent/a2tea v0.0.0-20260710210055-edbbf646b20e h1:NpJ9q++08MtyrSB79GoHS2PLGrSVhnZvmrlRzWK9VeU=
-github.com/joestump-agent/a2tea v0.0.0-20260710210055-edbbf646b20e/go.mod h1:OsU/M9Q6AkDpJStkS5ceVqTfRwo9FN5l31+yKDPkSNU=
+github.com/joestump-agent/a2tea v0.0.0-20260711072407-19a926ebb3b8 h1:9JA81wdBQANTxfvb9KgLP06XJxlHJzRvonTDAxP9qPE=
+github.com/joestump-agent/a2tea v0.0.0-20260711072407-19a926ebb3b8/go.mod h1:OsU/M9Q6AkDpJStkS5ceVqTfRwo9FN5l31+yKDPkSNU=
 github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
 github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/jordanella/go-ansi-paintbrush v0.0.0-20240728195301-b7ad996ecf3d h1:on25kP+Sx7sxUMRQiA8gdcToAGet4DK/EIA30mXre+4=

--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -174,7 +174,14 @@ func NewCoordinator(
 	}
 
 	// TODO: make this dynamic when we support multiple agents
-	prompt, err := coderPrompt(prompt.WithWorkingDir(c.cfg.WorkingDir()))
+	// WithA2UI: the chat TUI renders <a2ui-json> blocks in assistant replies
+	// via a2tea, so the coder is told it may emit them. Headless consumers of
+	// this coordinator see the blocks as plain text; the prompt phrases the
+	// capability as rare and optional, which keeps that acceptable.
+	prompt, err := coderPrompt(
+		prompt.WithWorkingDir(c.cfg.WorkingDir()),
+		prompt.WithA2UI(),
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -174,14 +174,13 @@ func NewCoordinator(
 	}
 
 	// TODO: make this dynamic when we support multiple agents
-	// WithA2UI: the chat TUI renders <a2ui-json> blocks in assistant replies
-	// via a2tea, so the coder is told it may emit them. Headless consumers of
-	// this coordinator see the blocks as plain text; the prompt phrases the
-	// capability as rare and optional, which keeps that acceptable.
-	prompt, err := coderPrompt(
-		prompt.WithWorkingDir(c.cfg.WorkingDir()),
-		prompt.WithA2UI(),
-	)
+	// A2UI is on unless the user disables it; see prompt.WithA2UI for the
+	// host-capability trade-off.
+	promptOpts := []prompt.Option{prompt.WithWorkingDir(c.cfg.WorkingDir())}
+	if !cfg.Config().Options.DisableA2UI {
+		promptOpts = append(promptOpts, prompt.WithA2UI())
+	}
+	prompt, err := coderPrompt(promptOpts...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/agent/prompt/prompt.go
+++ b/internal/agent/prompt/prompt.go
@@ -26,6 +26,7 @@ type Prompt struct {
 	now        func() time.Time
 	platform   string
 	workingDir string
+	a2ui       bool
 }
 
 type PromptDat struct {
@@ -40,6 +41,7 @@ type PromptDat struct {
 	ContextFiles       []ContextFile
 	GlobalContextFiles []ContextFile
 	AvailSkillXML      string
+	A2UI               bool
 }
 
 type ContextFile struct {
@@ -64,6 +66,16 @@ func WithPlatform(platform string) Option {
 func WithWorkingDir(workingDir string) Option {
 	return func(p *Prompt) {
 		p.workingDir = workingDir
+	}
+}
+
+// WithA2UI enables the template's A2UI section, which tells the model it may
+// emit <a2ui-json> surfaces. Only hosts that actually render A2UI (the chat
+// TUI, via a2tea) should set this — everywhere else the blocks would surface
+// as raw text.
+func WithA2UI() Option {
+	return func(p *Prompt) {
+		p.a2ui = true
 	}
 }
 
@@ -214,6 +226,7 @@ func (p *Prompt) promptData(ctx context.Context, provider, model string, store *
 		Platform:      platform,
 		Date:          p.now().Format("1/2/2006"),
 		AvailSkillXML: availSkillXML,
+		A2UI:          p.a2ui,
 	}
 	if isGit {
 		var err error

--- a/internal/agent/prompt/prompt.go
+++ b/internal/agent/prompt/prompt.go
@@ -2,10 +2,8 @@ package prompt
 
 import (
 	"cmp"
-
 	"context"
 	"fmt"
-	a2ui "github.com/tmc/a2ui"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -13,6 +11,8 @@ import (
 	"strings"
 	"text/template"
 	"time"
+
+	a2ui "github.com/tmc/a2ui"
 
 	"github.com/charmbracelet/crush/internal/config"
 	"github.com/charmbracelet/crush/internal/filepathext"

--- a/internal/agent/prompt/prompt.go
+++ b/internal/agent/prompt/prompt.go
@@ -2,8 +2,10 @@ package prompt
 
 import (
 	"cmp"
+
 	"context"
 	"fmt"
+	a2ui "github.com/tmc/a2ui"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -42,6 +44,7 @@ type PromptDat struct {
 	GlobalContextFiles []ContextFile
 	AvailSkillXML      string
 	A2UI               bool
+	A2UIVersion        string
 }
 
 type ContextFile struct {
@@ -70,9 +73,11 @@ func WithWorkingDir(workingDir string) Option {
 }
 
 // WithA2UI enables the template's A2UI section, which tells the model it may
-// emit <a2ui-json> surfaces. Only hosts that actually render A2UI (the chat
-// TUI, via a2tea) should set this — everywhere else the blocks would surface
-// as raw text.
+// emit <a2ui-json> surfaces. Crush's chat TUI renders those blocks via a2tea;
+// consumers that only ever see plain text (scripted crush run, headless serve
+// clients) receive them as raw markup, so deployments that need plain-text
+// output can turn the section off with options.disable_a2ui — the coordinator
+// applies that setting.
 func WithA2UI() Option {
 	return func(p *Prompt) {
 		p.a2ui = true
@@ -227,6 +232,7 @@ func (p *Prompt) promptData(ctx context.Context, provider, model string, store *
 		Date:          p.now().Format("1/2/2006"),
 		AvailSkillXML: availSkillXML,
 		A2UI:          p.a2ui,
+		A2UIVersion:   a2ui.Version,
 	}
 	if isGit {
 		var err error

--- a/internal/agent/prompts_a2ui_test.go
+++ b/internal/agent/prompts_a2ui_test.go
@@ -81,6 +81,7 @@ func TestA2UIPromptCatalogRenders(t *testing.T) {
 
 	for name, comps := range catalog {
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
 			msgs := []a2ui.ServerMessage{{
 				Version:          a2ui.Version,
 				UpdateComponents: &a2ui.UpdateComponents{SurfaceID: "s", Components: comps},

--- a/internal/agent/prompts_a2ui_test.go
+++ b/internal/agent/prompts_a2ui_test.go
@@ -1,0 +1,35 @@
+package agent
+
+import (
+	"testing"
+
+	"github.com/charmbracelet/crush/internal/agent/prompt"
+	"github.com/charmbracelet/crush/internal/config"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCoderPromptA2UIGate pins the A2UI section's gating: it appears in the
+// coder prompt only when the host opts in with prompt.WithA2UI (the chat TUI,
+// which renders <a2ui-json> blocks via a2tea). Recorded agent cassettes are
+// built without the option, so the gate also keeps them byte-stable.
+func TestCoderPromptA2UIGate(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	cfg, err := config.Init(dir, "", false)
+	require.NoError(t, err)
+
+	off, err := coderPrompt(prompt.WithWorkingDir(dir))
+	require.NoError(t, err)
+	offText, err := off.Build(t.Context(), "test", "test", cfg)
+	require.NoError(t, err)
+	require.NotContains(t, offText, "<a2ui>")
+
+	on, err := coderPrompt(prompt.WithWorkingDir(dir), prompt.WithA2UI())
+	require.NoError(t, err)
+	onText, err := on.Build(t.Context(), "test", "test", cfg)
+	require.NoError(t, err)
+	require.Contains(t, onText, "<a2ui>")
+	require.Contains(t, onText, "<a2ui-json>")
+	require.Contains(t, onText, "updateComponents")
+}

--- a/internal/agent/prompts_a2ui_test.go
+++ b/internal/agent/prompts_a2ui_test.go
@@ -1,35 +1,96 @@
 package agent
 
 import (
+	"strings"
 	"testing"
+	"text/template"
 
 	"github.com/charmbracelet/crush/internal/agent/prompt"
-	"github.com/charmbracelet/crush/internal/config"
+	a2tea "github.com/joestump-agent/a2tea"
 	"github.com/stretchr/testify/require"
+	a2ui "github.com/tmc/a2ui"
 )
 
-// TestCoderPromptA2UIGate pins the A2UI section's gating: it appears in the
-// coder prompt only when the host opts in with prompt.WithA2UI (the chat TUI,
-// which renders <a2ui-json> blocks via a2tea). Recorded agent cassettes are
-// built without the option, so the gate also keeps them byte-stable.
+// renderCoderTemplate executes the embedded coder template directly with the
+// given data — no ConfigStore, no filesystem discovery — so the test is
+// hermetic and fast. Recorded agent cassettes build the coder prompt without
+// WithA2UI; pinning the gate here keeps those cassettes byte-stable.
+func renderCoderTemplate(t *testing.T, dat prompt.PromptDat) string {
+	t.Helper()
+	tpl, err := template.New("coder").Parse(string(coderPromptTmpl))
+	require.NoError(t, err)
+	var b strings.Builder
+	require.NoError(t, tpl.Execute(&b, dat))
+	return b.String()
+}
+
 func TestCoderPromptA2UIGate(t *testing.T) {
 	t.Parallel()
 
-	dir := t.TempDir()
-	cfg, err := config.Init(dir, "", false)
-	require.NoError(t, err)
+	off := renderCoderTemplate(t, prompt.PromptDat{})
+	require.NotContains(t, off, "<a2ui>")
 
-	off, err := coderPrompt(prompt.WithWorkingDir(dir))
-	require.NoError(t, err)
-	offText, err := off.Build(t.Context(), "test", "test", cfg)
-	require.NoError(t, err)
-	require.NotContains(t, offText, "<a2ui>")
+	on := renderCoderTemplate(t, prompt.PromptDat{A2UI: true, A2UIVersion: a2ui.Version})
+	require.Contains(t, on, "<a2ui>")
+	// The example payload advertises the protocol version the pinned a2ui
+	// library actually speaks, not a hardcoded string.
+	require.Contains(t, on, `"version":"`+a2ui.Version+`"`)
+}
 
-	on, err := coderPrompt(prompt.WithWorkingDir(dir), prompt.WithA2UI())
-	require.NoError(t, err)
-	onText, err := on.Build(t.Context(), "test", "test", cfg)
-	require.NoError(t, err)
-	require.Contains(t, onText, "<a2ui>")
-	require.Contains(t, onText, "<a2ui-json>")
-	require.Contains(t, onText, "updateComponents")
+// TestA2UIPromptCatalogRenders guards the prompt's component catalog against
+// drifting from what the pinned a2tea actually renders: every component the
+// <a2ui> section advertises must render as real content, not an
+// "[a2tea: ...]" placeholder (which is also what missing/unsupported kinds
+// fall back to). If an a2tea bump drops or regresses a component, this fails
+// instead of users seeing placeholder junk in chat.
+func TestA2UIPromptCatalogRenders(t *testing.T) {
+	t.Parallel()
+
+	text := func(id, s string) a2ui.Component {
+		return a2ui.Component{ID: id, Text: &a2ui.TextComponent{Text: a2ui.StringLiteral(s)}}
+	}
+
+	// One minimal surface per advertised component.
+	catalog := map[string][]a2ui.Component{
+		"Text":    {{ID: "t", Text: &a2ui.TextComponent{Text: a2ui.StringLiteral("hi"), Variant: a2ui.TextVariantH2}}},
+		"Card":    {{ID: "c", Card: &a2ui.CardComponent{Child: "t"}}, text("t", "hi")},
+		"Column":  {{ID: "c", Column: &a2ui.ColumnComponent{Children: a2ui.ChildList{IDs: []string{"t"}}}}, text("t", "hi")},
+		"Row":     {{ID: "r", Row: &a2ui.RowComponent{Children: a2ui.ChildList{IDs: []string{"t"}}}}, text("t", "hi")},
+		"List":    {{ID: "l", List: &a2ui.ListComponent{Children: a2ui.ChildList{IDs: []string{"t"}}}}, text("t", "hi")},
+		"Divider": {{ID: "d", Divider: &a2ui.DividerComponent{}}},
+		"Button":  {{ID: "b", Button: &a2ui.ButtonComponent{Child: "t"}}, text("t", "OK")},
+		"TextField": {{ID: "f", TextField: &a2ui.TextFieldComponent{
+			Label: a2ui.StringLiteral("Name"),
+		}}},
+		"CheckBox": {{ID: "cb", CheckBox: &a2ui.CheckBoxComponent{
+			Label: a2ui.StringLiteral("Done"),
+			Value: a2ui.BoolLiteral(true),
+		}}},
+		"ChoicePicker": {{ID: "cp", ChoicePicker: &a2ui.ChoicePickerComponent{
+			Options: []a2ui.ChoiceOption{{Value: "a", Label: a2ui.StringLiteral("A")}},
+			Value:   a2ui.DynamicStringList{Literal: []string{"a"}},
+		}}},
+		"Slider": {{ID: "s", Slider: &a2ui.SliderComponent{
+			Max:   100,
+			Value: a2ui.NumberLiteral(40),
+		}}},
+		"DateTimeInput": {{ID: "dt", DateTimeInput: &a2ui.DateTimeInputComponent{
+			Value: a2ui.StringLiteral("2026-07-11"),
+		}}},
+	}
+
+	for name, comps := range catalog {
+		t.Run(name, func(t *testing.T) {
+			msgs := []a2ui.ServerMessage{{
+				Version:          a2ui.Version,
+				UpdateComponents: &a2ui.UpdateComponents{SurfaceID: "s", Components: comps},
+			}}
+			m, err := a2tea.Render(msgs)
+			require.NoError(t, err, "advertised component %s must render", name)
+			out := m.View().Content
+			require.NotContains(t, out, "[a2tea:",
+				"advertised component %s rendered a placeholder: %q", name, out)
+			require.NotEmpty(t, strings.TrimSpace(out))
+		})
+	}
 }

--- a/internal/agent/templates/coder.md.tpl
+++ b/internal/agent/templates/coder.md.tpl
@@ -355,14 +355,12 @@ Adapt verbosity to match the work completed:
 </final_answers>
 {{if .A2UI}}
 <a2ui>
-You MAY include an A2UI v0.9 surface in a reply when a compact visual element genuinely helps — a status card, an option list, a progress readout. Use it sparingly; prose stays primary and most replies need none.
+You MAY include an A2UI surface when a compact visual genuinely helps — a status card, an option list, a progress readout. Most replies need none; prose stays primary.
 
-Format: a single `<a2ui-json>{...}</a2ui-json>` block inline in your reply, containing one JSON `updateComponents` message. Components form a flat adjacency list — each has an `id`, a `component` type, and containers reference children by id.
+Emit a single inline `<a2ui-json>{...}</a2ui-json>` block containing one `updateComponents` message, as in this example:
+<a2ui-json>{"version":"{{.A2UIVersion}}","updateComponents":{"surfaceId":"s1","components":[{"component":"Card","id":"root","child":"col"},{"component":"Column","id":"col","children":["title","body"]},{"component":"Text","id":"title","variant":"h2","text":"Build passed"},{"component":"Text","id":"body","text":"142 tests, 0 failures."}]}}</a2ui-json>
 
-Well-rendered components: Text (variants h1-h5, caption), Card, Column, Row, List, Divider, Button. Input components (TextField, CheckBox, ChoicePicker, Slider, DateTimeInput) render read-only. Do not put code in a surface — use normal fenced code blocks.
-
-Example:
-<a2ui-json>{"version":"v0.9","updateComponents":{"surfaceId":"s1","components":[{"component":"Card","id":"root","child":"col"},{"component":"Column","id":"col","children":["title","body"]},{"component":"Text","id":"title","variant":"h2","text":"Build passed"},{"component":"Text","id":"body","text":"142 tests, 0 failures."}]}}</a2ui-json>
+Renderable components: Text (variants h1-h5, caption), Card, Column, Row, List, Divider, Button; input components render read-only. Never put code in a surface — use fenced code blocks.
 </a2ui>
 {{end}}
 <env>

--- a/internal/agent/templates/coder.md.tpl
+++ b/internal/agent/templates/coder.md.tpl
@@ -353,7 +353,18 @@ Adapt verbosity to match the work completed:
 - Don't use "Here's what I did" or "Let me know if..." style preambles/postambles
 - Keep tone direct and factual, like handing off work to a teammate
 </final_answers>
+{{if .A2UI}}
+<a2ui>
+You MAY include an A2UI v0.9 surface in a reply when a compact visual element genuinely helps — a status card, an option list, a progress readout. Use it sparingly; prose stays primary and most replies need none.
 
+Format: a single `<a2ui-json>{...}</a2ui-json>` block inline in your reply, containing one JSON `updateComponents` message. Components form a flat adjacency list — each has an `id`, a `component` type, and containers reference children by id.
+
+Well-rendered components: Text (variants h1-h5, caption), Card, Column, Row, List, Divider, Button. Input components (TextField, CheckBox, ChoicePicker, Slider, DateTimeInput) render read-only. Do not put code in a surface — use normal fenced code blocks.
+
+Example:
+<a2ui-json>{"version":"v0.9","updateComponents":{"surfaceId":"s1","components":[{"component":"Card","id":"root","child":"col"},{"component":"Column","id":"col","children":["title","body"]},{"component":"Text","id":"title","variant":"h2","text":"Build passed"},{"component":"Text","id":"body","text":"142 tests, 0 failures."}]}}</a2ui-json>
+</a2ui>
+{{end}}
 <env>
 Working directory: {{.WorkingDir}}
 Is directory a git repo: {{if .IsGitRepo}}yes{{else}}no{{end}}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -297,6 +297,7 @@ type Options struct {
 	DisableNotifications      bool         `json:"disable_notifications,omitempty" jsonschema:"description=Deprecated: Use notification_style instead. Disable desktop notifications,default=false"`
 	NotificationStyle         string       `json:"notification_style,omitempty" jsonschema:"description=Notification style to use. Options: auto (default), native, osc, bell, disabled. Auto selects based on environment: native for local sessions, osc for SSH (with automatic OSC 99/777 detection).,enum=auto,enum=native,enum=osc,enum=bell,enum=disabled,default=auto"`
 	DisabledSkills            []string     `json:"disabled_skills,omitempty" jsonschema:"description=List of skill names to disable and hide from the agent,example=crush-config"`
+	DisableA2UI               bool         `json:"disable_a2ui,omitempty" jsonschema:"description=Disable the A2UI prompt section that invites the model to emit renderable <a2ui-json> UI surfaces in chat,default=false"`
 }
 
 type MCPs map[string]MCPConfig

--- a/schema.json
+++ b/schema.json
@@ -531,6 +531,11 @@
           },
           "type": "array",
           "description": "List of skill names to disable and hide from the agent"
+        },
+        "disable_a2ui": {
+          "type": "boolean",
+          "description": "Disable the A2UI prompt section that invites the model to emit renderable \u003ca2ui-json\u003e UI surfaces in chat",
+          "default": false
         }
       },
       "additionalProperties": false,


### PR DESCRIPTION
## What

Closes the loop on A2UI: the coder system prompt now carries a compact `<a2ui>` section inviting the model to emit a single `<a2ui-json>` `updateComponents` block when a compact visual genuinely helps (status card, option list, progress readout). The chat TUI already renders those blocks via a2tea — this makes them appear without hand-feeding the model JSON.

## Gating (the review's main finding)

The coordinator serves rendering *and* non-rendering hosts (chat TUI, scripted `crush run`, headless serve clients), so the section is gated twice:

- **Template gate** (`{{if .A2UI}}`): with the flag off the prompt is **byte-identical** to before — verified empirically — so the recorded VCR cassettes stay stable. Pinned by `TestCoderPromptA2UIGate`, which executes the embedded template directly (hermetic: no ConfigStore, no filesystem discovery, no provider network sync).
- **Config gate** (`options.disable_a2ui`, schema regenerated): deployments that need plain-text output can turn it off. On by default — in serve mode the eventual client is unknowable at construction time, and the section phrases the capability as rare and optional.

## Keeping the prompt honest

- The advertised protocol version is templated from the pinned library (`a2ui.Version`), not hardcoded — a dep bump moves both halves of the wire contract together.
- `TestA2UIPromptCatalogRenders` renders **every component the prompt advertises** through the pinned a2tea and fails if any produces an `[a2tea: …]` placeholder — the catalog can't silently drift from what users actually see. (All 12 pass against the bumped pin.)
- Section trimmed to ~200 tokens: the example carries the non-inferable envelope; redundant prose removed per review.

## Review

`/code-review` (high) ran 8 finder angles + verification on this diff; all 13 surviving findings were addressed: the unconditional-`WithA2UI` altitude problem (→ config gate), doc/usage contradiction (→ realigned docs), non-hermetic and network-prone test (→ template-layer test), token wastage (→ trim), hardcoded version (→ templated), stale catalog claims (→ pin bump + drift-guard test), comment duplication (→ single-sourced).

Pre-existing edge cases surfaced by the review are now tracked as issues: #5 (streaming truncation leaves raw JSON, no alert), #6 (fenced-code examples render as live surfaces), #7 (bare-JSON parts can mask the missed-block alert), #8 (unrelated dispatch-test flake on main).

Carries the same a2tea pin as the README PR (#3); identical edits merge cleanly in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AtvfVcwLAeVKk9SkRjb7GN