### PR TITLE
fix: stabilize flaky concurrent dispatch test under repetition

### DIFF
--- a/internal/agent/dispatch_race_test.go
+++ b/internal/agent/dispatch_race_test.go
@@ -66,12 +66,50 @@ func (m *concurrencyProbeModel) StreamObject(context.Context, fantasy.ObjectCall
 	return nil, errors.New("not implemented")
 }
 
+// fastModel is a non-blocking model used as the small model in concurrency
+// tests. GenerateTitle runs on the small model; if it shares the probe model,
+// its Stream call races into inFlight/maxSeen and produces spurious failures.
+type fastModel struct{}
+
+func (fastModel) Provider() string { return "fake" }
+func (fastModel) Model() string    { return "fake-model" }
+
+func (fastModel) Generate(context.Context, fantasy.Call) (*fantasy.Response, error) {
+	return &fantasy.Response{
+		Content:      fantasy.ResponseContent{fantasy.TextContent{Text: "title"}},
+		FinishReason: fantasy.FinishReasonStop,
+	}, nil
+}
+
+func (fastModel) Stream(context.Context, fantasy.Call) (fantasy.StreamResponse, error) {
+	return func(yield func(fantasy.StreamPart) bool) {
+		yield(fantasy.StreamPart{Type: fantasy.StreamPartTypeTextStart, ID: "1"})
+		yield(fantasy.StreamPart{Type: fantasy.StreamPartTypeTextDelta, ID: "1", Delta: "title"})
+		yield(fantasy.StreamPart{Type: fantasy.StreamPartTypeTextEnd, ID: "1"})
+		yield(fantasy.StreamPart{Type: fantasy.StreamPartTypeFinish, FinishReason: fantasy.FinishReasonStop})
+	}, nil
+}
+
+func (fastModel) GenerateObject(context.Context, fantasy.ObjectCall) (*fantasy.ObjectResponse, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (fastModel) StreamObject(context.Context, fantasy.ObjectCall) (fantasy.ObjectStreamResponse, error) {
+	return nil, errors.New("not implemented")
+}
+
 // TestRun_ConcurrentInProcessDispatchStartsOneRun fires a burst of concurrent
 // in-process Run calls (the path channel events use) at an idle session. Only
 // one may become the active run; the rest must queue behind it. Before the
 // dispatch decision was serialized under the per-session mutex, two callers
 // could both pass the busy check and start two runs on the same session — this
 // test catches that regression (maxSeen would exceed one).
+//
+// fastModel is used as the small model so GenerateTitle (which runs on the
+// small model) does not race into the probe's inFlight/maxSeen counters. The
+// queue count is not asserted because PrepareStep drains queued prompts into
+// the active step before the model's Stream is called — by the time "entered"
+// fires the queue is already empty by design.
 func TestRun_ConcurrentInProcessDispatchStartsOneRun(t *testing.T) {
 	t.Parallel()
 	env := testEnv(t)
@@ -79,25 +117,25 @@ func TestRun_ConcurrentInProcessDispatchStartsOneRun(t *testing.T) {
 		entered: make(chan struct{}, 1),
 		release: make(chan struct{}),
 	}
-	sa := testSessionAgent(env, model, model, "system").(*sessionAgent)
+	sa := testSessionAgent(env, model, fastModel{}, "system").(*sessionAgent)
 
 	sess, err := env.sessions.Create(t.Context(), "session")
 	require.NoError(t, err)
 
 	const n = 8
 	var wg sync.WaitGroup
-	for i := range n {
+	for range n {
 		wg.Add(1)
-		go func(i int) {
+		go func() {
 			defer wg.Done()
 			_, _ = sa.Run(t.Context(), SessionAgentCall{
 				SessionID: sess.ID,
 				Prompt:    "event",
 			})
-		}(i)
+		}()
 	}
 
-	// Wait until one run is active (blocked in Stream).
+	// Wait until the active run's Stream is in flight (blocked on release).
 	select {
 	case <-model.entered:
 	case <-time.After(5 * time.Second):
@@ -106,12 +144,9 @@ func TestRun_ConcurrentInProcessDispatchStartsOneRun(t *testing.T) {
 		t.Fatal("no run became active")
 	}
 
-	// With the active run parked in Stream, every other dispatch must have
-	// enqueued rather than started its own run. Poll until the queue settles.
-	require.Eventually(t, func() bool {
-		return sa.QueuedPrompts(sess.ID) == n-1
-	}, 5*time.Second, time.Millisecond, "expected the other dispatches to queue behind the active run")
-
+	// Every other dispatch must have either queued (and been folded into the
+	// active step by PrepareStep) or never started its own Stream. Either way,
+	// at most one Stream may be in flight and the high-water mark must be one.
 	require.Equal(t, int32(1), model.inFlight.Load(), "exactly one run may be active")
 	require.Equal(t, int32(1), model.maxSeen.Load(), "no two runs may stream concurrently for one session")
 


### PR DESCRIPTION
## Summary

Fixes #8.

`TestRun_ConcurrentInProcessDispatchStartsOneRun` was flaky under `-count=10+` for two compounding reasons:

1. **`GenerateTitle` shared the probe model.** The test passed `concurrencyProbeModel` as both the large and small model. `GenerateTitle` runs on the small model and calls `Stream` concurrently — its closure incremented `inFlight`/`maxSeen`, producing spurious `expected: 1` failures when timing shifted under repetition.

2. **The queue count assertion was unreliable.** `PrepareStep` (which fires *before* the model's `Stream`) calls `drainQueueForStep`, folding queued prompts into the active step and emptying the queue. The `entered` signal arrives from `Stream` — *after* the drain — so `QueuedPrompts == n-1` could never be durably observed. With the original code this was masked because `entered` happened to arrive from `GenerateTitle`'s early `Stream` call, giving a brief window where the queue was still populated.

## Fix

- Add a `fastModel` (non-blocking, doesn't touch the probe counters) and use it as the small model so `GenerateTitle` can't race into `inFlight`/`maxSeen`.
- Remove the `QueuedPrompts == n-1` assertion: the queue is legitimately drained by `PrepareStep` before `Stream` fires, so the count is zero by design by the time `entered` is received.
- Keep the `inFlight == 1` and `maxSeen == 1` assertions — these directly prove no two runs stream concurrently for one session, which is the invariant the test exists to protect.

Verified with `-count=50` (pass) and `-count=10 -race` (pass).

💘 Generated with Crush