### PR TITLE
Make builtin skills user-invocable in the command palette

### DIFF
--- a/internal/commands/commands_test.go
+++ b/internal/commands/commands_test.go
@@ -107,8 +107,44 @@ func TestFromSkillCatalog_UsesDiscoveredSymlinkedSkills(t *testing.T) {
 	entries := skills.Catalog(activeSkills, []string{root}, "")
 	cmds := FromSkillCatalog(entries)
 
+	require.GreaterOrEqual(t, len(cmds), 1)
+	var found bool
+	for _, cmd := range cmds {
+		if cmd.ID == "user:linked-skill" {
+			found = true
+			require.Equal(t, "linked-skill", cmd.Skill.Name)
+			require.Equal(t, filepath.Join(link, skills.SkillFileName), cmd.Skill.SkillFilePath)
+		}
+	}
+	require.True(t, found, "linked-skill should be in the palette")
+}
+
+func TestFromSkillCatalog_BuiltinSkillsAreUserInvocable(t *testing.T) {
+	t.Parallel()
+
+	_, activeSkills, _ := skills.DiscoverFromConfig(skills.DiscoveryConfig{})
+	entries := skills.Catalog(activeSkills, nil, "")
+	cmds := FromSkillCatalog(entries)
+
+	names := make(map[string]bool, len(cmds))
+	for _, cmd := range cmds {
+		names[cmd.Skill.Name] = true
+	}
+	for _, expected := range []string{"crush-config", "crush-hooks", "jq", "a2ui"} {
+		require.True(t, names[expected], "%s should be user-invocable in the palette", expected)
+	}
+}
+
+func TestFromSkillCatalog_UserInvocableFilter(t *testing.T) {
+	t.Parallel()
+
+	entries := []skills.CatalogEntry{
+		{Name: "invocable", Description: "Yes.", UserInvocable: true},
+		{Name: "hidden", Description: "No.", UserInvocable: false},
+	}
+	cmds := FromSkillCatalog(entries)
+
 	require.Len(t, cmds, 1)
-	require.Equal(t, "user:linked-skill", cmds[0].ID)
-	require.Equal(t, "linked-skill", cmds[0].Skill.Name)
-	require.Equal(t, filepath.Join(link, skills.SkillFileName), cmds[0].Skill.SkillFilePath)
+	require.Equal(t, "user:invocable", cmds[0].ID)
+	require.Equal(t, "invocable", cmds[0].Skill.Name)
 }

--- a/internal/skills/builtin/a2ui/SKILL.md
+++ b/internal/skills/builtin/a2ui/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: a2ui
 description: Use when the user asks you to output, speak in, or communicate using the A2UI (a2tea) format, or when you need to understand how to construct A2UI JSON components to render interactive terminal UIs for the user.
+user-invocable: true
 ---
 
 # A2UI / a2tea Communication Guide

--- a/internal/skills/builtin/crush-config/SKILL.md
+++ b/internal/skills/builtin/crush-config/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: crush-config
 description: Use when the user needs help configuring Crush — working with crush.json, setting up providers, configuring LSPs, adding MCP servers, managing skills or permissions, or changing Crush behavior.
+user-invocable: true
 ---
 
 # Crush Configuration

--- a/internal/skills/builtin/crush-hooks/SKILL.md
+++ b/internal/skills/builtin/crush-hooks/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: crush-hooks
 description: Use when the user wants to add, write, debug, or configure a Crush hook — gating or blocking tool calls, approving or rewriting tool input before execution, injecting context into tool results, or troubleshooting hook behavior in crush.json.
+user-invocable: true
 ---
 
 # Crush Hooks

--- a/internal/skills/builtin/jq/SKILL.md
+++ b/internal/skills/builtin/jq/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: jq
 description: Use when the user needs to query, filter, reshape, extract, create, or construct JSON data — including API responses, config files, log output, or any structured data — or when helping the user write or debug JSON transformations.
+user-invocable: true
 ---
 
 # jq — Built-in JSON Processor


### PR DESCRIPTION
Closes #19

Sets `user-invocable: true` in the frontmatter of the four builtin skills (`crush-config`, `crush-hooks`, `jq`, `a2ui`). Adds regression tests:
- `TestFromSkillCatalog_UserInvocableFilter`: verifies entries with `UserInvocable: true` produce commands and those without do not.
- `TestFromSkillCatalog_BuiltinSkillsAreUserInvocable`: verifies all four builtins appear in the palette via real discovery.