### PR TITLE
Remove dead Editor.AddFile keybinding

### DIFF
--- a/internal/ui/model/keys.go
+++ b/internal/ui/model/keys.go
@@ -4,7 +4,6 @@ import "charm.land/bubbles/v2/key"
 
 type KeyMap struct {
 	Editor struct {
-		AddFile     key.Binding
 		SendMessage key.Binding
 		OpenEditor  key.Binding
 		Newline     key.Binding
@@ -105,10 +104,6 @@ func DefaultKeyMap() KeyMap {
 		),
 	}
 
-	km.Editor.AddFile = key.NewBinding(
-		key.WithKeys("/"),
-		key.WithHelp("/", "add file"),
-	)
 	km.Editor.SendMessage = key.NewBinding(
 		key.WithKeys("enter"),
 		key.WithHelp("enter", "send"),


### PR DESCRIPTION
Closes #38

Removed the unused `Editor.AddFile` field and its binding from `internal/ui/model/keys.go`. Confirmed zero references remain via `grep -rn AddFile internal/`.