### PR TITLE
fix(ui): pin sidebar to terminal's rightmost column so content is not clipped

### DIFF
--- a/internal/ui/model/sidebar_layout_test.go
+++ b/internal/ui/model/sidebar_layout_test.go
@@ -1,0 +1,31 @@
+package model
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestSidebarLayoutFlushToEdge verifies that in the non-compact chat view the
+// sidebar rectangle extends to the terminal's rightmost column and is the full
+// sidebarWidth (30). This pins the scrollbar gutter flush to the edge so
+// content is never clipped and the rightmost terminal column is not wasted.
+//
+// See: https://github.com/joestump-agent/crush/issues/112
+func TestSidebarLayoutFlushToEdge(t *testing.T) {
+	t.Parallel()
+
+	m := newSidebarTestUI()
+	// newSidebarTestUI defaults to uiChat + non-compact, which is the layout
+	// branch we need to exercise.
+	layout := m.generateLayout(m.width, 50)
+
+	const sidebarWidth = 30
+
+	require.Equal(t, sidebarWidth, layout.sidebar.Dx(),
+		"sidebar should be the full sidebarWidth (%d), got %d",
+		sidebarWidth, layout.sidebar.Dx())
+	require.Equal(t, m.width, layout.sidebar.Max.X,
+		"sidebar right edge should equal terminal width (%d) so the gutter is flush to the edge, got Max.X=%d",
+		m.width, layout.sidebar.Max.X)
+}

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -2975,7 +2975,10 @@ func (m *UI) generateLayout(w, h int) uiLayout {
 	helpHeight := 1
 	// The editor height: textarea height + margin for attachments and bottom spacing.
 	editorHeight := m.textarea.Height() + editorHeightMargin
-	// The sidebar width
+	// The sidebar width, budgeted right-to-left: the rightmost column is
+	// the scrollbar gutter (flush to the terminal edge), sidebarContentWidth
+	// is sidebarWidth-1, and 1 column of left padding separates sidebar from
+	// the main pane.
 	sidebarWidth := 30
 	// The header height
 	const landingHeaderHeight = 4
@@ -3121,8 +3124,13 @@ func (m *UI) generateLayout(w, h int) uiLayout {
 				layout.Len(appRect.Dx()-sidebarWidth),
 				layout.Fill(1),
 			).Split(appRect).Assign(&mainRect, &sideRect)
-			// Add padding left
+			// Add padding left (gap between main pane and sidebar)
 			sideRect.Min.X += 1
+			// The sidebar extends to the terminal's rightmost column so its
+			// reserved scrollbar gutter is flush to the edge and content is
+			// never clipped. The app-level right margin (appRect.Max.X -= 1)
+			// applies to the main pane; the sidebar claims that column back.
+			sideRect.Max.X = area.Max.X
 			var editorRect image.Rectangle
 			layout.Vertical(
 				layout.Len(mainRect.Dy()-editorHeight),


### PR DESCRIPTION
## Summary

The sidebar was one column too narrow, causing the compact `CRUSH` wordmark to lose its final stroke and leaving a dead blank column at the terminal's right edge.

**Root cause:** The global app right margin (`appRect.Max.X -= 1`) applied to both the main chat pane and the sidebar. The sidebar was carved from the rightmost portion of `appRect`, so its right edge landed at `terminal_width - 2`, wasting the terminal's rightmost column. Combined with the left-padding gutter (`sideRect.Min.X += 1`), the sidebar rect was 29 columns instead of the intended 30, and `sidebarContentWidth(29) = 28` was too narrow for the compact logo's natural width of 29.

**Fix:** Set `sideRect.Max.X = area.Max.X` after the horizontal split so the sidebar extends to the terminal's rightmost column. The app-level right margin still applies to the main pane; the sidebar claims that column for its scrollbar gutter.

### Column budget (right-to-left, w=100)

| Before | After |
|--------|-------|
| Col 99: **dead** (app margin) | Col 99: scrollbar gutter (flush to edge) |
| Col 98: scrollbar gutter | Col 98–70: sidebar content (**29 cols**) |
| Col 70–97: sidebar content (**28 cols** — clipped) | Col 69: 1-col gap |
| Col 69: 1-col gap | Col 1–68: main/chat pane |
| Col 1–68: main/chat pane | Col 0: left margin |
| Col 0: left margin | |

## Test plan

- [x] `TestSidebarLayoutFlushToEdge` — asserts `sidebar.Dx() == 30` and `sidebar.Max.X == terminalWidth`
- [x] `TestSidebarContentWidth` — existing test confirms `sidebarContentWidth(30) == 29`
- [x] All existing sidebar tests pass
- [ ] Manual: run in a real terminal and confirm the `CRUSH` wordmark renders complete, gutter sits in the last column, no horizontal shift between focused/unfocused states

Closes #112


💘 Generated with Crush