### PR TITLE
fix: route replies only to their originating channel (reconciled #30)

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -84,6 +84,7 @@ type SessionAgentCall struct {
 	// session that may be busy) MUST set it; SessionID alone is
 	// ambiguous when concurrent turns share the same session.
 	RunID            string
+	Channel          string
 	Prompt           string
 	ProviderOptions  fantasy.ProviderOptions
 	Attachments      []message.Attachment
@@ -124,6 +125,22 @@ type SessionAgentCall struct {
 	// paths treat as covered by any present mark, preserving the
 	// pre-sequence behavior.
 	acceptSeq uint64
+}
+
+func filterToolsForChannel(agentTools []fantasy.AgentTool, channel string, states map[string]mcp.ClientInfo) []fantasy.AgentTool {
+	filtered := make([]fantasy.AgentTool, 0, len(agentTools))
+	for _, agentTool := range agentTools {
+		mcpTool, ok := agentTool.(interface{ MCP() string })
+		if !ok {
+			filtered = append(filtered, agentTool)
+			continue
+		}
+		state, found := states[mcpTool.MCP()]
+		if !found || !state.Channel || channel == mcpTool.MCP() {
+			filtered = append(filtered, agentTool)
+		}
+	}
+	return filtered
 }
 
 type SessionAgent interface {
@@ -637,7 +654,7 @@ func (a *sessionAgent) Run(ctx context.Context, call SessionAgentCall) (result *
 	defer a.activeRequests.Del(call.SessionID)
 
 	// Copy mutable fields under lock to avoid races with SetTools/SetModels.
-	agentTools := a.tools.Copy()
+	agentTools := filterToolsForChannel(a.tools.Copy(), call.Channel, mcp.GetStates())
 	largeModel := a.largeModel.Get()
 	systemPrompt := a.systemPrompt.Get()
 	promptPrefix := a.systemPromptPrefix.Get()
@@ -792,7 +809,7 @@ func (a *sessionAgent) Run(ctx context.Context, call SessionAgentCall) (result *
 			}
 
 			// Use latest tools (updated by SetTools when MCP tools change).
-			prepared.Tools = a.tools.Copy()
+			prepared.Tools = filterToolsForChannel(a.tools.Copy(), call.Channel, mcp.GetStates())
 
 			// Drain queued follow-up prompts for this step. Calls covered
 			// by a cancel recorded while they sat in the queue are dropped:
@@ -852,6 +869,7 @@ func (a *sessionAgent) Run(ctx context.Context, call SessionAgentCall) (result *
 				return callContext, prepared, err
 			}
 			callContext = context.WithValue(callContext, tools.MessageIDContextKey, assistantMsg.ID)
+			callContext = context.WithValue(callContext, tools.ChannelContextKey, call.Channel)
 			callContext = context.WithValue(callContext, tools.SupportsImagesContextKey, largeModel.CatwalkCfg.SupportsImages)
 			callContext = context.WithValue(callContext, tools.ModelNameContextKey, largeModel.CatwalkCfg.Name)
 			currentAssistant = &assistantMsg

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -84,6 +84,7 @@ type SessionAgentCall struct {
 	// session that may be busy) MUST set it; SessionID alone is
 	// ambiguous when concurrent turns share the same session.
 	RunID            string
+	Channel          string
 	Prompt           string
 	ProviderOptions  fantasy.ProviderOptions
 	Attachments      []message.Attachment
@@ -124,6 +125,22 @@ type SessionAgentCall struct {
 	// paths treat as covered by any present mark, preserving the
 	// pre-sequence behavior.
 	acceptSeq uint64
+}
+
+func filterToolsForChannel(agentTools []fantasy.AgentTool, channel string, states map[string]mcp.ClientInfo) []fantasy.AgentTool {
+	filtered := make([]fantasy.AgentTool, 0, len(agentTools))
+	for _, agentTool := range agentTools {
+		mcpTool, ok := agentTool.(interface{ MCP() string })
+		if !ok {
+			filtered = append(filtered, agentTool)
+			continue
+		}
+		state, found := states[mcpTool.MCP()]
+		if !found || !state.Channel || channel == mcpTool.MCP() {
+			filtered = append(filtered, agentTool)
+		}
+	}
+	return filtered
 }
 
 type SessionAgent interface {
@@ -641,7 +658,7 @@ func (a *sessionAgent) Run(ctx context.Context, call SessionAgentCall) (result *
 	}
 
 	// Copy mutable fields under lock to avoid races with SetTools/SetModels.
-	agentTools := a.tools.Copy()
+	agentTools := filterToolsForChannel(a.tools.Copy(), call.Channel, mcp.GetStates())
 	largeModel := a.largeModel.Get()
 	systemPrompt := a.systemPrompt.Get()
 	promptPrefix := a.systemPromptPrefix.Get()
@@ -806,7 +823,7 @@ func (a *sessionAgent) Run(ctx context.Context, call SessionAgentCall) (result *
 			}
 
 			// Use latest tools (updated by SetTools when MCP tools change).
-			prepared.Tools = a.tools.Copy()
+			prepared.Tools = filterToolsForChannel(a.tools.Copy(), call.Channel, mcp.GetStates())
 
 			// Drain queued follow-up prompts for this step. Calls covered
 			// by a cancel recorded while they sat in the queue are dropped:
@@ -866,6 +883,7 @@ func (a *sessionAgent) Run(ctx context.Context, call SessionAgentCall) (result *
 				return callContext, prepared, err
 			}
 			callContext = context.WithValue(callContext, tools.MessageIDContextKey, assistantMsg.ID)
+			callContext = context.WithValue(callContext, tools.ChannelContextKey, call.Channel)
 			callContext = context.WithValue(callContext, tools.SupportsImagesContextKey, largeModel.CatwalkCfg.SupportsImages)
 			callContext = context.WithValue(callContext, tools.ModelNameContextKey, largeModel.CatwalkCfg.Name)
 			currentAssistant = &assistantMsg

--- a/internal/agent/channel.go
+++ b/internal/agent/channel.go
@@ -1,0 +1,18 @@
+package agent
+
+import "context"
+
+type channelContextKey struct{}
+
+// WithChannel returns ctx tagged with the channel that originated the turn.
+func WithChannel(ctx context.Context, channel string) context.Context {
+	return context.WithValue(ctx, channelContextKey{}, channel)
+}
+
+// ChannelFromContext returns the originating channel, or an empty string for local turns.
+func ChannelFromContext(ctx context.Context) string {
+	if channel, ok := ctx.Value(channelContextKey{}).(string); ok {
+		return channel
+	}
+	return ""
+}

--- a/internal/agent/channel_test.go
+++ b/internal/agent/channel_test.go
@@ -1,0 +1,54 @@
+package agent
+
+import (
+	"context"
+	"testing"
+
+	"charm.land/fantasy"
+	"github.com/charmbracelet/crush/internal/agent/tools/mcp"
+	"github.com/stretchr/testify/require"
+)
+
+func TestChannelContextIsScopedToTurn(t *testing.T) {
+	t.Parallel()
+	channelContext := WithChannel(context.Background(), "signal")
+	require.Equal(t, "signal", ChannelFromContext(channelContext))
+	require.Empty(t, ChannelFromContext(context.Background()))
+}
+
+func TestFilterToolsForChannel(t *testing.T) {
+	t.Parallel()
+	channelTool := &channelTestTool{name: "send", mcpName: "signal"}
+	plainTool := &fakeTool{name: "plain"}
+	states := map[string]mcp.ClientInfo{"signal": {Channel: true}}
+
+	local := filterToolsForChannel([]fantasy.AgentTool{channelTool, plainTool}, "", states)
+	require.Len(t, local, 1)
+	require.Equal(t, "plain", local[0].Info().Name)
+
+	matching := filterToolsForChannel([]fantasy.AgentTool{channelTool, plainTool}, "signal", states)
+	require.Len(t, matching, 2)
+}
+
+type channelTestTool struct {
+	name    string
+	mcpName string
+}
+
+func (t *channelTestTool) MCP() string {
+	return t.mcpName
+}
+
+func (t *channelTestTool) Info() fantasy.ToolInfo {
+	return fantasy.ToolInfo{Name: t.name}
+}
+
+func (*channelTestTool) Run(context.Context, fantasy.ToolCall) (fantasy.ToolResponse, error) {
+	return fantasy.NewTextResponse("ok"), nil
+}
+
+func (*channelTestTool) ProviderOptions() fantasy.ProviderOptions {
+	return nil
+}
+
+func (*channelTestTool) SetProviderOptions(fantasy.ProviderOptions) {}

--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -277,6 +277,7 @@ func (c *coordinator) run(ctx context.Context, accept *AcceptedRun, sessionID st
 		return c.currentAgent.Run(ctx, SessionAgentCall{
 			SessionID:        sessionID,
 			RunID:            runID,
+			Channel:          ChannelFromContext(ctx),
 			Prompt:           prompt,
 			Attachments:      attachments,
 			MaxOutputTokens:  maxTokens,

--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -271,6 +271,7 @@ func (c *coordinator) run(ctx context.Context, accept *AcceptedRun, sessionID st
 		return c.currentAgent.Run(ctx, SessionAgentCall{
 			SessionID:        sessionID,
 			RunID:            runID,
+			Channel:          ChannelFromContext(ctx),
 			Prompt:           prompt,
 			Attachments:      attachments,
 			MaxOutputTokens:  maxTokens,

--- a/internal/agent/tools/mcp-tools.go
+++ b/internal/agent/tools/mcp-tools.go
@@ -101,6 +101,9 @@ func (m *Tool) Run(ctx context.Context, params fantasy.ToolCall) (fantasy.ToolRe
 	if sessionID == "" {
 		return fantasy.ToolResponse{}, fmt.Errorf("session ID is required for creating a new file")
 	}
+	if state, ok := mcp.GetState(m.mcpName); ok && state.Channel && GetChannelFromContext(ctx) != m.mcpName {
+		return fantasy.NewTextErrorResponse("This channel tool is only available for messages from its originating channel."), nil
+	}
 
 	// Skip permission for whitelisted Docker MCP tools.
 	if !slices.Contains(whitelistDockerTools, params.Name) {

--- a/internal/agent/tools/mcp/channel.go
+++ b/internal/agent/tools/mcp/channel.go
@@ -183,6 +183,7 @@ func publishChannelMessage(name string, raw json.RawMessage) {
 	broker.Publish(pubsub.CreatedEvent, Event{
 		Type:           EventChannelMessage,
 		Name:           name,
+		ChannelMeta:    p.Meta,
 		ChannelMessage: renderChannel(name, p),
 	})
 }

--- a/internal/agent/tools/mcp/channel.go
+++ b/internal/agent/tools/mcp/channel.go
@@ -181,6 +181,7 @@ func publishChannelMessage(name string, raw json.RawMessage) {
 	broker.Publish(pubsub.CreatedEvent, Event{
 		Type:           EventChannelMessage,
 		Name:           name,
+		ChannelMeta:    p.Meta,
 		ChannelMessage: renderChannel(name, p),
 	})
 }

--- a/internal/agent/tools/mcp/channel_test.go
+++ b/internal/agent/tools/mcp/channel_test.go
@@ -15,6 +15,27 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
+func TestPublishChannelMessagePreservesMetadata(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	events := SubscribeEvents(ctx)
+	publishChannelMessage("signal", json.RawMessage(`{"content":"hello","meta":{"sender":"123"}}`))
+
+	select {
+	case event := <-events:
+		if event.Payload.Name != "signal" {
+			t.Fatalf("name = %q, want signal", event.Payload.Name)
+		}
+		if event.Payload.ChannelMeta["sender"] != "123" {
+			t.Fatalf("meta = %v", event.Payload.ChannelMeta)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for channel event")
+	}
+}
+
 func TestParseChannelParams(t *testing.T) {
 	t.Parallel()
 

--- a/internal/agent/tools/mcp/init.go
+++ b/internal/agent/tools/mcp/init.go
@@ -113,6 +113,7 @@ type Event struct {
 	// ChannelMessage is set only for EventChannelMessage: the fully rendered
 	// and escaped <channel>...</channel> element to inject into the session.
 	ChannelMessage string
+	ChannelMeta    map[string]string
 }
 
 // Counts number of available tools, prompts, etc.

--- a/internal/agent/tools/mcp/init.go
+++ b/internal/agent/tools/mcp/init.go
@@ -110,6 +110,7 @@ type Event struct {
 	// ChannelMessage is set only for EventChannelMessage: the fully rendered
 	// and escaped <channel>...</channel> element to inject into the session.
 	ChannelMessage string
+	ChannelMeta    map[string]string
 }
 
 // Counts number of available tools, prompts, etc.
@@ -126,6 +127,7 @@ type ClientInfo struct {
 	Error       error
 	Client      *ClientSession
 	Counts      Counts
+	Channel     bool
 	ConnectedAt time.Time
 }
 
@@ -338,6 +340,9 @@ func updateState(name string, state State, err error, client *ClientSession, cou
 		Client: client,
 		Counts: counts,
 	}
+	if previous, ok := states.Get(name); ok {
+		info.Channel = previous.Channel
+	}
 	switch state {
 	case StateConnected:
 		info.ConnectedAt = time.Now()
@@ -427,6 +432,10 @@ func createSession(ctx context.Context, name string, m config.MCPConfig, resolve
 	// config is not enough; this enforces the "listed is not enabled" model.
 	if channelOptIn && hasChannelCapability(session.InitializeResult()) {
 		channelGate.Store(true)
+		if info, ok := states.Get(name); ok {
+			info.Channel = true
+			states.Set(name, info)
+		}
 		slog.Info("MCP channel enabled", "name", name)
 	}
 

--- a/internal/agent/tools/tools.go
+++ b/internal/agent/tools/tools.go
@@ -15,6 +15,7 @@ type (
 	messageIDContextKey string
 	supportsImagesKey   string
 	modelNameKey        string
+	channelContextKey   string
 )
 
 const (
@@ -26,6 +27,8 @@ const (
 	SupportsImagesContextKey supportsImagesKey = "supports_images"
 	// ModelNameContextKey is the key for the model name in the context.
 	ModelNameContextKey modelNameKey = "model_name"
+	// ChannelContextKey is the key for the channel that originated the turn.
+	ChannelContextKey channelContextKey = "channel"
 )
 
 // getContextValue is a generic helper that retrieves a typed value from context.
@@ -44,6 +47,11 @@ func getContextValue[T any](ctx context.Context, key any, defaultValue T) T {
 // GetSessionFromContext retrieves the session ID from the context.
 func GetSessionFromContext(ctx context.Context) string {
 	return getContextValue(ctx, SessionIDContextKey, "")
+}
+
+// GetChannelFromContext retrieves the channel that originated the current turn.
+func GetChannelFromContext(ctx context.Context) string {
+	return getContextValue(ctx, ChannelContextKey, "")
 }
 
 // GetMessageFromContext retrieves the message ID from the context.

--- a/internal/app/resolve_session_test.go
+++ b/internal/app/resolve_session_test.go
@@ -60,6 +60,10 @@ func (m *mockSessionService) Save(_ context.Context, s session.Session) (session
 	return s, nil
 }
 
+func (m *mockSessionService) SetChannel(_ context.Context, sessionID, channel string) (session.Session, error) {
+	return session.Session{ID: sessionID, Channel: channel}, nil
+}
+
 func (m *mockSessionService) UpdateTitleAndUsage(context.Context, string, string, int64, int64, float64) error {
 	return nil
 }

--- a/internal/backend/agent.go
+++ b/internal/backend/agent.go
@@ -94,6 +94,9 @@ func (b *Backend) runAgent(ws *Workspace, msg proto.AgentMessage, accept *agent.
 	}
 	ctx = agent.WithRunCompleteMarker(ctx)
 
+	if msg.Channel != "" {
+		ctx = agent.WithChannel(ctx, msg.Channel)
+	}
 	_, err := ws.AgentCoordinator.RunAccepted(ctx, accept, msg.SessionID, msg.Prompt, proto.AttachmentsToMessage(msg.Attachments)...)
 	if err == nil || errors.Is(err, context.Canceled) {
 		return

--- a/internal/backend/channels.go
+++ b/internal/backend/channels.go
@@ -81,6 +81,7 @@ func (b *Backend) injectChannelMessage(ws *Workspace, serverName, content string
 	}
 	if err := b.SendMessage(ws.ID, proto.AgentMessage{
 		SessionID: sessionID,
+		Channel:   serverName,
 		Prompt:    content,
 	}); err != nil {
 		slog.Warn("Channel message dropped: dispatch failed",

--- a/internal/backend/channels_test.go
+++ b/internal/backend/channels_test.go
@@ -125,20 +125,23 @@ func TestWorkspaceViewedSessions(t *testing.T) {
 }
 
 // recordingCoordinator is a minimal agent.Coordinator that records the
-// session/prompt of each RunAccepted call.
+// session/prompt of each RunAccepted call, plus the per-turn channel
+// provenance carried on the context.
 type recordingCoordinator struct {
-	runs chan [2]string // {sessionID, prompt}
+	runs     chan [2]string // {sessionID, prompt}
+	channels chan string    // per-turn channel provenance
 }
 
 func newRecordingCoordinator() *recordingCoordinator {
-	return &recordingCoordinator{runs: make(chan [2]string, 8)}
+	return &recordingCoordinator{runs: make(chan [2]string, 8), channels: make(chan string, 8)}
 }
 
 func (c *recordingCoordinator) Run(context.Context, string, string, ...message.Attachment) (*fantasy.AgentResult, error) {
 	return nil, nil
 }
 
-func (c *recordingCoordinator) RunAccepted(_ context.Context, _ *agent.AcceptedRun, sessionID, prompt string, _ ...message.Attachment) (*fantasy.AgentResult, error) {
+func (c *recordingCoordinator) RunAccepted(ctx context.Context, _ *agent.AcceptedRun, sessionID, prompt string, _ ...message.Attachment) (*fantasy.AgentResult, error) {
+	c.channels <- agent.ChannelFromContext(ctx)
 	c.runs <- [2]string{sessionID, prompt}
 	return nil, nil
 }
@@ -245,6 +248,7 @@ func TestRouteChannelMessage_InjectsOncePerOptedInWorkspace(t *testing.T) {
 	case run := <-optedIn.runs:
 		require.Equal(t, "recent", run[0], "should land in the most recent session")
 		require.Equal(t, content, run[1])
+		require.Equal(t, "webhook", <-optedIn.channels, "the server-routed turn must carry its originating channel")
 	case <-time.After(5 * time.Second):
 		t.Fatal("expected the opted-in workspace to receive the channel push")
 	}

--- a/internal/client/proto.go
+++ b/internal/client/proto.go
@@ -412,10 +412,11 @@ func (c *Client) UpdateAgent(ctx context.Context, id string) error {
 // for completion detection. Pass "" when the caller does not need
 // to distinguish its own turn's terminal event from any concurrent
 // turn on the same session (e.g. interactive TUI usage).
-func (c *Client) SendMessage(ctx context.Context, id string, sessionID, runID, prompt string, attachments ...message.Attachment) error {
+func (c *Client) SendMessage(ctx context.Context, id string, sessionID, runID, channel, prompt string, attachments ...message.Attachment) error {
 	rsp, err := c.post(ctx, fmt.Sprintf("/workspaces/%s/agent", id), nil, jsonBody(proto.AgentMessage{
 		SessionID:   sessionID,
 		RunID:       runID,
+		Channel:     channel,
 		Prompt:      prompt,
 		Attachments: proto.AttachmentsFromMessage(attachments),
 	}), http.Header{"Content-Type": []string{"application/json"}})

--- a/internal/client/proto_test.go
+++ b/internal/client/proto_test.go
@@ -97,7 +97,22 @@ func TestSendMessageAcceptsStatusAccepted(t *testing.T) {
 	defer srv.Close()
 
 	c := captureClient(t, srv)
-	require.NoError(t, c.SendMessage(context.Background(), "ws1", "sess1", "", "hello"))
+	require.NoError(t, c.SendMessage(context.Background(), "ws1", "sess1", "", "", "hello"))
+}
+
+func TestSendMessageIncludesChannelOrigin(t *testing.T) {
+	t.Parallel()
+
+	var got proto.AgentMessage
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&got))
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer srv.Close()
+
+	c := captureClient(t, srv)
+	require.NoError(t, c.SendMessage(context.Background(), "ws1", "sess1", "", "signal", "hello"))
+	require.Equal(t, "signal", got.Channel)
 }
 
 func TestSendMessageAcceptsStatusOK(t *testing.T) {
@@ -109,7 +124,7 @@ func TestSendMessageAcceptsStatusOK(t *testing.T) {
 	defer srv.Close()
 
 	c := captureClient(t, srv)
-	require.NoError(t, c.SendMessage(context.Background(), "ws1", "sess1", "", "hello"))
+	require.NoError(t, c.SendMessage(context.Background(), "ws1", "sess1", "", "", "hello"))
 }
 
 func TestSendMessageDecodesErrorBody(t *testing.T) {
@@ -122,7 +137,7 @@ func TestSendMessageDecodesErrorBody(t *testing.T) {
 	defer srv.Close()
 
 	c := captureClient(t, srv)
-	err := c.SendMessage(context.Background(), "ws1", "", "", "hello")
+	err := c.SendMessage(context.Background(), "ws1", "", "", "", "hello")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "status code 400")
 	require.Contains(t, err.Error(), "session id is required")
@@ -138,7 +153,7 @@ func TestSendMessageFallsBackOnMalformedErrorBody(t *testing.T) {
 	defer srv.Close()
 
 	c := captureClient(t, srv)
-	err := c.SendMessage(context.Background(), "ws1", "sess1", "", "hello")
+	err := c.SendMessage(context.Background(), "ws1", "sess1", "", "", "hello")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "status code 500")
 	require.NotContains(t, err.Error(), "not json")
@@ -153,7 +168,7 @@ func TestSendMessageFallsBackOnEmptyErrorBody(t *testing.T) {
 	defer srv.Close()
 
 	c := captureClient(t, srv)
-	err := c.SendMessage(context.Background(), "ws1", "sess1", "", "hello")
+	err := c.SendMessage(context.Background(), "ws1", "sess1", "", "", "hello")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "status code 500")
 }

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -252,7 +252,7 @@ func runNonInteractive(
 	// loop would exit on whichever RunComplete arrived first for
 	// the same session and drop the queued prompt's output.
 	runID := uuid.New().String()
-	if err := c.SendMessage(ctx, ws.ID, sess.ID, runID, prompt); err != nil {
+	if err := c.SendMessage(ctx, ws.ID, sess.ID, runID, "", prompt); err != nil {
 		return fmt.Errorf("failed to send message: %w", err)
 	}
 

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -11,10 +11,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...any) (sql.Result, error)
+	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...any) *sql.Row
+	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
 }
 
 func New(db DBTX) *Queries {
@@ -125,6 +125,9 @@ func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	}
 	if q.renameSessionStmt, err = db.PrepareContext(ctx, renameSession); err != nil {
 		return nil, fmt.Errorf("error preparing query RenameSession: %w", err)
+	}
+	if q.setSessionChannelStmt, err = db.PrepareContext(ctx, setSessionChannel); err != nil {
+		return nil, fmt.Errorf("error preparing query SetSessionChannel: %w", err)
 	}
 	if q.updateMessageStmt, err = db.PrepareContext(ctx, updateMessage); err != nil {
 		return nil, fmt.Errorf("error preparing query UpdateMessage: %w", err)
@@ -310,6 +313,11 @@ func (q *Queries) Close() error {
 			err = fmt.Errorf("error closing renameSessionStmt: %w", cerr)
 		}
 	}
+	if q.setSessionChannelStmt != nil {
+		if cerr := q.setSessionChannelStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing setSessionChannelStmt: %w", cerr)
+		}
+	}
 	if q.updateMessageStmt != nil {
 		if cerr := q.updateMessageStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing updateMessageStmt: %w", cerr)
@@ -398,6 +406,7 @@ type Queries struct {
 	listUserMessagesBySessionStmt  *sql.Stmt
 	recordFileReadStmt             *sql.Stmt
 	renameSessionStmt              *sql.Stmt
+	setSessionChannelStmt          *sql.Stmt
 	updateMessageStmt              *sql.Stmt
 	updateSessionStmt              *sql.Stmt
 	updateSessionTitleAndUsageStmt *sql.Stmt
@@ -441,6 +450,7 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		listUserMessagesBySessionStmt:  q.listUserMessagesBySessionStmt,
 		recordFileReadStmt:             q.recordFileReadStmt,
 		renameSessionStmt:              q.renameSessionStmt,
+		setSessionChannelStmt:          q.setSessionChannelStmt,
 		updateMessageStmt:              q.updateMessageStmt,
 		updateSessionStmt:              q.updateSessionStmt,
 		updateSessionTitleAndUsageStmt: q.updateSessionTitleAndUsageStmt,

--- a/internal/db/migrations/20260713000000_add_channel_to_sessions.sql
+++ b/internal/db/migrations/20260713000000_add_channel_to_sessions.sql
@@ -1,0 +1,5 @@
+-- +goose Up
+ALTER TABLE sessions ADD COLUMN channel TEXT;
+
+-- +goose Down
+ALTER TABLE sessions DROP COLUMN channel;

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -49,4 +49,5 @@ type Session struct {
 	CreatedAt        int64          `json:"created_at"`
 	SummaryMessageID sql.NullString `json:"summary_message_id"`
 	Todos            sql.NullString `json:"todos"`
+	Channel          sql.NullString `json:"channel"`
 }

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -43,6 +43,7 @@ type Querier interface {
 	ListUserMessagesBySession(ctx context.Context, sessionID string) ([]Message, error)
 	RecordFileRead(ctx context.Context, arg RecordFileReadParams) error
 	RenameSession(ctx context.Context, arg RenameSessionParams) error
+	SetSessionChannel(ctx context.Context, arg SetSessionChannelParams) (Session, error)
 	UpdateMessage(ctx context.Context, arg UpdateMessageParams) error
 	UpdateSession(ctx context.Context, arg UpdateSessionParams) (Session, error)
 	UpdateSessionTitleAndUsage(ctx context.Context, arg UpdateSessionTitleAndUsageParams) error

--- a/internal/db/sessions.sql.go
+++ b/internal/db/sessions.sql.go
@@ -33,7 +33,7 @@ INSERT INTO sessions (
     null,
     strftime('%s', 'now'),
     strftime('%s', 'now')
-) RETURNING id, parent_session_id, title, message_count, prompt_tokens, completion_tokens, cost, updated_at, created_at, summary_message_id, todos
+) RETURNING id, parent_session_id, title, message_count, prompt_tokens, completion_tokens, cost, updated_at, created_at, summary_message_id, todos, channel
 `
 
 type CreateSessionParams struct {
@@ -69,6 +69,7 @@ func (q *Queries) CreateSession(ctx context.Context, arg CreateSessionParams) (S
 		&i.CreatedAt,
 		&i.SummaryMessageID,
 		&i.Todos,
+		&i.Channel,
 	)
 	return i, err
 }
@@ -84,7 +85,7 @@ func (q *Queries) DeleteSession(ctx context.Context, id string) error {
 }
 
 const getLastSession = `-- name: GetLastSession :one
-SELECT id, parent_session_id, title, message_count, prompt_tokens, completion_tokens, cost, updated_at, created_at, summary_message_id, todos
+SELECT id, parent_session_id, title, message_count, prompt_tokens, completion_tokens, cost, updated_at, created_at, summary_message_id, todos, channel
 FROM sessions
 ORDER BY updated_at DESC
 LIMIT 1
@@ -105,12 +106,13 @@ func (q *Queries) GetLastSession(ctx context.Context) (Session, error) {
 		&i.CreatedAt,
 		&i.SummaryMessageID,
 		&i.Todos,
+		&i.Channel,
 	)
 	return i, err
 }
 
 const getSessionByID = `-- name: GetSessionByID :one
-SELECT id, parent_session_id, title, message_count, prompt_tokens, completion_tokens, cost, updated_at, created_at, summary_message_id, todos
+SELECT id, parent_session_id, title, message_count, prompt_tokens, completion_tokens, cost, updated_at, created_at, summary_message_id, todos, channel
 FROM sessions
 WHERE id = ? LIMIT 1
 `
@@ -130,12 +132,13 @@ func (q *Queries) GetSessionByID(ctx context.Context, id string) (Session, error
 		&i.CreatedAt,
 		&i.SummaryMessageID,
 		&i.Todos,
+		&i.Channel,
 	)
 	return i, err
 }
 
 const listSessions = `-- name: ListSessions :many
-SELECT id, parent_session_id, title, message_count, prompt_tokens, completion_tokens, cost, updated_at, created_at, summary_message_id, todos
+SELECT id, parent_session_id, title, message_count, prompt_tokens, completion_tokens, cost, updated_at, created_at, summary_message_id, todos, channel
 FROM sessions
 WHERE parent_session_id is NULL
 ORDER BY updated_at DESC
@@ -162,6 +165,7 @@ func (q *Queries) ListSessions(ctx context.Context) ([]Session, error) {
 			&i.CreatedAt,
 			&i.SummaryMessageID,
 			&i.Todos,
+			&i.Channel,
 		); err != nil {
 			return nil, err
 		}
@@ -193,6 +197,38 @@ func (q *Queries) RenameSession(ctx context.Context, arg RenameSessionParams) er
 	return err
 }
 
+const setSessionChannel = `-- name: SetSessionChannel :one
+UPDATE sessions
+SET channel = ?
+WHERE id = ?
+RETURNING id, parent_session_id, title, message_count, prompt_tokens, completion_tokens, cost, updated_at, created_at, summary_message_id, todos, channel
+`
+
+type SetSessionChannelParams struct {
+	Channel sql.NullString `json:"channel"`
+	ID      string         `json:"id"`
+}
+
+func (q *Queries) SetSessionChannel(ctx context.Context, arg SetSessionChannelParams) (Session, error) {
+	row := q.queryRow(ctx, q.setSessionChannelStmt, setSessionChannel, arg.Channel, arg.ID)
+	var i Session
+	err := row.Scan(
+		&i.ID,
+		&i.ParentSessionID,
+		&i.Title,
+		&i.MessageCount,
+		&i.PromptTokens,
+		&i.CompletionTokens,
+		&i.Cost,
+		&i.UpdatedAt,
+		&i.CreatedAt,
+		&i.SummaryMessageID,
+		&i.Todos,
+		&i.Channel,
+	)
+	return i, err
+}
+
 const updateSession = `-- name: UpdateSession :one
 UPDATE sessions
 SET
@@ -201,9 +237,10 @@ SET
     completion_tokens = ?,
     summary_message_id = ?,
     cost = ?,
-    todos = ?
+    todos = ?,
+    channel = ?
 WHERE id = ?
-RETURNING id, parent_session_id, title, message_count, prompt_tokens, completion_tokens, cost, updated_at, created_at, summary_message_id, todos
+RETURNING id, parent_session_id, title, message_count, prompt_tokens, completion_tokens, cost, updated_at, created_at, summary_message_id, todos, channel
 `
 
 type UpdateSessionParams struct {
@@ -213,6 +250,7 @@ type UpdateSessionParams struct {
 	SummaryMessageID sql.NullString `json:"summary_message_id"`
 	Cost             float64        `json:"cost"`
 	Todos            sql.NullString `json:"todos"`
+	Channel          sql.NullString `json:"channel"`
 	ID               string         `json:"id"`
 }
 
@@ -224,6 +262,7 @@ func (q *Queries) UpdateSession(ctx context.Context, arg UpdateSessionParams) (S
 		arg.SummaryMessageID,
 		arg.Cost,
 		arg.Todos,
+		arg.Channel,
 		arg.ID,
 	)
 	var i Session
@@ -239,6 +278,7 @@ func (q *Queries) UpdateSession(ctx context.Context, arg UpdateSessionParams) (S
 		&i.CreatedAt,
 		&i.SummaryMessageID,
 		&i.Todos,
+		&i.Channel,
 	)
 	return i, err
 }

--- a/internal/db/sql/sessions.sql
+++ b/internal/db/sql/sessions.sql
@@ -48,7 +48,14 @@ SET
     completion_tokens = ?,
     summary_message_id = ?,
     cost = ?,
-    todos = ?
+    todos = ?,
+    channel = ?
+WHERE id = ?
+RETURNING *;
+
+-- name: SetSessionChannel :one
+UPDATE sessions
+SET channel = ?
 WHERE id = ?
 RETURNING *;
 

--- a/internal/proto/proto.go
+++ b/internal/proto/proto.go
@@ -134,6 +134,7 @@ func (a AgentInfo) IsZero() bool {
 type AgentMessage struct {
 	SessionID   string       `json:"session_id"`
 	RunID       string       `json:"run_id,omitempty"`
+	Channel     string       `json:"channel,omitempty"`
 	Prompt      string       `json:"prompt"`
 	Attachments []Attachment `json:"attachments,omitempty"`
 }

--- a/internal/proto/session.go
+++ b/internal/proto/session.go
@@ -23,6 +23,7 @@ type Session struct {
 	SummaryMessageID string  `json:"summary_message_id"`
 	Cost             float64 `json:"cost"`
 	Todos            []Todo  `json:"todos,omitempty"`
+	Channel          string  `json:"channel,omitempty"`
 	CreatedAt        int64   `json:"created_at"`
 	UpdatedAt        int64   `json:"updated_at"`
 	IsBusy           bool    `json:"is_busy"`

--- a/internal/server/events.go
+++ b/internal/server/events.go
@@ -167,6 +167,7 @@ func sessionToProto(s session.Session) proto.Session {
 		CompletionTokens: s.CompletionTokens,
 		Cost:             s.Cost,
 		Todos:            todosToProto(s.Todos),
+		Channel:          s.Channel,
 		CreatedAt:        s.CreatedAt,
 		UpdatedAt:        s.UpdatedAt,
 	}

--- a/internal/server/events.go
+++ b/internal/server/events.go
@@ -164,6 +164,7 @@ func sessionToProto(s session.Session) proto.Session {
 		CompletionTokens: s.CompletionTokens,
 		Cost:             s.Cost,
 		Todos:            todosToProto(s.Todos),
+		Channel:          s.Channel,
 		CreatedAt:        s.CreatedAt,
 		UpdatedAt:        s.UpdatedAt,
 	}

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -58,6 +58,7 @@ type Session struct {
 	SummaryMessageID string
 	Cost             float64
 	Todos            []Todo
+	Channel          string
 	CreatedAt        int64
 	UpdatedAt        int64
 }
@@ -71,6 +72,7 @@ type Service interface {
 	GetLast(ctx context.Context) (Session, error)
 	List(ctx context.Context) ([]Session, error)
 	Save(ctx context.Context, session Session) (Session, error)
+	SetChannel(ctx context.Context, sessionID, channel string) (Session, error)
 	UpdateTitleAndUsage(ctx context.Context, sessionID, title string, promptTokens, completionTokens int64, cost float64) error
 	Rename(ctx context.Context, id string, title string) error
 	Delete(ctx context.Context, id string) error
@@ -208,6 +210,10 @@ func (s *service) Save(ctx context.Context, session Session) (Session, error) {
 			String: todosJSON,
 			Valid:  todosJSON != "",
 		},
+		Channel: sql.NullString{
+			String: session.Channel,
+			Valid:  session.Channel != "",
+		},
 	})
 	if err != nil {
 		return Session{}, err
@@ -216,6 +222,23 @@ func (s *service) Save(ctx context.Context, session Session) (Session, error) {
 	s.setEstimatedUsageState(session.ID, estimatedUsage)
 	session = s.fromDBItem(dbSession)
 	session.EstimatedUsage = estimatedUsage
+	s.Publish(pubsub.UpdatedEvent, session)
+	return session, nil
+}
+
+func (s *service) SetChannel(ctx context.Context, sessionID, channel string) (Session, error) {
+	dbSession, err := s.q.SetSessionChannel(ctx, db.SetSessionChannelParams{
+		ID: sessionID,
+		Channel: sql.NullString{
+			String: channel,
+			Valid:  channel != "",
+		},
+	})
+	if err != nil {
+		return Session{}, err
+	}
+	session := s.fromDBItem(dbSession)
+	s.applyEstimatedUsageState(&session)
 	s.Publish(pubsub.UpdatedEvent, session)
 	return session, nil
 }
@@ -310,6 +333,7 @@ func (s *service) fromDBItem(item db.Session) Session {
 		SummaryMessageID: item.SummaryMessageID.String,
 		Cost:             item.Cost,
 		Todos:            todos,
+		Channel:          item.Channel.String,
 		CreatedAt:        item.CreatedAt,
 		UpdatedAt:        item.UpdatedAt,
 	}

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -48,6 +48,29 @@ func TestEstimatedUsageStateSurvivesFetchModifySave(t *testing.T) {
 	require.True(t, refetched.EstimatedUsage)
 }
 
+func TestSessionChannelPersists(t *testing.T) {
+	t.Parallel()
+	dataDir := t.TempDir()
+	t.Cleanup(func() {
+		require.NoError(t, db.Release(dataDir))
+		db.ResetPool()
+	})
+
+	conn, err := db.Connect(t.Context(), dataDir)
+	require.NoError(t, err)
+	sessions := NewService(db.New(conn), conn)
+
+	created, err := sessions.Create(t.Context(), "channel")
+	require.NoError(t, err)
+	updated, err := sessions.SetChannel(t.Context(), created.ID, "signal")
+	require.NoError(t, err)
+	require.Equal(t, "signal", updated.Channel)
+
+	fetched, err := sessions.Get(t.Context(), created.ID)
+	require.NoError(t, err)
+	require.Equal(t, "signal", fetched.Channel)
+}
+
 func TestEstimatedUsageStateCanBeClearedByExplicitSave(t *testing.T) {
 	dataDir := t.TempDir()
 	t.Cleanup(func() {

--- a/internal/ui/model/channel_test.go
+++ b/internal/ui/model/channel_test.go
@@ -27,9 +27,11 @@ type channelWorkspace struct {
 	createCalls  int
 	runCalls     []channelRun
 	runErr       error
+	channels     []string
 }
 
 type channelRun struct {
+	channel   string
 	sessionID string
 	prompt    string
 }
@@ -48,6 +50,16 @@ func (w *channelWorkspace) CreateSession(context.Context, string) (session.Sessi
 func (w *channelWorkspace) AgentRun(_ context.Context, sessionID, prompt string, _ ...message.Attachment) error {
 	w.runCalls = append(w.runCalls, channelRun{sessionID: sessionID, prompt: prompt})
 	return w.runErr
+}
+
+func (w *channelWorkspace) AgentRunChannel(_ context.Context, channel, sessionID, prompt string, _ ...message.Attachment) error {
+	w.runCalls = append(w.runCalls, channelRun{channel: channel, sessionID: sessionID, prompt: prompt})
+	return w.runErr
+}
+
+func (w *channelWorkspace) SetSessionChannel(_ context.Context, sessionID, channel string) (session.Session, error) {
+	w.channels = append(w.channels, channel)
+	return session.Session{ID: sessionID, Channel: channel}, nil
 }
 
 func (w *channelWorkspace) Config() *config.Config { return nil }
@@ -74,7 +86,7 @@ func TestHandleChannelMessageExistingSession(t *testing.T) {
 	m := newChannelUI(ws)
 	m.session = &session.Session{ID: "sess-1"}
 
-	cmd := m.handleChannelMessage(mcp.Event{ChannelMessage: "<channel source=\"s\">hi</channel>"})
+	cmd := m.handleChannelMessage(mcp.Event{Name: "s", ChannelMessage: "<channel source=\"s\">hi</channel>"})
 	if cmd == nil {
 		t.Fatal("expected a command for an active-session channel event")
 	}
@@ -86,6 +98,12 @@ func TestHandleChannelMessageExistingSession(t *testing.T) {
 	cmd()
 	if len(ws.runCalls) != 1 {
 		t.Fatalf("AgentRun calls = %d, want 1", len(ws.runCalls))
+	}
+	if ws.runCalls[0].channel != "s" {
+		t.Errorf("AgentRun channel = %q, want s", ws.runCalls[0].channel)
+	}
+	if len(ws.channels) != 1 || ws.channels[0] != "s" {
+		t.Errorf("session channels = %v, want [s]", ws.channels)
 	}
 	if ws.runCalls[0].sessionID != "sess-1" {
 		t.Errorf("AgentRun sessionID = %q, want sess-1", ws.runCalls[0].sessionID)
@@ -101,7 +119,7 @@ func TestHandleChannelMessageCreatesSessionWhenNoneActive(t *testing.T) {
 	m := newChannelUI(ws)
 	// No active session: a pushed event must not be dropped.
 
-	cmd := m.handleChannelMessage(mcp.Event{ChannelMessage: "<channel source=\"s\">hi</channel>"})
+	cmd := m.handleChannelMessage(mcp.Event{Name: "s", ChannelMessage: "<channel source=\"s\">hi</channel>"})
 	if cmd == nil {
 		t.Fatal("expected a command when auto-creating a session")
 	}

--- a/internal/ui/model/channel_test.go
+++ b/internal/ui/model/channel_test.go
@@ -26,9 +26,11 @@ type channelWorkspace struct {
 	createCalls int
 	runCalls    []channelRun
 	runErr      error
+	channels    []string
 }
 
 type channelRun struct {
+	channel   string
 	sessionID string
 	prompt    string
 }
@@ -46,6 +48,16 @@ func (w *channelWorkspace) CreateSession(context.Context, string) (session.Sessi
 func (w *channelWorkspace) AgentRun(_ context.Context, sessionID, prompt string, _ ...message.Attachment) error {
 	w.runCalls = append(w.runCalls, channelRun{sessionID: sessionID, prompt: prompt})
 	return w.runErr
+}
+
+func (w *channelWorkspace) AgentRunChannel(_ context.Context, channel, sessionID, prompt string, _ ...message.Attachment) error {
+	w.runCalls = append(w.runCalls, channelRun{channel: channel, sessionID: sessionID, prompt: prompt})
+	return w.runErr
+}
+
+func (w *channelWorkspace) SetSessionChannel(_ context.Context, sessionID, channel string) (session.Session, error) {
+	w.channels = append(w.channels, channel)
+	return session.Session{ID: sessionID, Channel: channel}, nil
 }
 
 func (w *channelWorkspace) Config() *config.Config { return nil }
@@ -72,7 +84,7 @@ func TestHandleChannelMessageExistingSession(t *testing.T) {
 	m := newChannelUI(ws)
 	m.session = &session.Session{ID: "sess-1"}
 
-	cmd := m.handleChannelMessage(mcp.Event{ChannelMessage: "<channel source=\"s\">hi</channel>"})
+	cmd := m.handleChannelMessage(mcp.Event{Name: "s", ChannelMessage: "<channel source=\"s\">hi</channel>"})
 	if cmd == nil {
 		t.Fatal("expected a command for an active-session channel event")
 	}
@@ -84,6 +96,12 @@ func TestHandleChannelMessageExistingSession(t *testing.T) {
 	cmd()
 	if len(ws.runCalls) != 1 {
 		t.Fatalf("AgentRun calls = %d, want 1", len(ws.runCalls))
+	}
+	if ws.runCalls[0].channel != "s" {
+		t.Errorf("AgentRun channel = %q, want s", ws.runCalls[0].channel)
+	}
+	if len(ws.channels) != 1 || ws.channels[0] != "s" {
+		t.Errorf("session channels = %v, want [s]", ws.channels)
 	}
 	if ws.runCalls[0].sessionID != "sess-1" {
 		t.Errorf("AgentRun sessionID = %q, want sess-1", ws.runCalls[0].sessionID)
@@ -99,7 +117,7 @@ func TestHandleChannelMessageCreatesSessionWhenNoneActive(t *testing.T) {
 	m := newChannelUI(ws)
 	// No active session: a pushed event must not be dropped.
 
-	cmd := m.handleChannelMessage(mcp.Event{ChannelMessage: "<channel source=\"s\">hi</channel>"})
+	cmd := m.handleChannelMessage(mcp.Event{Name: "s", ChannelMessage: "<channel source=\"s\">hi</channel>"})
 	if cmd == nil {
 		t.Fatal("expected a command when auto-creating a session")
 	}

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -3597,10 +3597,17 @@ func (m *UI) handleChannelMessage(ev mcp.Event) tea.Cmd {
 	if !m.hasSession() {
 		return loadCmd
 	}
+	updatedSession, err := m.com.Workspace.SetSessionChannel(context.Background(), m.session.ID, ev.Name)
+	if err != nil {
+		slog.Debug("Failed to set session channel", "error", err, "session", m.session.ID, "channel", ev.Name)
+		return loadCmd
+	}
+	m.session = &updatedSession
 	sessionID := m.session.ID
+	channel := ev.Name
 	content := ev.ChannelMessage
 	runCmd := func() tea.Msg {
-		if err := m.com.Workspace.AgentRun(context.Background(), sessionID, content); err != nil {
+		if err := m.com.Workspace.AgentRunChannel(context.Background(), channel, sessionID, content); err != nil {
 			slog.Debug("Failed to inject channel message", "error", err, "session", sessionID)
 		}
 		return nil

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -3588,10 +3588,17 @@ func (m *UI) handleChannelMessage(ev mcp.Event) tea.Cmd {
 	if !m.hasSession() {
 		return loadCmd
 	}
+	updatedSession, err := m.com.Workspace.SetSessionChannel(context.Background(), m.session.ID, ev.Name)
+	if err != nil {
+		slog.Debug("Failed to set session channel", "error", err, "session", m.session.ID, "channel", ev.Name)
+		return loadCmd
+	}
+	m.session = &updatedSession
 	sessionID := m.session.ID
+	channel := ev.Name
 	content := ev.ChannelMessage
 	runCmd := func() tea.Msg {
-		if err := m.com.Workspace.AgentRun(context.Background(), sessionID, content); err != nil {
+		if err := m.com.Workspace.AgentRunChannel(context.Background(), channel, sessionID, content); err != nil {
 			slog.Debug("Failed to inject channel message", "error", err, "session", sessionID)
 		}
 		return nil

--- a/internal/workspace/app_workspace.go
+++ b/internal/workspace/app_workspace.go
@@ -59,6 +59,10 @@ func (w *AppWorkspace) SaveSession(ctx context.Context, sess session.Session) (s
 	return w.app.Sessions.Save(ctx, sess)
 }
 
+func (w *AppWorkspace) SetSessionChannel(ctx context.Context, sessionID, channel string) (session.Session, error) {
+	return w.app.Sessions.SetChannel(ctx, sessionID, channel)
+}
+
 func (w *AppWorkspace) DeleteSession(ctx context.Context, sessionID string) error {
 	return w.app.Sessions.Delete(ctx, sessionID)
 }
@@ -111,6 +115,14 @@ func (w *AppWorkspace) AgentRun(ctx context.Context, sessionID, prompt string, a
 		return errors.New("agent coordinator not initialized")
 	}
 	_, err := w.app.AgentCoordinator.Run(ctx, sessionID, prompt, attachments...)
+	return err
+}
+
+func (w *AppWorkspace) AgentRunChannel(ctx context.Context, channel, sessionID, prompt string, attachments ...message.Attachment) error {
+	if w.app.AgentCoordinator == nil {
+		return errors.New("agent coordinator not initialized")
+	}
+	_, err := w.app.AgentCoordinator.Run(agent.WithChannel(ctx, channel), sessionID, prompt, attachments...)
 	return err
 }
 

--- a/internal/workspace/app_workspace.go
+++ b/internal/workspace/app_workspace.go
@@ -59,6 +59,10 @@ func (w *AppWorkspace) SaveSession(ctx context.Context, sess session.Session) (s
 	return w.app.Sessions.Save(ctx, sess)
 }
 
+func (w *AppWorkspace) SetSessionChannel(ctx context.Context, sessionID, channel string) (session.Session, error) {
+	return w.app.Sessions.SetChannel(ctx, sessionID, channel)
+}
+
 func (w *AppWorkspace) DeleteSession(ctx context.Context, sessionID string) error {
 	return w.app.Sessions.Delete(ctx, sessionID)
 }
@@ -107,6 +111,14 @@ func (w *AppWorkspace) AgentRun(ctx context.Context, sessionID, prompt string, a
 		return errors.New("agent coordinator not initialized")
 	}
 	_, err := w.app.AgentCoordinator.Run(ctx, sessionID, prompt, attachments...)
+	return err
+}
+
+func (w *AppWorkspace) AgentRunChannel(ctx context.Context, channel, sessionID, prompt string, attachments ...message.Attachment) error {
+	if w.app.AgentCoordinator == nil {
+		return errors.New("agent coordinator not initialized")
+	}
+	_, err := w.app.AgentCoordinator.Run(agent.WithChannel(ctx, channel), sessionID, prompt, attachments...)
 	return err
 }
 

--- a/internal/workspace/client_workspace.go
+++ b/internal/workspace/client_workspace.go
@@ -132,6 +132,15 @@ func (w *ClientWorkspace) SaveSession(ctx context.Context, sess session.Session)
 	return protoToSession(*saved), nil
 }
 
+func (w *ClientWorkspace) SetSessionChannel(ctx context.Context, sessionID, channel string) (session.Session, error) {
+	sess, err := w.GetSession(ctx, sessionID)
+	if err != nil {
+		return session.Session{}, err
+	}
+	sess.Channel = channel
+	return w.SaveSession(ctx, sess)
+}
+
 func (w *ClientWorkspace) DeleteSession(ctx context.Context, sessionID string) error {
 	return w.client.DeleteSession(ctx, w.workspaceID(), sessionID)
 }
@@ -197,7 +206,11 @@ func (w *ClientWorkspace) AgentRun(ctx context.Context, sessionID, prompt string
 	// completion detection (it observes message events directly),
 	// so passing an empty RunID is correct here: it skips the
 	// correlator stamping path without functional consequences.
-	return w.client.SendMessage(ctx, w.workspaceID(), sessionID, "", prompt, attachments...)
+	return w.client.SendMessage(ctx, w.workspaceID(), sessionID, "", "", prompt, attachments...)
+}
+
+func (w *ClientWorkspace) AgentRunChannel(ctx context.Context, channel, sessionID, prompt string, attachments ...message.Attachment) error {
+	return w.client.SendMessage(ctx, w.workspaceID(), sessionID, "", channel, prompt, attachments...)
 }
 
 func (w *ClientWorkspace) AgentRunShellCommand(ctx context.Context, sessionID, command string, termWidth int, _ func(string), _ bool) (proto.ShellCommandResponse, error) {
@@ -811,6 +824,7 @@ func protoToSession(s proto.Session) session.Session {
 		CompletionTokens: s.CompletionTokens,
 		Cost:             s.Cost,
 		Todos:            protoToTodos(s.Todos),
+		Channel:          s.Channel,
 		CreatedAt:        s.CreatedAt,
 		UpdatedAt:        s.UpdatedAt,
 	}
@@ -932,6 +946,7 @@ func sessionToProto(s session.Session) proto.Session {
 		CompletionTokens: s.CompletionTokens,
 		Cost:             s.Cost,
 		Todos:            todosToProto(s.Todos),
+		Channel:          s.Channel,
 		CreatedAt:        s.CreatedAt,
 		UpdatedAt:        s.UpdatedAt,
 	}

--- a/internal/workspace/client_workspace.go
+++ b/internal/workspace/client_workspace.go
@@ -132,6 +132,15 @@ func (w *ClientWorkspace) SaveSession(ctx context.Context, sess session.Session)
 	return protoToSession(*saved), nil
 }
 
+func (w *ClientWorkspace) SetSessionChannel(ctx context.Context, sessionID, channel string) (session.Session, error) {
+	sess, err := w.GetSession(ctx, sessionID)
+	if err != nil {
+		return session.Session{}, err
+	}
+	sess.Channel = channel
+	return w.SaveSession(ctx, sess)
+}
+
 func (w *ClientWorkspace) DeleteSession(ctx context.Context, sessionID string) error {
 	return w.client.DeleteSession(ctx, w.workspaceID(), sessionID)
 }
@@ -190,7 +199,11 @@ func (w *ClientWorkspace) AgentRun(ctx context.Context, sessionID, prompt string
 	// completion detection (it observes message events directly),
 	// so passing an empty RunID is correct here: it skips the
 	// correlator stamping path without functional consequences.
-	return w.client.SendMessage(ctx, w.workspaceID(), sessionID, "", prompt, attachments...)
+	return w.client.SendMessage(ctx, w.workspaceID(), sessionID, "", "", prompt, attachments...)
+}
+
+func (w *ClientWorkspace) AgentRunChannel(ctx context.Context, channel, sessionID, prompt string, attachments ...message.Attachment) error {
+	return w.client.SendMessage(ctx, w.workspaceID(), sessionID, "", channel, prompt, attachments...)
 }
 
 func (w *ClientWorkspace) AgentRunShellCommand(ctx context.Context, sessionID, command string, termWidth int, _ func(string), _ bool) (proto.ShellCommandResponse, error) {
@@ -800,6 +813,7 @@ func protoToSession(s proto.Session) session.Session {
 		CompletionTokens: s.CompletionTokens,
 		Cost:             s.Cost,
 		Todos:            protoToTodos(s.Todos),
+		Channel:          s.Channel,
 		CreatedAt:        s.CreatedAt,
 		UpdatedAt:        s.UpdatedAt,
 	}
@@ -921,6 +935,7 @@ func sessionToProto(s session.Session) proto.Session {
 		CompletionTokens: s.CompletionTokens,
 		Cost:             s.Cost,
 		Todos:            todosToProto(s.Todos),
+		Channel:          s.Channel,
 		CreatedAt:        s.CreatedAt,
 		UpdatedAt:        s.UpdatedAt,
 	}

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -66,6 +66,7 @@ type Workspace interface {
 	GetSession(ctx context.Context, sessionID string) (session.Session, error)
 	ListSessions(ctx context.Context) ([]session.Session, error)
 	SaveSession(ctx context.Context, sess session.Session) (session.Session, error)
+	SetSessionChannel(ctx context.Context, sessionID, channel string) (session.Session, error)
 	DeleteSession(ctx context.Context, sessionID string) error
 	CreateAgentToolSessionID(messageID, toolCallID string) string
 	ParseAgentToolSessionID(sessionID string) (messageID string, toolCallID string, ok bool)
@@ -92,6 +93,7 @@ type Workspace interface {
 
 	// Agent
 	AgentRun(ctx context.Context, sessionID, prompt string, attachments ...message.Attachment) error
+	AgentRunChannel(ctx context.Context, channel, sessionID, prompt string, attachments ...message.Attachment) error
 	AgentRunShellCommand(ctx context.Context, sessionID, command string, termWidth int, onProgress func(string), isFirstMessage bool) (proto.ShellCommandResponse, error)
 	AgentCancel(sessionID string)
 	AgentIsBusy() bool

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -66,6 +66,7 @@ type Workspace interface {
 	GetSession(ctx context.Context, sessionID string) (session.Session, error)
 	ListSessions(ctx context.Context) ([]session.Session, error)
 	SaveSession(ctx context.Context, sess session.Session) (session.Session, error)
+	SetSessionChannel(ctx context.Context, sessionID, channel string) (session.Session, error)
 	DeleteSession(ctx context.Context, sessionID string) error
 	CreateAgentToolSessionID(messageID, toolCallID string) string
 	ParseAgentToolSessionID(sessionID string) (messageID string, toolCallID string, ok bool)
@@ -83,6 +84,7 @@ type Workspace interface {
 
 	// Agent
 	AgentRun(ctx context.Context, sessionID, prompt string, attachments ...message.Attachment) error
+	AgentRunChannel(ctx context.Context, channel, sessionID, prompt string, attachments ...message.Attachment) error
 	AgentRunShellCommand(ctx context.Context, sessionID, command string, termWidth int, onProgress func(string), isFirstMessage bool) (proto.ShellCommandResponse, error)
 	AgentCancel(sessionID string)
 	AgentIsBusy() bool


### PR DESCRIPTION
Supersedes #30, reconciled with `main` and with an additional fix. Closes #27.

## What this does

Carries **immutable per-turn channel provenance** so an assistant reply is only routed to an external channel (e.g. Signal) when the *current* inbound message originated from that channel. Untagged/local turns are local-only — delivery is never inferred from an earlier turn, the last active channel, sender history, or which channel tools happen to exist. Responses always remain visible in Crush.

- Provenance rides the context and `SessionAgentCall.Channel`, not prompt text.
- `filterToolsForChannel` hides channel send-tools unless the turn's origin matches; `mcp-tools.go` also rejects a mismatched call at run time.
- Channel provenance is persisted on the session for identification (not used for routing).

## Why a new PR instead of merging #30

#30 was cut before `main` gained server-side channel routing (`6d76aa4`) and no longer merged cleanly. Reconciling surfaced a real gap:

- **Server-mode routing gap (fixed here):** `backend.injectChannelMessage` built the `AgentMessage` with no `Channel`, so in client/server mode a channel push arrived with empty provenance and `filterToolsForChannel` would hide the channel's send tool — the agent could never reply to the channel. It now carries `serverName` as the per-turn channel, matching the TUI path.
- **`init.go` collision (reconciled):** both branches added `ClientInfo.Channel`. Kept `main`'s cleaner version (derived from `client.channel` in `updateState`) and dropped #30's redundant `states.Get/Set` bookkeeping; kept the additive `ChannelMeta` field.
- **Test conflict (resolved):** combined `main`'s `routesRemote` stub field with #30's `channels` tracking.

## Validation

- `go build ./...`, `go vet`, and `git diff --check` clean.
- All affected packages pass: `agent/tools/mcp`, `backend`, `app`, `client`, `cmd`, `db`, `proto`, `server`, `session`, `ui/model`, `workspace`.
- Added a test asserting the **server-routed** turn carries its originating channel on the context.
- Pre-existing `TestCoderAgent/glm-5.1/parallel_tool_calls` fails identically on clean `main` (network-replay integration test, unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AhXhLeQrATJvbgPGvDneGY)_