### PR TITLE
docs(skills): add anti-patterns section to A2UI skill

### DIFF
--- a/internal/skills/builtin/a2ui/SKILL.md
+++ b/internal/skills/builtin/a2ui/SKILL.md
@@ -94,3 +94,93 @@ These components will render their current values, but currently do not allow th
 2. **One surface per block:** Provide all components inside the `components` array of a single `updateComponents` message.
 3. **Link correctly:** Ensure every ID in `child` or `children` corresponds to a component in your array. Dangling IDs will break the render.
 4. **Mix with Markdown:** You can put markdown text before and after the `<a2ui-json>` block.
+
+## Common Mistakes (Anti-Patterns)
+
+These are errors that models frequently make. Read carefully.
+
+### Buttons do NOT have a `text` or `label` field
+
+The A2UI spec has **no** `text`, `label`, or `name` field on `Button`. The label comes exclusively from a `child` Text component.
+
+**Wrong — the label will be empty:**
+```json
+{
+  "component": "Button",
+  "id": "btn",
+  "text": "Submit"
+}
+```
+The `"text"` key is silently ignored and the button renders with no visible label.
+
+**Wrong — `label` is not a real field either:**
+```json
+{
+  "component": "Button",
+  "id": "btn",
+  "label": "Submit"
+}
+```
+
+**Correct — use a child Text component:**
+```json
+{
+  "component": "Button",
+  "id": "btn",
+  "child": "btn-label"
+},
+{
+  "component": "Text",
+  "id": "btn-label",
+  "text": "Submit"
+}
+```
+
+### Every `child` / `children` ID must exist in the components array
+
+**Wrong — dangling reference:**
+```json
+{
+  "component": "Card",
+  "id": "root",
+  "child": "missing-id"
+}
+```
+There is no component with `id: "missing-id"` in the array, so the card renders `[a2tea: missing component "missing-id"]`.
+
+**Correct:** Always include a matching component for every referenced ID.
+
+### Do not nest components inline
+
+Components are a **flat list** (adjacency list). Do not embed component objects inside other components.
+
+**Wrong — inline nesting:**
+```json
+{
+  "component": "Card",
+  "id": "root",
+  "child": {
+    "component": "Text",
+    "text": "Hello"
+  }
+}
+```
+The `child` field is a **string ID**, not an object. Inline nesting will break the parser.
+
+**Correct:** Define each component separately and link by ID:
+```json
+{
+  "component": "Card",
+  "id": "root",
+  "child": "body"
+},
+{
+  "component": "Text",
+  "id": "body",
+  "text": "Hello"
+}
+```
+
+### Do not put code in an A2UI surface
+
+A2UI surfaces are for compact visual structures. Use standard markdown fenced code blocks (`` ``` ``) for code snippets, command output, or logs. Do not try to render code inside a `Text` component — it will not syntax-highlight.


### PR DESCRIPTION
## Summary
Models were emitting `{"component":"Button","text":"Send"}` despite the skill documenting the correct child-Text pattern. The skill instructions were correct but lacked explicit "do not do this" examples.

## Changes
Added a **Common Mistakes (Anti-Patterns)** section to `internal/skills/builtin/a2ui/SKILL.md` covering:
1. **Button label fields** — `text`/`label` on Button are silently ignored; label must come from a child Text component (the bug that prompted this)
2. **Dangling child IDs** — every `child`/`children` reference must point to a component in the array
3. **Inline nesting** — components are a flat adjacency list, not nested objects
4. **Code in surfaces** — use markdown fences, not Text components

Each anti-pattern shows a **Wrong** example and the **Correct** alternative.

## On JSON Schema enforcement (not in this PR)
A2UI payloads are free-text embedded in the model's markdown response, not structured tool outputs, so provider-side JSON Schema constrained decoding (`response_format` with `json_schema`) can't directly constrain them. However, the `a2ui/a2uischema` package has a full validator with embedded JSON schemas that is currently passed as `nil` to `ParseAndValidate`. Wiring that validator into a2tea's `Scan()` would catch malformed payloads at parse time and could feed an error back to the model for self-correction. That's a separate follow-up.

💘 Generated with Crush