### PR TITLE
fix: A2UI fenced-code, truncated-block, and alert-masking edge cases

### DIFF
--- a/internal/ui/chat/a2ui.go
+++ b/internal/ui/chat/a2ui.go
@@ -1,17 +1,109 @@
 package chat
 
 import (
+	"encoding/json"
+	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/charmbracelet/crush/internal/ui/common"
 	"github.com/joestump-agent/a2tea"
 )
 
-// contentHasA2UI reports whether the assistant content carries any A2UI, so the
-// renderer only takes the a2tea path when there is UI to draw. Detection (and
-// all parsing) lives in a2tea — crush does not hand-roll it.
+var fenceRe = regexp.MustCompile("(?s)```[^\n]*\n.*?```")
+
+// stripFencedCode removes markdown fenced code blocks entirely. Used for A2UI
+// detection where tags inside fences are examples, not live surfaces (#6).
+func stripFencedCode(content string) string {
+	if !strings.Contains(content, "```") {
+		return content
+	}
+	return fenceRe.ReplaceAllString(content, "")
+}
+
+// fenceReplacement tracks a masked fenced-code span for later restoration.
+type fenceReplacement struct {
+	placeholder string
+	original    string
+}
+
+// maskFencedCode replaces fenced code blocks with unique placeholders so
+// a2tea's markdown-unaware scanner does not extract A2UI JSON from code
+// examples (#6). Use unmaskFencedCode to restore the originals after
+// scanning.
+func maskFencedCode(content string) (string, []fenceReplacement) {
+	if !strings.Contains(content, "```") {
+		return content, nil
+	}
+	var reps []fenceReplacement
+	masked := fenceRe.ReplaceAllStringFunc(content, func(match string) string {
+		p := fmt.Sprintf("\x00FENCE%d\x00", len(reps))
+		reps = append(reps, fenceReplacement{p, match})
+		return p
+	})
+	return masked, reps
+}
+
+// unmaskFencedCode restores fenced code blocks replaced by maskFencedCode.
+func unmaskFencedCode(text string, reps []fenceReplacement) string {
+	for _, r := range reps {
+		text = strings.ReplaceAll(text, r.placeholder, r.original)
+	}
+	return text
+}
+
+// contentHasA2UI reports whether the assistant content carries any A2UI
+// outside fenced code blocks, so the renderer only takes the a2tea path when
+// there is live UI to draw.
 func contentHasA2UI(content string) bool {
-	return a2tea.Contains(content)
+	return a2tea.Contains(stripFencedCode(content))
+}
+
+// hasUnclosedA2UITag reports whether content contains an opening
+// <a2ui-json> tag whose matching </a2ui-json> close never arrives — a
+// truncated block (#5). Only meaningful for finished messages; while
+// streaming the close tag simply hasn't arrived yet.
+func hasUnclosedA2UITag(content string) bool {
+	openIdx := strings.Index(content, "<a2ui-json>")
+	if openIdx < 0 {
+		return false
+	}
+	afterOpen := content[openIdx+len("<a2ui-json>"):]
+	return !strings.Contains(afterOpen, "</a2ui-json>")
+}
+
+// contentHasUnclosedA2UI is the gate-level check (fences stripped) for
+// truncated A2UI blocks in finished messages.
+func contentHasUnclosedA2UI(content string) bool {
+	return hasUnclosedA2UITag(stripFencedCode(content))
+}
+
+// countDroppedTaggedBlocks scans content for complete
+// <a2ui-json>...</a2ui-json> pairs whose JSON body cannot be unmarshalled —
+// blocks a2tea silently drops. This is independent of bare-JSON parts, which
+// must not mask the alert (#7).
+func countDroppedTaggedBlocks(content string) int {
+	const openTag, closeTag = "<a2ui-json>", "</a2ui-json>"
+	var dropped int
+	s := content
+	for {
+		i := strings.Index(s, openTag)
+		if i < 0 {
+			break
+		}
+		s = s[i+len(openTag):]
+		j := strings.Index(s, closeTag)
+		if j < 0 {
+			break
+		}
+		body := strings.TrimSpace(s[:j])
+		s = s[j+len(closeTag):]
+		var raw map[string]any
+		if json.Unmarshal([]byte(body), &raw) != nil {
+			dropped++
+		}
+	}
+	return dropped
 }
 
 // renderContentWithA2UI renders assistant content that contains A2UI. a2tea
@@ -19,17 +111,19 @@ func contentHasA2UI(content string) bool {
 // crush renders the prose as markdown and hands each part's messages to
 // a2tea.Render, stitching the rendered surface in place.
 //
-// If the content advertised A2UI (contentHasA2UI gated us here) but the parser
-// produced no messages at all — malformed or unsupported JSON, which a2tea/
-// a2uistream drops silently — an alert element is appended so the block is
-// never silently lost. Messages that parse but describe nothing to draw (e.g.
-// a data-model update) are skipped without an alert.
+// Fenced code blocks are masked before scanning so that A2UI examples inside
+// code fences are not extracted as live surfaces (#6). If any complete tag
+// pair contains malformed JSON — a block a2tea drops silently — an alert
+// element is appended (#7). An unclosed <a2ui-json> tag (truncated
+// generation) also triggers the alert (#5).
 //
 // This deliberately bypasses the streaming-markdown prefix cache (which assumes
 // a single glamour render per item) and renders each segment directly. The
 // renderer is shared, so the whole multi-render sequence holds its lock.
 func (a *AssistantMessageItem) renderContentWithA2UI(content string, width int) string {
-	parts, err := a2tea.Scan(content)
+	masked, fenceReps := maskFencedCode(content)
+
+	parts, err := a2tea.Scan(masked)
 	if err != nil {
 		// Not parseable as A2UI — render everything as markdown so nothing is
 		// lost.
@@ -45,6 +139,8 @@ func (a *AssistantMessageItem) renderContentWithA2UI(content string, width int) 
 		if strings.TrimSpace(text) == "" {
 			return ""
 		}
+		// Restore fenced code blocks before markdown rendering.
+		text = unmaskFencedCode(text, fenceReps)
 		out, err := renderer.Render(text)
 		if err != nil {
 			return strings.TrimSpace(text)
@@ -63,13 +159,11 @@ func (a *AssistantMessageItem) renderContentWithA2UI(content string, width int) 
 		b.WriteString(s)
 	}
 
-	messageBearingParts := 0
 	for _, p := range parts {
 		writeChunk(renderMarkdown(p.Text))
 		if len(p.Messages) == 0 {
 			continue
 		}
-		messageBearingParts++
 		model, err := a2tea.Render(p.Messages)
 		if err != nil {
 			// Valid A2UI messages with nothing to draw (e.g. a data-model
@@ -82,15 +176,36 @@ func (a *AssistantMessageItem) renderContentWithA2UI(content string, width int) 
 		writeChunk(strings.TrimRight(model.View().Content, "\n"))
 	}
 
-	// Each <a2ui-json> block that a2tea parsed becomes one message-bearing
-	// part; a block that was malformed or used unsupported components is
-	// dropped by the parser and yields no part. If fewer blocks parsed than
-	// were advertised, at least one was dropped — alert rather than silently
-	// losing it.
-	if messageBearingParts < strings.Count(content, "<a2ui-json>") {
+	// Alert when a complete tag pair was dropped by the parser (#7) —
+	// checked directly so bare-JSON parts cannot mask the count — or when
+	// generation was truncated mid-block (#5).
+	if countDroppedTaggedBlocks(masked) > 0 || hasUnclosedA2UITag(masked) {
 		writeChunk(a.renderA2UIAlert(width))
 	}
 
+	return b.String()
+}
+
+// renderTruncatedA2UI handles a finished message whose <a2ui-json> block was
+// never closed — generation was truncated mid-block (#5). The prose before
+// the unclosed tag is rendered as markdown, and the truncated block is
+// surfaced through the standard A2UI alert instead of leaving a wall of raw
+// JSON.
+func (a *AssistantMessageItem) renderTruncatedA2UI(content string, width int) string {
+	stripped := stripFencedCode(content)
+	idx := strings.Index(stripped, "<a2ui-json>")
+
+	var b strings.Builder
+	if idx > 0 {
+		prose := stripped[:idx]
+		if strings.TrimSpace(prose) != "" {
+			b.WriteString(a.renderMarkdown(prose, width))
+		}
+	}
+	if b.Len() > 0 {
+		b.WriteString("\n\n")
+	}
+	b.WriteString(a.renderA2UIAlert(width))
 	return b.String()
 }
 

--- a/internal/ui/chat/a2ui_test.go
+++ b/internal/ui/chat/a2ui_test.go
@@ -21,6 +21,119 @@ func TestContentHasA2UI(t *testing.T) {
 	require.False(t, contentHasA2UI("plain prose"))
 }
 
+// --- Issue #6: fenced code blocks should not render as live surfaces ---
+
+func TestContentHasA2UIIgnoresFencedCode(t *testing.T) {
+	t.Parallel()
+	// A tagged block inside a fenced code block is an example, not live UI.
+	fenced := "Here is an example:\n\n```json\n" + a2uiSurface + "\n```\n\nDone."
+	require.False(t, contentHasA2UI(fenced))
+}
+
+func TestRenderContentWithA2UIFencedCodeNotLiveSurface(t *testing.T) {
+	t.Parallel()
+
+	sty := styles.CharmtonePantera()
+	item := &AssistantMessageItem{sty: &sty}
+
+	content := "Example:\n\n```json\n" + a2uiSurface + "\n```\n\nAnd some text."
+	out := item.renderContentWithA2UI(content, 80)
+	plain := ansi.Strip(out)
+
+	// The fenced example is rendered as code — the raw tags and JSON are
+	// visible as text, NOT extracted as a live surface.
+	require.Contains(t, plain, "a2ui-json")
+	// No alert — the fenced block is just an example, not a dropped surface.
+	require.NotContains(t, plain, "couldn't render")
+	// The surrounding text is preserved.
+	require.Contains(t, plain, "Example")
+	require.Contains(t, plain, "And some text")
+}
+
+func TestRenderContentWithA2UIRealSurfaceNextToFencedExample(t *testing.T) {
+	t.Parallel()
+
+	sty := styles.CharmtonePantera()
+	item := &AssistantMessageItem{sty: &sty}
+
+	// A real surface followed by a fenced example: both should render
+	// correctly — the real surface as live, the fenced example as code.
+	content := "Real: " + a2uiSurface + "\n\nExample:\n\n```json\n" + a2uiSurface + "\n```"
+	out := item.renderContentWithA2UI(content, 80)
+	plain := ansi.Strip(out)
+
+	require.Contains(t, plain, "Hello from A2UI") // real surface rendered
+}
+
+// --- Issue #5: truncated mid-block should show alert ---
+
+func TestContentHasUnclosedA2UI(t *testing.T) {
+	t.Parallel()
+	require.True(t, contentHasUnclosedA2UI("text <a2ui-json>{\"version\":\"v0"))
+	require.False(t, contentHasUnclosedA2UI("text "+a2uiSurface))
+	require.False(t, contentHasUnclosedA2UI("plain prose"))
+	// Unclosed tag inside a fenced block is not a truncation.
+	require.False(t, contentHasUnclosedA2UI("```json\n<a2ui-json>{bad\n```"))
+}
+
+func TestRenderTruncatedA2UI(t *testing.T) {
+	t.Parallel()
+
+	sty := styles.CharmtonePantera()
+	item := &AssistantMessageItem{sty: &sty}
+
+	content := "Here is a card:\n\n<a2ui-json>{\"version\":\"v0.9\",\"updateComponents"
+	out := item.renderTruncatedA2UI(content, 80)
+	plain := ansi.Strip(out)
+
+	// The prose before the truncated tag is preserved.
+	require.Contains(t, plain, "Here is a card")
+	// The alert is shown.
+	require.Contains(t, plain, "couldn't render")
+	// The raw partial JSON is NOT shown.
+	require.NotContains(t, plain, "updateComponents")
+}
+
+// --- Issue #7: bare JSON should not mask dropped tagged block alert ---
+
+func TestRenderContentWithA2UIMalformedShowsAlert(t *testing.T) {
+	t.Parallel()
+
+	sty := styles.CharmtonePantera()
+	item := &AssistantMessageItem{sty: &sty}
+
+	// Malformed JSON inside the tags: a2uistream drops it (no messages), so
+	// crush must alert rather than silently losing the block.
+	content := "Look: <a2ui-json>{not valid json}</a2ui-json>"
+	out := item.renderContentWithA2UI(content, 80)
+	plain := ansi.Strip(out)
+
+	require.Contains(t, plain, "A2UI")
+	require.Contains(t, plain, "couldn't render")
+	// The surrounding prose is still there.
+	require.Contains(t, plain, "Look")
+}
+
+func TestRenderContentWithA2UIMalformedNotMaskedByBareJSON(t *testing.T) {
+	t.Parallel()
+
+	sty := styles.CharmtonePantera()
+	item := &AssistantMessageItem{sty: &sty}
+
+	// One malformed tagged block + one bare JSON surface. The bare JSON must
+	// not offset the count and suppress the alert for the dropped tagged
+	// block.
+	bareJSON := `{"version":"v0.9","updateComponents":{"surfaceId":"s","components":[` +
+		`{"component":"Text","id":"t","text":"bare"}]}}`
+	content := "<a2ui-json>{not valid json}</a2ui-json>\n\n" + bareJSON
+	out := item.renderContentWithA2UI(content, 80)
+	plain := ansi.Strip(out)
+
+	require.Contains(t, plain, "couldn't render") // the malformed tagged block alerted
+}
+
+// --- Existing tests ---
+
 func TestRenderContentWithA2UI(t *testing.T) {
 	t.Parallel()
 
@@ -41,24 +154,6 @@ func TestRenderContentWithA2UI(t *testing.T) {
 	require.NotContains(t, plain, "updateComponents")
 	// No alert when the surface rendered fine.
 	require.NotContains(t, plain, "couldn't render")
-}
-
-func TestRenderContentWithA2UIMalformedShowsAlert(t *testing.T) {
-	t.Parallel()
-
-	sty := styles.CharmtonePantera()
-	item := &AssistantMessageItem{sty: &sty}
-
-	// Malformed JSON inside the tags: a2uistream drops it (no messages), so
-	// crush must alert rather than silently losing the block.
-	content := "Look: <a2ui-json>{not valid json}</a2ui-json>"
-	out := item.renderContentWithA2UI(content, 80)
-	plain := ansi.Strip(out)
-
-	require.Contains(t, plain, "A2UI")
-	require.Contains(t, plain, "couldn't render")
-	// The surrounding prose is still there.
-	require.Contains(t, plain, "Look")
 }
 
 func TestRenderContentWithA2UIMixedGoodAndBadAlerts(t *testing.T) {

--- a/internal/ui/chat/assistant.go
+++ b/internal/ui/chat/assistant.go
@@ -435,6 +435,10 @@ func (a *AssistantMessageItem) cachedContent(width int) string {
 		// The reply carries an A2UI document — route it through a2tea instead
 		// of rendering the raw JSON as a markdown code block.
 		out = a.renderContentWithA2UI(text, width)
+	} else if a.message.IsFinished() && contentHasUnclosedA2UI(text) {
+		// Generation was truncated mid-block: an <a2ui-json> tag never got
+		// its closing partner. Show the alert instead of raw partial JSON.
+		out = a.renderTruncatedA2UI(text, width)
 	} else {
 		out = a.renderMarkdown(text, width)
 	}


### PR DESCRIPTION
## Summary

Fixes #5, fixes #6, fixes #7.

Three A2UI rendering bugs in `internal/ui/chat/a2ui.go`, all surfaced by the code review of #4 and pre-existing since #1:

### 1. Fenced code blocks render as live surfaces (#6)

`a2uistream` is markdown-unaware: an `<a2ui-json>` block — or bare JSON with recognized keys — inside a ` ``` ` fence was extracted and rendered as a live surface, leaving stray fence markers. This collided with the coder prompt which instructs the model to put code in fenced blocks.

**Fix:** Mask fenced code spans with unique placeholders before `a2tea.Scan`, then restore them in each text part before markdown rendering. The gate (`contentHasA2UI`) also strips fences so purely-fenced A2UI examples never enter the A2UI path.

### 2. Truncated mid-block leaves permanent raw JSON (#5)

`contentHasA2UI` → `a2tea.Contains` requires a complete `</a2ui-json>` close tag. If generation was truncated (max tokens, cancel, error), the finished message permanently showed a wall of partial JSON with no alert — the alert path was only entered when a complete tag pair existed.

**Fix:** Add `contentHasUnclosedA2UI` and `renderTruncatedA2UI`. When a finished message has an unclosed `<a2ui-json>` tag, the prose before the tag is rendered as markdown and the alert element is shown instead of raw JSON. Also handles the case where complete pairs precede an unclosed tag (checked inside `renderContentWithA2UI`).

### 3. Bare-JSON parts mask dropped-block alert (#7)

The alert heuristic compared message-bearing parts against `strings.Count(content, "<a2ui-json>")`. Because `a2uistream` also extracts bare JSON, a bare-JSON part could offset a genuinely dropped malformed tagged block — one bad tagged block + one bare JSON object = no alert.

**Fix:** Replace the part-count comparison with `countDroppedTaggedBlocks`, which directly checks each complete tag pair for valid JSON. This is independent of bare-JSON parts.

## Tests

Added 7 new tests covering each fix path plus the combined scenario (real surface next to a fenced example). All existing tests continue to pass.

💘 Generated with Crush