### PR TITLE
fix(ui): three-state Tab + sidebar keys in help (reconciled #36)

### DIFF
--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -2616,9 +2616,16 @@ func (m *UI) ShortHelp() []key.Binding {
 			binds = append(binds, cancelBinding)
 		}
 
-		if m.focus == uiFocusEditor {
+		switch m.focus {
+		case uiFocusEditor:
 			tab.SetHelp("tab", "focus chat")
-		} else {
+		case uiFocusMain:
+			if m.isCompact {
+				tab.SetHelp("tab", "focus editor")
+			} else {
+				tab.SetHelp("tab", "focus sidebar")
+			}
+		case uiFocusSidebar:
 			tab.SetHelp("tab", "focus editor")
 		}
 
@@ -2647,6 +2654,15 @@ func (m *UI) ShortHelp() []key.Binding {
 			if m.pillsExpanded && hasIncompleteTodos(m.session.Todos) && m.promptQueue > 0 {
 				binds = append(binds, k.Chat.PillLeft)
 			}
+		case uiFocusSidebar:
+			esc := k.Editor.Escape
+			esc.SetHelp("esc", "back to editor")
+			k.Chat.UpDown.SetHelp("↑/↓", "scroll")
+			binds = append(
+				binds,
+				k.Chat.UpDown,
+				esc,
+			)
 		}
 	default:
 		// TODO: other states
@@ -2702,9 +2718,16 @@ func (m *UI) FullHelp() [][]key.Binding {
 
 		mainBinds := []key.Binding{}
 		tab := k.Tab
-		if m.focus == uiFocusEditor {
+		switch m.focus {
+		case uiFocusEditor:
 			tab.SetHelp("tab", "focus chat")
-		} else {
+		case uiFocusMain:
+			if m.isCompact {
+				tab.SetHelp("tab", "focus editor")
+			} else {
+				tab.SetHelp("tab", "focus sidebar")
+			}
+		case uiFocusSidebar:
 			tab.SetHelp("tab", "focus editor")
 		}
 


### PR DESCRIPTION
Supersedes #36. Lands the deferred help-text item from the #35 review (issue #20, item 6).

## What this does

`ShortHelp`/`FullHelp` now label Tab by focus state and surface the sidebar's own keys:
- **editor** → "focus chat"
- **main** → "focus sidebar" (or "focus editor" in compact mode)
- **sidebar** → "focus editor", plus `↑/↓ scroll` and `esc back to editor`

Identical change to #36 (+27/−4 in `ui.go`).

## Why a new PR instead of merging #36

#36 targets the `feat/focusable-sidebar` branch, which #35 already **squash-merged**. That makes the branch a squash diamond off a stale `main`: merging it 3-way auto-resolves the help region back to `main`'s version and **silently drops the help-text change** (verified locally — the post-merge tree is identical to `main`). Re-applying the change directly onto current `main` avoids that and guarantees it actually lands.

## Validation

- `go build`, `go vet`, `gofmt -l`, and `go test ./internal/ui/model/...` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AhXhLeQrATJvbgPGvDneGY)_