### PR TITLE
feat(ui): render channel-originated messages with styled metadata header

### DIFF
--- a/internal/ui/chat/user.go
+++ b/internal/ui/chat/user.go
@@ -3,6 +3,7 @@ package chat
 import (
 	"encoding/xml"
 	"strings"
+	"time"
 
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
@@ -19,6 +20,17 @@ type skillInvocation struct {
 	Description  string `xml:"description"`
 	Location     string `xml:"location"`
 	Instructions string `xml:"instructions"`
+}
+
+// channelMessage represents the XML structure for a channel-originated
+// message pushed by an MCP channel server.
+type channelMessage struct {
+	XMLName    xml.Name `xml:"channel"`
+	Source     string   `xml:"source,attr"`
+	Sender     string   `xml:"sender,attr"`
+	SenderName string   `xml:"sender_name,attr"`
+	Time       string   `xml:"time,attr"`
+	Content    string   `xml:",chardata"`
 }
 
 // UserMessageItem represents a user message in the chat UI.
@@ -73,6 +85,14 @@ func (m *UserMessageItem) RawRender(width int) string {
 		return m.renderHighlighted(content, cappedWidth, height)
 	}
 
+	// Check if this is a channel-originated message.
+	if strings.HasPrefix(msgContent, "<channel") {
+		content = m.renderChannelMessage(msgContent, cappedWidth)
+		height = lipgloss.Height(content)
+		m.setCachedRender(content, cappedWidth, height)
+		return m.renderHighlighted(content, cappedWidth, height)
+	}
+
 	renderer := common.MarkdownRenderer(m.sty, cappedWidth)
 	mu := common.LockMarkdownRenderer(renderer)
 
@@ -119,6 +139,72 @@ func (m *UserMessageItem) renderSkillInvocation(content string, width int) strin
 	}
 
 	return toolOutputSkillContent(m.sty, skill.Name, skill.Description)
+}
+
+// TODO(follow-up): suppress channel name for a session's default channel.
+
+// renderChannelMessage parses a <channel source="..." ...>body</channel> element
+// and renders a styled metadata header followed by the body as markdown.
+func (m *UserMessageItem) renderChannelMessage(raw string, width int) string {
+	var ch channelMessage
+	if err := xml.Unmarshal([]byte(raw), &ch); err != nil {
+		return m.fallbackRender(raw, width)
+	}
+
+	// Build the header line: channel source, sender, time.
+	header := m.sty.Tool.ResourceName.Render(ch.Source)
+
+	sender := ch.SenderName
+	if sender == "" {
+		sender = ch.Sender
+	}
+	if sender != "" {
+		header += " " + m.sty.Tool.ResourceSize.Render("·") + " " + m.sty.Tool.ResourceSize.Render(sender)
+	}
+
+	ts := ch.Time
+	if ts == "" && m.message.CreatedAt > 0 {
+		ts = time.Unix(m.message.CreatedAt, 0).Format(time.TimeOnly)
+	}
+	if ts != "" {
+		header += " " + m.sty.Tool.ResourceSize.Render("·") + " " + m.sty.Tool.ResourceSize.Render(ts)
+	}
+
+	headerLine := m.sty.Tool.Body.Render(header)
+
+	// Render the body content as markdown.
+	body := strings.TrimSpace(ch.Content)
+	var bodyRendered string
+	if body != "" {
+		renderer := common.MarkdownRenderer(m.sty, width)
+		mu := common.LockMarkdownRenderer(renderer)
+		mu.Lock()
+		result, err := renderer.Render(body)
+		mu.Unlock()
+		if err != nil {
+			bodyRendered = body
+		} else {
+			bodyRendered = strings.TrimSuffix(result, "\n")
+		}
+	}
+
+	if bodyRendered == "" {
+		return headerLine
+	}
+	return headerLine + "\n" + bodyRendered
+}
+
+// fallbackRender renders text as plain markdown when XML parsing fails.
+func (m *UserMessageItem) fallbackRender(content string, width int) string {
+	renderer := common.MarkdownRenderer(m.sty, width)
+	mu := common.LockMarkdownRenderer(renderer)
+	mu.Lock()
+	result, err := renderer.Render(content)
+	mu.Unlock()
+	if err != nil {
+		return content
+	}
+	return strings.TrimSuffix(result, "\n")
 }
 
 // Render implements MessageItem.

--- a/internal/ui/chat/user_test.go
+++ b/internal/ui/chat/user_test.go
@@ -1,0 +1,145 @@
+package chat
+
+import (
+	"testing"
+
+	"github.com/charmbracelet/crush/internal/message"
+	"github.com/charmbracelet/crush/internal/ui/attachments"
+	"github.com/charmbracelet/crush/internal/ui/styles"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestUserItem(text string, createdAt int64) *UserMessageItem {
+	sty := styles.CharmtonePantera()
+	msg := &message.Message{
+		ID:        "test-id",
+		Role:      message.User,
+		CreatedAt: createdAt,
+		Parts:     []message.ContentPart{message.TextContent{Text: text}},
+	}
+	r := attachments.NewRenderer(
+		sty.Attachments.Normal,
+		sty.Attachments.Deleting,
+		sty.Attachments.Image,
+		sty.Attachments.Text,
+		sty.Attachments.Skill,
+	)
+	return NewUserMessageItem(&sty, msg, r).(*UserMessageItem)
+}
+
+func TestRawRender_ChannelMessageFull(t *testing.T) {
+	t.Parallel()
+
+	text := `<channel source="signal" sender="+15551234567" sender_name="Alice" time="14:30">Hello from Signal!</channel>`
+
+	item := newTestUserItem(text, 0)
+	out := ansi.Strip(item.RawRender(80))
+
+	// Header should contain the channel source.
+	require.Contains(t, out, "signal")
+
+	// Header should contain the sender name.
+	require.Contains(t, out, "Alice")
+
+	// Header should contain the time from the XML attribute.
+	require.Contains(t, out, "14:30")
+
+	// Body should be rendered as markdown, not raw XML.
+	require.Contains(t, out, "Hello from Signal!")
+
+	// Raw XML tags must not be visible.
+	require.NotContains(t, out, "<channel")
+	require.NotContains(t, out, "</channel>")
+}
+
+func TestRawRender_ChannelMessageSourceOnly(t *testing.T) {
+	t.Parallel()
+
+	text := `<channel source="signal">Just the source, no sender or time.</channel>`
+
+	item := newTestUserItem(text, 1752456000) // CreatedAt fallback
+	out := ansi.Strip(item.RawRender(80))
+
+	// Header should contain the channel source.
+	require.Contains(t, out, "signal")
+
+	// Body should be present.
+	require.Contains(t, out, "Just the source")
+
+	// No raw XML tags.
+	require.NotContains(t, out, "<channel")
+	require.NotContains(t, out, "</channel>")
+}
+
+func TestRawRender_ChannelMessageMalformed(t *testing.T) {
+	t.Parallel()
+
+	// Incomplete/truncated XML should not panic and should fall back to
+	// plain rendering.
+	text := `<channel source="signal" sender="broken`
+
+	item := newTestUserItem(text, 0)
+	out := ansi.Strip(item.RawRender(80))
+
+	// Should not panic and should contain the raw text (fallback).
+	require.NotEmpty(t, out)
+	require.Contains(t, out, "<channel")
+}
+
+func TestRawRender_NormalMessage(t *testing.T) {
+	t.Parallel()
+
+	text := `This is a normal user message.`
+
+	item := newTestUserItem(text, 0)
+	out := ansi.Strip(item.RawRender(80))
+
+	require.Contains(t, out, "This is a normal user message.")
+	require.NotContains(t, out, "signal")
+	require.NotContains(t, out, "<channel")
+}
+
+func TestRawRender_ChannelMessageEmptyBody(t *testing.T) {
+	t.Parallel()
+
+	text := `<channel source="signal" sender="+15551234567" sender_name="Bob" time="09:15"></channel>`
+
+	item := newTestUserItem(text, 0)
+	out := ansi.Strip(item.RawRender(80))
+
+	require.Contains(t, out, "signal")
+	require.Contains(t, out, "Bob")
+	require.Contains(t, out, "09:15")
+	require.NotContains(t, out, "<channel")
+	require.NotContains(t, out, "</channel>")
+}
+
+func TestRawRender_ChannelMessageSenderFallback(t *testing.T) {
+	t.Parallel()
+
+	// sender provided but no sender_name — should show sender as the name.
+	text := `<channel source="signal" sender="+15559876543">Fallback sender</channel>`
+
+	item := newTestUserItem(text, 0)
+	out := ansi.Strip(item.RawRender(80))
+
+	require.Contains(t, out, "signal")
+	require.Contains(t, out, "+15559876543")
+	require.Contains(t, out, "Fallback sender")
+	require.NotContains(t, out, "<channel")
+}
+
+func TestRawRender_ChannelMessageCreatedAtFallback(t *testing.T) {
+	t.Parallel()
+
+	// No time attribute, but CreatedAt is set on the message.
+	text := `<channel source="signal">Uses CreatedAt</channel>`
+
+	item := newTestUserItem(text, 1752456000)
+	out := ansi.Strip(item.RawRender(80))
+
+	require.Contains(t, out, "signal")
+	require.Contains(t, out, "Uses CreatedAt")
+	require.NotContains(t, out, "<channel")
+}


### PR DESCRIPTION
## Summary
Messages arriving from external channels (Signal via MCP channel server) previously rendered as raw XML text in the chat. This adds a **styled metadata header** showing the channel name, sender (when available), and timestamp, followed by the message body as clean markdown.

## Changes
- **`internal/ui/chat/user.go`**: Added `channelMessage` struct for XML unmarshalling, `renderChannelMessage` method that builds a styled header (mirroring the existing `<loaded_skill>` pattern), and `fallbackRender` for malformed XML.
- **`internal/ui/chat/user_test.go`**: 7 test cases covering full metadata, source-only, malformed XML, normal messages, empty body, sender fallback, and CreatedAt fallback.

## Details
- Channel data is already embedded in the message text as XML attributes — no changes to the MCP/channel layer.
- Missing `sender`/`time` attributes degrade gracefully (omitted, no empty separators).
- `message.CreatedAt` used as a time fallback when no `time` attribute is provided.
- Malformed `<channel>` elements fall back to plain markdown rendering without panicking.
- `TODO(follow-up)` note left for suppressing the channel name on a session's default channel.

Closes #42

💘 Generated with Crush