### PR TITLE
docs: add A2UI/a2tea and Claude Channels to README features

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@
 - **Session-Based:** maintain multiple work sessions and contexts per project
 - **LSP-Enhanced:** Crush uses LSPs for additional context, just like you do
 - **Extensible:** add capabilities via MCPs (`http`, `stdio`, and `sse`)
-- **UI-Fluent:** models can speak [A2UI](https://a2ui.org) and Crush will draw it — cards, lists, and buttons right in the chat
+- **UI-Fluent:** models can speak [A2UI](https://a2ui.org) via [a2tea](https://github.com/charmbracelet/a2tea) and Crush will draw it — cards, lists, buttons, and dashboards rendered right in the chat
+- **Channel-Ready:** MCP servers can push real-time events into your session via [Claude Channels](https://code.claude.com/docs/en/channels-reference) — CI failures, webhooks, and more, acting on them without you typing a thing
 - **Works Everywhere:** first-class support in every terminal on macOS, Linux, Windows (PowerShell and WSL), Android, FreeBSD, OpenBSD, and NetBSD
 - **Industrial Grade:** built on the Charm ecosystem, powering 25k+ applications, from leading open source projects to business-critical infrastructure
 


### PR DESCRIPTION
## Summary

Updates the README Features section to highlight two major capabilities:

- **A2UI via a2tea** — enhanced the existing bullet to mention the a2tea library and dashboards
- **Claude Channels** — new bullet for the MCP-based channels feature that lets external servers push real-time events (CI failures, webhooks, etc.) into your session

💘 Generated with Crush