### PR TITLE
fix: clear prompt queue on idle and scope busy state to current session

### DIFF
--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -596,7 +596,7 @@ func (m *UI) loadMCPrompts() tea.Msg {
 // Update handles updates to the UI model.
 func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	var cmds []tea.Cmd
-	if m.hasSession() && m.isAgentBusy() {
+	if m.hasSession() {
 		queueSize := m.com.Workspace.AgentQueuedPrompts(m.session.ID)
 		if queueSize != m.promptQueue {
 			m.promptQueue = queueSize
@@ -759,12 +759,12 @@ func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.chat.RemoveMessage(msg.Payload.ID)
 		}
 		// start the spinner if there is a new message
-		if hasInProgressTodo(m.session.Todos) && m.isAgentBusy() && !m.todoIsSpinning {
+		if hasInProgressTodo(m.session.Todos) && m.isCurrentSessionBusy() && !m.todoIsSpinning {
 			m.todoIsSpinning = true
 			cmds = append(cmds, m.todoSpinner.Tick)
 		}
 		// stop the spinner if the agent is not busy anymore
-		if m.todoIsSpinning && !m.isAgentBusy() {
+		if m.todoIsSpinning && !m.isCurrentSessionBusy() {
 			m.todoIsSpinning = false
 		}
 		// there is a number of things that could change the pills here so we want to re-render
@@ -3379,6 +3379,21 @@ func (m *UI) isAgentBusy() bool {
 	}
 	return m.com.Workspace.AgentIsReady() &&
 		m.com.Workspace.AgentIsBusy()
+}
+
+// isCurrentSessionBusy reports whether the agent is actively processing a
+// request for the session the user is currently viewing. Unlike
+// isAgentBusy, activity in another session does not make the current
+// session appear busy.
+func (m *UI) isCurrentSessionBusy() bool {
+	if m.bangCancel != nil {
+		return true
+	}
+	if !m.hasSession() {
+		return false
+	}
+	return m.com.Workspace.AgentIsReady() &&
+		m.com.Workspace.AgentIsSessionBusy(m.session.ID)
 }
 
 // hasSession returns true if there is an active session with a valid ID.


### PR DESCRIPTION
- Refresh queue count on every Update (not just when busy) so it zeroes when the current session goes idle.
- Add `isCurrentSessionBusy()` using `AgentIsSessionBusy(sessionID)` and switch the spinner start/stop to it, so another session's activity no longer makes the current session look busy.

Closes #29

## Validation

- `go test ./internal/ui/model`
- `gofumpt -w internal/ui/model/ui.go`

💘 Generated with Crush