### PR TITLE
feat(ui): use framed-square glyph for image attachment icon

### DIFF
--- a/internal/ui/styles/styles.go
+++ b/internal/ui/styles/styles.go
@@ -41,7 +41,7 @@ const (
 	TodoPendingIcon    string = "•"
 	TodoInProgressIcon string = "→"
 
-	ImageIcon string = "■"
+	ImageIcon string = "▣"
 	TextIcon  string = "≡"
 	SkillIcon string = "▲"
 


### PR DESCRIPTION
Replaces the plain black square (■, U+25A0) with a framed square (▣, U+25A3) for image attachment chips. The new glyph reads more clearly as "picture" while staying in the same geometric icon family as the text (≡) and skill (▲) icons.

💘 Generated with Crush