### PR TITLE
fix(ui): stabilize footer help and preserve sidebar scrollbar spacing

### DIFF
--- a/internal/ui/model/sidebar.go
+++ b/internal/ui/model/sidebar.go
@@ -250,12 +250,11 @@ func (m *UI) drawSidebar(scr uv.Screen, area uv.Rectangle) {
 	}
 	scrolledContent := strings.Join(contentLines, "\n")
 
-	// Reserve 1 column for scrollbar when focused (same pattern as chat panel).
+	const scrollbarWidth = 1
+	scrollbarNeeded := contentHeight > height
 	contentWidth := width
-	var scrollbar string
-	if focused && contentHeight > height {
-		contentWidth = width - 1
-		scrollbar = common.Scrollbar(t, height, contentHeight, height, scroll)
+	if scrollbarNeeded {
+		contentWidth = max(width-scrollbarWidth, 0)
 	}
 
 	contentStyle := lipgloss.NewStyle().
@@ -263,7 +262,21 @@ func (m *UI) drawSidebar(scr uv.Screen, area uv.Rectangle) {
 		MaxHeight(height)
 	rendered := contentStyle.Render(scrolledContent)
 
-	if scrollbar != "" {
+	if scrollbarNeeded {
+		var scrollbar string
+		if focused {
+			scrollbar = common.Scrollbar(t, height, contentHeight, height, scroll)
+		} else {
+			var sb strings.Builder
+			for i := 0; i < height; i++ {
+				if i > 0 {
+					sb.WriteString("\n")
+				}
+				sb.WriteString(" ")
+			}
+			scrollbar = sb.String()
+		}
+
 		rendered = lipgloss.JoinHorizontal(lipgloss.Top, rendered, scrollbar)
 	}
 

--- a/internal/ui/model/sidebar.go
+++ b/internal/ui/model/sidebar.go
@@ -144,6 +144,21 @@ func (m *UI) scrollSidebarOnWheel(msg common.CoalescedWheelMsg) bool {
 	return true
 }
 
+// sidebarScrollbarLayout decides how the sidebar splits its horizontal space
+// between content and the scrollbar column. When the content overflows the
+// viewport a 1-column gutter is reserved regardless of focus — focused draws a
+// real scrollbar, unfocused a blank spacer — so the content width (and thus the
+// alignment of elements like the logo) stays stable across focus transitions.
+func sidebarScrollbarLayout(width, contentHeight, viewportHeight int) (contentWidth int, scrollbarNeeded bool) {
+	const scrollbarWidth = 1
+	scrollbarNeeded = contentHeight > viewportHeight
+	contentWidth = width
+	if scrollbarNeeded {
+		contentWidth = max(width-scrollbarWidth, 0)
+	}
+	return contentWidth, scrollbarNeeded
+}
+
 // sidebar renders the chat sidebar containing session title, working
 // directory, model info, file list, LSP status, and MCP status.
 func (m *UI) drawSidebar(scr uv.Screen, area uv.Rectangle) {
@@ -250,12 +265,7 @@ func (m *UI) drawSidebar(scr uv.Screen, area uv.Rectangle) {
 	}
 	scrolledContent := strings.Join(contentLines, "\n")
 
-	const scrollbarWidth = 1
-	scrollbarNeeded := contentHeight > height
-	contentWidth := width
-	if scrollbarNeeded {
-		contentWidth = max(width-scrollbarWidth, 0)
-	}
+	contentWidth, scrollbarNeeded := sidebarScrollbarLayout(width, contentHeight, height)
 
 	contentStyle := lipgloss.NewStyle().
 		MaxWidth(contentWidth).

--- a/internal/ui/model/sidebar_focus_test.go
+++ b/internal/ui/model/sidebar_focus_test.go
@@ -25,6 +25,7 @@ func newSidebarTestUI() *UI {
 		dialog:   dialog.NewOverlay(),
 		chat:     NewChat(com, config.ScrollbarDefault),
 		textarea: textarea.New(),
+		keyMap:   DefaultKeyMap(),
 	}
 }
 

--- a/internal/ui/model/sidebar_scrollbar_test.go
+++ b/internal/ui/model/sidebar_scrollbar_test.go
@@ -1,0 +1,72 @@
+package model
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestShortHelpTabStability verifies that the Tab key binding description
+// in ShortHelp remains stable and focus-neutral, rather than fluctuating,
+// and doesn't pollute the global/base key map definitions when focus changes.
+func TestShortHelpTabStability(t *testing.T) {
+	t.Parallel()
+	m := newSidebarTestUI()
+
+	// Capture initial tab help description
+	m.focus = uiFocusEditor
+	bindsEditor := m.ShortHelp()
+	var editorTabHelp string
+	for _, b := range bindsEditor {
+		if b.Help().Key == "tab" {
+			editorTabHelp = b.Help().Desc
+			break
+		}
+	}
+
+	// Change focus to Main
+	m.focus = uiFocusMain
+	bindsMain := m.ShortHelp()
+	var mainTabHelp string
+	for _, b := range bindsMain {
+		if b.Help().Key == "tab" {
+			mainTabHelp = b.Help().Desc
+			break
+		}
+	}
+
+	// Change focus to Sidebar
+	m.focus = uiFocusSidebar
+	bindsSidebar := m.ShortHelp()
+	var sidebarTabHelp string
+	for _, b := range bindsSidebar {
+		if b.Help().Key == "tab" {
+			sidebarTabHelp = b.Help().Desc
+			break
+		}
+	}
+
+	// Validate they are all stable and focus-neutral ("change focus")
+	// rather than shifting to "focus chat", "focus sidebar", or "focus editor".
+	require.Equal(t, "change focus", editorTabHelp)
+	require.Equal(t, "change focus", mainTabHelp)
+	require.Equal(t, "change focus", sidebarTabHelp)
+}
+
+// TestSidebarUpDownHelpNoStatePollution verifies that customizing UpDown help
+// text during sidebar focus is scoped correctly and doesn't permanently pollute
+// the base keymap configuration.
+func TestSidebarUpDownHelpNoStatePollution(t *testing.T) {
+	t.Parallel()
+	m := newSidebarTestUI()
+
+	// First verify default state is preserved
+	require.Equal(t, "scroll", m.keyMap.Chat.UpDown.Help().Desc)
+
+	// Trigger ShortHelp when focused on sidebar (which updates the cloned UpDown)
+	m.focus = uiFocusSidebar
+	m.ShortHelp()
+
+	// Ensure base keymap is unpolluted
+	require.Equal(t, "scroll", m.keyMap.Chat.UpDown.Help().Desc)
+}

--- a/internal/ui/model/sidebar_scrollbar_test.go
+++ b/internal/ui/model/sidebar_scrollbar_test.go
@@ -6,6 +6,38 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestSidebarScrollbarLayout verifies the scrollbar gutter is reserved whenever
+// content overflows the viewport (independent of focus), keeping the content
+// width stable, and that no gutter is reserved when it fits.
+func TestSidebarScrollbarLayout(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		width         int
+		contentHeight int
+		viewport      int
+		wantWidth     int
+		wantScrollbar bool
+	}{
+		{"fits exactly, no gutter", 30, 10, 10, 30, false},
+		{"fits under, no gutter", 30, 5, 10, 30, false},
+		{"overflows, reserve gutter", 30, 40, 10, 29, true},
+		{"overflows by one, reserve gutter", 30, 11, 10, 29, true},
+		{"overflow with zero width clamps", 0, 40, 10, 0, true},
+		{"overflow with width one clamps to zero", 1, 40, 10, 0, true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			gotWidth, gotScrollbar := sidebarScrollbarLayout(tc.width, tc.contentHeight, tc.viewport)
+			require.Equal(t, tc.wantWidth, gotWidth, "content width")
+			require.Equal(t, tc.wantScrollbar, gotScrollbar, "scrollbar needed")
+		})
+	}
+}
+
 // TestShortHelpTabStability verifies that the Tab key binding description
 // in ShortHelp remains stable and focus-neutral, rather than fluctuating,
 // and doesn't pollute the global/base key map definitions when focus changes.
@@ -60,13 +92,18 @@ func TestSidebarUpDownHelpNoStatePollution(t *testing.T) {
 	t.Parallel()
 	m := newSidebarTestUI()
 
-	// First verify default state is preserved
-	require.Equal(t, "scroll", m.keyMap.Chat.UpDown.Help().Desc)
+	// The base UpDown help ("↑↓", "scroll"); the sidebar footer overrides the
+	// key label to "↑/↓". The Desc stays "scroll" either way, so assert on the
+	// Key — that's what actually reveals in-place mutation of the shared keymap.
+	defaultKey := m.keyMap.Chat.UpDown.Help().Key
+	require.Equal(t, "↑↓", defaultKey)
 
-	// Trigger ShortHelp when focused on sidebar (which updates the cloned UpDown)
+	// Trigger ShortHelp when focused on sidebar (which sets the cloned UpDown's
+	// help to "↑/↓" / "scroll").
 	m.focus = uiFocusSidebar
 	m.ShortHelp()
 
-	// Ensure base keymap is unpolluted
+	// The base keymap must be unchanged — not mutated to the sidebar's "↑/↓".
+	require.Equal(t, defaultKey, m.keyMap.Chat.UpDown.Help().Key, "base keymap UpDown key must not be polluted by ShortHelp")
 	require.Equal(t, "scroll", m.keyMap.Chat.UpDown.Help().Desc)
 }

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -3440,6 +3440,9 @@ func (m *UI) isAgentBusy() bool {
 	if m.bangCancel != nil {
 		return true
 	}
+	if m.com == nil || m.com.Workspace == nil {
+		return false
+	}
 	return m.com.Workspace.AgentIsReady() &&
 		m.com.Workspace.AgentIsBusy()
 }

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -2663,19 +2663,6 @@ func (m *UI) ShortHelp() []key.Binding {
 			binds = append(binds, cancelBinding)
 		}
 
-		switch m.focus {
-		case uiFocusEditor:
-			tab.SetHelp("tab", "focus chat")
-		case uiFocusMain:
-			if m.isCompact {
-				tab.SetHelp("tab", "focus editor")
-			} else {
-				tab.SetHelp("tab", "focus sidebar")
-			}
-		case uiFocusSidebar:
-			tab.SetHelp("tab", "focus editor")
-		}
-
 		binds = append(
 			binds,
 			tab,
@@ -2704,10 +2691,11 @@ func (m *UI) ShortHelp() []key.Binding {
 		case uiFocusSidebar:
 			esc := k.Editor.Escape
 			esc.SetHelp("esc", "back to editor")
-			k.Chat.UpDown.SetHelp("↑/↓", "scroll")
+			upDown := k.Chat.UpDown
+			upDown.SetHelp("↑/↓", "scroll")
 			binds = append(
 				binds,
-				k.Chat.UpDown,
+				upDown,
 				esc,
 			)
 		}
@@ -2765,18 +2753,6 @@ func (m *UI) FullHelp() [][]key.Binding {
 
 		mainBinds := []key.Binding{}
 		tab := k.Tab
-		switch m.focus {
-		case uiFocusEditor:
-			tab.SetHelp("tab", "focus chat")
-		case uiFocusMain:
-			if m.isCompact {
-				tab.SetHelp("tab", "focus editor")
-			} else {
-				tab.SetHelp("tab", "focus sidebar")
-			}
-		case uiFocusSidebar:
-			tab.SetHelp("tab", "focus editor")
-		}
 
 		mainBinds = append(
 			mainBinds,


### PR DESCRIPTION
This pull request addresses two TUI layout bugs:

- **Sidebar Scrollbar Overlap:** The sidebar content width now always reserves 1 column for the scrollbar if the content height exceeds the viewport height. When unfocused, this column renders a blank spacer track to ensure alignment stays consistent and elements (like the logo) are not overlapped.
- **Footer Help Menus:** Removed dynamic focus-based help text changes for the Tab key to keep descriptions stable and focus-neutral, preventing wrapping shifts in the bottom metadata row. Fixed key binding mutation by copying the `UpDown` binding before modifying its help labels in focus blocks.

💘 Generated with Crush