### PR TITLE
feat(ui): add clickable remove button to attachment chips

### DIFF
--- a/internal/ui/attachments/attachments.go
+++ b/internal/ui/attachments/attachments.go
@@ -74,6 +74,22 @@ func (m *Attachments) Update(msg tea.Msg) bool {
 	return false
 }
 
+// HandleClick processes a mouse click at the given x offset within the
+// attachment row. If the click lands on a remove button, the
+// corresponding attachment is removed. It returns true if the click was
+// handled.
+func (m *Attachments) HandleClick(x int) bool {
+	if m.deleting || len(m.list) == 0 {
+		return false
+	}
+	idx := m.renderer.HitTestRemove(m.list, x)
+	if idx >= 0 && idx < len(m.list) {
+		m.list = slices.Delete(m.list, idx, idx+1)
+		return true
+	}
+	return false
+}
+
 func (m *Attachments) Render(width int) string {
 	return m.renderer.Render(m.list, m.deleting, width)
 }
@@ -82,35 +98,52 @@ func (m *Attachments) Render(width int) string {
 // styles in place.
 func (m *Attachments) Renderer() *Renderer { return m.renderer }
 
-func NewRenderer(normalStyle, deletingStyle, imageStyle, textStyle, skillStyle lipgloss.Style) *Renderer {
+func NewRenderer(normalStyle, deletingStyle, imageStyle, textStyle, skillStyle, removeStyle lipgloss.Style) *Renderer {
 	return &Renderer{
 		normalStyle:   normalStyle,
 		textStyle:     textStyle,
 		imageStyle:    imageStyle,
 		skillStyle:    skillStyle,
+		removeStyle:   removeStyle,
 		deletingStyle: deletingStyle,
 	}
 }
 
 // SetStyles updates the renderer styles in place.
-func (r *Renderer) SetStyles(normalStyle, deletingStyle, imageStyle, textStyle, skillStyle lipgloss.Style) {
+func (r *Renderer) SetStyles(normalStyle, deletingStyle, imageStyle, textStyle, skillStyle, removeStyle lipgloss.Style) {
 	r.normalStyle = normalStyle
 	r.textStyle = textStyle
 	r.imageStyle = imageStyle
 	r.skillStyle = skillStyle
+	r.removeStyle = removeStyle
 	r.deletingStyle = deletingStyle
 }
 
 type Renderer struct {
-	normalStyle, textStyle, imageStyle, skillStyle, deletingStyle lipgloss.Style
+	normalStyle, textStyle, imageStyle, skillStyle, removeStyle, deletingStyle lipgloss.Style
+	// bounds stores the X-coordinate ranges of each chip's remove
+	// button from the most recent Render call, for mouse hit-testing.
+	bounds []chipBounds
 }
 
+// chipBounds holds the rendered strings and the X-coordinate range of
+// each chip's remove button for hit-testing.
+type chipBounds struct {
+	startX    int
+	removeEnd int // exclusive end X of the remove button (0 if none)
+}
+
+// Render renders the attachment chips. When not in deleting mode, each
+// chip shows an icon, filename, and a remove button (✕) on the right.
 func (r *Renderer) Render(attachments []message.Attachment, deleting bool, width int) string {
 	var chips []string
+	r.bounds = r.bounds[:0]
 
-	maxItemWidth := lipgloss.Width(r.imageStyle.String() + r.normalStyle.Render(strings.Repeat("x", maxFilename)))
+	removeStr := r.removeStyle.String()
+	maxItemWidth := lipgloss.Width(r.imageStyle.String() + r.normalStyle.Render(strings.Repeat("x", maxFilename)) + removeStr)
 	fits := int(math.Floor(float64(width)/float64(maxItemWidth))) - 1
 
+	var offset int
 	for i, att := range attachments {
 		filename := filepath.Base(att.FileName)
 		// Truncate if needed.
@@ -124,12 +157,26 @@ func (r *Renderer) Render(attachments []message.Attachment, deleting bool, width
 				r.deletingStyle.Render(fmt.Sprintf("%d", i)),
 				r.normalStyle.Render(filename),
 			)
+			offset += lipgloss.Width(r.deletingStyle.Render(fmt.Sprintf("%d", i))) + lipgloss.Width(r.normalStyle.Render(filename))
 		} else {
+			iconStr := r.icon(att).String()
+			nameStr := r.normalStyle.Render(filename)
+
 			chips = append(
 				chips,
-				r.icon(att).String(),
-				r.normalStyle.Render(filename),
+				iconStr,
+				nameStr,
+				removeStr,
 			)
+
+			chipW := lipgloss.Width(iconStr) + lipgloss.Width(nameStr)
+			removeStart := offset + chipW
+			removeW := lipgloss.Width(removeStr)
+			r.bounds = append(r.bounds, chipBounds{
+				startX:    removeStart,
+				removeEnd: removeStart + removeW,
+			})
+			offset = removeStart + removeW
 		}
 
 		if i == fits && len(attachments) > i {
@@ -139,6 +186,17 @@ func (r *Renderer) Render(attachments []message.Attachment, deleting bool, width
 	}
 
 	return lipgloss.JoinHorizontal(lipgloss.Left, chips...)
+}
+
+// HitTestRemove returns the index of the attachment whose remove button
+// contains the given x coordinate, or -1 if none.
+func (r *Renderer) HitTestRemove(_ []message.Attachment, x int) int {
+	for i, b := range r.bounds {
+		if x >= b.startX && x < b.removeEnd {
+			return i
+		}
+	}
+	return -1
 }
 
 func (r *Renderer) icon(a message.Attachment) lipgloss.Style {

--- a/internal/ui/attachments/attachments_test.go
+++ b/internal/ui/attachments/attachments_test.go
@@ -1,0 +1,189 @@
+package attachments
+
+import (
+	"testing"
+
+	"github.com/charmbracelet/crush/internal/message"
+	"github.com/charmbracelet/crush/internal/ui/styles"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestRenderer() *Renderer {
+	sty := styles.CharmtonePantera()
+	return NewRenderer(
+		sty.Attachments.Normal,
+		sty.Attachments.Deleting,
+		sty.Attachments.Image,
+		sty.Attachments.Text,
+		sty.Attachments.Skill,
+		sty.Attachments.Remove,
+	)
+}
+
+func TestRender_IncludesRemoveButton(t *testing.T) {
+	t.Parallel()
+
+	r := newTestRenderer()
+	atts := []message.Attachment{
+		{FileName: "test.txt"},
+	}
+	out := r.Render(atts, false, 80)
+	require.Contains(t, out, styles.RemoveIcon)
+}
+
+func TestRender_DeletingModeNoRemoveButton(t *testing.T) {
+	t.Parallel()
+
+	r := newTestRenderer()
+	atts := []message.Attachment{
+		{FileName: "test.txt"},
+	}
+	out := r.Render(atts, true, 80)
+	require.NotContains(t, out, styles.RemoveIcon)
+}
+
+func TestRender_MultipleChipsEachHaveRemoveButton(t *testing.T) {
+	t.Parallel()
+
+	r := newTestRenderer()
+	atts := []message.Attachment{
+		{FileName: "a.txt"},
+		{FileName: "b.txt"},
+		{FileName: "c.txt"},
+	}
+	out := r.Render(atts, false, 120)
+	// Count occurrences of the remove glyph.
+	count := 0
+	for _, c := range out {
+		if string(c) == styles.RemoveIcon {
+			count++
+		}
+	}
+	require.Equal(t, 3, count, "each chip should have a remove button")
+}
+
+func TestHitTestRemove_ClickOnFirstChipRemove(t *testing.T) {
+	t.Parallel()
+
+	r := newTestRenderer()
+	atts := []message.Attachment{
+		{FileName: "first.txt"},
+		{FileName: "second.txt"},
+	}
+	_ = r.Render(atts, false, 120)
+
+	// The remove button of the first chip should be hit-testable.
+	// Click at various X positions to verify we hit the right chip.
+	idx := r.HitTestRemove(atts, 0)
+	// At x=0 we're on the icon, not the remove button.
+	require.Equal(t, -1, idx)
+}
+
+func TestHitTestRemove_ReturnsCorrectIndex(t *testing.T) {
+	t.Parallel()
+
+	r := newTestRenderer()
+	atts := []message.Attachment{
+		{FileName: "first.txt"},
+		{FileName: "second.txt"},
+	}
+	_ = r.Render(atts, false, 120)
+
+	// Each chip bounds are stored after render. Verify there are two.
+	require.Len(t, r.bounds, 2)
+
+	// Click on the first chip's remove button.
+	b0 := r.bounds[0]
+	idx := r.HitTestRemove(atts, b0.startX)
+	require.Equal(t, 0, idx)
+
+	// Click on the second chip's remove button.
+	b1 := r.bounds[1]
+	idx = r.HitTestRemove(atts, b1.startX)
+	require.Equal(t, 1, idx)
+}
+
+func TestHitTestRemove_OutsideAnyRemoveReturnsMinusOne(t *testing.T) {
+	t.Parallel()
+
+	r := newTestRenderer()
+	atts := []message.Attachment{
+		{FileName: "test.txt"},
+	}
+	_ = r.Render(atts, false, 80)
+
+	// Click far past the remove button.
+	idx := r.HitTestRemove(atts, 999)
+	require.Equal(t, -1, idx)
+}
+
+func TestHandleClick_RemovesAttachment(t *testing.T) {
+	t.Parallel()
+
+	r := newTestRenderer()
+	km := Keymap{}
+	m := New(r, km)
+	m.list = []message.Attachment{
+		{FileName: "first.txt"},
+		{FileName: "second.txt"},
+	}
+
+	// Render so bounds are populated.
+	_ = m.Render(120)
+
+	// Click the first chip's remove button.
+	b0 := r.bounds[0]
+	handled := m.HandleClick(b0.startX)
+	require.True(t, handled)
+	require.Len(t, m.list, 1)
+	require.Equal(t, "second.txt", m.list[0].FileName)
+}
+
+func TestHandleClick_ClickOutsideRemoveDoesNothing(t *testing.T) {
+	t.Parallel()
+
+	r := newTestRenderer()
+	km := Keymap{}
+	m := New(r, km)
+	m.list = []message.Attachment{
+		{FileName: "test.txt"},
+	}
+
+	_ = m.Render(80)
+
+	// Click at x=0 (the icon area, not the remove button).
+	handled := m.HandleClick(0)
+	require.False(t, handled)
+	require.Len(t, m.list, 1)
+}
+
+func TestHandleClick_DeletingModeIgnored(t *testing.T) {
+	t.Parallel()
+
+	r := newTestRenderer()
+	km := Keymap{}
+	m := New(r, km)
+	m.list = []message.Attachment{
+		{FileName: "test.txt"},
+	}
+	m.deleting = true
+
+	_ = m.Render(80)
+
+	// bounds are empty in deleting mode since remove buttons aren't rendered.
+	require.Empty(t, r.bounds)
+	// Click anywhere — should be ignored.
+	handled := m.HandleClick(10)
+	require.False(t, handled)
+}
+
+func TestHandleClick_EmptyListIgnored(t *testing.T) {
+	t.Parallel()
+
+	r := newTestRenderer()
+	km := Keymap{}
+	m := New(r, km)
+
+	handled := m.HandleClick(5)
+	require.False(t, handled)
+}

--- a/internal/ui/chat/messages.go
+++ b/internal/ui/chat/messages.go
@@ -495,6 +495,7 @@ func ExtractMessageItems(sty *styles.Styles, msg *message.Message, toolResults m
 			sty.Attachments.Image,
 			sty.Attachments.Text,
 			sty.Attachments.Skill,
+			sty.Attachments.Remove,
 		)
 		items = []MessageItem{NewUserMessageItem(sty, msg, r)}
 		if IsChannelMessage(msg) {

--- a/internal/ui/chat/prefix_cache_test.go
+++ b/internal/ui/chat/prefix_cache_test.go
@@ -117,6 +117,7 @@ func TestUserMessageItemRender_PrefixCacheFocusBlur(t *testing.T) {
 		sty.Attachments.Image,
 		sty.Attachments.Text,
 		sty.Attachments.Skill,
+		sty.Attachments.Remove,
 	)
 	item := NewUserMessageItem(&sty, msg, r).(*UserMessageItem)
 

--- a/internal/ui/chat/user_test.go
+++ b/internal/ui/chat/user_test.go
@@ -25,6 +25,7 @@ func newTestUserItem(text string, createdAt int64) *UserMessageItem {
 		sty.Attachments.Image,
 		sty.Attachments.Text,
 		sty.Attachments.Skill,
+		sty.Attachments.Remove,
 	)
 	return NewUserMessageItem(&sty, msg, r).(*UserMessageItem)
 }

--- a/internal/ui/chat/version_bump_test.go
+++ b/internal/ui/chat/version_bump_test.go
@@ -84,6 +84,7 @@ func TestUserMessageItem_MutatorsBumpVersion(t *testing.T) {
 		sty.Attachments.Image,
 		sty.Attachments.Text,
 		sty.Attachments.Skill,
+		sty.Attachments.Remove,
 	)
 	msg := &message.Message{
 		ID:   "u-mut",
@@ -255,6 +256,7 @@ func TestUserMessageItem_FinishedAlwaysTrue(t *testing.T) {
 		sty.Attachments.Image,
 		sty.Attachments.Text,
 		sty.Attachments.Skill,
+		sty.Attachments.Remove,
 	)
 	msg := &message.Message{
 		ID:    "u-fin",

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -360,6 +360,7 @@ func New(com *common.Common, initialSessionID string, continueLast bool) *UI {
 			com.Styles.Attachments.Image,
 			com.Styles.Attachments.Text,
 			com.Styles.Attachments.Skill,
+			com.Styles.Attachments.Remove,
 		),
 		attachments.Keymap{
 			DeleteMode: keyMap.Editor.AttachmentDeleteMode,
@@ -844,6 +845,16 @@ func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		if cmd := m.handleClickFocus(msg); cmd != nil {
 			cmds = append(cmds, cmd)
+		}
+
+		// Check if the click landed on an attachment's remove button.
+		// The attachment chips are rendered on the first row of the
+		// editor layout area, above the textarea.
+		if len(m.attachments.List()) > 0 && msg.Y == m.layout.editor.Min.Y {
+			relX := msg.X - m.layout.editor.Min.X
+			if m.attachments.HandleClick(relX) {
+				return m, tea.Batch(cmds...)
+			}
 		}
 
 		switch m.state {
@@ -3604,6 +3615,7 @@ func (m *UI) refreshStyles() {
 		t.Attachments.Image,
 		t.Attachments.Text,
 		t.Attachments.Skill,
+		t.Attachments.Remove,
 	)
 	m.todoSpinner.Style = t.Pills.TodoSpinner
 	m.status.help.Styles = t.Help

--- a/internal/ui/styles/quickstyle.go
+++ b/internal/ui/styles/quickstyle.go
@@ -985,6 +985,7 @@ func quickStyle(o quickStyleOpts) Styles {
 	s.Attachments.Text = attachmentIconStyle.SetString(TextIcon)
 	s.Attachments.Skill = attachmentIconStyle.SetString(SkillIcon)
 	s.Attachments.Normal = base.Padding(0, 1).MarginRight(1).Background(o.fgMoreSubtle).Foreground(o.fgBase)
+	s.Attachments.Remove = base.Padding(0, 1).Background(o.bgLessVisible).Foreground(o.fgSubtle).SetString(RemoveIcon)
 	s.Attachments.Deleting = base.Padding(0, 1).Bold(true).Background(o.destructive).Foreground(o.fgBase)
 
 	// Pills styles

--- a/internal/ui/styles/styles.go
+++ b/internal/ui/styles/styles.go
@@ -41,9 +41,10 @@ const (
 	TodoPendingIcon    string = "•"
 	TodoInProgressIcon string = "→"
 
-	ImageIcon string = "▣"
-	TextIcon  string = "≡"
-	SkillIcon string = "▲"
+	ImageIcon  string = "▣"
+	TextIcon   string = "≡"
+	SkillIcon  string = "▲"
+	RemoveIcon string = "✕"
 
 	ScrollbarThumb string = "┃"
 	ScrollbarTrack string = "│"
@@ -542,6 +543,7 @@ type Styles struct {
 		Image    lipgloss.Style
 		Text     lipgloss.Style
 		Skill    lipgloss.Style
+		Remove   lipgloss.Style
 		Deleting lipgloss.Style
 	}
 


### PR DESCRIPTION
Each attachment chip now shows a ✕ button on the right side with a gray/charcoal background (`bgLessVisible`/`fgSubtle`). Clicking it removes the attachment before sending.

## Changes

- **New `RemoveIcon` glyph** (`✕`, U+2715) and `Attachments.Remove` style in the styling system
- **Renderer tracks hit-boxes**: each chip's remove button X-coordinate range is stored during `Render()` for mouse hit-testing via `HitTestRemove()`
- **Mouse click wiring**: clicks on the attachments row (first line of editor layout) are intercepted in `ui.go` and routed to `Attachments.HandleClick()`, which removes the corresponding attachment
- **10 new tests** covering rendering, hit-testing, click removal, deleting-mode guard, and empty-list edge cases

The remove button only appears in the editor/prompt area (pre-send). Chat history attachment chips are render-only and don't get remove buttons since those are already-sent messages.

💘 Generated with Crush