### PR TITLE
feat: make sidebar focusable and interactive

### DIFF
--- a/internal/ui/model/sidebar.go
+++ b/internal/ui/model/sidebar.go
@@ -192,15 +192,18 @@ func (m *UI) drawSidebar(scr uv.Screen, area uv.Rectangle) {
 
 	maxFiles, maxLSPs, maxMCPs, maxSkills := getDynamicHeightLimits(remainingHeight, filesCount, lspsCount, mcpsCount, skillsCount)
 
+	// When focused, show all items so scroll can reveal truncated content.
+	if focused {
+		maxFiles = max(maxFiles, filesCount)
+		maxLSPs = max(maxLSPs, lspsCount)
+		maxMCPs = max(maxMCPs, mcpsCount)
+		maxSkills = max(maxSkills, skillsCount)
+	}
+
 	lspSection := m.lspInfo(width, maxLSPs, true)
 	mcpSection := m.mcpInfo(width, maxMCPs, true)
 	skillsSection := m.skillsInfo(width, maxSkills, true)
 	filesSection := m.filesInfo(m.com.Workspace.WorkingDir(), width, maxFiles, true)
-
-	var borderStyle lipgloss.Border = lipgloss.NormalBorder()
-	if focused {
-		borderStyle = lipgloss.ThickBorder()
-	}
 
 	fullContent := lipgloss.JoinVertical(
 		lipgloss.Left,
@@ -214,22 +217,23 @@ func (m *UI) drawSidebar(scr uv.Screen, area uv.Rectangle) {
 		skillsSection,
 	)
 
-	// Apply scroll offset when focused.
+	// Apply scroll offset when focused. Clamp against real content height.
 	contentLines := strings.Split(fullContent, "\n")
-	if m.sidebarScroll > 0 && m.sidebarScroll < len(contentLines) {
-		contentLines = contentLines[m.sidebarScroll:]
-	} else if m.sidebarScroll >= len(contentLines) {
-		contentLines = contentLines[max(0, len(contentLines)-1):]
+	maxScroll := max(0, len(contentLines)-height)
+	m.sidebarScroll = min(m.sidebarScroll, maxScroll)
+	scroll := min(m.sidebarScroll, maxScroll)
+	if scroll > 0 && scroll < len(contentLines) {
+		contentLines = contentLines[scroll:]
 	}
-	m.sidebarScroll = min(m.sidebarScroll, max(0, len(contentLines)-1))
 	scrolledContent := strings.Join(contentLines, "\n")
 
+	renderStyle := lipgloss.NewStyle().
+		MaxWidth(width).
+		MaxHeight(height)
+	if focused {
+		renderStyle = renderStyle.BorderLeft(true).BorderStyle(lipgloss.ThickBorder())
+	}
 	uv.NewStyledString(
-		lipgloss.NewStyle().
-			MaxWidth(width).
-			MaxHeight(height).
-			BorderLeft(true).
-			BorderStyle(borderStyle).
-			Render(scrolledContent),
+		renderStyle.Render(scrolledContent),
 	).Draw(scr, area)
 }

--- a/internal/ui/model/sidebar.go
+++ b/internal/ui/model/sidebar.go
@@ -139,6 +139,8 @@ func (m *UI) drawSidebar(scr uv.Screen, area uv.Rectangle) {
 	width := area.Dx()
 	height := area.Dy()
 
+	focused := m.focus == uiFocusSidebar
+
 	title := t.Sidebar.SessionTitle.Width(width).MaxHeight(2).Render(m.session.Title)
 	cwd := common.PrettyPath(t, m.com.Workspace.WorkingDir(), width)
 	sidebarLogo := m.sidebarLogo
@@ -194,22 +196,25 @@ func (m *UI) drawSidebar(scr uv.Screen, area uv.Rectangle) {
 	skillsSection := m.skillsInfo(width, maxSkills, true)
 	filesSection := m.filesInfo(m.com.Workspace.WorkingDir(), width, maxFiles, true)
 
+	style := lipgloss.NewStyle().
+		MaxWidth(width).
+		MaxHeight(height)
+	if focused {
+		style = style.BorderLeft(true).BorderStyle(lipgloss.ThickBorder())
+	}
 	uv.NewStyledString(
-		lipgloss.NewStyle().
-			MaxWidth(width).
-			MaxHeight(height).
-			Render(
-				lipgloss.JoinVertical(
-					lipgloss.Left,
-					sidebarHeader,
-					filesSection,
-					"",
-					lspSection,
-					"",
-					mcpSection,
-					"",
-					skillsSection,
-				),
+		style.Render(
+			lipgloss.JoinVertical(
+				lipgloss.Left,
+				sidebarHeader,
+				filesSection,
+				"",
+				lspSection,
+				"",
+				mcpSection,
+				"",
+				skillsSection,
 			),
+		),
 	).Draw(scr, area)
 }

--- a/internal/ui/model/sidebar.go
+++ b/internal/ui/model/sidebar.go
@@ -4,6 +4,7 @@ import (
 	"cmp"
 	"fmt"
 	"image"
+	"strings"
 
 	"charm.land/lipgloss/v2"
 	"github.com/charmbracelet/crush/internal/ui/common"
@@ -196,25 +197,39 @@ func (m *UI) drawSidebar(scr uv.Screen, area uv.Rectangle) {
 	skillsSection := m.skillsInfo(width, maxSkills, true)
 	filesSection := m.filesInfo(m.com.Workspace.WorkingDir(), width, maxFiles, true)
 
-	style := lipgloss.NewStyle().
-		MaxWidth(width).
-		MaxHeight(height)
+	var borderStyle lipgloss.Border = lipgloss.NormalBorder()
 	if focused {
-		style = style.BorderLeft(true).BorderStyle(lipgloss.ThickBorder())
+		borderStyle = lipgloss.ThickBorder()
 	}
+
+	fullContent := lipgloss.JoinVertical(
+		lipgloss.Left,
+		sidebarHeader,
+		filesSection,
+		"",
+		lspSection,
+		"",
+		mcpSection,
+		"",
+		skillsSection,
+	)
+
+	// Apply scroll offset when focused.
+	contentLines := strings.Split(fullContent, "\n")
+	if m.sidebarScroll > 0 && m.sidebarScroll < len(contentLines) {
+		contentLines = contentLines[m.sidebarScroll:]
+	} else if m.sidebarScroll >= len(contentLines) {
+		contentLines = contentLines[max(0, len(contentLines)-1):]
+	}
+	m.sidebarScroll = min(m.sidebarScroll, max(0, len(contentLines)-1))
+	scrolledContent := strings.Join(contentLines, "\n")
+
 	uv.NewStyledString(
-		style.Render(
-			lipgloss.JoinVertical(
-				lipgloss.Left,
-				sidebarHeader,
-				filesSection,
-				"",
-				lspSection,
-				"",
-				mcpSection,
-				"",
-				skillsSection,
-			),
-		),
+		lipgloss.NewStyle().
+			MaxWidth(width).
+			MaxHeight(height).
+			BorderLeft(true).
+			BorderStyle(borderStyle).
+			Render(scrolledContent),
 	).Draw(scr, area)
 }

--- a/internal/ui/model/sidebar_focus_test.go
+++ b/internal/ui/model/sidebar_focus_test.go
@@ -1,0 +1,48 @@
+package model
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFocusCycleNonCompact(t *testing.T) {
+	t.Parallel()
+
+	focus := uiFocusEditor
+	focus = nextFocus(focus, false)
+	require.Equal(t, uiFocusMain, focus, "editor → main")
+	focus = nextFocus(focus, false)
+	require.Equal(t, uiFocusSidebar, focus, "main → sidebar")
+	focus = nextFocus(focus, false)
+	require.Equal(t, uiFocusEditor, focus, "sidebar → editor")
+}
+
+func TestFocusCycleCompact(t *testing.T) {
+	t.Parallel()
+
+	focus := uiFocusEditor
+	focus = nextFocus(focus, true)
+	require.Equal(t, uiFocusMain, focus, "editor → main (compact)")
+	focus = nextFocus(focus, true)
+	require.Equal(t, uiFocusEditor, focus, "main → editor (compact)")
+}
+
+func nextFocus(current uiFocusState, isCompact bool) uiFocusState {
+	if isCompact {
+		switch current {
+		case uiFocusEditor:
+			return uiFocusMain
+		default:
+			return uiFocusEditor
+		}
+	}
+	switch current {
+	case uiFocusEditor:
+		return uiFocusMain
+	case uiFocusMain:
+		return uiFocusSidebar
+	default:
+		return uiFocusEditor
+	}
+}

--- a/internal/ui/model/sidebar_focus_test.go
+++ b/internal/ui/model/sidebar_focus_test.go
@@ -3,46 +3,67 @@ package model
 import (
 	"testing"
 
+	"charm.land/bubbles/v2/key"
+	"charm.land/bubbles/v2/textarea"
+	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/crush/internal/config"
+	"github.com/charmbracelet/crush/internal/ui/common"
+	"github.com/charmbracelet/crush/internal/ui/dialog"
+	"github.com/charmbracelet/crush/internal/ui/styles"
 	"github.com/stretchr/testify/require"
 )
 
-func TestFocusCycleNonCompact(t *testing.T) {
-	t.Parallel()
-
-	focus := uiFocusEditor
-	focus = nextFocus(focus, false)
-	require.Equal(t, uiFocusMain, focus, "editor → main")
-	focus = nextFocus(focus, false)
-	require.Equal(t, uiFocusSidebar, focus, "main → sidebar")
-	focus = nextFocus(focus, false)
-	require.Equal(t, uiFocusEditor, focus, "sidebar → editor")
+func newSidebarTestUI() *UI {
+	s := styles.CharmtonePantera()
+	com := &common.Common{Styles: &s}
+	return &UI{
+		com:      com,
+		state:    uiChat,
+		focus:    uiFocusEditor,
+		width:    140,
+		dialog:   dialog.NewOverlay(),
+		chat:     NewChat(com, config.ScrollbarDefault),
+		textarea: textarea.New(),
+	}
 }
 
-func TestFocusCycleCompact(t *testing.T) {
+// TestTabSidebarGoesToEditor exercises the real handleKeyPressMsg to verify
+// that Tab from the sidebar returns focus to the editor.
+func TestTabSidebarGoesToEditor(t *testing.T) {
 	t.Parallel()
+	m := newSidebarTestUI()
+	m.focus = uiFocusSidebar
+	m.keyMap.Tab = key.NewBinding(key.WithKeys("tab"))
 
-	focus := uiFocusEditor
-	focus = nextFocus(focus, true)
-	require.Equal(t, uiFocusMain, focus, "editor → main (compact)")
-	focus = nextFocus(focus, true)
-	require.Equal(t, uiFocusEditor, focus, "main → editor (compact)")
+	m.handleKeyPressMsg(tea.KeyPressMsg{Code: tea.KeyTab, Text: "tab"})
+	require.Equal(t, uiFocusEditor, m.focus)
 }
 
-func nextFocus(current uiFocusState, isCompact bool) uiFocusState {
-	if isCompact {
-		switch current {
-		case uiFocusEditor:
-			return uiFocusMain
-		default:
-			return uiFocusEditor
-		}
-	}
-	switch current {
-	case uiFocusEditor:
-		return uiFocusMain
-	case uiFocusMain:
-		return uiFocusSidebar
-	default:
-		return uiFocusEditor
-	}
+func TestSidebarScrollClampsAtZero(t *testing.T) {
+	t.Parallel()
+	m := newSidebarTestUI()
+	m.focus = uiFocusSidebar
+	m.keyMap.Chat.Up = key.NewBinding(key.WithKeys("up"))
+	m.sidebarScroll = 0
+
+	m.handleKeyPressMsg(tea.KeyPressMsg{Code: tea.KeyUp})
+	require.Equal(t, 0, m.sidebarScroll, "scroll should not go below 0")
+}
+
+func TestSidebarScrollIncrements(t *testing.T) {
+	t.Parallel()
+	m := newSidebarTestUI()
+	m.focus = uiFocusSidebar
+	m.keyMap.Chat.Down = key.NewBinding(key.WithKeys("down"))
+
+	m.handleKeyPressMsg(tea.KeyPressMsg{Code: tea.KeyDown})
+	require.Greater(t, m.sidebarScroll, 0, "scroll should increment on down")
+}
+
+// TestSidebarFocusEnumExists documents the three-state non-compact cycle.
+func TestSidebarFocusEnumExists(t *testing.T) {
+	t.Parallel()
+	require.NotEqual(t, uiFocusEditor, uiFocusSidebar)
+	require.NotEqual(t, uiFocusMain, uiFocusSidebar)
+	require.NotEqual(t, uiFocusNone, uiFocusSidebar)
 }

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -2170,14 +2170,10 @@ func (m *UI) handleKeyPressMsg(msg tea.KeyPressMsg) tea.Cmd {
 				}
 			case key.Matches(msg, m.keyMap.Tab):
 				if m.state != uiLanding {
-					if m.isCompact {
-						m.setState(m.state, uiFocusMain)
-						m.textarea.Blur()
-						m.chat.Focus()
-						m.chat.SetSelected(m.chat.Len() - 1)
-					} else {
-						m.focusSidebar()
-					}
+					m.setState(m.state, uiFocusMain)
+					m.textarea.Blur()
+					m.chat.Focus()
+					m.chat.SetSelected(m.chat.Len() - 1)
 				}
 			case key.Matches(msg, m.keyMap.Editor.OpenEditor):
 				if m.isAgentBusy() {
@@ -2311,18 +2307,13 @@ func (m *UI) handleKeyPressMsg(msg tea.KeyPressMsg) tea.Cmd {
 			}
 		case uiFocusSidebar:
 			switch {
-			case key.Matches(msg, m.keyMap.Tab):
+			case key.Matches(msg, m.keyMap.Tab), key.Matches(msg, m.keyMap.Editor.Escape):
 				m.focus = uiFocusEditor
 				cmds = append(cmds, m.textarea.Focus())
-				m.sidebarScroll = 0
 			case key.Matches(msg, m.keyMap.Chat.Up):
 				m.sidebarScroll = max(0, m.sidebarScroll-1)
 			case key.Matches(msg, m.keyMap.Chat.Down):
 				m.sidebarScroll++
-			case msg.Code == 'g' && msg.Text == "g":
-				m.sidebarScroll = 0
-			case msg.Code == 'G':
-				m.sidebarScroll = 9999
 			}
 		case uiFocusMain:
 			switch {
@@ -3417,6 +3408,7 @@ func (m *UI) focusSidebar() {
 	m.focus = uiFocusSidebar
 	m.textarea.Blur()
 	m.chat.Blur()
+	m.updateLayoutAndSize()
 }
 
 // mimeOf detects the MIME type of the given content.

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -97,6 +97,7 @@ const (
 	uiFocusNone uiFocusState = iota
 	uiFocusEditor
 	uiFocusMain
+	uiFocusSidebar
 )
 
 type uiState uint8
@@ -297,6 +298,7 @@ type UI struct {
 	pillsAutoExpanded  bool
 	focusedPillSection pillSection
 	promptQueue        int
+	sidebarScroll      int
 	pillsView          string
 
 	// Todo spinner
@@ -1319,6 +1321,7 @@ func (m *UI) handleClickFocus(msg tea.MouseClickMsg) (cmd tea.Cmd) {
 	case m.state != uiChat:
 		return nil
 	case image.Pt(msg.X, msg.Y).In(m.layout.sidebar):
+		m.focusSidebar()
 		return nil
 	case m.focus != uiFocusEditor && image.Pt(msg.X, msg.Y).In(m.layout.editor):
 		m.focus = uiFocusEditor
@@ -2167,10 +2170,14 @@ func (m *UI) handleKeyPressMsg(msg tea.KeyPressMsg) tea.Cmd {
 				}
 			case key.Matches(msg, m.keyMap.Tab):
 				if m.state != uiLanding {
-					m.setState(m.state, uiFocusMain)
-					m.textarea.Blur()
-					m.chat.Focus()
-					m.chat.SetSelected(m.chat.Len() - 1)
+					if m.isCompact {
+						m.setState(m.state, uiFocusMain)
+						m.textarea.Blur()
+						m.chat.Focus()
+						m.chat.SetSelected(m.chat.Len() - 1)
+					} else {
+						m.focusSidebar()
+					}
 				}
 			case key.Matches(msg, m.keyMap.Editor.OpenEditor):
 				if m.isAgentBusy() {
@@ -2302,12 +2309,31 @@ func (m *UI) handleKeyPressMsg(msg tea.KeyPressMsg) tea.Cmd {
 					}
 				}
 			}
-		case uiFocusMain:
+		case uiFocusSidebar:
 			switch {
 			case key.Matches(msg, m.keyMap.Tab):
 				m.focus = uiFocusEditor
 				cmds = append(cmds, m.textarea.Focus())
-				m.chat.Blur()
+				m.sidebarScroll = 0
+			case key.Matches(msg, m.keyMap.Chat.Up):
+				m.sidebarScroll = max(0, m.sidebarScroll-1)
+			case key.Matches(msg, m.keyMap.Chat.Down):
+				m.sidebarScroll++
+			case msg.Code == 'g' && msg.Text == "g":
+				m.sidebarScroll = 0
+			case msg.Code == 'G':
+				m.sidebarScroll = 9999
+			}
+		case uiFocusMain:
+			switch {
+			case key.Matches(msg, m.keyMap.Tab):
+				if m.isCompact {
+					m.focus = uiFocusEditor
+					cmds = append(cmds, m.textarea.Focus())
+					m.chat.Blur()
+				} else {
+					m.focusSidebar()
+				}
 			case key.Matches(msg, m.keyMap.Chat.NewSession):
 				if !m.hasSession() {
 					break
@@ -3384,6 +3410,13 @@ func (m *UI) isAgentBusy() bool {
 // hasSession returns true if there is an active session with a valid ID.
 func (m *UI) hasSession() bool {
 	return m.session != nil && m.session.ID != ""
+}
+
+// focusSidebar moves focus to the sidebar panel, blurring the editor and chat.
+func (m *UI) focusSidebar() {
+	m.focus = uiFocusSidebar
+	m.textarea.Blur()
+	m.chat.Blur()
 }
 
 // mimeOf detects the MIME type of the given content.


### PR DESCRIPTION
- Add `uiFocusSidebar` to the focus state enum and extend Tab to cycle editor → main → sidebar (non-compact mode keeps editor ↔ main).
- Clicking inside the sidebar now focuses it instead of being a no-op.
- When focused, up/down scrolls through sections and a thick left border provides a visual focus indicator.

Closes #20

## Validation

- `go test ./internal/ui/model`
- `go vet ./internal/ui/model`
- `gofumpt -w internal/ui/model/ui.go internal/ui/model/sidebar.go`
- `git diff --check`

💘 Generated with Crush