### PR TITLE
fix: replace sidebar focus border with scrollbar, add mouse scrolling

### DIFF
--- a/internal/ui/model/sidebar.go
+++ b/internal/ui/model/sidebar.go
@@ -217,9 +217,10 @@ func (m *UI) drawSidebar(scr uv.Screen, area uv.Rectangle) {
 		skillsSection,
 	)
 
-	// Apply scroll offset when focused. Clamp against real content height.
+	// Apply scroll offset. Clamp against real content height.
 	contentLines := strings.Split(fullContent, "\n")
-	maxScroll := max(0, len(contentLines)-height)
+	contentHeight := len(contentLines)
+	maxScroll := max(0, contentHeight-height)
 	m.sidebarScroll = min(m.sidebarScroll, maxScroll)
 	scroll := min(m.sidebarScroll, maxScroll)
 	if scroll > 0 && scroll < len(contentLines) {
@@ -227,13 +228,22 @@ func (m *UI) drawSidebar(scr uv.Screen, area uv.Rectangle) {
 	}
 	scrolledContent := strings.Join(contentLines, "\n")
 
-	renderStyle := lipgloss.NewStyle().
-		MaxWidth(width).
-		MaxHeight(height)
-	if focused {
-		renderStyle = renderStyle.BorderLeft(true).BorderStyle(lipgloss.ThickBorder())
+	// Reserve 1 column for scrollbar when focused (same pattern as chat panel).
+	contentWidth := width
+	var scrollbar string
+	if focused && contentHeight > height {
+		contentWidth = width - 1
+		scrollbar = common.Scrollbar(t, height, contentHeight, height, scroll)
 	}
-	uv.NewStyledString(
-		renderStyle.Render(scrolledContent),
-	).Draw(scr, area)
+
+	contentStyle := lipgloss.NewStyle().
+		MaxWidth(contentWidth).
+		MaxHeight(height)
+	rendered := contentStyle.Render(scrolledContent)
+
+	if scrollbar != "" {
+		rendered = lipgloss.JoinHorizontal(lipgloss.Top, rendered, scrollbar)
+	}
+
+	uv.NewStyledString(rendered).Draw(scr, area)
 }

--- a/internal/ui/model/sidebar.go
+++ b/internal/ui/model/sidebar.go
@@ -127,6 +127,21 @@ func getDynamicHeightLimits(availableHeight, fileCount, lspCount, mcpCount, skil
 	return maxFiles, maxLSPs, maxMCPs, maxSkills
 }
 
+// scrollSidebarOnWheel scrolls the sidebar when a wheel event lands over it,
+// returning true if it handled the event. DeltaY>0 is a scroll-down (matching
+// list.ScrollBy and the chat wheel handler), and a higher sidebarScroll shows
+// lower content, so the delta is added — keeping the wheel consistent with the
+// chat panel and the Down key. The upper bound is clamped at draw time.
+func (m *UI) scrollSidebarOnWheel(msg common.CoalescedWheelMsg) bool {
+	if msg.Mouse.X < m.layout.sidebar.Min.X || msg.Mouse.X >= m.layout.sidebar.Max.X {
+		return false
+	}
+	if lines := int(msg.DeltaY); lines != 0 {
+		m.sidebarScroll = max(0, m.sidebarScroll+lines)
+	}
+	return true
+}
+
 // sidebar renders the chat sidebar containing session title, working
 // directory, model info, file list, LSP status, and MCP status.
 func (m *UI) drawSidebar(scr uv.Screen, area uv.Rectangle) {

--- a/internal/ui/model/sidebar_focus_test.go
+++ b/internal/ui/model/sidebar_focus_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/charmbracelet/crush/internal/ui/common"
 	"github.com/charmbracelet/crush/internal/ui/dialog"
 	"github.com/charmbracelet/crush/internal/ui/styles"
+	uv "github.com/charmbracelet/ultraviolet"
 	"github.com/stretchr/testify/require"
 )
 
@@ -58,6 +59,29 @@ func TestSidebarScrollIncrements(t *testing.T) {
 
 	m.handleKeyPressMsg(tea.KeyPressMsg{Code: tea.KeyDown})
 	require.Greater(t, m.sidebarScroll, 0, "scroll should increment on down")
+}
+
+// TestSidebarMouseWheelScrollsInChatDirection verifies the mouse wheel over
+// the sidebar scrolls in the same direction as the chat panel and the Down
+// key: wheel-down (DeltaY>0) increases the scroll offset (shows lower content).
+func TestSidebarMouseWheelScrollsInChatDirection(t *testing.T) {
+	t.Parallel()
+	m := newSidebarTestUI()
+	m.layout.sidebar = uv.Rect(0, 0, 40, 50) // sidebar spans x in [0,40)
+	m.sidebarScroll = 5
+
+	// Wheel down over the sidebar → scroll down (offset increases).
+	handled := m.scrollSidebarOnWheel(common.CoalescedWheelMsg{Mouse: tea.Mouse{X: 10}, DeltaY: 3})
+	require.True(t, handled, "wheel over the sidebar should be handled by the sidebar")
+	require.Equal(t, 8, m.sidebarScroll, "wheel down should scroll the sidebar down")
+
+	// Wheel up over the sidebar → scroll up (offset decreases).
+	m.scrollSidebarOnWheel(common.CoalescedWheelMsg{Mouse: tea.Mouse{X: 10}, DeltaY: -2})
+	require.Equal(t, 6, m.sidebarScroll, "wheel up should scroll the sidebar up")
+
+	// Wheel outside the sidebar's x-range is not handled here.
+	handled = m.scrollSidebarOnWheel(common.CoalescedWheelMsg{Mouse: tea.Mouse{X: 100}, DeltaY: 3})
+	require.False(t, handled, "wheel outside the sidebar should not be handled by it")
 }
 
 // TestSidebarFocusEnumExists documents the three-state non-compact cycle.

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -935,6 +935,14 @@ func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// others send DeltaY=1.
 		switch m.state {
 		case uiChat:
+			// Route wheel events to the sidebar if the cursor is over it.
+			if msg.Mouse.X >= m.layout.sidebar.Min.X && msg.Mouse.X < m.layout.sidebar.Max.X {
+				lines := int(msg.DeltaY)
+				if lines != 0 {
+					m.sidebarScroll = max(0, m.sidebarScroll-lines)
+				}
+				break
+			}
 			if msg.DeltaX != 0 {
 				m.chat.ScrollSelectedShellHorizontal(int(msg.DeltaX))
 			}

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -936,11 +936,7 @@ func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		switch m.state {
 		case uiChat:
 			// Route wheel events to the sidebar if the cursor is over it.
-			if msg.Mouse.X >= m.layout.sidebar.Min.X && msg.Mouse.X < m.layout.sidebar.Max.X {
-				lines := int(msg.DeltaY)
-				if lines != 0 {
-					m.sidebarScroll = max(0, m.sidebarScroll-lines)
-				}
+			if m.scrollSidebarOnWheel(msg) {
 				break
 			}
 			if msg.DeltaX != 0 {


### PR DESCRIPTION
## Changes

1. **Focus indicator**: Replaced the thick white `ThickBorder` with a subtle scrollbar (same `common.Scrollbar` component used by the chat panel). Only renders when the sidebar is focused AND content overflows the viewport. No layout shift on focus transitions.

2. **Mouse wheel scrolling**: `CoalescedWheelMsg` events are now routed to the sidebar when the cursor X position falls within the sidebar layout rectangle. Scrolling adjusts `sidebarScroll` proportionally to wheel delta.

3. **Mouse click focus**: Already working from PR #35 — clicking the sidebar calls `focusSidebar()`. No changes needed.

## Validation

- `go build ./...`
- `go test ./internal/ui/model/...`
- `go vet ./internal/ui/model/...`
- `gofumpt -w`