### PR TITLE
feat(ui): add Skills dialog with list, reload, and toggle

### DIFF
--- a/internal/backend/config.go
+++ b/internal/backend/config.go
@@ -207,6 +207,29 @@ func (b *Backend) ListSkills(workspaceID string) ([]proto.SkillInfo, error) {
 	return result, nil
 }
 
+// ReloadSkills re-discovers skills from disk for a workspace.
+func (b *Backend) ReloadSkills(workspaceID string) error {
+	ws, err := b.GetWorkspace(workspaceID)
+	if err != nil {
+		return err
+	}
+	mgr := ws.Skills
+	if mgr == nil {
+		return nil
+	}
+	discoveryCfg := skills.DiscoveryConfig{
+		WorkingDir: ws.Cfg.WorkingDir(),
+		Resolver:   ws.Cfg.Resolver().ResolveValue,
+	}
+	opts := ws.Cfg.Config().Options
+	if opts != nil {
+		discoveryCfg.SkillsPaths = opts.SkillsPaths
+		discoveryCfg.DisabledSkills = opts.DisabledSkills
+	}
+	mgr.Reload(discoveryCfg)
+	return nil
+}
+
 // EnableDockerMCP validates Docker MCP availability, stages the
 // configuration, starts the MCP client, and persists the config.
 func (b *Backend) EnableDockerMCP(ctx context.Context, workspaceID string) error {

--- a/internal/client/config.go
+++ b/internal/client/config.go
@@ -252,6 +252,19 @@ func (c *Client) ReadSkill(ctx context.Context, id, skillID string) (*proto.Read
 	return &result, nil
 }
 
+// ReloadSkills triggers a skill re-discovery on the server.
+func (c *Client) ReloadSkills(ctx context.Context, id string) error {
+	rsp, err := c.post(ctx, fmt.Sprintf("/workspaces/%s/skills/reload", id), nil, nil, nil)
+	if err != nil {
+		return fmt.Errorf("failed to reload skills: %w", err)
+	}
+	defer rsp.Body.Close()
+	if rsp.StatusCode != http.StatusOK {
+		return fmt.Errorf("failed to reload skills: status code %d", rsp.StatusCode)
+	}
+	return nil
+}
+
 // MCPResourceContents holds the contents of an MCP resource.
 type MCPResourceContents struct {
 	URI      string `json:"uri"`

--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -317,6 +317,24 @@ func (c *controllerV1) handlePostWorkspaceSkillRead(w http.ResponseWriter, r *ht
 	jsonEncode(w, proto.ReadSkillResponse{Content: content, Result: result})
 }
 
+// handlePostWorkspaceSkillsReload triggers a skill re-discovery.
+//
+//	@Summary		Reload skills
+//	@Tags			skills
+//	@Param			id	path	string	true	"Workspace ID"
+//	@Success		200
+//	@Failure		404	{object}	proto.Error
+//	@Failure		500	{object}	proto.Error
+//	@Router			/workspaces/{id}/skills/reload [post]
+func (c *controllerV1) handlePostWorkspaceSkillsReload(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	if err := c.backend.ReloadSkills(id); err != nil {
+		c.handleError(w, r, err)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+}
+
 // handlePostWorkspaceMCPEnableDocker enables the Docker MCP server.
 //
 //	@Summary		Enable Docker MCP

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -203,6 +203,7 @@ func (s *Server) installHandler() {
 	mux.HandleFunc("GET /v1/workspaces/{id}/project/init-prompt", c.handleGetWorkspaceProjectInitPrompt)
 	mux.HandleFunc("GET /v1/workspaces/{id}/skills", c.handleGetWorkspaceSkills)
 	mux.HandleFunc("POST /v1/workspaces/{id}/skills/read", c.handlePostWorkspaceSkillRead)
+	mux.HandleFunc("POST /v1/workspaces/{id}/skills/reload", c.handlePostWorkspaceSkillsReload)
 	mux.HandleFunc("POST /v1/workspaces/{id}/mcp/refresh-tools", c.handlePostWorkspaceMCPRefreshTools)
 	mux.HandleFunc("POST /v1/workspaces/{id}/mcp/read-resource", c.handlePostWorkspaceMCPReadResource)
 	mux.HandleFunc("POST /v1/workspaces/{id}/mcp/get-prompt", c.handlePostWorkspaceMCPGetPrompt)

--- a/internal/skills/manager.go
+++ b/internal/skills/manager.go
@@ -162,6 +162,19 @@ func (m *Manager) Shutdown() {
 	}
 }
 
+// Reload re-runs discovery from the given config, replaces all internal
+// skill lists and states, and publishes the new states to subscribers.
+// This is the mechanism for hot-reloading skills without restarting Crush.
+func (m *Manager) Reload(cfg DiscoveryConfig) {
+	allSkills, activeSkills, states := DiscoverFromConfig(cfg)
+	m.mu.Lock()
+	m.allSkills = allSkills
+	m.activeSkills = activeSkills
+	m.resolvedPaths = cfg.ResolvePaths()
+	m.mu.Unlock()
+	m.PublishStates(states)
+}
+
 // DiscoverFromConfig walks the embedded builtin FS and every path in
 // cfg.Options.SkillsPaths (after home / env expansion), then dedups and
 // filters by cfg.Options.DisabledSkills. It returns the three slices the

--- a/internal/ui/dialog/actions.go
+++ b/internal/ui/dialog/actions.go
@@ -114,6 +114,12 @@ type (
 	ActionMCPRefreshResources struct {
 		ServerName string
 	}
+	// ActionSkillsReload triggers a full skill re-discovery from disk.
+	ActionSkillsReload struct{}
+	// ActionSkillToggle toggles a skill's enabled/disabled state.
+	ActionSkillToggle struct {
+		SkillName string
+	}
 )
 
 // Messages for API key input dialog.

--- a/internal/ui/dialog/commands.go
+++ b/internal/ui/dialog/commands.go
@@ -622,6 +622,9 @@ func (c *Commands) defaultCommands() []*CommandItem {
 	// Add MCP servers command — opens the MCP servers management dialog.
 	commands = append(commands, NewCommandItem(c.com.Styles, "mcp_servers", "MCP Servers", "", ActionOpenDialog{DialogID: MCPServersID}))
 
+	// Add Skills management command.
+	commands = append(commands, NewCommandItem(c.com.Styles, "skills", "Skills", "", ActionOpenDialog{DialogID: SkillsID}))
+
 	commands = append(
 		commands,
 		NewCommandItem(c.com.Styles, "quit", "Quit", "ctrl+c", tea.QuitMsg{}).WithAliases("exit"),

--- a/internal/ui/dialog/skills.go
+++ b/internal/ui/dialog/skills.go
@@ -1,0 +1,371 @@
+package dialog
+
+import (
+	"fmt"
+	"strings"
+
+	"charm.land/bubbles/v2/help"
+	"charm.land/bubbles/v2/key"
+	"charm.land/bubbles/v2/textinput"
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/crush/internal/skills"
+	"github.com/charmbracelet/crush/internal/ui/common"
+	"github.com/charmbracelet/crush/internal/ui/list"
+	"github.com/charmbracelet/crush/internal/ui/styles"
+	"github.com/charmbracelet/crush/internal/workspace"
+	uv "github.com/charmbracelet/ultraviolet"
+	"github.com/sahilm/fuzzy"
+)
+
+// SkillsID is the identifier for the skills dialog.
+const SkillsID = "skills"
+
+// SkillItem wraps a skill catalog entry and its state as a list item.
+type SkillItem struct {
+	*list.Versioned
+	entry    skills.CatalogEntry
+	state    *skills.SkillState
+	disabled bool
+	t        *styles.Styles
+	m        fuzzy.Match
+	cache    map[int]string
+	focused  bool
+}
+
+var _ ListItem = &SkillItem{Versioned: list.NewVersioned()}
+
+// NewSkillItem creates a new SkillItem.
+func NewSkillItem(t *styles.Styles, entry skills.CatalogEntry, state *skills.SkillState, disabled bool) *SkillItem {
+	return &SkillItem{
+		Versioned: list.NewVersioned(),
+		t:         t,
+		entry:     entry,
+		state:     state,
+		disabled:  disabled,
+	}
+}
+
+// Finished implements list.Item.
+func (s *SkillItem) Finished() bool { return true }
+
+// Filter implements ListItem.
+func (s *SkillItem) Filter() string {
+	return s.entry.Name + " " + s.entry.Description
+}
+
+// ID implements ListItem.
+func (s *SkillItem) ID() string {
+	return s.entry.ID
+}
+
+// SetFocused implements ListItem.
+func (s *SkillItem) SetFocused(focused bool) {
+	if s.focused == focused {
+		return
+	}
+	s.cache = nil
+	s.focused = focused
+	if s.Versioned != nil {
+		s.Bump()
+	}
+}
+
+// SetMatch implements ListItem.
+func (s *SkillItem) SetMatch(match fuzzy.Match) {
+	if sameFuzzyMatch(s.m, match) {
+		return
+	}
+	s.cache = nil
+	s.m = match
+	if s.Versioned != nil {
+		s.Bump()
+	}
+}
+
+// Render implements ListItem.
+func (s *SkillItem) Render(width int) string {
+	itemStyles := ListItemStyles{
+		ItemBlurred:     s.t.Dialog.NormalItem,
+		ItemFocused:     s.t.Dialog.SelectedItem,
+		InfoTextBlurred: s.t.Dialog.ListItem.InfoBlurred,
+		InfoTextFocused: s.t.Dialog.ListItem.InfoFocused,
+	}
+
+	// Build the info text: source, state indicator, user-invocable flag.
+	var parts []string
+	parts = append(parts, string(s.entry.Source))
+
+	if s.disabled {
+		parts = append(parts, "off")
+	} else if s.state != nil && s.state.State == skills.StateError {
+		parts = append(parts, "error")
+	} else {
+		parts = append(parts, "on")
+	}
+
+	if s.entry.UserInvocable {
+		parts = append(parts, "user")
+	}
+
+	info := strings.Join(parts, " ")
+	return renderItem(itemStyles, s.entry.Name, info, s.focused, width, s.cache, &s.m)
+}
+
+// Skills is a dialog that lists discovered skills and provides reload/toggle actions.
+type Skills struct {
+	com    *common.Common
+	help   help.Model
+	list   *list.FilterableList
+	input  textinput.Model
+	ws     workspace.Workspace
+	keyMap struct {
+		Reload,
+		Toggle,
+		Next,
+		Previous,
+		UpDown,
+		Close key.Binding
+	}
+}
+
+var _ Dialog = (*Skills)(nil)
+
+// NewSkills creates a new skills dialog.
+func NewSkills(com *common.Common, ws workspace.Workspace) *Skills {
+	d := &Skills{
+		com: com,
+		ws:  ws,
+	}
+
+	help := help.New()
+	help.Styles = com.Styles.DialogHelpStyles()
+	d.help = help
+
+	d.list = list.NewFilterableList(d.skillItems()...)
+	d.list.Focus()
+	d.list.SetSelected(0)
+
+	d.input = textinput.New()
+	d.input.SetVirtualCursor(false)
+	d.input.Placeholder = "Type to filter"
+	d.input.SetStyles(com.Styles.TextInput)
+	d.input.Focus()
+
+	d.keyMap.Reload = key.NewBinding(
+		key.WithKeys("ctrl+r"),
+		key.WithHelp("ctrl+r", "reload"),
+	)
+	d.keyMap.Toggle = key.NewBinding(
+		key.WithKeys("enter", "ctrl+d"),
+		key.WithHelp("enter", "toggle"),
+	)
+	d.keyMap.UpDown = key.NewBinding(
+		key.WithKeys("up", "down"),
+		key.WithHelp("↑/↓", "choose"),
+	)
+	d.keyMap.Next = key.NewBinding(
+		key.WithKeys("down"),
+		key.WithHelp("↓", "next"),
+	)
+	d.keyMap.Previous = key.NewBinding(
+		key.WithKeys("up"),
+		key.WithHelp("↑", "previous"),
+	)
+	closeKey := CloseKey
+	closeKey.SetHelp("esc", "close")
+	d.keyMap.Close = closeKey
+
+	return d
+}
+
+// skillItems builds the list items from current skill catalog entries and states.
+func (d *Skills) skillItems() []list.FilterableItem {
+	entries, err := d.ws.ListSkills(nil)
+	if err != nil || len(entries) == 0 {
+		return nil
+	}
+
+	states := d.ws.GetSkillStates()
+	stateMap := make(map[string]*skills.SkillState, len(states))
+	for i := range states {
+		stateMap[states[i].Name] = states[i]
+	}
+
+	// Get the config's disabled skills list to check which skills are disabled.
+	disabledSet := make(map[string]bool)
+	if cfg := d.com.Config(); cfg != nil && cfg.Options != nil {
+		for _, name := range cfg.Options.DisabledSkills {
+			disabledSet[name] = true
+		}
+	}
+
+	// Also include disabled skills from all skills, not just active catalog.
+	// The catalog only returns active skills, so we also need to include
+	// disabled ones from the states list.
+	seenIDs := make(map[string]bool, len(entries))
+	items := make([]list.FilterableItem, 0, len(entries))
+	for _, entry := range entries {
+		seenIDs[entry.ID] = true
+		state := stateMap[entry.Name]
+		items = append(items, NewSkillItem(d.com.Styles, entry, state, disabledSet[entry.Name]))
+	}
+
+	// Add skills that are discovered but disabled (not in the active catalog).
+	for _, st := range states {
+		if seenIDs[st.Name] {
+			continue
+		}
+		entry := skills.CatalogEntry{
+			ID:          st.Name,
+			Name:        st.Name,
+			Description: "",
+			Source:      skills.SourceProject,
+		}
+		items = append(items, NewSkillItem(d.com.Styles, entry, st, true))
+	}
+
+	return items
+}
+
+// ID implements Dialog.
+func (d *Skills) ID() string { return SkillsID }
+
+// HandleMsg implements Dialog.
+func (d *Skills) HandleMsg(msg tea.Msg) Action {
+	switch msg := msg.(type) {
+	case tea.KeyPressMsg:
+		switch {
+		case key.Matches(msg, d.keyMap.Close):
+			return ActionClose{}
+		case key.Matches(msg, d.keyMap.Previous):
+			d.list.Focus()
+			if d.list.IsSelectedFirst() {
+				d.list.SelectLast()
+			} else {
+				d.list.SelectPrev()
+			}
+			d.list.ScrollToSelected()
+		case key.Matches(msg, d.keyMap.Next):
+			d.list.Focus()
+			if d.list.IsSelectedLast() {
+				d.list.SelectFirst()
+			} else {
+				d.list.SelectNext()
+			}
+			d.list.ScrollToSelected()
+		case key.Matches(msg, d.keyMap.Reload):
+			return ActionSkillsReload{}
+		case key.Matches(msg, d.keyMap.Toggle):
+			if item := d.selectedSkill(); item != nil {
+				return ActionSkillToggle{SkillName: item.entry.Name}
+			}
+		default:
+			var cmd tea.Cmd
+			d.input, cmd = d.input.Update(msg)
+			value := d.input.Value()
+			d.list.SetFilter(value)
+			d.list.ScrollToTop()
+			d.list.SetSelected(0)
+			return ActionCmd{cmd}
+		}
+	}
+	return nil
+}
+
+// selectedSkill returns the currently selected SkillItem, or nil.
+func (d *Skills) selectedSkill() *SkillItem {
+	item := d.list.SelectedItem()
+	if item == nil {
+		return nil
+	}
+	if si, ok := item.(*SkillItem); ok {
+		return si
+	}
+	return nil
+}
+
+// Cursor returns the cursor position relative to the dialog.
+func (d *Skills) Cursor() *tea.Cursor {
+	return InputCursor(d.com.Styles, d.input.Cursor())
+}
+
+// Draw implements Dialog.
+func (d *Skills) Draw(scr uv.Screen, area uv.Rectangle) *tea.Cursor {
+	t := d.com.Styles
+	width := max(0, min(defaultDialogMaxWidth, area.Dx()-t.Dialog.View.GetHorizontalBorderSize()))
+	height := max(0, min(defaultDialogHeight, area.Dy()-t.Dialog.View.GetVerticalBorderSize()))
+	innerWidth := width - t.Dialog.View.GetHorizontalFrameSize()
+	heightOffset := t.Dialog.Title.GetVerticalFrameSize() + titleContentHeight +
+		t.Dialog.InputPrompt.GetVerticalFrameSize() + inputContentHeight +
+		t.Dialog.HelpView.GetVerticalFrameSize() +
+		t.Dialog.View.GetVerticalFrameSize()
+
+	d.input.SetWidth(max(0, innerWidth-t.Dialog.InputPrompt.GetHorizontalFrameSize()-1))
+
+	listHeight := height - heightOffset
+	listWidth := max(0, innerWidth-3)
+	d.list.SetSize(listWidth, listHeight)
+	d.help.SetWidth(innerWidth)
+
+	rc := NewRenderContext(t, width)
+	rc.Title = "Skills"
+	inputView := t.Dialog.InputPrompt.Render(d.input.View())
+	rc.AddPart(inputView)
+	listView := t.Dialog.List.Height(d.list.Height()).Render(d.list.Render())
+	scrollbar := common.Scrollbar(t, listHeight, d.list.TotalHeight(), listHeight, d.list.Offset())
+	if scrollbar != "" {
+		listView = lipgloss.JoinHorizontal(lipgloss.Top, listView, scrollbar)
+	}
+	rc.AddPart(listView)
+	rc.Help = d.help.View(d)
+
+	view := rc.Render()
+	cur := d.Cursor()
+	DrawCenterCursor(scr, area, view, cur)
+	return cur
+}
+
+// ShortHelp implements help.KeyMap.
+func (d *Skills) ShortHelp() []key.Binding {
+	return []key.Binding{
+		d.keyMap.UpDown,
+		d.keyMap.Toggle,
+		d.keyMap.Reload,
+		d.keyMap.Close,
+	}
+}
+
+// FullHelp implements help.KeyMap.
+func (d *Skills) FullHelp() [][]key.Binding {
+	return [][]key.Binding{
+		{d.keyMap.Toggle, d.keyMap.Reload, d.keyMap.UpDown, d.keyMap.Close},
+	}
+}
+
+// Refresh reloads the skill items from the workspace. Call after a reload
+// or toggle action to update the list.
+func (d *Skills) Refresh() {
+	d.list.SetItems(d.skillItems()...)
+	d.list.SetFilter("")
+	d.list.ScrollToTop()
+	d.list.SetSelected(0)
+	d.input.SetValue("")
+}
+
+// skillCount returns a formatted string with skill statistics.
+func skillCount(items []list.FilterableItem) string {
+	active, errored, disabled := 0, 0, 0
+	for _, item := range items {
+		if si, ok := item.(*SkillItem); ok {
+			if si.disabled {
+				disabled++
+			} else if si.state != nil && si.state.State == skills.StateError {
+				errored++
+			} else {
+				active++
+			}
+		}
+	}
+	return fmt.Sprintf("%d active · %d disabled · %d errors", active, disabled, errored)
+}

--- a/internal/ui/dialog/skills.go
+++ b/internal/ui/dialog/skills.go
@@ -1,7 +1,7 @@
 package dialog
 
 import (
-	"fmt"
+	"context"
 	"strings"
 
 	"charm.land/bubbles/v2/help"
@@ -181,7 +181,7 @@ func NewSkills(com *common.Common, ws workspace.Workspace) *Skills {
 
 // skillItems builds the list items from current skill catalog entries and states.
 func (d *Skills) skillItems() []list.FilterableItem {
-	entries, err := d.ws.ListSkills(nil)
+	entries, err := d.ws.ListSkills(context.Background())
 	if err != nil || len(entries) == 0 {
 		return nil
 	}
@@ -203,17 +203,21 @@ func (d *Skills) skillItems() []list.FilterableItem {
 	// Also include disabled skills from all skills, not just active catalog.
 	// The catalog only returns active skills, so we also need to include
 	// disabled ones from the states list.
-	seenIDs := make(map[string]bool, len(entries))
+	// Track which skills are already listed by NAME. CatalogEntry.ID is the
+	// skill's file path, not its name, whereas SkillState.Name is the name —
+	// so the disabled-skill dedup below must key on name, or every active
+	// skill would be re-appended as "off".
+	seenNames := make(map[string]bool, len(entries))
 	items := make([]list.FilterableItem, 0, len(entries))
 	for _, entry := range entries {
-		seenIDs[entry.ID] = true
+		seenNames[entry.Name] = true
 		state := stateMap[entry.Name]
 		items = append(items, NewSkillItem(d.com.Styles, entry, state, disabledSet[entry.Name]))
 	}
 
 	// Add skills that are discovered but disabled (not in the active catalog).
 	for _, st := range states {
-		if seenIDs[st.Name] {
+		if seenNames[st.Name] {
 			continue
 		}
 		entry := skills.CatalogEntry{
@@ -351,21 +355,4 @@ func (d *Skills) Refresh() {
 	d.list.ScrollToTop()
 	d.list.SetSelected(0)
 	d.input.SetValue("")
-}
-
-// skillCount returns a formatted string with skill statistics.
-func skillCount(items []list.FilterableItem) string {
-	active, errored, disabled := 0, 0, 0
-	for _, item := range items {
-		if si, ok := item.(*SkillItem); ok {
-			if si.disabled {
-				disabled++
-			} else if si.state != nil && si.state.State == skills.StateError {
-				errored++
-			} else {
-				active++
-			}
-		}
-	}
-	return fmt.Sprintf("%d active · %d disabled · %d errors", active, disabled, errored)
 }

--- a/internal/ui/dialog/skills_test.go
+++ b/internal/ui/dialog/skills_test.go
@@ -1,0 +1,226 @@
+package dialog
+
+import (
+	"context"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/crush/internal/config"
+	"github.com/charmbracelet/crush/internal/skills"
+	"github.com/charmbracelet/crush/internal/ui/common"
+	"github.com/charmbracelet/crush/internal/ui/styles"
+	"github.com/charmbracelet/crush/internal/workspace"
+	"github.com/stretchr/testify/require"
+)
+
+type stubSkillsWorkspace struct {
+	workspace.Workspace
+	entries []skills.CatalogEntry
+	states  []*skills.SkillState
+	cfg     *config.Config
+}
+
+func (w *stubSkillsWorkspace) ListSkills(_ context.Context) ([]skills.CatalogEntry, error) {
+	return w.entries, nil
+}
+
+func (w *stubSkillsWorkspace) GetSkillStates() []*skills.SkillState {
+	return w.states
+}
+
+func (w *stubSkillsWorkspace) Config() *config.Config {
+	return w.cfg
+}
+
+func newTestSkillsDialog(t *testing.T, entries []skills.CatalogEntry, states []*skills.SkillState, disabled []string) *Skills {
+	t.Helper()
+	s := styles.CharmtonePantera()
+	cfg := &config.Config{
+		Options: &config.Options{
+			DisabledSkills: disabled,
+		},
+	}
+	com := &common.Common{
+		Workspace: &stubSkillsWorkspace{entries: entries, states: states, cfg: cfg},
+		Styles:    &s,
+	}
+	return NewSkills(com, com.Workspace)
+}
+
+func TestSkillsDialog_EscCloses(t *testing.T) {
+	t.Parallel()
+
+	d := newTestSkillsDialog(t,
+		[]skills.CatalogEntry{{ID: "a", Name: "Alpha", Source: skills.SourceSystem}},
+		nil,
+		nil,
+	)
+
+	action := d.HandleMsg(tea.KeyPressMsg{Code: tea.KeyEscape})
+	_, ok := action.(ActionClose)
+	require.True(t, ok, "Esc should close the dialog")
+}
+
+func TestSkillsDialog_ReloadAction(t *testing.T) {
+	t.Parallel()
+
+	d := newTestSkillsDialog(t,
+		[]skills.CatalogEntry{{ID: "a", Name: "Alpha", Source: skills.SourceSystem}},
+		nil,
+		nil,
+	)
+
+	action := d.HandleMsg(tea.KeyPressMsg{Code: 'r', Mod: tea.ModCtrl})
+	_, ok := action.(ActionSkillsReload)
+	require.True(t, ok, "Ctrl+R should fire ActionSkillsReload")
+}
+
+func TestSkillsDialog_ToggleAction(t *testing.T) {
+	t.Parallel()
+
+	d := newTestSkillsDialog(t,
+		[]skills.CatalogEntry{{ID: "alpha", Name: "Alpha", Source: skills.SourceSystem}},
+		nil,
+		nil,
+	)
+
+	action := d.HandleMsg(tea.KeyPressMsg{Code: tea.KeyEnter})
+	toggle, ok := action.(ActionSkillToggle)
+	require.True(t, ok, "Enter should fire ActionSkillToggle")
+	require.Equal(t, "Alpha", toggle.SkillName)
+}
+
+func TestSkillsDialog_NavigationWraps(t *testing.T) {
+	t.Parallel()
+
+	d := newTestSkillsDialog(t,
+		[]skills.CatalogEntry{
+			{ID: "a", Name: "Alpha", Source: skills.SourceSystem},
+			{ID: "b", Name: "Beta", Source: skills.SourceUser},
+		},
+		nil,
+		nil,
+	)
+
+	first := d.selectedSkill()
+	require.NotNil(t, first)
+
+	d.HandleMsg(tea.KeyPressMsg{Code: tea.KeyDown})
+	second := d.selectedSkill()
+	require.NotNil(t, second)
+	require.NotEqual(t, first.entry.Name, second.entry.Name)
+
+	d.HandleMsg(tea.KeyPressMsg{Code: tea.KeyDown})
+	wrapped := d.selectedSkill()
+	require.NotNil(t, wrapped)
+	require.Equal(t, first.entry.Name, wrapped.entry.Name)
+
+	d.HandleMsg(tea.KeyPressMsg{Code: tea.KeyUp})
+	upWrapped := d.selectedSkill()
+	require.NotNil(t, upWrapped)
+	require.Equal(t, second.entry.Name, upWrapped.entry.Name)
+}
+
+func TestSkillsDialog_FilterNarrowsList(t *testing.T) {
+	t.Parallel()
+
+	d := newTestSkillsDialog(t,
+		[]skills.CatalogEntry{
+			{ID: "alpha", Name: "Alpha", Source: skills.SourceSystem},
+			{ID: "beta", Name: "Beta", Source: skills.SourceUser},
+		},
+		nil,
+		nil,
+	)
+
+	d.HandleMsg(keyMsg('a'))
+	d.HandleMsg(keyMsg('l'))
+
+	filtered := d.list.FilteredItems()
+	require.Len(t, filtered, 1)
+	item := filtered[0].(*SkillItem)
+	require.Equal(t, "Alpha", item.entry.Name)
+}
+
+func TestSkillsDialog_EmptyNoPanic(t *testing.T) {
+	t.Parallel()
+
+	d := newTestSkillsDialog(t, nil, nil, nil)
+
+	action := d.HandleMsg(tea.KeyPressMsg{Code: tea.KeyEnter})
+	require.Nil(t, action, "no action when no skill selected")
+}
+
+func TestSkillItem_RenderDoesNotPanic(t *testing.T) {
+	t.Parallel()
+
+	s := styles.CharmtonePantera()
+	entry := skills.CatalogEntry{
+		ID:          "test",
+		Name:        "Test Skill",
+		Description: "A test skill",
+		Source:      skills.SourceSystem,
+	}
+	state := &skills.SkillState{Name: "Test Skill", State: skills.StateNormal}
+	item := NewSkillItem(&s, entry, state, false)
+
+	rendered := item.Render(60)
+	require.NotEmpty(t, rendered)
+}
+
+func TestSkillItem_FilterMatchesNameAndDescription(t *testing.T) {
+	t.Parallel()
+
+	s := styles.CharmtonePantera()
+	entry := skills.CatalogEntry{
+		ID:          "jq",
+		Name:        "jq",
+		Description: "Process JSON data",
+		Source:      skills.SourceSystem,
+	}
+	item := NewSkillItem(&s, entry, nil, false)
+	require.Contains(t, item.Filter(), "jq")
+	require.Contains(t, item.Filter(), "JSON")
+}
+
+func TestSkillItem_DisabledRendering(t *testing.T) {
+	t.Parallel()
+
+	s := styles.CharmtonePantera()
+	entry := skills.CatalogEntry{
+		ID:     "disabled-skill",
+		Name:   "Disabled",
+		Source: skills.SourceUser,
+	}
+	item := NewSkillItem(&s, entry, nil, true)
+	rendered := item.Render(60)
+	require.NotEmpty(t, rendered)
+}
+
+func TestSkillsDialog_ShowsDisabledSkillsFromStates(t *testing.T) {
+	t.Parallel()
+
+	// Catalog returns only active skills. A disabled skill should still
+	// appear via the states list.
+	d := newTestSkillsDialog(t,
+		[]skills.CatalogEntry{{ID: "active", Name: "Active", Source: skills.SourceSystem}},
+		[]*skills.SkillState{
+			{Name: "Active", State: skills.StateNormal},
+			{Name: "DisabledOne", State: skills.StateNormal},
+		},
+		[]string{"DisabledOne"},
+	)
+
+	items := d.list.FilteredItems()
+	// Should have both the active skill and the disabled one from states.
+	require.GreaterOrEqual(t, len(items), 2)
+
+	names := make(map[string]bool, len(items))
+	for _, item := range items {
+		if si, ok := item.(*SkillItem); ok {
+			names[si.entry.Name] = true
+		}
+	}
+	require.True(t, names["Active"])
+	require.True(t, names["DisabledOne"])
+}

--- a/internal/ui/dialog/skills_test.go
+++ b/internal/ui/dialog/skills_test.go
@@ -50,7 +50,8 @@ func newTestSkillsDialog(t *testing.T, entries []skills.CatalogEntry, states []*
 func TestSkillsDialog_EscCloses(t *testing.T) {
 	t.Parallel()
 
-	d := newTestSkillsDialog(t,
+	d := newTestSkillsDialog(
+		t,
 		[]skills.CatalogEntry{{ID: "a", Name: "Alpha", Source: skills.SourceSystem}},
 		nil,
 		nil,
@@ -64,7 +65,8 @@ func TestSkillsDialog_EscCloses(t *testing.T) {
 func TestSkillsDialog_ReloadAction(t *testing.T) {
 	t.Parallel()
 
-	d := newTestSkillsDialog(t,
+	d := newTestSkillsDialog(
+		t,
 		[]skills.CatalogEntry{{ID: "a", Name: "Alpha", Source: skills.SourceSystem}},
 		nil,
 		nil,
@@ -78,7 +80,8 @@ func TestSkillsDialog_ReloadAction(t *testing.T) {
 func TestSkillsDialog_ToggleAction(t *testing.T) {
 	t.Parallel()
 
-	d := newTestSkillsDialog(t,
+	d := newTestSkillsDialog(
+		t,
 		[]skills.CatalogEntry{{ID: "alpha", Name: "Alpha", Source: skills.SourceSystem}},
 		nil,
 		nil,
@@ -93,7 +96,8 @@ func TestSkillsDialog_ToggleAction(t *testing.T) {
 func TestSkillsDialog_NavigationWraps(t *testing.T) {
 	t.Parallel()
 
-	d := newTestSkillsDialog(t,
+	d := newTestSkillsDialog(
+		t,
 		[]skills.CatalogEntry{
 			{ID: "a", Name: "Alpha", Source: skills.SourceSystem},
 			{ID: "b", Name: "Beta", Source: skills.SourceUser},
@@ -124,7 +128,8 @@ func TestSkillsDialog_NavigationWraps(t *testing.T) {
 func TestSkillsDialog_FilterNarrowsList(t *testing.T) {
 	t.Parallel()
 
-	d := newTestSkillsDialog(t,
+	d := newTestSkillsDialog(
+		t,
 		[]skills.CatalogEntry{
 			{ID: "alpha", Name: "Alpha", Source: skills.SourceSystem},
 			{ID: "beta", Name: "Beta", Source: skills.SourceUser},
@@ -202,7 +207,8 @@ func TestSkillsDialog_ShowsDisabledSkillsFromStates(t *testing.T) {
 
 	// Catalog returns only active skills. A disabled skill should still
 	// appear via the states list.
-	d := newTestSkillsDialog(t,
+	d := newTestSkillsDialog(
+		t,
 		[]skills.CatalogEntry{{ID: "active", Name: "Active", Source: skills.SourceSystem}},
 		[]*skills.SkillState{
 			{Name: "Active", State: skills.StateNormal},
@@ -223,4 +229,29 @@ func TestSkillsDialog_ShowsDisabledSkillsFromStates(t *testing.T) {
 	}
 	require.True(t, names["Active"])
 	require.True(t, names["DisabledOne"])
+}
+
+func TestSkillsDialog_ActiveSkillNotDuplicatedByState(t *testing.T) {
+	t.Parallel()
+
+	// In production CatalogEntry.ID is the skill's file path (not its name),
+	// while SkillState.Name is the name, and the states list includes active
+	// skills. The dedup must key on name, or an active skill present in both
+	// the catalog and the states list gets listed twice (once "on", once
+	// "off").
+	d := newTestSkillsDialog(
+		t,
+		[]skills.CatalogEntry{
+			{ID: "/skills/alpha/SKILL.md", Name: "Alpha", Source: skills.SourceUser},
+		},
+		[]*skills.SkillState{
+			{Name: "Alpha", State: skills.StateNormal},
+		},
+		nil,
+	)
+
+	items := d.list.FilteredItems()
+	require.Len(t, items, 1, "an active skill must not be duplicated by its states entry")
+	require.Equal(t, "Alpha", items[0].(*SkillItem).entry.Name)
+	require.False(t, items[0].(*SkillItem).disabled, "the single entry should be the active one")
 }

--- a/internal/ui/dialog/skills_test.go
+++ b/internal/ui/dialog/skills_test.go
@@ -2,6 +2,7 @@ package dialog
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
@@ -18,10 +19,11 @@ type stubSkillsWorkspace struct {
 	entries []skills.CatalogEntry
 	states  []*skills.SkillState
 	cfg     *config.Config
+	listErr error
 }
 
 func (w *stubSkillsWorkspace) ListSkills(_ context.Context) ([]skills.CatalogEntry, error) {
-	return w.entries, nil
+	return w.entries, w.listErr
 }
 
 func (w *stubSkillsWorkspace) GetSkillStates() []*skills.SkillState {
@@ -229,6 +231,31 @@ func TestSkillsDialog_ShowsDisabledSkillsFromStates(t *testing.T) {
 	}
 	require.True(t, names["Active"])
 	require.True(t, names["DisabledOne"])
+}
+
+func TestSkillsDialog_ListSkillsErrorRendersEmpty(t *testing.T) {
+	t.Parallel()
+
+	// When ListSkills fails, the dialog should render empty rather than
+	// panicking or showing stale data, and key actions must be safe no-ops.
+	s := styles.CharmtonePantera()
+	com := &common.Common{
+		Workspace: &stubSkillsWorkspace{
+			listErr: errors.New("boom"),
+			cfg:     &config.Config{Options: &config.Options{}},
+		},
+		Styles: &s,
+	}
+	d := NewSkills(com, com.Workspace)
+
+	require.Empty(t, d.list.FilteredItems(), "no items when ListSkills errors")
+	require.Nil(t, d.selectedSkill(), "no selection when the list is empty")
+
+	// Enter (toggle) and Ctrl+R (reload) must not panic with no selection.
+	require.Nil(t, d.HandleMsg(tea.KeyPressMsg{Code: tea.KeyEnter}), "toggle is a no-op with no selection")
+	reload := d.HandleMsg(tea.KeyPressMsg{Code: 'r', Mod: tea.ModCtrl})
+	_, ok := reload.(ActionSkillsReload)
+	require.True(t, ok, "reload should still fire even when the list is empty")
 }
 
 func TestSkillsDialog_ActiveSkillNotDuplicatedByState(t *testing.T) {

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -1698,6 +1698,17 @@ func (m *UI) handleDialogMsg(msg tea.Msg) tea.Cmd {
 		}
 		cmds = append(cmds, m.initializeProject())
 		m.dialog.CloseDialog(dialog.CommandsID)
+	case dialog.ActionSkillsReload:
+		cmds = append(cmds, func() tea.Msg {
+			if err := m.com.Workspace.ReloadSkills(); err != nil {
+				return util.ReportError(err)()
+			}
+			return util.NewInfoMsg("Skills reloaded")
+		})
+		m.dialog.CloseDialog(dialog.SkillsID)
+	case dialog.ActionSkillToggle:
+		cmds = append(cmds, m.toggleSkill(msg.SkillName))
+		m.dialog.CloseDialog(dialog.SkillsID)
 
 	case dialog.ActionSelectModel:
 		if cmd := m.handleSelectModel(msg); cmd != nil {
@@ -3882,6 +3893,8 @@ func (m *UI) openDialog(id string) tea.Cmd {
 		if cmd := m.openQuitDialog(); cmd != nil {
 			cmds = append(cmds, cmd)
 		}
+	case dialog.SkillsID:
+		m.openSkillsDialog()
 	default:
 		// Unknown dialog
 		break
@@ -3983,6 +3996,16 @@ func (m *UI) openMCPServersDialog() {
 	}
 	mcpDialog := dialog.NewMCPServers(m.com, m.com.Workspace)
 	m.dialog.OpenDialog(mcpDialog)
+}
+
+// openSkillsDialog opens the skills management dialog.
+func (m *UI) openSkillsDialog() {
+	if m.dialog.ContainsDialog(dialog.SkillsID) {
+		m.dialog.BringToFront(dialog.SkillsID)
+		return
+	}
+	skillsDialog := dialog.NewSkills(m.com, m.com.Workspace)
+	m.dialog.OpenDialog(skillsDialog)
 }
 
 // openSessionsDialog opens the sessions dialog. If the dialog is already open,
@@ -4500,6 +4523,45 @@ func (m *UI) disableDockerMCP() tea.Msg {
 	}
 
 	return util.NewInfoMsg("Docker MCP disabled successfully")
+}
+
+// toggleSkill enables or disables a skill by name, persisting the change
+// to config and reloading skills so the change takes effect immediately.
+func (m *UI) toggleSkill(skillName string) tea.Cmd {
+	return func() tea.Msg {
+		cfg := m.com.Config()
+		if cfg == nil || cfg.Options == nil {
+			return util.NewErrorMsg(fmt.Errorf("no config available"))
+		}
+
+		disabled := cfg.Options.DisabledSkills
+		found := false
+		var newList []string
+		for _, name := range disabled {
+			if name == skillName {
+				found = true
+				continue
+			}
+			newList = append(newList, name)
+		}
+
+		action := "enabled"
+		if !found {
+			newList = append(newList, skillName)
+			action = "disabled"
+		}
+
+		if err := m.com.Workspace.SetConfigField(config.ScopeGlobal, "options.disabled_skills", newList); err != nil {
+			return util.ReportError(err)()
+		}
+
+		// Reload skills so the change takes effect immediately.
+		if err := m.com.Workspace.ReloadSkills(); err != nil {
+			return util.ReportError(err)()
+		}
+
+		return util.NewInfoMsg(fmt.Sprintf("Skill %q %s", skillName, action))
+	}
 }
 
 // renderLogo renders the Crush logo with the given styles and dimensions.

--- a/internal/workspace/app_workspace.go
+++ b/internal/workspace/app_workspace.go
@@ -389,6 +389,31 @@ func (w *AppWorkspace) ReadSkill(_ context.Context, skillID string) ([]byte, ski
 	return skills.ReadContent(mgr.ActiveSkills(), mgr.ResolvedPaths(), mgr.WorkingDir(), skillID)
 }
 
+func (w *AppWorkspace) ReloadSkills() error {
+	mgr := w.app.Skills
+	if mgr == nil {
+		return nil
+	}
+	discoveryCfg := skills.DiscoveryConfig{
+		WorkingDir: w.store.WorkingDir(),
+		Resolver:   w.store.Resolver().ResolveValue,
+	}
+	opts := w.store.Config().Options
+	if opts != nil {
+		discoveryCfg.SkillsPaths = opts.SkillsPaths
+		discoveryCfg.DisabledSkills = opts.DisabledSkills
+	}
+	mgr.Reload(discoveryCfg)
+	return nil
+}
+
+func (w *AppWorkspace) GetSkillStates() []*skills.SkillState {
+	if w.app.Skills == nil {
+		return nil
+	}
+	return w.app.Skills.States()
+}
+
 // -- MCP operations --
 
 func (w *AppWorkspace) MCPGetStates() map[string]mcptools.ClientInfo {

--- a/internal/workspace/client_workspace.go
+++ b/internal/workspace/client_workspace.go
@@ -561,6 +561,17 @@ func (w *ClientWorkspace) ReadSkill(ctx context.Context, skillID string) ([]byte
 	}, nil
 }
 
+func (w *ClientWorkspace) ReloadSkills() error {
+	return w.client.ReloadSkills(context.Background(), w.workspaceID())
+}
+
+func (w *ClientWorkspace) GetSkillStates() []*skills.SkillState {
+	if w.skills == nil {
+		return nil
+	}
+	return w.skills.States()
+}
+
 // -- MCP operations --
 
 func (w *ClientWorkspace) MCPGetStates() map[string]mcp.ClientInfo {

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -157,6 +157,11 @@ type Workspace interface {
 	InitializePrompt() (string, error)
 	ListSkills(ctx context.Context) ([]skills.CatalogEntry, error)
 	ReadSkill(ctx context.Context, skillID string) ([]byte, skills.SkillReadResult, error)
+	// ReloadSkills re-discovers skills from disk and publishes updated
+	// states to all subscribers (sidebar, commands dialog, etc.).
+	ReloadSkills() error
+	// GetSkillStates returns the current per-skill discovery states.
+	GetSkillStates() []*skills.SkillState
 
 	// MCP operations (server-side in client mode)
 	MCPGetStates() map[string]mcptools.ClientInfo


### PR DESCRIPTION
## Summary
Adds a "Skills" dialog to the commands palette that lists all discovered skills with their source, state (on/off/error), and user-invocable flag. Per-skill actions include **toggle** (enable/disable — persisted to config and immediately reloaded) and **reload all** (re-discovers skills from disk and publishes updated states via pubsub so the sidebar and commands dialog auto-update).

## Changes

### Skills Manager (`internal/skills/manager.go`)
- Added `Manager.Reload(cfg DiscoveryConfig)` — re-runs `DiscoverFromConfig`, replaces internal skill lists/states, and publishes new states to subscribers.

### New dialog (`internal/ui/dialog/skills.go`)
- `Skills` dialog listing all skills with source, on/off/error state, and user-invocable flag
- `SkillItem` implements `ListItem` with two-column rendering (name + metadata)
- Key bindings: Enter (toggle), Ctrl+R (reload all), Esc (close)
- Shows disabled skills from the states list (not just active catalog entries)
- `Refresh()` method to rebuild the list after reload/toggle

### New action types (`internal/ui/dialog/actions.go`)
- `ActionSkillsReload{}` — trigger full re-discovery
- `ActionSkillToggle{SkillName}` — toggle a skill's enabled state

### Wiring through all layers
- **Workspace interface**: added `ReloadSkills() error` and `GetSkillStates() []*skills.SkillState`
- **AppWorkspace**: calls `Manager.Reload` with discovery config from the config store
- **ClientWorkspace**: calls client API (`Client.ReloadSkills`)
- **Backend**: `Backend.ReloadSkills` runs `Manager.Reload` on the workspace's manager
- **Server**: new `POST /v1/workspaces/{id}/skills/reload` endpoint
- **Client API**: `Client.ReloadSkills(ctx, id)`
- **UI model**: handles reload (calls `ReloadSkills`, shows info message) and toggle (persists to `options.disabled_skills`, reloads skills, shows info message)
- **Commands dialog**: new "Skills" item opens the dialog

### Tests (`internal/ui/dialog/skills_test.go`)
10 tests covering: Esc closes, reload action, toggle action, navigation wrapping, filter narrowing, empty state (no panic), item rendering, filter matching, disabled rendering, and disabled skills visibility from states list.

Closes #16

💘 Generated with Crush