### PR TITLE
fix(ui): hide irrelevant help options when sidebar is focused

### DIFF
--- a/internal/ui/model/sidebar_help_test.go
+++ b/internal/ui/model/sidebar_help_test.go
@@ -1,0 +1,124 @@
+package model
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/crush/internal/ui/attachments"
+	"github.com/stretchr/testify/require"
+)
+
+// TestShortHelpSidebarHidesCommandOptions verifies that when the sidebar is
+// focused, ShortHelp does not include the commands (ctrl+p), models
+// (ctrl+m/ctrl+l), or help/more (ctrl+g) bindings — those actions are not
+// meaningful from the sidebar.
+func TestShortHelpSidebarHidesCommandOptions(t *testing.T) {
+	t.Parallel()
+
+	// Helper: collect all help keys from ShortHelp bindings.
+	collectKeys := func(m *UI) map[string]bool {
+		out := make(map[string]bool)
+		for _, b := range m.ShortHelp() {
+			out[b.Help().Key] = true
+		}
+		return out
+	}
+
+	t.Run("sidebar focus hides command options", func(t *testing.T) {
+		t.Parallel()
+		m := newSidebarTestUI()
+		m.focus = uiFocusSidebar
+		keys := collectKeys(m)
+
+		for _, key := range []string{"ctrl+l", "ctrl+m", "ctrl+g", "ctrl+p", "/ or ctrl+p"} {
+			require.False(t, keys[key], "key %q should NOT appear in ShortHelp when sidebar is focused", key)
+		}
+	})
+
+	t.Run("editor focus still shows command options", func(t *testing.T) {
+		t.Parallel()
+		m := newSidebarTestUI()
+		m.focus = uiFocusEditor
+		keys := collectKeys(m)
+
+		require.True(t, keys["ctrl+l"] || keys["ctrl+m"], "models binding should appear for editor focus")
+		require.True(t, keys["ctrl+g"], "help/more binding should appear for editor focus")
+		require.True(t, keys["ctrl+p"] || keys["/ or ctrl+p"], "commands binding should appear for editor focus")
+	})
+
+	t.Run("main focus still shows command options", func(t *testing.T) {
+		t.Parallel()
+		m := newSidebarTestUI()
+		m.focus = uiFocusMain
+		keys := collectKeys(m)
+
+		require.True(t, keys["ctrl+l"] || keys["ctrl+m"], "models binding should appear for main focus")
+		require.True(t, keys["ctrl+g"], "help/more binding should appear for main focus")
+		require.True(t, keys["ctrl+p"], "commands binding should appear for main focus")
+	})
+}
+
+// TestFullHelpSidebarHidesCommandOptions verifies that when the sidebar is
+// focused, FullHelp does not include the commands, models, or help/more
+// bindings.
+func TestFullHelpSidebarHidesCommandOptions(t *testing.T) {
+	t.Parallel()
+	m := newSidebarTestUI()
+	m.attachments = attachments.New(nil, attachments.Keymap{})
+	m.focus = uiFocusSidebar
+	binds := m.FullHelp()
+
+	helpKeys := make(map[string]bool)
+	for _, row := range binds {
+		for _, b := range row {
+			helpKeys[b.Help().Key] = true
+		}
+	}
+
+	for _, key := range []string{"ctrl+p", "ctrl+l", "ctrl+m", "ctrl+g", "/ or ctrl+p"} {
+		require.False(t, helpKeys[key], "key %q should NOT appear in FullHelp when sidebar is focused", key)
+	}
+}
+
+// TestShortHelpSidebarOnlyRelevantOptions verifies that ShortHelp for sidebar
+// focus contains only the expected set of help keys.
+func TestShortHelpSidebarOnlyRelevantOptions(t *testing.T) {
+	t.Parallel()
+	m := newSidebarTestUI()
+	m.focus = uiFocusSidebar
+	binds := m.ShortHelp()
+
+	// Sidebar help should only show: tab, scroll (↑/↓), esc, and quit.
+	expected := map[string]bool{
+		"tab":    true,
+		"↑/↓":    true,
+		"esc":    true,
+		"ctrl+c": true,
+	}
+	for _, b := range binds {
+		key := b.Help().Key
+		require.True(t, expected[key], "unexpected key %q in sidebar ShortHelp", key)
+	}
+	// Ensure we don't accidentally produce an empty list.
+	require.NotEmpty(t, binds)
+}
+
+// TestFullHelpSidebarNoIrrelevantDescs does a description-based check to
+// ensure that none of the FullHelp entries mention "commands", "models", or
+// "more"/"less" when the sidebar is focused.
+func TestFullHelpSidebarNoIrrelevantDescs(t *testing.T) {
+	t.Parallel()
+	m := newSidebarTestUI()
+	m.attachments = attachments.New(nil, attachments.Keymap{})
+	m.focus = uiFocusSidebar
+	binds := m.FullHelp()
+
+	for _, row := range binds {
+		for _, b := range row {
+			desc := strings.ToLower(b.Help().Desc)
+			require.False(t, desc == "commands", "commands binding should not appear in sidebar FullHelp")
+			require.False(t, desc == "models", "models binding should not appear in sidebar FullHelp")
+			require.False(t, desc == "more" || desc == "less", "help toggle should not appear in sidebar FullHelp")
+		}
+	}
+}

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -2663,12 +2663,13 @@ func (m *UI) ShortHelp() []key.Binding {
 			binds = append(binds, cancelBinding)
 		}
 
-		binds = append(
-			binds,
-			tab,
-			commands,
-			k.Models,
-		)
+		isSidebar := m.focus == uiFocusSidebar
+
+		commonBinds := []key.Binding{tab}
+		if !isSidebar {
+			commonBinds = append(commonBinds, commands, k.Models)
+		}
+		binds = append(binds, commonBinds...)
 
 		switch m.focus {
 		case uiFocusEditor:
@@ -2711,10 +2712,14 @@ func (m *UI) ShortHelp() []key.Binding {
 		)
 	}
 
+	isSidebar := m.focus == uiFocusSidebar
+	footerBinds := []key.Binding{k.Quit}
+	if !isSidebar {
+		footerBinds = append(footerBinds, k.Help)
+	}
 	binds = append(
 		binds,
-		k.Quit,
-		k.Help,
+		footerBinds...,
 	)
 
 	return binds
@@ -2754,11 +2759,16 @@ func (m *UI) FullHelp() [][]key.Binding {
 		mainBinds := []key.Binding{}
 		tab := k.Tab
 
+		isSidebar := m.focus == uiFocusSidebar
+
 		mainBinds = append(
 			mainBinds,
 			tab,
-			commands,
-			k.Models,
+		)
+		if !isSidebar {
+			mainBinds = append(mainBinds, commands, k.Models)
+		}
+		mainBinds = append(mainBinds,
 			k.Sessions,
 			k.ToggleYolo,
 		)
@@ -2847,12 +2857,14 @@ func (m *UI) FullHelp() [][]key.Binding {
 		}
 	}
 
+	isSidebar := m.focus == uiFocusSidebar
+	footerBinds := []key.Binding{k.Quit}
+	if !isSidebar {
+		footerBinds = append([]key.Binding{help}, footerBinds...)
+	}
 	binds = append(
 		binds,
-		[]key.Binding{
-			help,
-			k.Quit,
-		},
+		footerBinds,
 	)
 
 	return binds


### PR DESCRIPTION

## Summary

When the sidebar is focused, the help footer and full help menu displayed three options that don't make sense in that context: `ctrl+p` (commands), `ctrl+m`/`ctrl+l` (models), and `ctrl+g` (more/help). These are now hidden from both `ShortHelp` and `FullHelp` when the sidebar has focus, leaving only the relevant bindings: `tab`, `↑/↓ scroll`, `esc`, and `ctrl+c quit`.

## Changes

- **`internal/ui/model/ui.go`** — In `ShortHelp()` and `FullHelp()`, conditionally skip appending the commands, models, and help bindings when `m.focus == uiFocusSidebar`
- **`internal/ui/model/sidebar_help_test.go`** — New test file verifying the sidebar help menu hides irrelevant options while editor/main focus still show them

## Test plan

- [x] `go test ./internal/ui/model/` passes
- [x] `gofumpt -w .` clean
- [x] `go vet ./internal/ui/model/` clean
- [ ] Manual: focus sidebar, confirm help footer only shows tab/scroll/esc/quit

💘 Generated with Crush