### PR TITLE
fix(ui): remove redundant historyReset in /clear and tighten compact tests

### DIFF
--- a/internal/ui/model/slash_command_test.go
+++ b/internal/ui/model/slash_command_test.go
@@ -124,6 +124,10 @@ func TestSlashCompactTriggersSummarize(t *testing.T) {
 	if cmd == nil {
 		t.Fatal("expected a command to be returned")
 	}
+	cmd()
+	if ws.summCall != "s1" {
+		t.Fatalf("expected AgentSummarize called with s1, got %q", ws.summCall)
+	}
 }
 
 // TestSlashCompactNoSession verifies /compact is a no-op without a session.
@@ -138,7 +142,8 @@ func TestSlashCompactNoSession(t *testing.T) {
 	}
 }
 
-// TestSlashCompactBlockedWhenAgentBusy verifies /compact warns when busy.
+// TestSlashCompactBlockedWhenAgentBusy verifies /compact warns when busy and
+// does not call AgentSummarize even if the returned cmd is executed.
 func TestSlashCompactBlockedWhenAgentBusy(t *testing.T) {
 	t.Parallel()
 
@@ -146,9 +151,12 @@ func TestSlashCompactBlockedWhenAgentBusy(t *testing.T) {
 	m := newSlashCommandUI(ws)
 	m.session = &session.Session{ID: "s1"}
 
-	_, ok := m.handleSlashCommand("/compact")
+	cmd, ok := m.handleSlashCommand("/compact")
 	if !ok {
 		t.Fatal("handleSlashCommand(/compact) should still match when busy")
+	}
+	if cmd != nil {
+		cmd()
 	}
 	if ws.summCall != "" {
 		t.Fatal("AgentSummarize should not be called when agent is busy")

--- a/internal/ui/model/slash_command_test.go
+++ b/internal/ui/model/slash_command_test.go
@@ -93,12 +93,15 @@ func TestSlashClearStartsNewSession(t *testing.T) {
 	}
 }
 
-// TestSlashClearBlockedWhenAgentBusy verifies /clear warns when busy.
+// TestSlashClearBlockedWhenAgentBusy verifies /clear warns when busy, keeps
+// the session, and still resets the prompt history.
 func TestSlashClearBlockedWhenAgentBusy(t *testing.T) {
 	t.Parallel()
 
 	m := newSlashCommandUI(&slashCommandWorkspace{ready: true, busy: map[string]bool{"s1": true}})
 	m.session = &session.Session{ID: "s1"}
+	m.promptHistory.index = 3
+	m.promptHistory.draft = "wip"
 
 	_, ok := m.handleSlashCommand("/clear")
 	if !ok {
@@ -106,6 +109,31 @@ func TestSlashClearBlockedWhenAgentBusy(t *testing.T) {
 	}
 	if m.session == nil {
 		t.Fatal("session should not be cleared when agent is busy")
+	}
+	if m.promptHistory.index != -1 || m.promptHistory.draft != "" {
+		t.Fatalf("prompt history not reset on busy /clear: index=%d draft=%q", m.promptHistory.index, m.promptHistory.draft)
+	}
+}
+
+// TestSlashClearNoSessionResetsHistory verifies /clear with no active session
+// is a no-op for session state but still resets the prompt history/draft —
+// newSession early-returns without resetting, so /clear handles it directly.
+func TestSlashClearNoSessionResetsHistory(t *testing.T) {
+	t.Parallel()
+
+	m := newSlashCommandUI(&slashCommandWorkspace{ready: true})
+	m.promptHistory.index = 3
+	m.promptHistory.draft = "wip"
+
+	cmd, ok := m.handleSlashCommand("/clear")
+	if !ok {
+		t.Fatal("handleSlashCommand(/clear) should match without a session")
+	}
+	if cmd != nil {
+		t.Fatal("expected no command when there is no session to clear")
+	}
+	if m.promptHistory.index != -1 || m.promptHistory.draft != "" {
+		t.Fatalf("prompt history not reset on no-session /clear: index=%d draft=%q", m.promptHistory.index, m.promptHistory.draft)
 	}
 }
 

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -4133,8 +4133,8 @@ func (m *UI) handleSlashCommand(value string) (tea.Cmd, bool) {
 	switch value {
 	case "/clear":
 		m.randomizePlaceholders()
-		m.historyReset()
 		if m.isAgentBusy() {
+			m.historyReset()
 			return util.ReportWarn("Agent is busy, please wait before starting a new session..."), true
 		}
 		return m.newSession(), true

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -4137,6 +4137,13 @@ func (m *UI) handleSlashCommand(value string) (tea.Cmd, bool) {
 			m.historyReset()
 			return util.ReportWarn("Agent is busy, please wait before starting a new session..."), true
 		}
+		if !m.hasSession() {
+			// No active session to start fresh from, but /clear should still
+			// reset the input history/draft — matching /compact and the prior
+			// behaviour. newSession would early-return without resetting.
+			m.historyReset()
+			return nil, true
+		}
 		return m.newSession(), true
 
 	case "/compact":


### PR DESCRIPTION
## Summary

Addresses two review nits from #104:

1. **Redundant `historyReset()` in `/clear`**: The `/clear` slash command called `historyReset()` unconditionally, but `newSession()` already calls it on the success path. Moved the call into the busy-guard branch only, so it runs when the agent is busy (early return) but defers to `newSession()` otherwise.

2. **Weak `TestSlashCompactBlockedWhenAgentBusy`**: The test asserted `summCall == ""` but never executed the returned `tea.Cmd`, so the assertion held trivially even on the non-busy path. Now executes the returned cmd in both the busy and non-busy compact tests, making the assertions meaningful.

## Test plan

- [x] `go build .` passes
- [x] `go test ./internal/ui/model/... -run TestSlash -v` — all 6 tests pass
- [x] `gofumpt -w` applied


💘 Generated with Crush