### PR TITLE
fix(a2ui skill): Button uses a child Text ID, not a nonexistent label field

### DIFF
--- a/internal/skills/builtin/a2ui/SKILL.md
+++ b/internal/skills/builtin/a2ui/SKILL.md
@@ -45,7 +45,12 @@ Embed a single inline `<a2ui-json>{...}</a2ui-json>` block in your response. Ins
       {
         "component": "Button",
         "id": "btn-ok",
-        "label": "Acknowledge"
+        "child": "btn-ok-label"
+      },
+      {
+        "component": "Text",
+        "id": "btn-ok-label",
+        "text": "Acknowledge"
       }
     ]
   }
@@ -65,7 +70,7 @@ These components render beautifully with full styling and layout:
 - `Row`: Lays out children horizontally. Expects a `children` array of IDs.
 - `List`: Lays out children as a list. Expects a `children` array of IDs.
 - `Divider`: A horizontal rule.
-- `Button`: Focusable button. Uses `label` (string). Pressing Enter emits a click event to the host.
+- `Button`: Focusable button. Its label comes from a single `child` ID pointing at a `Text` component (there is no `label` field). Pressing Enter emits a click event to the host.
 
 ### Input Components (Read-Only Visuals)
 

--- a/internal/ui/chat/a2ui_skill_test.go
+++ b/internal/ui/chat/a2ui_skill_test.go
@@ -1,0 +1,83 @@
+package chat
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/crush/internal/skills"
+	"github.com/joestump-agent/a2tea"
+	"github.com/stretchr/testify/require"
+)
+
+// TestA2UISkillExampleRenders guards the builtin a2ui skill's documented
+// wire-format example against drift: every real <a2ui-json> payload embedded
+// in SKILL.md must render through the pinned a2tea as actual content, not an
+// "[a2tea: ...]" placeholder. This caught the Button using a nonexistent
+// "label" field (a2ui Buttons take a child Text ID); if the doc regresses to
+// a payload the renderer can't draw, this fails instead of shipping a broken
+// reference to the model.
+func TestA2UISkillExampleRenders(t *testing.T) {
+	t.Parallel()
+
+	var instructions string
+	for _, s := range skills.DiscoverBuiltin() {
+		if s.Name == "a2ui" {
+			instructions = s.Instructions
+			break
+		}
+	}
+	require.NotEmpty(t, instructions, "a2ui builtin skill not found")
+
+	// SKILL.md mentions <a2ui-json>{...}</a2ui-json> inline as a placeholder as
+	// well as carrying the real example; render only the payloads that
+	// actually describe a surface (an updateComponents message).
+	blocks := extractA2UIBlocks(instructions)
+	var rendered int
+	var all strings.Builder
+	for _, block := range blocks {
+		if !strings.Contains(block, "updateComponents") {
+			continue
+		}
+		parts, err := a2tea.Scan(block)
+		require.NoError(t, err, "documented example must parse as A2UI")
+		for _, p := range parts {
+			if len(p.Messages) == 0 {
+				continue
+			}
+			m, err := a2tea.Render(p.Messages)
+			require.NoError(t, err, "documented example must render")
+			all.WriteString(m.View().Content)
+			rendered++
+		}
+	}
+	require.Positive(t, rendered, "SKILL.md must contain a renderable <a2ui-json> example")
+
+	out := all.String()
+	require.NotContains(t, out, "[a2tea:",
+		"documented example rendered a placeholder (broken wire format): %q", out)
+	// The example's button label and body text must survive to the surface —
+	// the button label in particular only renders if it uses a child Text ID.
+	require.Contains(t, out, "Acknowledge")
+	require.Contains(t, out, "Build passed")
+}
+
+// extractA2UIBlocks returns every <a2ui-json>...</a2ui-json> span (tags
+// included) found in s, in order.
+func extractA2UIBlocks(s string) []string {
+	const open, close = "<a2ui-json>", "</a2ui-json>"
+	var out []string
+	for {
+		i := strings.Index(s, open)
+		if i < 0 {
+			break
+		}
+		j := strings.Index(s[i:], close)
+		if j < 0 {
+			break
+		}
+		end := i + j + len(close)
+		out = append(out, s[i:end])
+		s = s[end:]
+	}
+	return out
+}


### PR DESCRIPTION
## What

Follow-up to #11. The builtin `a2ui` skill's `SKILL.md` example emits a Button with a `"label"` field, but A2UI v0.9's `ButtonComponent` (`github.com/tmc/a2ui`) has no `label` — a button's text comes from a **child `Text` component**, resolved by ID. A model that follows the skill verbatim renders this in chat:

```
╭───────────────────────────────────╮
│ Build passed                      │
│ 142 tests, 0 failures.            │
│ [ [a2tea: missing component ""] ] │   ← the "label" button
╰───────────────────────────────────╯
```

instead of `[ Acknowledge ]`.

## Changes

- Point the example's `Button` at a child `Text` component (`btn-ok` → `btn-ok-label`) and correct the Button entry in the component catalog (`child` ID, no `label` field).
- Add `TestA2UISkillExampleRenders`: it pulls every real `<a2ui-json>` payload embedded in `SKILL.md` and renders it through the pinned a2tea, failing if any produces an `[a2tea: …]` placeholder. This ties the documented wire format to what the renderer actually draws, so the example can't silently drift back to a form the renderer can't display. Verified it fails against the old `label` form and passes on the fix.

## Verification

`go build ./...`, `go test ./internal/skills/ ./internal/ui/chat/`, and `golangci-lint` (v2.11) all green; `go.mod`/`go.sum` unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AtvfVcwLAeVKk9SkRjb7GN

---
_Generated by [Claude Code](https://claude.ai/code/session_0179FVEXKxJi8NVmLLWr5m8q)_