### PR TITLE
feat(ui): add hierarchical sub-menus to commands dialog

### DIFF
--- a/internal/ui/dialog/commands.go
+++ b/internal/ui/dialog/commands.go
@@ -23,7 +23,6 @@ const CommandsID = "commands"
 // menuLevel captures the parent state when navigating into a sub-menu.
 type menuLevel struct {
 	items []list.Item
-	title string
 }
 
 // CommandType represents the type of commands being displayed.
@@ -430,7 +429,6 @@ func (c *Commands) pushMenu(parent *CommandItem) {
 	// Save current visible items (includes FilterableItem interface).
 	c.menuStack = append(c.menuStack, menuLevel{
 		items: c.list.FilteredItems(),
-		title: parent.title,
 	})
 	c.breadcrumb = append(c.breadcrumb, parent.title)
 
@@ -461,9 +459,7 @@ func (c *Commands) popMenu() {
 			fitems = append(fitems, fi)
 		}
 	}
-	if len(fitems) > 0 {
-		c.list.SetItems(fitems...)
-	}
+	c.list.SetItems(fitems...)
 	c.list.SetFilter("")
 	c.list.ScrollToTop()
 	c.list.SetSelected(0)

--- a/internal/ui/dialog/commands.go
+++ b/internal/ui/dialog/commands.go
@@ -20,6 +20,12 @@ import (
 // CommandsID is the identifier for the commands dialog.
 const CommandsID = "commands"
 
+// menuLevel captures the parent state when navigating into a sub-menu.
+type menuLevel struct {
+	items []list.Item
+	title string
+}
+
 // CommandType represents the type of commands being displayed.
 type CommandType uint
 
@@ -50,6 +56,7 @@ type Commands struct {
 		Previous,
 		Tab,
 		ShiftTab,
+		Back,
 		Close key.Binding
 	}
 
@@ -73,6 +80,9 @@ type Commands struct {
 
 	dockerMCPAvailable     *bool
 	dockerMCPCheckInFlight bool
+
+	menuStack  []menuLevel
+	breadcrumb []string
 }
 
 var _ Dialog = (*Commands)(nil)
@@ -129,6 +139,10 @@ func NewCommands(com *common.Common, sessionID string, hasSession, hasTodos, has
 		key.WithKeys("shift+tab"),
 		key.WithHelp("shift+tab", "switch selection prev"),
 	)
+	c.keyMap.Back = key.NewBinding(
+		key.WithKeys("backspace", "alt+left"),
+		key.WithHelp("backspace", "back"),
+	)
 	closeKey := CloseKey
 	closeKey.SetHelp("esc", "cancel")
 	c.keyMap.Close = closeKey
@@ -172,7 +186,16 @@ func (c *Commands) HandleMsg(msg tea.Msg) Action {
 	case tea.KeyPressMsg:
 		switch {
 		case key.Matches(msg, c.keyMap.Close):
+			if c.inSubMenu() {
+				c.popMenu()
+				return nil
+			}
 			return ActionClose{}
+		case key.Matches(msg, c.keyMap.Back):
+			if c.inSubMenu() {
+				c.popMenu()
+				return nil
+			}
 		case key.Matches(msg, c.keyMap.Previous):
 			c.list.Focus()
 			if c.list.IsSelectedFirst() {
@@ -192,16 +215,20 @@ func (c *Commands) HandleMsg(msg tea.Msg) Action {
 		case key.Matches(msg, c.keyMap.Select):
 			if selectedItem := c.list.SelectedItem(); selectedItem != nil {
 				if item, ok := selectedItem.(*CommandItem); ok && item != nil {
+					if item.HasChildren() {
+						c.pushMenu(item)
+						return nil
+					}
 					return item.Action()
 				}
 			}
 		case key.Matches(msg, c.keyMap.Tab):
-			if len(c.customCommands) > 0 || len(c.mcpPrompts) > 0 {
+			if !c.inSubMenu() && (len(c.customCommands) > 0 || len(c.mcpPrompts) > 0) {
 				c.selected = c.nextCommandType()
 				c.setCommandItems(c.selected)
 			}
 		case key.Matches(msg, c.keyMap.ShiftTab):
-			if len(c.customCommands) > 0 || len(c.mcpPrompts) > 0 {
+			if !c.inSubMenu() && (len(c.customCommands) > 0 || len(c.mcpPrompts) > 0) {
 				c.selected = c.previousCommandType()
 				c.setCommandItems(c.selected)
 			}
@@ -210,6 +237,10 @@ func (c *Commands) HandleMsg(msg tea.Msg) Action {
 			for _, item := range c.list.FilteredItems() {
 				if item, ok := item.(*CommandItem); ok && item != nil {
 					if msg.String() == item.Shortcut() {
+						if item.HasChildren() {
+							c.pushMenu(item)
+							return nil
+						}
 						return item.Action()
 					}
 				}
@@ -296,7 +327,11 @@ func (c *Commands) Draw(scr uv.Screen, area uv.Rectangle) *tea.Cursor {
 
 	rc := NewRenderContext(t, width)
 	rc.Title = "Commands"
-	rc.TitleInfo = commandsRadioView(t, c.selected, len(c.customCommands) > 0, len(c.mcpPrompts) > 0)
+	if c.inSubMenu() {
+		rc.Title = "Commands ▸ " + strings.Join(c.breadcrumb, " ▸ ")
+	} else {
+		rc.TitleInfo = commandsRadioView(t, c.selected, len(c.customCommands) > 0, len(c.mcpPrompts) > 0)
+	}
 	inputView := t.Dialog.InputPrompt.Render(c.input.View())
 	rc.AddPart(inputView)
 	listView := t.Dialog.List.Height(c.list.Height()).Render(c.list.Render())
@@ -376,6 +411,56 @@ func (c *Commands) previousCommandType() CommandType {
 	default:
 		return SystemCommands
 	}
+}
+
+// inSubMenu reports whether the dialog is currently inside a sub-menu.
+func (c *Commands) inSubMenu() bool {
+	return len(c.menuStack) > 0
+}
+
+// pushMenu saves the current list state and navigates into a sub-menu.
+func (c *Commands) pushMenu(parent *CommandItem) {
+	// Save current visible items (includes FilterableItem interface).
+	c.menuStack = append(c.menuStack, menuLevel{
+		items: c.list.FilteredItems(),
+		title: parent.title,
+	})
+	c.breadcrumb = append(c.breadcrumb, parent.title)
+
+	children := make([]list.FilterableItem, len(parent.children))
+	for i, child := range parent.children {
+		children[i] = child
+	}
+	c.list.SetItems(children...)
+	c.list.SetFilter("")
+	c.list.ScrollToTop()
+	c.list.SetSelected(0)
+	c.input.SetValue("")
+}
+
+// popMenu restores the previous menu level from the stack.
+func (c *Commands) popMenu() {
+	if len(c.menuStack) == 0 {
+		return
+	}
+	level := c.menuStack[len(c.menuStack)-1]
+	c.menuStack = c.menuStack[:len(c.menuStack)-1]
+	c.breadcrumb = c.breadcrumb[:len(c.breadcrumb)-1]
+
+	// Restore items by re-setting them as FilterableItems.
+	fitems := make([]list.FilterableItem, 0, len(level.items))
+	for _, item := range level.items {
+		if fi, ok := item.(list.FilterableItem); ok {
+			fitems = append(fitems, fi)
+		}
+	}
+	if len(fitems) > 0 {
+		c.list.SetItems(fitems...)
+	}
+	c.list.SetFilter("")
+	c.list.ScrollToTop()
+	c.list.SetSelected(0)
+	c.input.SetValue("")
 }
 
 // setCommandItems sets the command items based on the specified command type.

--- a/internal/ui/dialog/commands.go
+++ b/internal/ui/dialog/commands.go
@@ -420,6 +420,13 @@ func (c *Commands) inSubMenu() bool {
 
 // pushMenu saves the current list state and navigates into a sub-menu.
 func (c *Commands) pushMenu(parent *CommandItem) {
+	// Clear any active filter before snapshotting so we save the FULL parent
+	// list, not just the currently-matched subset. Otherwise popping back would
+	// drop every top-level item that didn't match the filter that was active
+	// when the user entered the sub-menu.
+	c.input.SetValue("")
+	c.list.SetFilter("")
+
 	// Save current visible items (includes FilterableItem interface).
 	c.menuStack = append(c.menuStack, menuLevel{
 		items: c.list.FilteredItems(),

--- a/internal/ui/dialog/commands_item.go
+++ b/internal/ui/dialog/commands_item.go
@@ -19,6 +19,7 @@ type CommandItem struct {
 	description string
 	action      Action
 	aliases     []string
+	children    []*CommandItem
 	t           *styles.Styles
 	m           fuzzy.Match
 	cache       map[int]string
@@ -56,6 +57,17 @@ func (c *CommandItem) WithAliases(aliases ...string) *CommandItem {
 func (c *CommandItem) WithDescription(desc string) *CommandItem {
 	c.description = desc
 	return c
+}
+
+// WithChildren returns the CommandItem with child sub-menu items.
+func (c *CommandItem) WithChildren(children ...*CommandItem) *CommandItem {
+	c.children = children
+	return c
+}
+
+// HasChildren reports whether the item has a sub-menu.
+func (c *CommandItem) HasChildren() bool {
+	return len(c.children) > 0
 }
 
 // Filter implements ListItem.

--- a/internal/ui/dialog/commands_test.go
+++ b/internal/ui/dialog/commands_test.go
@@ -187,6 +187,35 @@ func TestCommands_BreadcrumbDraw(t *testing.T) {
 
 // setupMenuHierarchy creates a Commands dialog with a parent item that has
 // children, where one child is itself a parent with a nested leaf.
+func TestCommands_PopRestoresFullParentList(t *testing.T) {
+	t.Parallel()
+
+	c := newTestCommands(t)
+
+	leaf := NewCommandItem(c.com.Styles, "leaf", "Leaf", "", ActionNewSession{})
+	parent := NewCommandItem(c.com.Styles, "parent", "Alpha", "", nil).WithChildren(leaf)
+	sibling := NewCommandItem(c.com.Styles, "sibling", "Zulu", "", ActionNewSession{})
+
+	items := []list.FilterableItem{parent, sibling}
+	c.list.SetItems(items...)
+	c.list.SetSelected(0)
+
+	// Filter so only the parent ("Alpha") matches, leaving the sibling hidden.
+	c.HandleMsg(keyMsg('a'))
+	require.Len(t, c.list.FilteredItems(), 1, "filter should narrow to the parent")
+
+	// Enter the parent's sub-menu, then pop back to the top level.
+	c.HandleMsg(tea.KeyPressMsg{Code: tea.KeyEnter})
+	require.True(t, c.inSubMenu())
+	c.HandleMsg(tea.KeyPressMsg{Code: tea.KeyEscape})
+	require.False(t, c.inSubMenu())
+
+	// Both top-level items must be restored — not just the previously-filtered
+	// subset. Regression guard for pushMenu snapshotting FilteredItems() while a
+	// filter was active.
+	require.Len(t, c.list.FilteredItems(), 2, "popping should restore the full parent list")
+}
+
 func setupMenuHierarchy(t *testing.T) *Commands {
 	t.Helper()
 	c := newTestCommands(t)

--- a/internal/ui/dialog/commands_test.go
+++ b/internal/ui/dialog/commands_test.go
@@ -1,0 +1,204 @@
+package dialog
+
+import (
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/crush/internal/config"
+	"github.com/charmbracelet/crush/internal/ui/common"
+	"github.com/charmbracelet/crush/internal/ui/list"
+	"github.com/charmbracelet/crush/internal/ui/styles"
+	"github.com/charmbracelet/crush/internal/workspace"
+	"github.com/stretchr/testify/require"
+)
+
+type testCommandsWorkspace struct {
+	workspace.Workspace
+	cfg *config.Config
+}
+
+func (w *testCommandsWorkspace) Config() *config.Config {
+	return w.cfg
+}
+
+func newTestCommands(t *testing.T) *Commands {
+	t.Helper()
+	s := styles.CharmtonePantera()
+	cfg := &config.Config{}
+	com := &common.Common{
+		Workspace: &testCommandsWorkspace{cfg: cfg},
+		Styles:    &s,
+	}
+	c, err := NewCommands(com, "", false, false, false, nil, nil)
+	require.NoError(t, err)
+	return c
+}
+
+func TestCommands_SubMenuNavigation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		keys       []tea.KeyPressMsg
+		wantStack  int
+		wantBread  []string
+		wantClose  bool
+		wantAction bool
+	}{
+		{
+			name:      "enter parent pushes sub-menu, no action fires",
+			keys:      []tea.KeyPressMsg{{Code: tea.KeyEnter}},
+			wantStack: 1,
+			wantBread: []string{"Parent"},
+		},
+		{
+			name:      "esc in sub-menu pops back",
+			keys:      []tea.KeyPressMsg{{Code: tea.KeyEnter}, {Code: tea.KeyEscape}},
+			wantStack: 0,
+			wantBread: []string{},
+		},
+		{
+			name:      "backspace in sub-menu pops back",
+			keys:      []tea.KeyPressMsg{{Code: tea.KeyEnter}, {Code: tea.KeyBackspace}},
+			wantStack: 0,
+			wantBread: []string{},
+		},
+		{
+			name:      "esc at top level closes dialog",
+			keys:      []tea.KeyPressMsg{{Code: tea.KeyEscape}},
+			wantStack: 0,
+			wantClose: true,
+		},
+		{
+			name:       "leaf child action fires on enter",
+			keys:       []tea.KeyPressMsg{{Code: tea.KeyEnter}, {Code: tea.KeyEnter}, {Code: tea.KeyEnter}},
+			wantStack:  2,
+			wantBread:  []string{"Parent", "Child A"},
+			wantAction: true,
+		},
+		{
+			name:      "nested sub-menu pushes twice",
+			keys:      []tea.KeyPressMsg{{Code: tea.KeyEnter}, {Code: tea.KeyEnter}},
+			wantStack: 2,
+			wantBread: []string{"Parent", "Child A"},
+		},
+		{
+			name:      "pop from nested restores to first sub-menu",
+			keys:      []tea.KeyPressMsg{{Code: tea.KeyEnter}, {Code: tea.KeyEnter}, {Code: tea.KeyEscape}},
+			wantStack: 1,
+			wantBread: []string{"Parent"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			c := setupMenuHierarchy(t)
+
+			var gotAction Action
+			for _, k := range tc.keys {
+				gotAction = c.HandleMsg(k)
+			}
+
+			require.Equal(t, tc.wantStack, len(c.menuStack), "menu stack depth")
+			require.Equal(t, tc.wantBread, c.breadcrumb, "breadcrumb")
+
+			if tc.wantClose {
+				_, ok := gotAction.(ActionClose)
+				require.True(t, ok, "expected ActionClose")
+			}
+			if tc.wantAction {
+				require.NotNil(t, gotAction, "expected an action to fire")
+				_, ok := gotAction.(ActionNewSession)
+				require.True(t, ok, "expected ActionNewSession from leaf")
+			}
+		})
+	}
+}
+
+func TestCommands_FilterScopedToCurrentLevel(t *testing.T) {
+	t.Parallel()
+
+	c := setupMenuHierarchy(t)
+
+	// Navigate into the sub-menu.
+	c.HandleMsg(tea.KeyPressMsg{Code: tea.KeyEnter})
+	require.True(t, c.inSubMenu())
+
+	// Type a filter that matches a child but not the parent.
+	c.HandleMsg(keyMsg('a'))
+
+	filtered := c.list.FilteredItems()
+	// Should have at least one item (Child A matches "a").
+	require.NotEmpty(t, filtered)
+
+	// None of the filtered items should be the parent.
+	for _, item := range filtered {
+		if ci, ok := item.(*CommandItem); ok {
+			require.NotEqual(t, ci.id, "parent", "filter should not show parent items")
+		}
+	}
+}
+
+func TestCommands_TabDisabledInSubMenu(t *testing.T) {
+	t.Parallel()
+
+	c := setupMenuHierarchy(t)
+	require.False(t, c.inSubMenu())
+
+	// Tab normally cycles command types (no-op here since no custom commands).
+	c.HandleMsg(tea.KeyPressMsg{Code: tea.KeyTab})
+	require.Equal(t, SystemCommands, c.selected)
+
+	// Navigate into sub-menu.
+	c.HandleMsg(tea.KeyPressMsg{Code: tea.KeyEnter})
+	require.True(t, c.inSubMenu())
+
+	// Tab should be a no-op while in sub-menu (selected stays SystemCommands).
+	c.HandleMsg(tea.KeyPressMsg{Code: tea.KeyTab})
+	require.Equal(t, SystemCommands, c.selected)
+}
+
+func TestCommands_LeafEnterFiresActionAndCloses(t *testing.T) {
+	t.Parallel()
+
+	c := newTestCommands(t)
+
+	// Add a leaf item to the system commands.
+	leaf := NewCommandItem(c.com.Styles, "leaf", "Leaf Item", "", ActionNewSession{})
+	items := make([]list.FilterableItem, 1)
+	items[0] = leaf
+	c.list.SetItems(items...)
+	c.list.SetSelected(0)
+
+	action := c.HandleMsg(tea.KeyPressMsg{Code: tea.KeyEnter})
+	_, ok := action.(ActionNewSession)
+	require.True(t, ok, "leaf item should fire its action")
+}
+
+func TestCommands_BreadcrumbDraw(t *testing.T) {
+	t.Parallel()
+
+	c := setupMenuHierarchy(t)
+	c.HandleMsg(tea.KeyPressMsg{Code: tea.KeyEnter})
+	require.True(t, c.inSubMenu())
+	require.Equal(t, []string{"Parent"}, c.breadcrumb)
+}
+
+// setupMenuHierarchy creates a Commands dialog with a parent item that has
+// children, where one child is itself a parent with a nested leaf.
+func setupMenuHierarchy(t *testing.T) *Commands {
+	t.Helper()
+	c := newTestCommands(t)
+
+	leaf := NewCommandItem(c.com.Styles, "leaf", "Leaf", "", ActionNewSession{})
+	nestedParent := NewCommandItem(c.com.Styles, "child_a", "Child A", "", nil).WithChildren(leaf)
+	leaf2 := NewCommandItem(c.com.Styles, "child_b", "Child B", "", ActionNewSession{})
+	parent := NewCommandItem(c.com.Styles, "parent", "Parent", "", nil).WithChildren(nestedParent, leaf2)
+
+	items := make([]list.FilterableItem, 1)
+	items[0] = parent
+	c.list.SetItems(items...)
+	c.list.SetSelected(0)
+	return c
+}


### PR DESCRIPTION
## Summary
Adds hierarchical sub-menu navigation to the commands dialog. Enter on an item with children pushes into the sub-menu with a breadcrumb; Esc/Backspace pops back to the parent level. Tab switching is disabled inside sub-menus. This unblocks #16 (`/skills`) and #17 (`/mcp`) which will register their items as children.

## Changes
- **`commands_item.go`**: Added `children []*CommandItem`, `WithChildren(...)` builder, `HasChildren() bool`.
- **`commands.go`**: Added `menuLevel` struct, `menuStack`/`breadcrumb` fields, `Back` key binding (Backspace/Alt+Left). Updated `HandleMsg`: Enter on parent pushes sub-menu (no action fired), Esc/Back pops when in sub-menu, Esc at top still closes. Tab/ShiftTab disabled in sub-menus. Shortcut matching also handles parent items. Updated `Draw` to show `Commands ▸ Parent` breadcrumb title and hide radio tabs in sub-menus.
- **`commands_test.go`**: Table-driven tests for navigation (enter-submenu, esc-back, backspace-back, nested push/pop), filter scoping, tab disabling, leaf action firing, and breadcrumb rendering.

## Details
- Filter is scoped to the current level — children replace the list entirely.
- Malformed navigation (pop at top) is a no-op.
- `menuLevel` stores `[]list.Item` from `FilteredItems()` for restoration.

Closes #15

💘 Generated with Crush