### PR TITLE
fix: distinguish paused To-Dos from active execution

### DIFF
--- a/internal/ui/model/pills.go
+++ b/internal/ui/model/pills.go
@@ -274,6 +274,8 @@ func (m *UI) renderPills() {
 	inProgressIcon := t.Tool.TodoInProgressIcon.Render(styles.SpinnerIcon)
 	if m.todoIsSpinning {
 		inProgressIcon = m.todoSpinner.View()
+	} else if !m.isCurrentSessionBusy() {
+		inProgressIcon = t.Tool.TodoInProgressIcon.Render("‖")
 	}
 
 	var pills []string

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -3381,6 +3381,21 @@ func (m *UI) isAgentBusy() bool {
 		m.com.Workspace.AgentIsBusy()
 }
 
+// isCurrentSessionBusy reports whether the agent is actively processing a
+// request for the session the user is currently viewing. Unlike
+// isAgentBusy, activity in another session does not make the current
+// session appear busy.
+func (m *UI) isCurrentSessionBusy() bool {
+	if m.bangCancel != nil {
+		return true
+	}
+	if !m.hasSession() || m.com == nil || m.com.Workspace == nil {
+		return false
+	}
+	return m.com.Workspace.AgentIsReady() &&
+		m.com.Workspace.AgentIsSessionBusy(m.session.ID)
+}
+
 // hasSession returns true if there is an active session with a valid ID.
 func (m *UI) hasSession() bool {
 	return m.session != nil && m.session.ID != ""


### PR DESCRIPTION
- Add `isCurrentSessionBusy()` using `AgentIsSessionBusy(sessionID)` for session-scoped busy checks.
- Render a pause icon (‖) instead of the spinner for in-progress To-Dos when the current session is idle, so users can tell the difference between active work and persisted task state.

Closes #28

## Validation

- `go test ./internal/ui/model`
- `gofumpt -w internal/ui/model/ui.go internal/ui/model/pills.go`
- `go vet ./internal/ui/model`

💘 Generated with Crush