### PR TITLE
fix(ui): allow backspace in the top-level commands filter

### DIFF
--- a/internal/ui/dialog/commands.go
+++ b/internal/ui/dialog/commands.go
@@ -190,11 +190,13 @@ func (c *Commands) HandleMsg(msg tea.Msg) Action {
 				return nil
 			}
 			return ActionClose{}
-		case key.Matches(msg, c.keyMap.Back):
-			if c.inSubMenu() {
-				c.popMenu()
-				return nil
-			}
+		case key.Matches(msg, c.keyMap.Back) && c.inSubMenu():
+			// Backspace pops out of a sub-menu, but only while in one. At the
+			// top level it must fall through to the input so it can edit the
+			// type-ahead filter (otherwise the case swallows it and backspace
+			// does nothing).
+			c.popMenu()
+			return nil
 		case key.Matches(msg, c.keyMap.Previous):
 			c.list.Focus()
 			if c.list.IsSelectedFirst() {

--- a/internal/ui/dialog/commands_test.go
+++ b/internal/ui/dialog/commands_test.go
@@ -216,6 +216,26 @@ func TestCommands_PopRestoresFullParentList(t *testing.T) {
 	require.Len(t, c.list.FilteredItems(), 2, "popping should restore the full parent list")
 }
 
+func TestCommands_BackspaceEditsTopLevelFilter(t *testing.T) {
+	t.Parallel()
+
+	c := newTestCommands(t)
+
+	// Type into the top-level type-ahead filter.
+	c.HandleMsg(keyMsg('m'))
+	c.HandleMsg(keyMsg('c'))
+	c.HandleMsg(keyMsg('p'))
+	require.Equal(t, "mcp", c.input.Value())
+	require.False(t, c.inSubMenu())
+
+	// Backspace at the top level must edit the filter, not be swallowed by the
+	// Back (pop-sub-menu) key binding. Regression guard for the case matching
+	// backspace unconditionally.
+	c.HandleMsg(tea.KeyPressMsg{Code: tea.KeyBackspace})
+	require.False(t, c.inSubMenu())
+	require.Equal(t, "mc", c.input.Value(), "backspace should delete a char from the top-level filter")
+}
+
 func setupMenuHierarchy(t *testing.T) *Commands {
 	t.Helper()
 	c := newTestCommands(t)


### PR DESCRIPTION
## Summary
Fixes a regression from #60: **you can't backspace in the top-level commands type-ahead filter** (e.g. after typing `mcp`). Backspace works fine inside a sub-menu (it pops back), which is the tell.

## Root cause
The `Back` key binding (`backspace` / `alt+left`) was matched unconditionally in `Commands.HandleMsg`:

```go
case key.Matches(msg, c.keyMap.Back):
    if c.inSubMenu() {
        c.popMenu()
        return nil
    }
```

At the top level `c.inSubMenu()` is false, so the body is a no-op — and since a Go `switch` doesn't fall through, backspace never reaches the `default` case where `c.input.Update(msg)` edits the filter. The keypress is silently swallowed.

## Fix
Guard the case so `Back` only matches while in a sub-menu:

```go
case key.Matches(msg, c.keyMap.Back) && c.inSubMenu():
    c.popMenu()
    return nil
```

Top-level backspace now falls through to the input and edits the filter; sub-menu backspace still pops.

## Tests
Adds `TestCommands_BackspaceEditsTopLevelFilter` (type `mcp`, backspace, assert the filter becomes `mc`). It **fails on the pre-fix code** (filter stuck at `mcp`) and passes now. The existing "backspace in sub-menu pops back" test still passes, confirming no regression to sub-menu navigation.

Verified locally on the `go1.26.4` toolchain: `gofumpt` clean, `go build ./...`, full `internal/ui/dialog` package green.
