### PR TITLE
fix: distinguish paused To-Dos from active execution (reconciled #33)

### DIFF
--- a/internal/ui/model/pills.go
+++ b/internal/ui/model/pills.go
@@ -274,6 +274,8 @@ func (m *UI) renderPills() {
 	inProgressIcon := t.Tool.TodoInProgressIcon.Render(styles.SpinnerIcon)
 	if m.todoIsSpinning {
 		inProgressIcon = m.todoSpinner.View()
+	} else if !m.isCurrentSessionBusy() {
+		inProgressIcon = t.Tool.TodoInProgressIcon.Render("‖")
 	}
 
 	var pills []string

--- a/internal/ui/model/session_busy_test.go
+++ b/internal/ui/model/session_busy_test.go
@@ -1,0 +1,97 @@
+package model
+
+import (
+	"testing"
+
+	"charm.land/bubbles/v2/textarea"
+
+	"github.com/charmbracelet/crush/internal/config"
+	"github.com/charmbracelet/crush/internal/session"
+	"github.com/charmbracelet/crush/internal/ui/common"
+	"github.com/charmbracelet/crush/internal/workspace"
+)
+
+// busyWorkspace is a workspace.Workspace stub that reports readiness and
+// per-session busy state. Only the methods isCurrentSessionBusy touches are
+// implemented; the embedded interface panics on anything else.
+type busyWorkspace struct {
+	workspace.Workspace
+	ready    bool
+	busy     map[string]bool
+	busyCall []string
+}
+
+func (w *busyWorkspace) AgentIsReady() bool { return w.ready }
+
+func (w *busyWorkspace) AgentIsSessionBusy(sessionID string) bool {
+	w.busyCall = append(w.busyCall, sessionID)
+	return w.busy[sessionID]
+}
+
+func (w *busyWorkspace) Config() *config.Config { return nil }
+
+func newBusyUI(ws *busyWorkspace) *UI {
+	com := common.DefaultCommon(ws)
+	return &UI{
+		com:      com,
+		status:   NewStatus(com, nil),
+		chat:     NewChat(com, config.ScrollbarDefault),
+		textarea: textarea.New(),
+		state:    uiChat,
+		focus:    uiFocusEditor,
+		width:    140,
+		height:   45,
+	}
+}
+
+// TestIsCurrentSessionBusyIsSessionScoped is the core of #28/#29: the current
+// session's busy state must reflect only its own activity, never another
+// session's, so a paused To-Do is not shown as actively executing.
+func TestIsCurrentSessionBusyIsSessionScoped(t *testing.T) {
+	t.Parallel()
+
+	t.Run("current session busy", func(t *testing.T) {
+		t.Parallel()
+		ws := &busyWorkspace{ready: true, busy: map[string]bool{"sess-1": true}}
+		m := newBusyUI(ws)
+		m.session = &session.Session{ID: "sess-1"}
+		if !m.isCurrentSessionBusy() {
+			t.Fatal("expected the viewed session's own activity to read as busy")
+		}
+	})
+
+	t.Run("another session busy does not affect current", func(t *testing.T) {
+		t.Parallel()
+		ws := &busyWorkspace{ready: true, busy: map[string]bool{"other": true}}
+		m := newBusyUI(ws)
+		m.session = &session.Session{ID: "sess-1"}
+		if m.isCurrentSessionBusy() {
+			t.Fatal("another session's activity must not mark the current session busy")
+		}
+		// The check must be scoped to the current session ID.
+		for _, id := range ws.busyCall {
+			if id != "sess-1" {
+				t.Fatalf("AgentIsSessionBusy queried %q, want only sess-1", id)
+			}
+		}
+	})
+
+	t.Run("agent not ready", func(t *testing.T) {
+		t.Parallel()
+		ws := &busyWorkspace{ready: false, busy: map[string]bool{"sess-1": true}}
+		m := newBusyUI(ws)
+		m.session = &session.Session{ID: "sess-1"}
+		if m.isCurrentSessionBusy() {
+			t.Fatal("a not-ready agent must not read as busy")
+		}
+	})
+
+	t.Run("no active session", func(t *testing.T) {
+		t.Parallel()
+		ws := &busyWorkspace{ready: true, busy: map[string]bool{"sess-1": true}}
+		m := newBusyUI(ws)
+		if m.isCurrentSessionBusy() {
+			t.Fatal("no active session must not read as busy")
+		}
+	})
+}

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -3389,7 +3389,7 @@ func (m *UI) isCurrentSessionBusy() bool {
 	if m.bangCancel != nil {
 		return true
 	}
-	if !m.hasSession() {
+	if !m.hasSession() || m.com == nil || m.com.Workspace == nil {
 		return false
 	}
 	return m.com.Workspace.AgentIsReady() &&


### PR DESCRIPTION
Supersedes #33, reconciled with #32 (now merged). Closes #28.

## What this does

Renders a pause icon (`‖`) instead of the spinner for an in-progress To-Do when the current session is idle, so users can tell active work apart from persisted task state.

## Why a new PR instead of merging #33

#33 and #32 both introduced `isCurrentSessionBusy()` in `internal/ui/model/ui.go`, so once #32 merged, #33 no longer applied cleanly (duplicate definition). This branch carries only #33's unique contribution on top of the merged #32:

- `pills.go`: the paused-icon rendering (#33's actual feature).
- `ui.go`: keeps the more defensive `isCurrentSessionBusy` guard (`m.com == nil || m.com.Workspace == nil`) from #33, since it is now also called from the render path (`renderPills`), not just `Update`.

## Tests added

Neither #32 nor #33 shipped the regressions the issues asked for, so this adds `TestIsCurrentSessionBusyIsSessionScoped` covering the core contract of #28/#29:

- the viewed session's own activity reads as busy;
- **another session's activity does not** mark the current session busy (and the check is scoped to the current session ID);
- a not-ready agent and a no-active-session state both read as not busy.

## Validation

- `go build ./...`, `go vet ./internal/ui/model`, `gofmt -l`, and `git diff --check` all clean.
- `go test ./internal/ui/model/...` passes, including the new test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AhXhLeQrATJvbgPGvDneGY)_