### PR TITLE
feat: A2UI surface rendering, builtin skill, and test coverage

### DIFF
--- a/internal/skills/builtin/a2ui/SKILL.md
+++ b/internal/skills/builtin/a2ui/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: a2ui
+description: Use when the user asks you to output, speak in, or communicate using the A2UI (a2tea) format, or when you need to understand how to construct A2UI JSON components to render interactive terminal UIs for the user.
+---
+
+# A2UI / a2tea Communication Guide
+
+Crush supports rendering rich, interactive terminal UI components embedded directly in your markdown responses using **a2tea** (a bridge to the [A2UI](https://a2ui.org) protocol).
+
+You can emit an A2UI surface when a compact visual genuinely helps — such as a status card, an option list, a progress readout, or a form. Most of your replies should remain prose, but when a visual structure adds value, use A2UI.
+
+## Wire Format
+
+Embed a single inline `<a2ui-json>{...}</a2ui-json>` block in your response. Inside, provide an A2UI v0.9 payload containing an `updateComponents` message.
+
+### Example Payload
+
+```json
+<a2ui-json>{
+  "version": "v0.9",
+  "updateComponents": {
+    "surfaceId": "s1",
+    "components": [
+      {
+        "component": "Card",
+        "id": "root",
+        "child": "col"
+      },
+      {
+        "component": "Column",
+        "id": "col",
+        "children": ["title", "body", "btn-ok"]
+      },
+      {
+        "component": "Text",
+        "id": "title",
+        "variant": "h2",
+        "text": "Build passed"
+      },
+      {
+        "component": "Text",
+        "id": "body",
+        "text": "142 tests, 0 failures."
+      },
+      {
+        "component": "Button",
+        "id": "btn-ok",
+        "label": "Acknowledge"
+      }
+    ]
+  }
+}</a2ui-json>
+```
+
+## Component Architecture
+
+A2UI components live in a flat list (adjacency list) and reference their children by `id`. The renderer resolves the tree from the root (the component that nothing else references as a child).
+
+### Core Catalog (Fully Supported)
+
+These components render beautifully with full styling and layout:
+- `Text`: Text display. Options: `text` (string), `variant` (h1-h5, caption).
+- `Card`: A rounded border container. Expects a single `child` ID.
+- `Column`: Lays out children vertically. Expects a `children` array of IDs.
+- `Row`: Lays out children horizontally. Expects a `children` array of IDs.
+- `List`: Lays out children as a list. Expects a `children` array of IDs.
+- `Divider`: A horizontal rule.
+- `Button`: Focusable button. Uses `label` (string). Pressing Enter emits a click event to the host.
+
+### Input Components (Read-Only Visuals)
+
+These components will render their current values, but currently do not allow the user to interactively edit them or send input back to the agent:
+- `TextField`
+- `CheckBox`
+- `ChoicePicker`
+- `Slider`
+- `DateTimeInput`
+
+### Media & Layout Placeholders
+
+- `Image`, `Icon`, `Video`, `AudioPlayer`: Render as compact one-line placeholders.
+- `Tabs`: Render the title bar and only the *first* tab's content.
+- `Modal`: Renders only its trigger, content stays hidden.
+
+## Best Practices
+
+1. **Keep it compact:** A2UI surfaces should be concise summaries, controls, or dashboards. Use standard markdown fences for code or long logs.
+2. **One surface per block:** Provide all components inside the `components` array of a single `updateComponents` message.
+3. **Link correctly:** Ensure every ID in `child` or `children` corresponds to a component in your array. Dangling IDs will break the render.
+4. **Mix with Markdown:** You can put markdown text before and after the `<a2ui-json>` block.

--- a/internal/skills/skills_test.go
+++ b/internal/skills/skills_test.go
@@ -446,6 +446,19 @@ func TestDiscoverBuiltin(t *testing.T) {
 		}
 	}
 	require.True(t, foundHooks, "crush-hooks builtin skill not found")
+
+	var foundA2UI bool
+	for _, s := range discovered {
+		if s.Name == "a2ui" {
+			foundA2UI = true
+			require.Equal(t, "crush://skills/a2ui/SKILL.md", s.SkillFilePath)
+			require.Equal(t, "crush://skills/a2ui", s.Path)
+			require.NotEmpty(t, s.Description)
+			require.NotEmpty(t, s.Instructions)
+			require.True(t, s.Builtin)
+		}
+	}
+	require.True(t, foundA2UI, "a2ui builtin skill not found")
 }
 
 func TestDeduplicate(t *testing.T) {

--- a/internal/ui/chat/a2ui.go
+++ b/internal/ui/chat/a2ui.go
@@ -59,17 +59,14 @@ func contentHasA2UI(content string) bool {
 	return a2tea.Contains(stripFencedCode(content))
 }
 
-// hasUnclosedA2UITag reports whether content contains an opening
-// <a2ui-json> tag whose matching </a2ui-json> close never arrives — a
-// truncated block (#5). Only meaningful for finished messages; while
-// streaming the close tag simply hasn't arrived yet.
+// hasUnclosedA2UITag reports whether content has more opening
+// <a2ui-json> tags than closing </a2ui-json> tags — a truncated block
+// (#5). This catches both a single unclosed block and the rarer case of
+// a complete surface followed by a second truncated block. Only
+// meaningful for finished messages; while streaming the close tag
+// simply hasn't arrived yet.
 func hasUnclosedA2UITag(content string) bool {
-	openIdx := strings.Index(content, "<a2ui-json>")
-	if openIdx < 0 {
-		return false
-	}
-	afterOpen := content[openIdx+len("<a2ui-json>"):]
-	return !strings.Contains(afterOpen, "</a2ui-json>")
+	return strings.Count(content, "<a2ui-json>") > strings.Count(content, "</a2ui-json>")
 }
 
 // contentHasUnclosedA2UI is the gate-level check (fences stripped) for

--- a/internal/ui/chat/a2ui_test.go
+++ b/internal/ui/chat/a2ui_test.go
@@ -74,6 +74,8 @@ func TestContentHasUnclosedA2UI(t *testing.T) {
 	require.False(t, contentHasUnclosedA2UI("plain prose"))
 	// Unclosed tag inside a fenced block is not a truncation.
 	require.False(t, contentHasUnclosedA2UI("```json\n<a2ui-json>{bad\n```"))
+	// Complete surface followed by a second truncated block.
+	require.True(t, contentHasUnclosedA2UI(a2uiSurface+"\n\n<a2ui-json>{\"version\":\"v0"))
 }
 
 func TestRenderTruncatedA2UI(t *testing.T) {


### PR DESCRIPTION
## Summary

Adds end-to-end A2UI (a2tea) support so the coder agent can emit rich, interactive terminal UI surfaces embedded in its markdown responses.

- **Agent prompt + config gating**: Teaches the coder it may emit `<a2ui-json>` blocks, gated behind a `disable_a2ui` config flag (`internal/agent/templates/coder.md.tpl`, `internal/agent/prompt/prompt.go`)
- **Rendering layer**: Parses and renders A2UI surfaces in the TUI, with fixes for fenced-code, truncated-block, and alert-masking edge cases (`internal/ui/chat/a2ui.go`, `internal/ui/chat/assistant.go`)
- **Builtin skill**: New `a2ui` skill (`internal/skills/builtin/a2ui/SKILL.md`) giving the model a reference for the component catalog and wire format, auto-discovered via the existing `//go:embed builtin/*` mechanism
- **Test coverage**: `TestDiscoverBuiltin` now asserts the `a2ui` skill is present with correct paths and metadata; A2UI rendering tests cover catalog components and edge cases
- **Docs**: README section explaining A2UI, schema.json updated for the new config flag

💘 Generated with Crush