### PR TITLE
feat(ui): render channel metadata below body as sender/via/at line

### DIFF
--- a/internal/ui/chat/user.go
+++ b/internal/ui/chat/user.go
@@ -2,6 +2,7 @@ package chat
 
 import (
 	"encoding/xml"
+	"fmt"
 	"strings"
 	"time"
 
@@ -141,36 +142,15 @@ func (m *UserMessageItem) renderSkillInvocation(content string, width int) strin
 	return toolOutputSkillContent(m.sty, skill.Name, skill.Description)
 }
 
-// TODO(follow-up): suppress channel name for a session's default channel.
-
 // renderChannelMessage parses a <channel source="..." ...>body</channel> element
-// and renders a styled metadata header followed by the body as markdown.
+// and renders the body as markdown followed by a metadata line showing
+// "[sender] via [channel] at [timestamp]" in the same Section style used
+// for the assistant info line.
 func (m *UserMessageItem) renderChannelMessage(raw string, width int) string {
 	var ch channelMessage
 	if err := xml.Unmarshal([]byte(raw), &ch); err != nil {
 		return m.fallbackRender(raw, width)
 	}
-
-	// Build the header line: channel source, sender, time.
-	header := m.sty.Tool.ResourceName.Render(ch.Source)
-
-	sender := ch.SenderName
-	if sender == "" {
-		sender = ch.Sender
-	}
-	if sender != "" {
-		header += " " + m.sty.Tool.ResourceSize.Render("·") + " " + m.sty.Tool.ResourceSize.Render(sender)
-	}
-
-	ts := ch.Time
-	if ts == "" && m.message.CreatedAt > 0 {
-		ts = time.Unix(m.message.CreatedAt, 0).Format(time.TimeOnly)
-	}
-	if ts != "" {
-		header += " " + m.sty.Tool.ResourceSize.Render("·") + " " + m.sty.Tool.ResourceSize.Render(ts)
-	}
-
-	headerLine := m.sty.Tool.Body.Render(header)
 
 	// Render the body content as markdown.
 	body := strings.TrimSpace(ch.Content)
@@ -188,10 +168,35 @@ func (m *UserMessageItem) renderChannelMessage(raw string, width int) string {
 		}
 	}
 
-	if bodyRendered == "" {
-		return headerLine
+	// Build the metadata line: [sender] via [channel] at [timestamp].
+	metaParts := make([]string, 0, 3)
+
+	sender := ch.SenderName
+	if sender == "" {
+		sender = ch.Sender
 	}
-	return headerLine + "\n" + bodyRendered
+	if sender != "" {
+		metaParts = append(metaParts, m.sty.Messages.ChannelInfoSender.Render(sender))
+	}
+
+	if ch.Source != "" {
+		metaParts = append(metaParts, m.sty.Messages.ChannelInfoProvider.Render(fmt.Sprintf("via %s", ch.Source)))
+	}
+
+	ts := ch.Time
+	if ts == "" && m.message.CreatedAt > 0 {
+		ts = time.Unix(m.message.CreatedAt, 0).Format(time.TimeOnly)
+	}
+	if ts != "" {
+		metaParts = append(metaParts, m.sty.Messages.ChannelInfoTimestamp.Render(fmt.Sprintf("at %s", ts)))
+	}
+
+	metaLine := common.Section(m.sty, strings.Join(metaParts, " "), width)
+
+	if bodyRendered == "" {
+		return metaLine
+	}
+	return bodyRendered + "\n" + metaLine
 }
 
 // fallbackRender renders text as plain markdown when XML parsing fails.

--- a/internal/ui/chat/user.go
+++ b/internal/ui/chat/user.go
@@ -191,8 +191,13 @@ func (m *UserMessageItem) renderChannelMessage(raw string, width int) string {
 		metaParts = append(metaParts, m.sty.Messages.ChannelInfoTimestamp.Render(fmt.Sprintf("at %s", ts)))
 	}
 
-	metaLine := common.Section(m.sty, strings.Join(metaParts, " "), width)
+	// With no metadata attributes at all, render the body alone rather than a
+	// lone separator line under it.
+	if len(metaParts) == 0 {
+		return bodyRendered
+	}
 
+	metaLine := common.Section(m.sty, strings.Join(metaParts, " "), width)
 	if bodyRendered == "" {
 		return metaLine
 	}

--- a/internal/ui/chat/user_test.go
+++ b/internal/ui/chat/user_test.go
@@ -199,6 +199,8 @@ func TestRawRender_ChannelMessageNoMetadata(t *testing.T) {
 	require.NotContains(t, out, "via")
 	require.NotContains(t, out, "at ")
 	require.NotContains(t, out, "<channel")
+	// With no metadata, there must be no lone Section separator line under the body.
+	require.NotContains(t, out, styles.SectionSeparator, "no separator line when there is no metadata")
 }
 
 // TestRawRender_ChannelMessageMetadataFormat verifies the exact format of the

--- a/internal/ui/chat/user_test.go
+++ b/internal/ui/chat/user_test.go
@@ -1,6 +1,7 @@
 package chat
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/charmbracelet/crush/internal/message"
@@ -28,6 +29,9 @@ func newTestUserItem(text string, createdAt int64) *UserMessageItem {
 	return NewUserMessageItem(&sty, msg, r).(*UserMessageItem)
 }
 
+// TestRawRender_ChannelMessageFull verifies the happy path: a channel message
+// with all attributes renders the body first, then a metadata line below in
+// "[sender] via [channel] at [timestamp]" format.
 func TestRawRender_ChannelMessageFull(t *testing.T) {
 	t.Parallel()
 
@@ -36,14 +40,14 @@ func TestRawRender_ChannelMessageFull(t *testing.T) {
 	item := newTestUserItem(text, 0)
 	out := ansi.Strip(item.RawRender(80))
 
-	// Header should contain the channel source.
-	require.Contains(t, out, "signal")
-
-	// Header should contain the sender name.
+	// Metadata should contain the sender name.
 	require.Contains(t, out, "Alice")
 
-	// Header should contain the time from the XML attribute.
-	require.Contains(t, out, "14:30")
+	// Metadata should contain "via" and the channel source.
+	require.Contains(t, out, "via signal")
+
+	// Metadata should contain "at" and the time from the XML attribute.
+	require.Contains(t, out, "at 14:30")
 
 	// Body should be rendered as markdown, not raw XML.
 	require.Contains(t, out, "Hello from Signal!")
@@ -51,8 +55,18 @@ func TestRawRender_ChannelMessageFull(t *testing.T) {
 	// Raw XML tags must not be visible.
 	require.NotContains(t, out, "<channel")
 	require.NotContains(t, out, "</channel>")
+
+	// Metadata must appear below the body.
+	bodyIdx := strings.Index(out, "Hello from Signal!")
+	metaIdx := strings.Index(out, "via signal")
+	require.Greater(t, bodyIdx, -1, "body must be present")
+	require.Greater(t, metaIdx, -1, "metadata must be present")
+	require.Less(t, bodyIdx, metaIdx, "body must appear before metadata")
 }
 
+// TestRawRender_ChannelMessageSourceOnly verifies that a message with only a
+// source (no sender, no time) still renders the body and shows the channel
+// name in the metadata.
 func TestRawRender_ChannelMessageSourceOnly(t *testing.T) {
 	t.Parallel()
 
@@ -61,8 +75,8 @@ func TestRawRender_ChannelMessageSourceOnly(t *testing.T) {
 	item := newTestUserItem(text, 1752456000) // CreatedAt fallback
 	out := ansi.Strip(item.RawRender(80))
 
-	// Header should contain the channel source.
-	require.Contains(t, out, "signal")
+	// Metadata should contain "via" and the channel source.
+	require.Contains(t, out, "via signal")
 
 	// Body should be present.
 	require.Contains(t, out, "Just the source")
@@ -72,11 +86,11 @@ func TestRawRender_ChannelMessageSourceOnly(t *testing.T) {
 	require.NotContains(t, out, "</channel>")
 }
 
+// TestRawRender_ChannelMessageMalformed verifies that truncated/invalid XML
+// does not panic and falls back to plain markdown rendering.
 func TestRawRender_ChannelMessageMalformed(t *testing.T) {
 	t.Parallel()
 
-	// Incomplete/truncated XML should not panic and should fall back to
-	// plain rendering.
 	text := `<channel source="signal" sender="broken`
 
 	item := newTestUserItem(text, 0)
@@ -87,6 +101,8 @@ func TestRawRender_ChannelMessageMalformed(t *testing.T) {
 	require.Contains(t, out, "<channel")
 }
 
+// TestRawRender_NormalMessage verifies that non-channel messages are not
+// affected by channel rendering logic.
 func TestRawRender_NormalMessage(t *testing.T) {
 	t.Parallel()
 
@@ -97,9 +113,12 @@ func TestRawRender_NormalMessage(t *testing.T) {
 
 	require.Contains(t, out, "This is a normal user message.")
 	require.NotContains(t, out, "signal")
+	require.NotContains(t, out, "via")
 	require.NotContains(t, out, "<channel")
 }
 
+// TestRawRender_ChannelMessageEmptyBody verifies that a channel message with
+// no body content still renders the metadata line.
 func TestRawRender_ChannelMessageEmptyBody(t *testing.T) {
 	t.Parallel()
 
@@ -108,38 +127,93 @@ func TestRawRender_ChannelMessageEmptyBody(t *testing.T) {
 	item := newTestUserItem(text, 0)
 	out := ansi.Strip(item.RawRender(80))
 
-	require.Contains(t, out, "signal")
 	require.Contains(t, out, "Bob")
-	require.Contains(t, out, "09:15")
+	require.Contains(t, out, "via signal")
+	require.Contains(t, out, "at 09:15")
 	require.NotContains(t, out, "<channel")
 	require.NotContains(t, out, "</channel>")
 }
 
+// TestRawRender_ChannelMessageSenderFallback verifies that when sender is
+// provided but sender_name is not, the raw sender value is shown.
 func TestRawRender_ChannelMessageSenderFallback(t *testing.T) {
 	t.Parallel()
 
-	// sender provided but no sender_name — should show sender as the name.
 	text := `<channel source="signal" sender="+15559876543">Fallback sender</channel>`
 
 	item := newTestUserItem(text, 0)
 	out := ansi.Strip(item.RawRender(80))
 
-	require.Contains(t, out, "signal")
 	require.Contains(t, out, "+15559876543")
+	require.Contains(t, out, "via signal")
 	require.Contains(t, out, "Fallback sender")
 	require.NotContains(t, out, "<channel")
 }
 
+// TestRawRender_ChannelMessageCreatedAtFallback verifies that when no time
+// attribute is present, the message's CreatedAt timestamp is used.
 func TestRawRender_ChannelMessageCreatedAtFallback(t *testing.T) {
 	t.Parallel()
 
-	// No time attribute, but CreatedAt is set on the message.
 	text := `<channel source="signal">Uses CreatedAt</channel>`
 
 	item := newTestUserItem(text, 1752456000)
 	out := ansi.Strip(item.RawRender(80))
 
-	require.Contains(t, out, "signal")
+	require.Contains(t, out, "via signal")
 	require.Contains(t, out, "Uses CreatedAt")
+	require.Contains(t, out, "at ") // CreatedAt-formatted time
 	require.NotContains(t, out, "<channel")
+}
+
+// TestRawRender_ChannelMessageNoSource verifies the unhappy path where the
+// channel element has no source attribute — metadata should omit the "via"
+// clause but still render without panicking.
+func TestRawRender_ChannelMessageNoSource(t *testing.T) {
+	t.Parallel()
+
+	text := `<channel sender="+1234" sender_name="Eve" time="08:00">No source attr</channel>`
+
+	item := newTestUserItem(text, 0)
+	out := ansi.Strip(item.RawRender(80))
+
+	require.Contains(t, out, "Eve")
+	require.Contains(t, out, "at 08:00")
+	require.Contains(t, out, "No source attr")
+	require.NotContains(t, out, "via")
+	require.NotContains(t, out, "<channel")
+}
+
+// TestRawRender_ChannelMessageNoMetadata verifies the unhappy path where only
+// the body is present with no metadata attributes — the body should still
+// render and no metadata parts should be shown.
+func TestRawRender_ChannelMessageNoMetadata(t *testing.T) {
+	t.Parallel()
+
+	text := `<channel>Just a body, nothing else.</channel>`
+
+	item := newTestUserItem(text, 0)
+	out := ansi.Strip(item.RawRender(80))
+
+	require.Contains(t, out, "Just a body, nothing else.")
+	require.NotContains(t, out, "via")
+	require.NotContains(t, out, "at ")
+	require.NotContains(t, out, "<channel")
+}
+
+// TestRawRender_ChannelMessageMetadataFormat verifies the exact format of the
+// metadata line: "[sender] via [channel] at [timestamp]" with the body above.
+func TestRawRender_ChannelMessageMetadataFormat(t *testing.T) {
+	t.Parallel()
+
+	text := `<channel source="signal" sender="+15551234567" sender_name="Alice" time="14:30">Hello!</channel>`
+
+	item := newTestUserItem(text, 0)
+	out := ansi.Strip(item.RawRender(80))
+
+	// The metadata section must contain the full formatted string.
+	require.Contains(t, out, "Alice via signal at 14:30")
+
+	// The old "·" separator style must not be used.
+	require.NotContains(t, out, "·")
 }

--- a/internal/ui/styles/quickstyle.go
+++ b/internal/ui/styles/quickstyle.go
@@ -860,6 +860,11 @@ func quickStyle(o quickStyleOpts) Styles {
 	s.Messages.AssistantInfoDuration = subtle
 	s.Messages.AssistantCanceled = lipgloss.NewStyle().Foreground(o.fgBase).Italic(true)
 
+	// Channel message metadata styles.
+	s.Messages.ChannelInfoSender = muted
+	s.Messages.ChannelInfoProvider = subtle
+	s.Messages.ChannelInfoTimestamp = subtle
+
 	// Thinking section styles
 	s.Messages.ThinkingBox = subtle.Background(o.bgLeastVisible)
 	s.Messages.ThinkingTruncationHint = muted

--- a/internal/ui/styles/styles.go
+++ b/internal/ui/styles/styles.go
@@ -279,6 +279,11 @@ type Styles struct {
 		AssistantInfoProvider  lipgloss.Style
 		AssistantInfoDuration  lipgloss.Style
 		AssistantCanceled      lipgloss.Style // Italic "Canceled" footer
+
+		// Channel message metadata line styles.
+		ChannelInfoSender    lipgloss.Style // Sender name in channel metadata line
+		ChannelInfoProvider  lipgloss.Style // "via <channel>" text
+		ChannelInfoTimestamp lipgloss.Style // "at <timestamp>" text
 	}
 
 	// Tool - styles for tool call rendering


### PR DESCRIPTION
## Summary

Reworks channel message rendering to match the assistant info line style. Channel-originated messages now show the body first, with a metadata line below in `[sender] via [channel] at [timestamp]` format — the same Section separator style used for the `◇ GLM-5.2 via Z.ai` line on assistant messages.

### Changes

- **Body-first layout**: Message content renders first, metadata line appears below (previously metadata was a header above the body)
- **New format**: `[sender] via [channel] at [timestamp]` replaces the old `channel · sender · time` format
- **New styles**: Added `ChannelInfoSender`, `ChannelInfoProvider`, `ChannelInfoTimestamp` to the Messages style group, matching `AssistantInfo*` visual treatment
- **Section separator**: Uses `common.Section` to render the metadata with the fill-line style consistent with assistant info
- Removed old `·` separator approach and the stale TODO comment

### Test coverage

- Happy path: full metadata (sender + via + at), body-before-metadata ordering, exact format string
- Unhappy paths: missing source, no metadata at all, empty body, malformed XML fallback
- Edge cases: sender fallback (raw ID when no name), CreatedAt timestamp fallback

💘 Generated with Crush