### PR TITLE
fix(ui): future-proof sidebar key routing — gate commands/models/help + guardrail test

### DIFF
--- a/internal/ui/model/sidebar_inert_keys_test.go
+++ b/internal/ui/model/sidebar_inert_keys_test.go
@@ -1,0 +1,72 @@
+package model
+
+import (
+	"testing"
+
+	"charm.land/bubbles/v2/key"
+	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/crush/internal/ui/dialog"
+	"github.com/stretchr/testify/require"
+)
+
+// ctrl builds a KeyPressMsg for ctrl+<r>. Note: a Text field would override the
+// derived key string (e.g. "p" instead of "ctrl+p") and silently break matching
+// — so it is intentionally omitted.
+func ctrl(r rune) tea.KeyPressMsg {
+	return tea.KeyPressMsg{Code: r, Mod: tea.ModCtrl}
+}
+
+// TestSidebarSuppressesGlobalKeys pins the invariant that the commands (ctrl+p),
+// models (ctrl+m/ctrl+l), and help (ctrl+g) actions are inert while the sidebar
+// is focused — matching the sidebar help, which hides them (see #114 /
+// sidebar_help_test.go). Today the sidebar focus case does not route to the
+// global key handler at all; handleGlobalKeys also gates these keys for sidebar
+// focus. This test guards both: if a future change (e.g. the interactive
+// secondary-agent sidebar) starts routing sidebar keys through the global
+// handler, this fails unless commands/models/help remain suppressed.
+func TestSidebarSuppressesGlobalKeys(t *testing.T) {
+	t.Parallel()
+
+	// Sanity: confirm these key events really are the global bindings, so the
+	// assertions below can't pass vacuously if a binding changes.
+	km := DefaultKeyMap()
+	require.True(t, key.Matches(ctrl('p'), km.Commands), "ctrl+p must map to Commands")
+	require.True(t, key.Matches(ctrl('m'), km.Models), "ctrl+m must map to Models")
+	require.True(t, key.Matches(ctrl('l'), km.Models), "ctrl+l must map to Models")
+	require.True(t, key.Matches(ctrl('g'), km.Help), "ctrl+g must map to Help")
+
+	newUI := func() *UI {
+		m := newSidebarTestUI()
+		// ToggleHelp() derefs m.status; give it a real one so an un-suppressed
+		// Help key would toggle (and be caught) rather than nil-panic.
+		m.status = NewStatus(m.com, m)
+		m.focus = uiFocusSidebar
+		return m
+	}
+
+	t.Run("commands key does not open the commands dialog", func(t *testing.T) {
+		t.Parallel()
+		m := newUI()
+		m.handleKeyPressMsg(ctrl('p'))
+		require.False(t, m.dialog.ContainsDialog(dialog.CommandsID),
+			"ctrl+p must be inert while the sidebar is focused")
+	})
+
+	t.Run("models keys do not open the models dialog", func(t *testing.T) {
+		t.Parallel()
+		m := newUI()
+		m.handleKeyPressMsg(ctrl('m'))
+		m.handleKeyPressMsg(ctrl('l'))
+		require.False(t, m.dialog.ContainsDialog(dialog.ModelsID),
+			"ctrl+m / ctrl+l must be inert while the sidebar is focused")
+	})
+
+	t.Run("help key does not toggle help", func(t *testing.T) {
+		t.Parallel()
+		m := newUI()
+		require.False(t, m.status.ShowingAll())
+		m.handleKeyPressMsg(ctrl('g'))
+		require.False(t, m.status.ShowingAll(),
+			"ctrl+g must be inert while the sidebar is focused")
+	})
+}

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -2019,17 +2019,27 @@ func (m *UI) handleKeyPressMsg(msg tea.KeyPressMsg) tea.Cmd {
 	var cmds []tea.Cmd
 
 	handleGlobalKeys := func(msg tea.KeyPressMsg) bool {
+		// Commands, models, and help/more are not meaningful from the sidebar,
+		// so they are hidden from its help (see ShortHelp/FullHelp, #114) and
+		// gated off here. The sidebar case in the focus switch below does not
+		// currently route through this handler, so today this only matters as a
+		// guarantee: when the interactive secondary-agent sidebar lands and
+		// starts routing unhandled keys through handleGlobalKeys (like the
+		// editor/main cases already do), these three stay inert unless the help
+		// is deliberately updated to advertise them. Keep this in lockstep with
+		// the sidebar help and TestSidebarSuppressesGlobalKeys.
+		notSidebar := m.focus != uiFocusSidebar
 		switch {
-		case key.Matches(msg, m.keyMap.Help):
+		case notSidebar && key.Matches(msg, m.keyMap.Help):
 			m.status.ToggleHelp()
 			m.updateLayoutAndSize()
 			return true
-		case key.Matches(msg, m.keyMap.Commands):
+		case notSidebar && key.Matches(msg, m.keyMap.Commands):
 			if cmd := m.openCommandsDialog(); cmd != nil {
 				cmds = append(cmds, cmd)
 			}
 			return true
-		case key.Matches(msg, m.keyMap.Models):
+		case notSidebar && key.Matches(msg, m.keyMap.Models):
 			if cmd := m.openModelsDialog(); cmd != nil {
 				cmds = append(cmds, cmd)
 			}
@@ -2353,6 +2363,14 @@ func (m *UI) handleKeyPressMsg(msg tea.KeyPressMsg) tea.Cmd {
 				}
 			}
 		case uiFocusSidebar:
+			// The sidebar is currently a read-only status panel, so it only
+			// handles focus/scroll keys and intentionally does NOT fall through
+			// to handleGlobalKeys — every other key is inert while it's focused.
+			// When the interactive secondary-agent sidebar lands, route its keys
+			// here (and add `default: handleGlobalKeys(msg)` to keep global keys
+			// working, mirroring the editor/main cases). handleGlobalKeys already
+			// gates commands/models/help for sidebar focus, so those stay inert
+			// unless you also un-hide them from the sidebar help (#114).
 			switch {
 			case key.Matches(msg, m.keyMap.Tab), key.Matches(msg, m.keyMap.Editor.Escape):
 				m.focus = uiFocusEditor


### PR DESCRIPTION
## Context

Follow-up to #114. That PR hid the commands (`ctrl+p`), models (`ctrl+m`/`ctrl+l`), and help (`ctrl+g`) options from the help footer/menu when the sidebar is focused. Reviewing the key routing revealed those keys are **already inert** during sidebar focus — the `uiFocusSidebar` case in `handleKeyPressMsg` only handles Tab/Esc/Up/Down and, unlike the editor/main cases, does **not** fall through to `handleGlobalKeys`. So today nothing needs disabling.

**But** the sidebar is about to become a fully interactive secondary-agent chat (the reason it was made focusable + scrollable). When that lands, whoever wires it up will naturally add `default: handleGlobalKeys(msg)` to the sidebar case (mirroring editor/main) — which would silently re-enable commands/models/help from the sidebar and contradict the #114 help. This PR future-proofs that path so it can't happen by accident.

## Changes

- **Gate** commands/models/help in `handleGlobalKeys` on `m.focus != uiFocusSidebar`. It's inert today (the sidebar doesn't reach this handler yet), but it means the moment the sidebar *does* route keys through the global handler, those three stay consistent with the sidebar help instead of re-enabling.
- **Signpost comment** at the `uiFocusSidebar` dead-end explaining that it deliberately doesn't route to `handleGlobalKeys` yet, and how to wire keys in later without regressing the invariant.
- **`TestSidebarSuppressesGlobalKeys`** pins the invariant. It drives the real `handleKeyPressMsg` with the sidebar focused and asserts ctrl+p/ctrl+m/ctrl+l/ctrl+g are inert (no dialog opens, help doesn't toggle), with `key.Matches` sanity checks so it can't pass vacuously if a binding changes.

## Validation (that the guardrail actually has teeth)

Simulated the future change locally:

- Add `default: handleGlobalKeys(msg)` to the sidebar case **with the gate kept** → test **passes** (the gate keeps the three inert once the sidebar routes keys). ✅
- Same routing **with the gate neutralized** → test **fails** (dialog opens / help toggles). ✅

So the test enforces the coupling: enabling these keys in the sidebar requires a *conscious* change to the gate **and** the sidebar help **and** this test — never a silent regression.

## Test plan

- [x] `go build ./...`, `go vet ./internal/ui/model/`, `go test ./internal/ui/model/` all pass
- [x] Guardrail validated in both directions (see above)
- [ ] Revisit when the interactive sidebar lands: decide whether commands/models/help *should* work from the sidebar chat; if so, update the gate + help + this test together

🤖 Posted on behalf of `@joestump` by [Claude](https://claude.ai).