### PR TITLE
fix(ui): render channel metadata as separate list item below body

### DIFF
--- a/internal/ui/chat/messages.go
+++ b/internal/ui/chat/messages.go
@@ -1,6 +1,7 @@
 package chat
 
 import (
+	"encoding/xml"
 	"fmt"
 	"image"
 	"strings"
@@ -354,6 +355,117 @@ func (a *AssistantInfoItem) renderContent(width int) string {
 	return common.Section(a.sty, assistant, width)
 }
 
+// ChannelInfoID returns a stable ID for channel-info items.
+func ChannelInfoID(messageID string) string {
+	return fmt.Sprintf("%s:channel-info", messageID)
+}
+
+// ChannelInfoItem renders sender/channel/timestamp metadata for a
+// channel-originated user message. It is emitted as a separate list item
+// below the message body, mirroring how AssistantInfoItem appears below
+// assistant messages.
+type ChannelInfoItem struct {
+	*list.Versioned
+	*cachedMessageItem
+
+	id      string
+	message *message.Message
+	sty     *styles.Styles
+}
+
+// NewChannelInfoItem creates a new ChannelInfoItem.
+func NewChannelInfoItem(sty *styles.Styles, msg *message.Message) MessageItem {
+	return &ChannelInfoItem{
+		Versioned:         list.NewVersioned(),
+		cachedMessageItem: &cachedMessageItem{},
+		id:                ChannelInfoID(msg.ID),
+		message:           msg,
+		sty:               sty,
+	}
+}
+
+// Finished implements list.Item. Channel metadata is immutable once
+// rendered, so the entry is always safe to freeze.
+func (c *ChannelInfoItem) Finished() bool {
+	return true
+}
+
+// ID implements MessageItem.
+func (c *ChannelInfoItem) ID() string {
+	return c.id
+}
+
+// RawRender implements MessageItem.
+func (c *ChannelInfoItem) RawRender(width int) string {
+	innerWidth := max(0, width-MessageLeftPaddingTotal)
+	content, _, ok := c.getCachedRender(innerWidth)
+	if !ok {
+		content = c.renderContent(innerWidth)
+		height := lipgloss.Height(content)
+		c.setCachedRender(content, innerWidth, height)
+	}
+	return content
+}
+
+// Render implements MessageItem.
+func (c *ChannelInfoItem) Render(width int) string {
+	if cached, ok := c.getCachedPrefixedRender(width, 0); ok {
+		return cached
+	}
+	prefix := c.sty.Messages.SectionHeader.Render()
+	lines := strings.Split(c.RawRender(width), "\n")
+	for i, line := range lines {
+		lines[i] = prefix + line
+	}
+	out := strings.Join(lines, "\n")
+	c.setCachedPrefixedRender(out, width, 0)
+	return out
+}
+
+func (c *ChannelInfoItem) renderContent(width int) string {
+	raw := strings.TrimSpace(c.message.Content().Text)
+	var ch channelMessage
+	if err := xml.Unmarshal([]byte(raw), &ch); err != nil {
+		return ""
+	}
+
+	parts := make([]string, 0, 3)
+
+	sender := ch.SenderName
+	if sender == "" {
+		sender = ch.Sender
+	}
+	if sender != "" {
+		parts = append(parts, c.sty.Messages.ChannelInfoSender.Render(sender))
+	}
+
+	if ch.Source != "" {
+		parts = append(parts, c.sty.Messages.ChannelInfoProvider.Render(fmt.Sprintf("via %s", ch.Source)))
+	}
+
+	ts := ch.Time
+	if ts == "" && c.message.CreatedAt > 0 {
+		ts = time.Unix(c.message.CreatedAt, 0).Format(time.TimeOnly)
+	}
+	if ts != "" {
+		parts = append(parts, c.sty.Messages.ChannelInfoTimestamp.Render(fmt.Sprintf("at %s", ts)))
+	}
+
+	if len(parts) == 0 {
+		return ""
+	}
+
+	icon := c.sty.Messages.ChannelInfoIcon.Render(styles.ChannelIcon)
+	metaStr := fmt.Sprintf("%s %s", icon, strings.Join(parts, " "))
+	return common.Section(c.sty, metaStr, width)
+}
+
+// IsChannelMessage reports whether the given message content is a
+// channel-originated message (i.e. starts with the <channel XML tag).
+func IsChannelMessage(msg *message.Message) bool {
+	return strings.HasPrefix(strings.TrimSpace(msg.Content().Text), "<channel")
+}
+
 // cappedMessageWidth returns the maximum width for message content for readability.
 func cappedMessageWidth(availableWidth int) int {
 	return min(availableWidth-MessageLeftPaddingTotal, maxTextWidth)
@@ -384,7 +496,11 @@ func ExtractMessageItems(sty *styles.Styles, msg *message.Message, toolResults m
 			sty.Attachments.Text,
 			sty.Attachments.Skill,
 		)
-		return []MessageItem{NewUserMessageItem(sty, msg, r)}
+		items = []MessageItem{NewUserMessageItem(sty, msg, r)}
+		if IsChannelMessage(msg) {
+			items = append(items, NewChannelInfoItem(sty, msg))
+		}
+		return items
 	case message.Assistant:
 		var items []MessageItem
 		if ShouldRenderAssistantMessage(msg) {

--- a/internal/ui/chat/user.go
+++ b/internal/ui/chat/user.go
@@ -2,9 +2,7 @@ package chat
 
 import (
 	"encoding/xml"
-	"fmt"
 	"strings"
-	"time"
 
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
@@ -142,66 +140,31 @@ func (m *UserMessageItem) renderSkillInvocation(content string, width int) strin
 	return toolOutputSkillContent(m.sty, skill.Name, skill.Description)
 }
 
-// renderChannelMessage parses a <channel source="..." ...>body</channel> element
-// and renders the body as markdown followed by a metadata line showing
-// "[sender] via [channel] at [timestamp]" in the same Section style used
-// for the assistant info line.
+// renderChannelMessage parses a <channel source="..." ...>body</channel>
+// element and renders only the body as markdown. The metadata
+// (sender, channel source, timestamp) is rendered separately by
+// ChannelInfoItem so it appears outside the message body, mirroring
+// the assistant info line.
 func (m *UserMessageItem) renderChannelMessage(raw string, width int) string {
 	var ch channelMessage
 	if err := xml.Unmarshal([]byte(raw), &ch); err != nil {
 		return m.fallbackRender(raw, width)
 	}
 
-	// Render the body content as markdown.
 	body := strings.TrimSpace(ch.Content)
-	var bodyRendered string
-	if body != "" {
-		renderer := common.MarkdownRenderer(m.sty, width)
-		mu := common.LockMarkdownRenderer(renderer)
-		mu.Lock()
-		result, err := renderer.Render(body)
-		mu.Unlock()
-		if err != nil {
-			bodyRendered = body
-		} else {
-			bodyRendered = strings.TrimSuffix(result, "\n")
-		}
+	if body == "" {
+		return ""
 	}
 
-	// Build the metadata line: [sender] via [channel] at [timestamp].
-	metaParts := make([]string, 0, 3)
-
-	sender := ch.SenderName
-	if sender == "" {
-		sender = ch.Sender
+	renderer := common.MarkdownRenderer(m.sty, width)
+	mu := common.LockMarkdownRenderer(renderer)
+	mu.Lock()
+	result, err := renderer.Render(body)
+	mu.Unlock()
+	if err != nil {
+		return body
 	}
-	if sender != "" {
-		metaParts = append(metaParts, m.sty.Messages.ChannelInfoSender.Render(sender))
-	}
-
-	if ch.Source != "" {
-		metaParts = append(metaParts, m.sty.Messages.ChannelInfoProvider.Render(fmt.Sprintf("via %s", ch.Source)))
-	}
-
-	ts := ch.Time
-	if ts == "" && m.message.CreatedAt > 0 {
-		ts = time.Unix(m.message.CreatedAt, 0).Format(time.TimeOnly)
-	}
-	if ts != "" {
-		metaParts = append(metaParts, m.sty.Messages.ChannelInfoTimestamp.Render(fmt.Sprintf("at %s", ts)))
-	}
-
-	// With no metadata attributes at all, render the body alone rather than a
-	// lone separator line under it.
-	if len(metaParts) == 0 {
-		return bodyRendered
-	}
-
-	metaLine := common.Section(m.sty, strings.Join(metaParts, " "), width)
-	if bodyRendered == "" {
-		return metaLine
-	}
-	return bodyRendered + "\n" + metaLine
+	return strings.TrimSuffix(result, "\n")
 }
 
 // fallbackRender renders text as plain markdown when XML parsing fails.

--- a/internal/ui/chat/user_test.go
+++ b/internal/ui/chat/user_test.go
@@ -29,25 +29,28 @@ func newTestUserItem(text string, createdAt int64) *UserMessageItem {
 	return NewUserMessageItem(&sty, msg, r).(*UserMessageItem)
 }
 
-// TestRawRender_ChannelMessageFull verifies the happy path: a channel message
-// with all attributes renders the body first, then a metadata line below in
-// "[sender] via [channel] at [timestamp]" format.
-func TestRawRender_ChannelMessageFull(t *testing.T) {
+func newTestChannelInfoItem(text string, createdAt int64) *ChannelInfoItem {
+	sty := styles.CharmtonePantera()
+	msg := &message.Message{
+		ID:        "test-id",
+		Role:      message.User,
+		CreatedAt: createdAt,
+		Parts:     []message.ContentPart{message.TextContent{Text: text}},
+	}
+	return NewChannelInfoItem(&sty, msg).(*ChannelInfoItem)
+}
+
+// --- UserMessageItem body tests (body only, no metadata) ---
+
+// TestRawRender_ChannelMessageBody verifies that the UserMessageItem for a
+// channel message renders only the body content, not the metadata line.
+func TestRawRender_ChannelMessageBody(t *testing.T) {
 	t.Parallel()
 
 	text := `<channel source="signal" sender="+15551234567" sender_name="Alice" time="14:30">Hello from Signal!</channel>`
 
 	item := newTestUserItem(text, 0)
 	out := ansi.Strip(item.RawRender(80))
-
-	// Metadata should contain the sender name.
-	require.Contains(t, out, "Alice")
-
-	// Metadata should contain "via" and the channel source.
-	require.Contains(t, out, "via signal")
-
-	// Metadata should contain "at" and the time from the XML attribute.
-	require.Contains(t, out, "at 14:30")
 
 	// Body should be rendered as markdown, not raw XML.
 	require.Contains(t, out, "Hello from Signal!")
@@ -56,34 +59,25 @@ func TestRawRender_ChannelMessageFull(t *testing.T) {
 	require.NotContains(t, out, "<channel")
 	require.NotContains(t, out, "</channel>")
 
-	// Metadata must appear below the body.
-	bodyIdx := strings.Index(out, "Hello from Signal!")
-	metaIdx := strings.Index(out, "via signal")
-	require.Greater(t, bodyIdx, -1, "body must be present")
-	require.Greater(t, metaIdx, -1, "metadata must be present")
-	require.Less(t, bodyIdx, metaIdx, "body must appear before metadata")
+	// Metadata must NOT appear in the body — it is rendered by ChannelInfoItem.
+	require.NotContains(t, out, "via signal")
+	require.NotContains(t, out, "at 14:30")
 }
 
-// TestRawRender_ChannelMessageSourceOnly verifies that a message with only a
-// source (no sender, no time) still renders the body and shows the channel
-// name in the metadata.
-func TestRawRender_ChannelMessageSourceOnly(t *testing.T) {
+// TestRawRender_ChannelMessageSourceOnlyBody verifies that a message with
+// only a source renders just the body in UserMessageItem.
+func TestRawRender_ChannelMessageSourceOnlyBody(t *testing.T) {
 	t.Parallel()
 
 	text := `<channel source="signal">Just the source, no sender or time.</channel>`
 
-	item := newTestUserItem(text, 1752456000) // CreatedAt fallback
+	item := newTestUserItem(text, 1752456000)
 	out := ansi.Strip(item.RawRender(80))
 
-	// Metadata should contain "via" and the channel source.
-	require.Contains(t, out, "via signal")
-
-	// Body should be present.
 	require.Contains(t, out, "Just the source")
-
-	// No raw XML tags.
 	require.NotContains(t, out, "<channel")
 	require.NotContains(t, out, "</channel>")
+	require.NotContains(t, out, "via signal")
 }
 
 // TestRawRender_ChannelMessageMalformed verifies that truncated/invalid XML
@@ -96,7 +90,6 @@ func TestRawRender_ChannelMessageMalformed(t *testing.T) {
 	item := newTestUserItem(text, 0)
 	out := ansi.Strip(item.RawRender(80))
 
-	// Should not panic and should contain the raw text (fallback).
 	require.NotEmpty(t, out)
 	require.Contains(t, out, "<channel")
 }
@@ -118,7 +111,7 @@ func TestRawRender_NormalMessage(t *testing.T) {
 }
 
 // TestRawRender_ChannelMessageEmptyBody verifies that a channel message with
-// no body content still renders the metadata line.
+// no body renders an empty string in UserMessageItem.
 func TestRawRender_ChannelMessageEmptyBody(t *testing.T) {
 	t.Parallel()
 
@@ -127,16 +120,14 @@ func TestRawRender_ChannelMessageEmptyBody(t *testing.T) {
 	item := newTestUserItem(text, 0)
 	out := ansi.Strip(item.RawRender(80))
 
-	require.Contains(t, out, "Bob")
-	require.Contains(t, out, "via signal")
-	require.Contains(t, out, "at 09:15")
 	require.NotContains(t, out, "<channel")
 	require.NotContains(t, out, "</channel>")
+	require.NotContains(t, out, "via signal")
 }
 
-// TestRawRender_ChannelMessageSenderFallback verifies that when sender is
-// provided but sender_name is not, the raw sender value is shown.
-func TestRawRender_ChannelMessageSenderFallback(t *testing.T) {
+// TestRawRender_ChannelMessageSenderFallbackBody verifies that the body
+// renders correctly when sender is provided but sender_name is not.
+func TestRawRender_ChannelMessageSenderFallbackBody(t *testing.T) {
 	t.Parallel()
 
 	text := `<channel source="signal" sender="+15559876543">Fallback sender</channel>`
@@ -144,78 +135,119 @@ func TestRawRender_ChannelMessageSenderFallback(t *testing.T) {
 	item := newTestUserItem(text, 0)
 	out := ansi.Strip(item.RawRender(80))
 
-	require.Contains(t, out, "+15559876543")
-	require.Contains(t, out, "via signal")
 	require.Contains(t, out, "Fallback sender")
 	require.NotContains(t, out, "<channel")
 }
 
-// TestRawRender_ChannelMessageCreatedAtFallback verifies that when no time
-// attribute is present, the message's CreatedAt timestamp is used.
-func TestRawRender_ChannelMessageCreatedAtFallback(t *testing.T) {
-	t.Parallel()
+// --- ChannelInfoItem metadata tests ---
 
-	text := `<channel source="signal">Uses CreatedAt</channel>`
-
-	item := newTestUserItem(text, 1752456000)
-	out := ansi.Strip(item.RawRender(80))
-
-	require.Contains(t, out, "via signal")
-	require.Contains(t, out, "Uses CreatedAt")
-	require.Contains(t, out, "at ") // CreatedAt-formatted time
-	require.NotContains(t, out, "<channel")
-}
-
-// TestRawRender_ChannelMessageNoSource verifies the unhappy path where the
-// channel element has no source attribute — metadata should omit the "via"
-// clause but still render without panicking.
-func TestRawRender_ChannelMessageNoSource(t *testing.T) {
-	t.Parallel()
-
-	text := `<channel sender="+1234" sender_name="Eve" time="08:00">No source attr</channel>`
-
-	item := newTestUserItem(text, 0)
-	out := ansi.Strip(item.RawRender(80))
-
-	require.Contains(t, out, "Eve")
-	require.Contains(t, out, "at 08:00")
-	require.Contains(t, out, "No source attr")
-	require.NotContains(t, out, "via")
-	require.NotContains(t, out, "<channel")
-}
-
-// TestRawRender_ChannelMessageNoMetadata verifies the unhappy path where only
-// the body is present with no metadata attributes — the body should still
-// render and no metadata parts should be shown.
-func TestRawRender_ChannelMessageNoMetadata(t *testing.T) {
-	t.Parallel()
-
-	text := `<channel>Just a body, nothing else.</channel>`
-
-	item := newTestUserItem(text, 0)
-	out := ansi.Strip(item.RawRender(80))
-
-	require.Contains(t, out, "Just a body, nothing else.")
-	require.NotContains(t, out, "via")
-	require.NotContains(t, out, "at ")
-	require.NotContains(t, out, "<channel")
-	// With no metadata, there must be no lone Section separator line under the body.
-	require.NotContains(t, out, styles.SectionSeparator, "no separator line when there is no metadata")
-}
-
-// TestRawRender_ChannelMessageMetadataFormat verifies the exact format of the
-// metadata line: "[sender] via [channel] at [timestamp]" with the body above.
-func TestRawRender_ChannelMessageMetadataFormat(t *testing.T) {
+// TestChannelInfo_Full verifies that the ChannelInfoItem renders the full
+// metadata line: "[icon] [sender] via [channel] at [timestamp]".
+func TestChannelInfo_Full(t *testing.T) {
 	t.Parallel()
 
 	text := `<channel source="signal" sender="+15551234567" sender_name="Alice" time="14:30">Hello!</channel>`
 
-	item := newTestUserItem(text, 0)
+	item := newTestChannelInfoItem(text, 0)
 	out := ansi.Strip(item.RawRender(80))
 
-	// The metadata section must contain the full formatted string.
-	require.Contains(t, out, "Alice via signal at 14:30")
+	// Must contain sender, channel source, and timestamp.
+	require.Contains(t, out, "Alice")
+	require.Contains(t, out, "via signal")
+	require.Contains(t, out, "at 14:30")
 
-	// The old "·" separator style must not be used.
-	require.NotContains(t, out, "·")
+	// Must contain the chat-bubble glyph icon.
+	require.Contains(t, out, styles.ChannelIcon)
+
+	// Must NOT contain the body content — that's in UserMessageItem.
+	require.NotContains(t, out, "Hello!")
+
+	// Must NOT contain raw XML.
+	require.NotContains(t, out, "<channel")
+	require.NotContains(t, out, "</channel>")
+}
+
+// TestChannelInfo_SenderFallback verifies that when sender is provided but
+// sender_name is not, the raw sender value is shown.
+func TestChannelInfo_SenderFallback(t *testing.T) {
+	t.Parallel()
+
+	text := `<channel source="signal" sender="+15559876543">Body text</channel>`
+
+	item := newTestChannelInfoItem(text, 0)
+	out := ansi.Strip(item.RawRender(80))
+
+	require.Contains(t, out, "+15559876543")
+	require.Contains(t, out, "via signal")
+}
+
+// TestChannelInfo_CreatedAtFallback verifies that when no time attribute is
+// present, the message's CreatedAt timestamp is used.
+func TestChannelInfo_CreatedAtFallback(t *testing.T) {
+	t.Parallel()
+
+	text := `<channel source="signal">Uses CreatedAt</channel>`
+
+	item := newTestChannelInfoItem(text, 1752456000)
+	out := ansi.Strip(item.RawRender(80))
+
+	require.Contains(t, out, "via signal")
+	require.Contains(t, out, "at ")
+}
+
+// TestChannelInfo_NoSource verifies that when no source attribute is present,
+// the "via" clause is omitted but metadata still renders without panicking.
+func TestChannelInfo_NoSource(t *testing.T) {
+	t.Parallel()
+
+	text := `<channel sender="+1234" sender_name="Eve" time="08:00">No source</channel>`
+
+	item := newTestChannelInfoItem(text, 0)
+	out := ansi.Strip(item.RawRender(80))
+
+	require.Contains(t, out, "Eve")
+	require.Contains(t, out, "at 08:00")
+	require.NotContains(t, out, "via")
+}
+
+// TestChannelInfo_NoMetadata verifies that when only the body is present with
+// no metadata attributes, the ChannelInfoItem renders an empty string.
+func TestChannelInfo_NoMetadata(t *testing.T) {
+	t.Parallel()
+
+	text := `<channel>Just a body, nothing else.</channel>`
+
+	item := newTestChannelInfoItem(text, 0)
+	out := ansi.Strip(item.RawRender(80))
+
+	// With no metadata, the info item should be empty.
+	require.Empty(t, out)
+}
+
+// TestChannelInfo_MalformedXML verifies that malformed XML does not panic.
+func TestChannelInfo_MalformedXML(t *testing.T) {
+	t.Parallel()
+
+	text := `<channel source="signal" sender="broken`
+
+	item := newTestChannelInfoItem(text, 0)
+	out := ansi.Strip(item.RawRender(80))
+
+	// Should not panic and should be empty (XML parse fails).
+	require.Empty(t, out)
+}
+
+// TestChannelInfo_RenderHasSectionHeader verifies that the Render method
+// applies the SectionHeader padding ( paddingLeft(2) ), confirming the
+// metadata appears as a separate item outside the message body.
+func TestChannelInfo_RenderHasSectionHeader(t *testing.T) {
+	t.Parallel()
+
+	text := `<channel source="signal" sender_name="Alice" time="14:30">Hi</channel>`
+
+	item := newTestChannelInfoItem(text, 0)
+	out := ansi.Strip(item.Render(80))
+
+	// The rendered output should start with at least 2 spaces (paddingLeft(2)).
+	require.True(t, strings.HasPrefix(out, "  "), "ChannelInfoItem.Render must apply SectionHeader padding")
 }

--- a/internal/ui/styles/quickstyle.go
+++ b/internal/ui/styles/quickstyle.go
@@ -861,6 +861,7 @@ func quickStyle(o quickStyleOpts) Styles {
 	s.Messages.AssistantCanceled = lipgloss.NewStyle().Foreground(o.fgBase).Italic(true)
 
 	// Channel message metadata styles.
+	s.Messages.ChannelInfoIcon = subtle
 	s.Messages.ChannelInfoSender = muted
 	s.Messages.ChannelInfoProvider = subtle
 	s.Messages.ChannelInfoTimestamp = subtle

--- a/internal/ui/styles/styles.go
+++ b/internal/ui/styles/styles.go
@@ -48,6 +48,8 @@ const (
 	ScrollbarThumb string = "┃"
 	ScrollbarTrack string = "│"
 
+	ChannelIcon string = "󰍩"
+
 	LSPErrorIcon   string = "E"
 	LSPWarningIcon string = "W"
 	LSPInfoIcon    string = "I"
@@ -281,6 +283,7 @@ type Styles struct {
 		AssistantCanceled      lipgloss.Style // Italic "Canceled" footer
 
 		// Channel message metadata line styles.
+		ChannelInfoIcon      lipgloss.Style // Chat-bubble glyph prefix
 		ChannelInfoSender    lipgloss.Style // Sender name in channel metadata line
 		ChannelInfoProvider  lipgloss.Style // "via <channel>" text
 		ChannelInfoTimestamp lipgloss.Style // "at <timestamp>" text


### PR DESCRIPTION
## Summary

Renders channel message metadata (sender, via channel, timestamp) as a **separate list item** below the message body — exactly like the `◇ GLM-5.2 via Z.ai` model/provider line appears below assistant messages.

### Problem

PR #98 rendered the metadata line *inside* the `UserMessageItem.RawRender`, which meant it appeared within the message body block (indented and styled as part of the user message content). It should appear outside the body as a standalone info line.

### Changes

- **New `ChannelInfoItem`** (`messages.go`): A separate list item that renders the `[icon] [sender] via [channel] at [timestamp]` metadata line using `common.Section` with `SectionHeader` padding — identical pattern to `AssistantInfoItem`.
- **Simplified `renderChannelMessage`** (`user.go`): Now renders only the body content as markdown. All metadata-building logic removed.
- **`ExtractMessageItems`** (`messages.go`): Appends a `ChannelInfoItem` after the `UserMessageItem` when the message is channel-originated.
- **`ChannelIcon` glyph** (`styles.go`): Added a Nerd Font chat-bubble glyph (`󰍩`, nf-md-chat) as the prefix icon for the metadata line, mirroring the `◇` model icon.
- **`ChannelInfoIcon` style** (`styles.go`, `quickstyle.go`): Added styled icon field matching `AssistantInfoIcon`.
- **Tests**: Rewrote tests to cover body-only rendering in `UserMessageItem` and metadata rendering in `ChannelInfoItem` separately. Added a test verifying `Render()` applies `SectionHeader` padding (confirming the metadata appears outside the body).

### Visual layout

```
  Hello from Signal!           ← UserMessageItem (body only)

    󰍩 Alice via signal at 14:30 ─────────────    ← ChannelInfoItem (separate item)
```

This matches the assistant info line layout:
```
  Assistant response text...   ← AssistantMessageItem

    ◇ GLM-5.2 via Z.ai 1.2s ─────────────────    ← AssistantInfoItem
```

💘 Generated with Crush