### PR TITLE
fix(ui): add right-pad column between sidebar content and scrollbar

### DIFF
--- a/internal/ui/model/sidebar.go
+++ b/internal/ui/model/sidebar.go
@@ -145,21 +145,27 @@ func (m *UI) scrollSidebarOnWheel(msg common.CoalescedWheelMsg) bool {
 }
 
 // sidebarScrollbarWidth is the fixed 1-column gutter the sidebar reserves for
-// its scroll indicator.
+// its scroll indicator (flush to the terminal's rightmost column).
 const sidebarScrollbarWidth = 1
 
+// sidebarRightPadWidth is a fixed 1-column blank spacer between the sidebar
+// content and the scrollbar gutter, so the scrollbar never sits flush against
+// the content.
+const sidebarRightPadWidth = 1
+
 // sidebarContentWidth returns the width available for sidebar content after
-// reserving the scrollbar gutter. The gutter is reserved unconditionally (not
-// only when content overflows) so the content — including the fixed-width logo,
-// which is cached at this same width — is always rendered at its final width
-// and never clipped when the scrollbar is drawn. Keeping it focus- and
-// overflow-independent also stops the content from shifting on focus changes.
+// reserving the right pad and the scrollbar gutter. Both are reserved
+// unconditionally (not only when content overflows) so the content — including
+// the fixed-width logo, which is cached at this same width — is always rendered
+// at its final width and never clipped when the scrollbar is drawn. Keeping it
+// focus- and overflow-independent also stops the content from shifting on focus
+// changes.
 func sidebarContentWidth(sidebarWidth int) int {
-	return max(sidebarWidth-sidebarScrollbarWidth, 0)
+	return max(sidebarWidth-sidebarScrollbarWidth-sidebarRightPadWidth, 0)
 }
 
-// blankSidebarColumn renders an empty gutter column height rows tall, used when
-// the sidebar reserves scrollbar space but has no scrollbar to draw.
+// blankSidebarColumn renders an empty column height rows tall, used for the
+// right pad and for the scrollbar gutter when there is no scrollbar to draw.
 func blankSidebarColumn(height int) string {
 	if height <= 0 {
 		return ""
@@ -290,11 +296,13 @@ func (m *UI) drawSidebar(scr uv.Screen, area uv.Rectangle) {
 		MaxHeight(height)
 	rendered := contentStyle.Render(scrolledContent)
 
-	// The gutter column is always reserved (see sidebarContentWidth). Draw a
-	// real scrollbar when the sidebar is focused and its content overflows;
-	// otherwise fill the gutter with a blank spacer so nothing shifts and the
-	// scrollbar never overlaps content. Scrollbar returns "" when the content
-	// fits, so an unfocused or non-overflowing sidebar gets the blank spacer.
+	// The right pad and gutter columns are always reserved (see
+	// sidebarContentWidth). Draw a real scrollbar in the gutter when the sidebar
+	// is focused and its content overflows; otherwise fill it with a blank
+	// spacer so nothing shifts and the scrollbar never overlaps content.
+	// Scrollbar returns "" when the content fits, so an unfocused or
+	// non-overflowing sidebar gets the blank spacer. The pad is always blank,
+	// keeping the scrollbar off the content.
 	var gutter string
 	if focused {
 		gutter = common.Scrollbar(t, height, contentHeight, height, scroll)
@@ -302,7 +310,8 @@ func (m *UI) drawSidebar(scr uv.Screen, area uv.Rectangle) {
 	if gutter == "" {
 		gutter = blankSidebarColumn(height)
 	}
-	rendered = lipgloss.JoinHorizontal(lipgloss.Top, rendered, gutter)
+	pad := blankSidebarColumn(height)
+	rendered = lipgloss.JoinHorizontal(lipgloss.Top, rendered, pad, gutter)
 
 	uv.NewStyledString(rendered).Draw(scr, area)
 }

--- a/internal/ui/model/sidebar_layout_test.go
+++ b/internal/ui/model/sidebar_layout_test.go
@@ -8,7 +8,7 @@ import (
 
 // TestSidebarLayoutFlushToEdge verifies that in the non-compact chat view the
 // sidebar rectangle extends to the terminal's rightmost column and is the full
-// sidebarWidth (30). This pins the scrollbar gutter flush to the edge so
+// sidebarWidth (32). This pins the scrollbar gutter flush to the edge so
 // content is never clipped and the rightmost terminal column is not wasted.
 //
 // See: https://github.com/joestump-agent/crush/issues/112
@@ -20,7 +20,7 @@ func TestSidebarLayoutFlushToEdge(t *testing.T) {
 	// branch we need to exercise.
 	layout := m.generateLayout(m.width, 50)
 
-	const sidebarWidth = 30
+	const sidebarWidth = 32
 
 	require.Equal(t, sidebarWidth, layout.sidebar.Dx(),
 		"sidebar should be the full sidebarWidth (%d), got %d",

--- a/internal/ui/model/sidebar_scrollbar_test.go
+++ b/internal/ui/model/sidebar_scrollbar_test.go
@@ -7,9 +7,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestSidebarContentWidth verifies the sidebar always reserves exactly one
-// column for the scrollbar gutter (so the cached full-width logo, rendered at
-// this same width, is never clipped) and clamps at zero for tiny widths.
+// TestSidebarContentWidth verifies the sidebar always reserves two columns —
+// the right pad plus the scrollbar gutter (so the cached full-width logo,
+// rendered at this same width, is never clipped and the scrollbar never sits
+// flush against content) — and clamps at zero for tiny widths.
 func TestSidebarContentWidth(t *testing.T) {
 	t.Parallel()
 
@@ -17,8 +18,9 @@ func TestSidebarContentWidth(t *testing.T) {
 		sidebarWidth int
 		want         int
 	}{
-		{30, 29},
-		{2, 1},
+		{32, 30},
+		{3, 1},
+		{2, 0},
 		{1, 0},
 		{0, 0},
 	}

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -2975,11 +2975,12 @@ func (m *UI) generateLayout(w, h int) uiLayout {
 	helpHeight := 1
 	// The editor height: textarea height + margin for attachments and bottom spacing.
 	editorHeight := m.textarea.Height() + editorHeightMargin
-	// The sidebar width, budgeted right-to-left: the rightmost column is
-	// the scrollbar gutter (flush to the terminal edge), sidebarContentWidth
-	// is sidebarWidth-1, and 1 column of left padding separates sidebar from
+	// The sidebar width, budgeted right-to-left: the rightmost column is the
+	// scrollbar gutter (flush to the terminal edge), then a 1-column right pad
+	// keeps the scrollbar off the content, then sidebarContentWidth
+	// (sidebarWidth-2), and 1 column of left padding separates the sidebar from
 	// the main pane.
-	sidebarWidth := 30
+	sidebarWidth := 32
 	// The header height
 	const landingHeaderHeight = 4
 


### PR DESCRIPTION
## Summary

Follow-up to #113 (which fixed the sidebar clip from #112). With the sidebar pinned flush to the terminal's rightmost column, the scrollbar gutter sat **directly against the content** — no breathing room, and asymmetric with the 1-column gap on the sidebar's left.

This reserves a **blank pad column between the content and the scrollbar gutter**, keeping the scrollbar flush to the edge while giving the content room.

## Change

Budget the sidebar right-to-left as: `scrollbar gutter (1) + right pad (1) + content`. To keep content wide enough for the compact `CRUSH` logo (natural width **29**), the sidebar grows from **30 → 32** columns, so content stays at **30**:

- `sidebarWidth := 32` (`ui.go`)
- new `sidebarRightPadWidth = 1`; `sidebarContentWidth` now reserves pad **and** gutter (`sidebarWidth - 2`)
- `drawSidebar` joins `content + pad + gutter`; the pad is always blank, the gutter is the scrollbar (focused + overflowing) or blank otherwise

**Cost:** the main/chat pane gives up 2 columns (sidebar 30 → 32). Negligible at normal widths.

### Column budget (right-to-left, w=100)

| Before (#113) | After |
|--------|-------|
| Col 99: scrollbar gutter (flush) | Col 99: scrollbar gutter (flush) |
| Col 70–98: content (**29**) | Col 98: blank right pad |
| Col 69: 1-col left gap | Col 69–97: content (**30**) |
| Col 1–68: main/chat | Col 68: 1-col left gap |
| | Col 1–67: main/chat |

## Test plan

- [x] `TestSidebarLayoutFlushToEdge` — updated to assert `sidebar.Dx() == 32` and `sidebar.Max.X == terminalWidth` (still flush)
- [x] `TestSidebarContentWidth` — updated: reserves two columns now (`sidebarContentWidth(32) == 30`)
- [x] `go build ./...`, `go vet ./internal/ui/model/`, and `go test ./internal/ui/...` all pass locally
- [ ] Manual: confirm in a real terminal that the scrollbar has a 1-col gap from content, still flush to the edge, no shift between focused/unfocused

🤖 Posted on behalf of `@joestump` by [Claude](https://claude.ai).