### PR TITLE
fix(ui): render sidebar content at the reserved width so the logo isn't clipped

### DIFF
--- a/internal/ui/model/sidebar.go
+++ b/internal/ui/model/sidebar.go
@@ -144,19 +144,34 @@ func (m *UI) scrollSidebarOnWheel(msg common.CoalescedWheelMsg) bool {
 	return true
 }
 
-// sidebarScrollbarLayout decides how the sidebar splits its horizontal space
-// between content and the scrollbar column. When the content overflows the
-// viewport a 1-column gutter is reserved regardless of focus — focused draws a
-// real scrollbar, unfocused a blank spacer — so the content width (and thus the
-// alignment of elements like the logo) stays stable across focus transitions.
-func sidebarScrollbarLayout(width, contentHeight, viewportHeight int) (contentWidth int, scrollbarNeeded bool) {
-	const scrollbarWidth = 1
-	scrollbarNeeded = contentHeight > viewportHeight
-	contentWidth = width
-	if scrollbarNeeded {
-		contentWidth = max(width-scrollbarWidth, 0)
+// sidebarScrollbarWidth is the fixed 1-column gutter the sidebar reserves for
+// its scroll indicator.
+const sidebarScrollbarWidth = 1
+
+// sidebarContentWidth returns the width available for sidebar content after
+// reserving the scrollbar gutter. The gutter is reserved unconditionally (not
+// only when content overflows) so the content — including the fixed-width logo,
+// which is cached at this same width — is always rendered at its final width
+// and never clipped when the scrollbar is drawn. Keeping it focus- and
+// overflow-independent also stops the content from shifting on focus changes.
+func sidebarContentWidth(sidebarWidth int) int {
+	return max(sidebarWidth-sidebarScrollbarWidth, 0)
+}
+
+// blankSidebarColumn renders an empty gutter column height rows tall, used when
+// the sidebar reserves scrollbar space but has no scrollbar to draw.
+func blankSidebarColumn(height int) string {
+	if height <= 0 {
+		return ""
 	}
-	return contentWidth, scrollbarNeeded
+	var sb strings.Builder
+	for i := 0; i < height; i++ {
+		if i > 0 {
+			sb.WriteString("\n")
+		}
+		sb.WriteString(" ")
+	}
+	return sb.String()
 }
 
 // sidebar renders the chat sidebar containing session title, working
@@ -172,13 +187,18 @@ func (m *UI) drawSidebar(scr uv.Screen, area uv.Rectangle) {
 	width := area.Dx()
 	height := area.Dy()
 
+	// All content renders into the width left after reserving the scrollbar
+	// gutter, so the fixed-width logo (cached at this same width) and every
+	// section fit exactly and are never clipped when the gutter is drawn.
+	contentWidth := sidebarContentWidth(width)
+
 	focused := m.focus == uiFocusSidebar
 
-	title := t.Sidebar.SessionTitle.Width(width).MaxHeight(2).Render(m.session.Title)
-	cwd := common.PrettyPath(t, m.com.Workspace.WorkingDir(), width)
+	title := t.Sidebar.SessionTitle.Width(contentWidth).MaxHeight(2).Render(m.session.Title)
+	cwd := common.PrettyPath(t, m.com.Workspace.WorkingDir(), contentWidth)
 	sidebarLogo := m.sidebarLogo
 	if height < logoHeightBreakpoint {
-		sidebarLogo = logo.SmallRender(m.com.Styles, width, logo.Opts{
+		sidebarLogo = logo.SmallRender(m.com.Styles, contentWidth, logo.Opts{
 			Hyper: m.com.IsHyper(),
 		})
 	}
@@ -188,7 +208,7 @@ func (m *UI) drawSidebar(scr uv.Screen, area uv.Rectangle) {
 		"",
 		cwd,
 		"",
-		m.modelInfo(width),
+		m.modelInfo(contentWidth),
 		"",
 	}
 
@@ -234,11 +254,11 @@ func (m *UI) drawSidebar(scr uv.Screen, area uv.Rectangle) {
 		maxChannels = max(maxChannels, channelsCount)
 	}
 
-	lspSection := m.lspInfo(width, maxLSPs, true)
-	mcpSection := m.mcpInfo(width, maxMCPs, true)
-	skillsSection := m.skillsInfo(width, maxSkills, true)
-	channelsSection := m.channelsInfo(width, maxChannels, true)
-	filesSection := m.filesInfo(m.com.Workspace.WorkingDir(), width, maxFiles, true)
+	lspSection := m.lspInfo(contentWidth, maxLSPs, true)
+	mcpSection := m.mcpInfo(contentWidth, maxMCPs, true)
+	skillsSection := m.skillsInfo(contentWidth, maxSkills, true)
+	channelsSection := m.channelsInfo(contentWidth, maxChannels, true)
+	filesSection := m.filesInfo(m.com.Workspace.WorkingDir(), contentWidth, maxFiles, true)
 
 	fullContent := lipgloss.JoinVertical(
 		lipgloss.Left,
@@ -265,30 +285,24 @@ func (m *UI) drawSidebar(scr uv.Screen, area uv.Rectangle) {
 	}
 	scrolledContent := strings.Join(contentLines, "\n")
 
-	contentWidth, scrollbarNeeded := sidebarScrollbarLayout(width, contentHeight, height)
-
 	contentStyle := lipgloss.NewStyle().
 		MaxWidth(contentWidth).
 		MaxHeight(height)
 	rendered := contentStyle.Render(scrolledContent)
 
-	if scrollbarNeeded {
-		var scrollbar string
-		if focused {
-			scrollbar = common.Scrollbar(t, height, contentHeight, height, scroll)
-		} else {
-			var sb strings.Builder
-			for i := 0; i < height; i++ {
-				if i > 0 {
-					sb.WriteString("\n")
-				}
-				sb.WriteString(" ")
-			}
-			scrollbar = sb.String()
-		}
-
-		rendered = lipgloss.JoinHorizontal(lipgloss.Top, rendered, scrollbar)
+	// The gutter column is always reserved (see sidebarContentWidth). Draw a
+	// real scrollbar when the sidebar is focused and its content overflows;
+	// otherwise fill the gutter with a blank spacer so nothing shifts and the
+	// scrollbar never overlaps content. Scrollbar returns "" when the content
+	// fits, so an unfocused or non-overflowing sidebar gets the blank spacer.
+	var gutter string
+	if focused {
+		gutter = common.Scrollbar(t, height, contentHeight, height, scroll)
 	}
+	if gutter == "" {
+		gutter = blankSidebarColumn(height)
+	}
+	rendered = lipgloss.JoinHorizontal(lipgloss.Top, rendered, gutter)
 
 	uv.NewStyledString(rendered).Draw(scr, area)
 }

--- a/internal/ui/model/sidebar_scrollbar_test.go
+++ b/internal/ui/model/sidebar_scrollbar_test.go
@@ -1,41 +1,45 @@
 package model
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
-// TestSidebarScrollbarLayout verifies the scrollbar gutter is reserved whenever
-// content overflows the viewport (independent of focus), keeping the content
-// width stable, and that no gutter is reserved when it fits.
-func TestSidebarScrollbarLayout(t *testing.T) {
+// TestSidebarContentWidth verifies the sidebar always reserves exactly one
+// column for the scrollbar gutter (so the cached full-width logo, rendered at
+// this same width, is never clipped) and clamps at zero for tiny widths.
+func TestSidebarContentWidth(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name          string
-		width         int
-		contentHeight int
-		viewport      int
-		wantWidth     int
-		wantScrollbar bool
+		sidebarWidth int
+		want         int
 	}{
-		{"fits exactly, no gutter", 30, 10, 10, 30, false},
-		{"fits under, no gutter", 30, 5, 10, 30, false},
-		{"overflows, reserve gutter", 30, 40, 10, 29, true},
-		{"overflows by one, reserve gutter", 30, 11, 10, 29, true},
-		{"overflow with zero width clamps", 0, 40, 10, 0, true},
-		{"overflow with width one clamps to zero", 1, 40, 10, 0, true},
+		{30, 29},
+		{2, 1},
+		{1, 0},
+		{0, 0},
 	}
-
 	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-			gotWidth, gotScrollbar := sidebarScrollbarLayout(tc.width, tc.contentHeight, tc.viewport)
-			require.Equal(t, tc.wantWidth, gotWidth, "content width")
-			require.Equal(t, tc.wantScrollbar, gotScrollbar, "scrollbar needed")
-		})
+		require.Equal(t, tc.want, sidebarContentWidth(tc.sidebarWidth),
+			"sidebarContentWidth(%d)", tc.sidebarWidth)
 	}
+}
+
+// TestBlankSidebarColumn verifies the gutter spacer is a single column, height
+// rows tall, and empty for non-positive heights.
+func TestBlankSidebarColumn(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, "", blankSidebarColumn(0))
+	require.Equal(t, "", blankSidebarColumn(-3))
+	require.Equal(t, " ", blankSidebarColumn(1))
+
+	got := blankSidebarColumn(3)
+	require.Equal(t, " \n \n ", got, "3 rows of a single-space column")
+	require.Equal(t, 3, strings.Count(got, " "), "one space per row")
 }
 
 // TestShortHelpTabStability verifies that the Tab key binding description

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -3517,9 +3517,12 @@ func (m *UI) renderEditorView(width int) string {
 	}, "\n")
 }
 
-// cacheSidebarLogo renders and caches the sidebar logo at the specified width.
+// cacheSidebarLogo renders and caches the sidebar logo. width is the full
+// sidebar width; the logo is rendered at the content width (i.e. minus the
+// reserved scrollbar gutter) so it matches drawSidebar and is never clipped
+// when the gutter is drawn.
 func (m *UI) cacheSidebarLogo(width int) {
-	m.sidebarLogo = renderLogo(m.com.Styles, true, m.com.IsHyper(), width)
+	m.sidebarLogo = renderLogo(m.com.Styles, true, m.com.IsHyper(), sidebarContentWidth(width))
 }
 
 // applyThemeForProvider swaps the active theme to the one associated with


### PR DESCRIPTION
## The bug

The sidebar CRUSH logo renders **cut off on its right edge**, with the focused scrollbar appearing as a **heavy full-height magenta bar** next to the mangled logo — the whole sidebar looks broken. (Reported on a focused sidebar; the footer shows the sidebar bindings `↑/↓ scroll · esc back to editor`.)

## Root cause

The logo is **cached at the full sidebar width** — `cacheSidebarLogo(m.layout.sidebar.Dx())` → `renderLogo(..., width)` — so it fills every column.

But `drawSidebar` reserved the scrollbar column the wrong way: it rendered **all** content at the full `width`, then applied `lipgloss…MaxWidth(width-1)` to the finished block and appended the scrollbar. So the gutter was **stolen from the content** rather than the content being rendered narrower. Every section is left-aligned and shorter than the width (its clipped column is just padding), **but the logo is the one element that fills the full width — so it loses its rightmost column.**

The magenta bar is the scrollbar itself: `ScrollbarThumb` uses the theme's accent color, and because the content only slightly overflows the viewport the thumb is nearly the full height — so it reads as a solid bar rather than a small handle.

**Why the earlier PRs didn't fix it:** #94 introduced the `MaxWidth` clip (only when focused + overflowing). #108 extended the reservation to the unfocused case (blank spacer) but kept the post-render clip — so the logo clipping now happened in *more* states. That's the regression.

## The fix

Reserve the gutter **consistently** and render the content **at the reduced width** instead of clipping after the fact:

- **`sidebarContentWidth(sidebarWidth)`** (= `width-1`, clamped ≥ 0) is now the single source of truth for the gutter reservation.
- **`cacheSidebarLogo`** renders the logo at that content width, and **`drawSidebar`** renders every section (title, cwd, model, files, LSPs, MCPs, skills, channels) at it too. Nothing exceeds the content area, so nothing is clipped — the logo is complete and the scrollbar sits cleanly in its own column beside it.
- The gutter always holds a 1-column strip: a real scrollbar when the sidebar is **focused and overflowing**, otherwise a **blank spacer** — so content width is stable across focus and overflow (which was #108's stated goal, implemented correctly).

## Tests

- `TestSidebarContentWidth` — the 1-col reservation + clamp (the invariant that keeps the cached logo and the rendered content the same width).
- `TestBlankSidebarColumn` — the gutter spacer shape.

Replaces `sidebarScrollbarLayout`, whose width-only reservation still relied on the post-render clip. (`drawSidebar` itself needs a full render harness — session + workspace + screen — to test end-to-end, so the invariants that actually cause/prevent the clip are unit-tested instead.)

Verified: `go build -race ./...`, `go vet`, `gofumpt`, `go mod tidy` clean, full `internal/ui/model` package green.
