### PR TITLE
feat(mcp): add OAuth support for HTTP MCP servers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -69,6 +69,7 @@ require (
 	go.uber.org/goleak v1.3.0
 	golang.design/x/clipboard v0.8.0
 	golang.org/x/net v0.56.0
+	golang.org/x/oauth2 v0.36.0
 	golang.org/x/sync v0.21.0
 	golang.org/x/sys v0.46.0
 	golang.org/x/text v0.38.0
@@ -205,7 +206,6 @@ require (
 	golang.org/x/image v0.43.0 // indirect
 	golang.org/x/mobile v0.0.0-20250606033058-a2a15c67f36f // indirect
 	golang.org/x/mod v0.36.0 // indirect
-	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/term v0.44.0 // indirect
 	golang.org/x/time v0.15.0 // indirect
 	golang.org/x/tools v0.45.0 // indirect

--- a/internal/agent/tools/mcp/init.go
+++ b/internal/agent/tools/mcp/init.go
@@ -510,10 +510,19 @@ func createTransport(ctx context.Context, m config.MCPConfig, resolver config.Va
 				headers: headers,
 			},
 		}
-		return &mcp.StreamableClientTransport{
+		transport := &mcp.StreamableClientTransport{
 			Endpoint:   url,
 			HTTPClient: client,
-		}, nil
+		}
+		// Enable OAuth for HTTP servers that don't have a static
+		// Authorization header. This allows browser-based OAuth flows
+		// (e.g. Cairn, other MCP servers using OIDC) to work
+		// automatically: on 401, the SDK opens a browser for the user
+		// to authenticate, captures the callback, and retries.
+		if !hasAuthHeader(headers) {
+			transport.OAuthHandler = newMCPOAuthHandler(url)
+		}
+		return transport, nil
 	case config.MCPSSE:
 		url, err := m.ResolvedURL(resolver)
 		if err != nil {
@@ -542,6 +551,18 @@ func createTransport(ctx context.Context, m config.MCPConfig, resolver config.Va
 
 type headerRoundTripper struct {
 	headers map[string]string
+}
+
+// hasAuthHeader reports whether the headers map contains an
+// Authorization key (case-insensitive). When true, the server is
+// using static bearer-token auth and the OAuth handler is skipped.
+func hasAuthHeader(headers map[string]string) bool {
+	for k := range headers {
+		if strings.EqualFold(k, "Authorization") {
+			return true
+		}
+	}
+	return false
 }
 
 func (rt headerRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {

--- a/internal/agent/tools/mcp/oauth.go
+++ b/internal/agent/tools/mcp/oauth.go
@@ -174,7 +174,7 @@ func (h *mcpOAuthHandler) buildInner() (*auth.AuthorizationCodeHandler, error) {
 		},
 		RedirectURL: redirectURL,
 		AuthorizationCodeFetcher: func(fetchCtx context.Context, args *auth.AuthorizationArgs) (*auth.AuthorizationResult, error) {
-			return openBrowserAndCapture(fetchCtx, args.URL, port)
+			return openBrowserAndCapture(fetchCtx, args.URL, port, h.serverURL)
 		},
 	}
 	return auth.NewAuthorizationCodeHandler(cfg)
@@ -240,7 +240,7 @@ func (h *mcpOAuthHandler) discoverEndpoints(ctx context.Context, serverURL strin
 
 // openBrowserAndCapture opens the authorization URL in the user's
 // browser and listens on the given port for the OAuth callback redirect.
-func openBrowserAndCapture(ctx context.Context, authURL string, port int) (*auth.AuthorizationResult, error) {
+func openBrowserAndCapture(ctx context.Context, authURL string, port int, serverName string) (*auth.AuthorizationResult, error) {
 	resultCh := make(chan auth.AuthorizationResult, 1)
 	errCh := make(chan error, 1)
 
@@ -277,9 +277,14 @@ func openBrowserAndCapture(ctx context.Context, authURL string, port int) (*auth
 
 	slog.Info("Opening browser for MCP server authorization", "url", authURL)
 	if err := browser.OpenURL(authURL); err != nil {
-		// If the browser can't be opened (headless, etc.), log the
-		// URL so the user can open it manually.
-		slog.Warn("Failed to open browser for MCP OAuth. Please open this URL manually", "url", authURL, "error", err)
+		// If the browser can't be opened (headless, remote SSH, etc.), return
+		// a user-facing error containing the exact URL so the TUI can show it.
+		return nil, fmt.Errorf(
+			"could not open browser for MCP OAuth (%s): %w\nopen this URL manually to continue:\n%s",
+			serverName,
+			err,
+			authURL,
+		)
 	}
 
 	select {

--- a/internal/agent/tools/mcp/oauth.go
+++ b/internal/agent/tools/mcp/oauth.go
@@ -1,0 +1,299 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/charmbracelet/crush/internal/config"
+	"github.com/modelcontextprotocol/go-sdk/auth"
+	"github.com/modelcontextprotocol/go-sdk/oauthex"
+	"github.com/pkg/browser"
+	"golang.org/x/oauth2"
+)
+
+// tokenFileName is the file where MCP OAuth tokens are persisted.
+const tokenFileName = "mcp-oauth-tokens.json"
+
+// mcptoken stores a serialised OAuth token plus the client registration
+// info needed to refresh it.
+type mcptoken struct {
+	Token     *oauth2.Token `json:"token"`
+	ClientID  string        `json:"client_id,omitempty"`
+	Endpoints struct {
+		AuthURL  string `json:"auth_url"`
+		TokenURL string `json:"token_url"`
+	} `json:"endpoints"`
+}
+
+// tokenStore persists MCP OAuth tokens keyed by server URL. It is safe
+// for concurrent access.
+type tokenStore struct {
+	mu   sync.Mutex
+	path string
+	data map[string]mcptoken
+}
+
+func newTokenStore() *tokenStore {
+	dir := filepath.Dir(globalConfigPath())
+	return &tokenStore{
+		path: filepath.Join(dir, tokenFileName),
+		data: make(map[string]mcptoken),
+	}
+}
+
+func (s *tokenStore) load() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	b, err := os.ReadFile(s.path)
+	if err != nil {
+		return
+	}
+	_ = json.Unmarshal(b, &s.data)
+}
+
+func (s *tokenStore) get(serverURL string) (mcptoken, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	t, ok := s.data[serverURL]
+	return t, ok
+}
+
+func (s *tokenStore) save(serverURL string, t mcptoken) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.data[serverURL] = t
+	b, err := json.MarshalIndent(s.data, "", "  ")
+	if err != nil {
+		return
+	}
+	_ = os.WriteFile(s.path, b, 0o600)
+}
+
+// mcpOAuthHandler implements auth.OAuthHandler for MCP HTTP servers.
+// It delegates the heavy lifting to the SDK's AuthorizationCodeHandler
+// and persists tokens across restarts.
+type mcpOAuthHandler struct {
+	serverURL string
+	store     *tokenStore
+	inner     *auth.AuthorizationCodeHandler
+	mu        sync.Mutex
+	tokenSrc  oauth2.TokenSource
+}
+
+var _ auth.OAuthHandler = (*mcpOAuthHandler)(nil)
+
+func newMCPOAuthHandler(serverURL string) *mcpOAuthHandler {
+	store := newTokenStore()
+	store.load()
+	h := &mcpOAuthHandler{
+		serverURL: serverURL,
+		store:     store,
+	}
+	// Restore any saved token so we can skip the browser flow on
+	// subsequent startups.
+	if saved, ok := store.get(serverURL); ok && saved.Token != nil {
+		cfg := &oauth2.Config{
+			ClientID: saved.ClientID,
+			Endpoint: oauth2.Endpoint{
+				AuthURL:  saved.Endpoints.AuthURL,
+				TokenURL: saved.Endpoints.TokenURL,
+			},
+		}
+		h.tokenSrc = cfg.TokenSource(context.Background(), saved.Token)
+	} else {
+		slog.Debug("No saved MCP OAuth token found", "server", serverURL)
+	}
+	return h
+}
+
+// TokenSource implements auth.OAuthHandler.
+func (h *mcpOAuthHandler) TokenSource(_ context.Context) (oauth2.TokenSource, error) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.tokenSrc, nil
+}
+
+// Authorize implements auth.OAuthHandler. It performs the full OAuth
+// authorization-code flow (discovery, registration, browser, PKCE,
+// token exchange) then persists the resulting token.
+func (h *mcpOAuthHandler) Authorize(ctx context.Context, req *http.Request, resp *http.Response) error {
+	inner, err := h.buildInner()
+	if err != nil {
+		resp.Body.Close()
+		return err
+	}
+	if err := inner.Authorize(ctx, req, resp); err != nil {
+		return err
+	}
+	// After a successful Authorize the inner handler holds a fresh
+	// token source. Cache it and persist to disk.
+	ts, _ := inner.TokenSource(ctx)
+	h.mu.Lock()
+	h.tokenSrc = ts
+	h.inner = inner
+	h.mu.Unlock()
+	if ts != nil {
+		if tok, err := ts.Token(); err == nil {
+			h.persistToken(tok)
+		}
+	}
+	return nil
+}
+
+// buildInner lazily creates the SDK AuthorizationCodeHandler. The
+// redirect URL is allocated on first use because we need a free port.
+func (h *mcpOAuthHandler) buildInner() (*auth.AuthorizationCodeHandler, error) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return nil, fmt.Errorf("failed to allocate callback port: %w", err)
+	}
+	port := ln.Addr().(*net.TCPAddr).Port
+	_ = ln.Close() // the handler's callback server will re-listen
+	redirectURL := fmt.Sprintf("http://localhost:%d/callback", port)
+
+	cfg := &auth.AuthorizationCodeHandlerConfig{
+		DynamicClientRegistrationConfig: &auth.DynamicClientRegistrationConfig{
+			Metadata: &oauthex.ClientRegistrationMetadata{
+				ClientName:              "Crush",
+				RedirectURIs:            []string{redirectURL},
+				GrantTypes:              []string{"authorization_code", "refresh_token"},
+				ResponseTypes:           []string{"code"},
+				TokenEndpointAuthMethod: "none",
+				Scope:                   "mcp",
+			},
+		},
+		RedirectURL: redirectURL,
+		AuthorizationCodeFetcher: func(fetchCtx context.Context, args *auth.AuthorizationArgs) (*auth.AuthorizationResult, error) {
+			return openBrowserAndCapture(fetchCtx, args.URL, port)
+		},
+	}
+	return auth.NewAuthorizationCodeHandler(cfg)
+}
+
+// persistToken saves the current token to the store. It is called
+// after Authorize succeeds and lazily captures the endpoint/client info
+// from the inner handler.
+func (h *mcpOAuthHandler) persistToken(tok *oauth2.Token) {
+	entry := mcptoken{Token: tok}
+	h.mu.Lock()
+	inner := h.inner
+	h.mu.Unlock()
+	if inner != nil {
+		// Best-effort: the inner handler doesn't expose its config, so
+		// we fetch the metadata endpoints now to persist them for use
+		// on the next startup.
+		endpoints, clientID := h.discoverEndpoints(context.Background(), h.serverURL)
+		entry.Endpoints.AuthURL = endpoints.AuthURL
+		entry.Endpoints.TokenURL = endpoints.TokenURL
+		entry.ClientID = clientID
+	}
+	h.store.save(h.serverURL, entry)
+}
+
+// discoverEndpoints fetches the OAuth metadata for the server URL to
+// extract the authorization and token endpoints. This is used to
+// persist enough info to restore the token source on restart.
+func (h *mcpOAuthHandler) discoverEndpoints(ctx context.Context, serverURL string) (struct{ AuthURL, TokenURL string }, string) {
+	result := struct{ AuthURL, TokenURL string }{}
+	u, err := url.Parse(serverURL)
+	if err != nil {
+		return result, ""
+	}
+	// Try RFC 9728 protected resource metadata.
+	prmURLs := []string{
+		fmt.Sprintf("%s/.well-known/oauth-protected-resource/%s", fmt.Sprintf("%s://%s", u.Scheme, u.Host), strings.TrimLeft(u.Path, "/")),
+		fmt.Sprintf("%s://%s/.well-known/oauth-protected-resource", u.Scheme, u.Host),
+	}
+	client := &http.Client{Timeout: 10 * time.Second}
+	for _, pURL := range prmURLs {
+		prm, err := oauthex.GetProtectedResourceMetadata(ctx, pURL, serverURL, client)
+		if err != nil || prm == nil || len(prm.AuthorizationServers) == 0 {
+			continue
+		}
+		asm, err := auth.GetAuthServerMetadata(ctx, prm.AuthorizationServers[0], client)
+		if err != nil || asm == nil {
+			continue
+		}
+		result.AuthURL = asm.AuthorizationEndpoint
+		result.TokenURL = asm.TokenEndpoint
+		return result, ""
+	}
+	// Fallback: server root as authorization server.
+	authServer := fmt.Sprintf("%s://%s", u.Scheme, u.Host)
+	asm, err := auth.GetAuthServerMetadata(ctx, authServer, client)
+	if err == nil && asm != nil {
+		result.AuthURL = asm.AuthorizationEndpoint
+		result.TokenURL = asm.TokenEndpoint
+	}
+	return result, ""
+}
+
+// openBrowserAndCapture opens the authorization URL in the user's
+// browser and listens on the given port for the OAuth callback redirect.
+func openBrowserAndCapture(ctx context.Context, authURL string, port int) (*auth.AuthorizationResult, error) {
+	resultCh := make(chan auth.AuthorizationResult, 1)
+	errCh := make(chan error, 1)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/callback", func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query()
+		if codeErr := q.Get("error"); codeErr != "" {
+			desc := q.Get("error_description")
+			if desc == "" {
+				desc = codeErr
+			}
+			fmt.Fprintf(w, "Authorization failed: %s", desc)
+			errCh <- fmt.Errorf("authorization error: %s", desc)
+			return
+		}
+		code := q.Get("code")
+		state := q.Get("state")
+		if code == "" {
+			http.Error(w, "missing code parameter", http.StatusBadRequest)
+			errCh <- fmt.Errorf("callback missing code parameter")
+			return
+		}
+		fmt.Fprint(w, "Authorization successful. You can close this tab and return to Crush.")
+		resultCh <- auth.AuthorizationResult{Code: code, State: state}
+	})
+
+	srv := &http.Server{Handler: mux}
+	ln, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
+	if err != nil {
+		return nil, fmt.Errorf("failed to listen on callback port: %w", err)
+	}
+	go srv.Serve(ln)
+	defer srv.Shutdown(context.Background())
+
+	slog.Info("Opening browser for MCP server authorization", "url", authURL)
+	if err := browser.OpenURL(authURL); err != nil {
+		// If the browser can't be opened (headless, etc.), log the
+		// URL so the user can open it manually.
+		slog.Warn("Failed to open browser for MCP OAuth. Please open this URL manually", "url", authURL, "error", err)
+	}
+
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case err := <-errCh:
+		return nil, err
+	case result := <-resultCh:
+		return &result, nil
+	}
+}
+
+// globalConfigPath returns the directory containing the global crush
+// config file. The token store lives alongside it.
+func globalConfigPath() string {
+	return filepath.Dir(config.GlobalConfig())
+}

--- a/internal/agent/tools/mcp/oauth.go
+++ b/internal/agent/tools/mcp/oauth.go
@@ -44,7 +44,11 @@ type tokenStore struct {
 }
 
 func newTokenStore() *tokenStore {
-	dir := filepath.Dir(globalConfigPath())
+	// globalConfigPath already returns the crush config directory, so the
+	// token file sits alongside crush.json (e.g. ~/.config/crush/). Do not
+	// take filepath.Dir again — that would drop the file a level too high
+	// (e.g. ~/.config/).
+	dir := globalConfigPath()
 	return &tokenStore{
 		path: filepath.Join(dir, tokenFileName),
 		data: make(map[string]mcptoken),

--- a/internal/agent/tools/mcp/oauth_test.go
+++ b/internal/agent/tools/mcp/oauth_test.go
@@ -1,0 +1,105 @@
+package mcp
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
+)
+
+func TestTokenStore_SaveLoad(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	store := &tokenStore{
+		path: filepath.Join(dir, "tokens.json"),
+		data: make(map[string]mcptoken),
+	}
+
+	tok := mcptoken{
+		Token: &oauth2.Token{
+			AccessToken:  "abc123",
+			RefreshToken: "refresh456",
+			TokenType:    "Bearer",
+		},
+		ClientID: "test-client",
+	}
+	tok.Endpoints.AuthURL = "https://auth.example.com/authorize"
+	tok.Endpoints.TokenURL = "https://auth.example.com/token"
+
+	store.save("https://mcp.example.com/mcp", tok)
+
+	// Reload from disk into a fresh store.
+	store2 := &tokenStore{
+		path: store.path,
+		data: make(map[string]mcptoken),
+	}
+	store2.load()
+
+	got, ok := store2.get("https://mcp.example.com/mcp")
+	require.True(t, ok)
+	require.Equal(t, "abc123", got.Token.AccessToken)
+	require.Equal(t, "refresh456", got.Token.RefreshToken)
+	require.Equal(t, "test-client", got.ClientID)
+	require.Equal(t, "https://auth.example.com/authorize", got.Endpoints.AuthURL)
+	require.Equal(t, "https://auth.example.com/token", got.Endpoints.TokenURL)
+}
+
+func TestTokenStore_FilePermissions(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix file permissions not supported on Windows")
+	}
+	dir := t.TempDir()
+	store := &tokenStore{
+		path: filepath.Join(dir, "tokens.json"),
+		data: make(map[string]mcptoken),
+	}
+
+	store.save("https://server.example.com", mcptoken{
+		Token: &oauth2.Token{AccessToken: "secret"},
+	})
+
+	info, err := os.Stat(store.path)
+	require.NoError(t, err)
+	// Token files should only be readable by the owner.
+	require.Equal(t, os.FileMode(0o600), info.Mode().Perm())
+}
+
+func TestHasAuthHeader(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		headers map[string]string
+		want    bool
+	}{
+		{"nil headers", nil, false},
+		{"empty headers", map[string]string{}, false},
+		{"non-auth headers only", map[string]string{"Content-Type": "application/json"}, false},
+		{"Authorization header", map[string]string{"Authorization": "Bearer token"}, true},
+		{"lowercase authorization", map[string]string{"authorization": "Bearer token"}, true},
+		{"AUTHORIZATION uppercase", map[string]string{"AUTHORIZATION": "Bearer token"}, true},
+		{"mixed with auth", map[string]string{"Content-Type": "application/json", "Authorization": "Bearer token"}, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.want, hasAuthHeader(tt.headers))
+		})
+	}
+}
+
+func TestMCPOAuthHandler_TokenSourceEmptyByDefault(t *testing.T) {
+	// A handler for a server with no saved tokens should return a nil
+	// token source, which tells the transport to send requests without
+	// an Authorization header (triggering the 401 → Authorize flow).
+	t.Setenv("CRUSH_GLOBAL_CONFIG", t.TempDir())
+	h := newMCPOAuthHandler("https://mcp.example.com/mcp")
+	ts, err := h.TokenSource(t.Context())
+	require.NoError(t, err)
+	require.Nil(t, ts)
+}

--- a/internal/agent/tools/mcp/oauth_test.go
+++ b/internal/agent/tools/mcp/oauth_test.go
@@ -6,6 +6,7 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/charmbracelet/crush/internal/config"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/oauth2"
 )
@@ -102,4 +103,68 @@ func TestMCPOAuthHandler_TokenSourceEmptyByDefault(t *testing.T) {
 	ts, err := h.TokenSource(t.Context())
 	require.NoError(t, err)
 	require.Nil(t, ts)
+}
+
+func TestTokenStore_GetUnknownServer(t *testing.T) {
+	t.Parallel()
+	store := &tokenStore{
+		path: filepath.Join(t.TempDir(), "tokens.json"),
+		data: make(map[string]mcptoken),
+	}
+	_, ok := store.get("https://never-saved.example.com")
+	require.False(t, ok, "get should report ok=false for an unknown server")
+}
+
+func TestTokenStore_LoadMissingFile(t *testing.T) {
+	t.Parallel()
+	// Pointing at a non-existent file must not panic and must leave the
+	// store empty (first-run / no-tokens-yet case).
+	store := &tokenStore{
+		path: filepath.Join(t.TempDir(), "does-not-exist.json"),
+		data: make(map[string]mcptoken),
+	}
+	store.load()
+	require.Empty(t, store.data, "load of a missing file should leave the store empty")
+	_, ok := store.get("https://x.example.com")
+	require.False(t, ok)
+}
+
+func TestTokenStore_LoadCorruptFile(t *testing.T) {
+	t.Parallel()
+	// A corrupt token file must be ignored gracefully rather than crashing
+	// Crush on startup.
+	path := filepath.Join(t.TempDir(), "tokens.json")
+	require.NoError(t, os.WriteFile(path, []byte("{ not valid json"), 0o600))
+	store := &tokenStore{path: path, data: make(map[string]mcptoken)}
+	require.NotPanics(t, func() { store.load() })
+	require.Empty(t, store.data, "a corrupt token file should be ignored, leaving the store empty")
+}
+
+func TestMCPOAuthHandler_RestoresSavedToken(t *testing.T) {
+	// With a token already persisted for the server, a new handler should
+	// restore a non-nil token source so the browser flow is skipped.
+	globalDir := t.TempDir()
+	t.Setenv("CRUSH_GLOBAL_CONFIG", globalDir)
+
+	serverURL := "https://mcp.example.com/mcp"
+	seed := &tokenStore{
+		path: filepath.Join(filepath.Dir(config.GlobalConfig()), tokenFileName),
+		data: make(map[string]mcptoken),
+	}
+	saved := mcptoken{
+		Token:    &oauth2.Token{AccessToken: "abc123", RefreshToken: "refresh456", TokenType: "Bearer"},
+		ClientID: "test-client",
+	}
+	saved.Endpoints.AuthURL = "https://auth.example.com/authorize"
+	saved.Endpoints.TokenURL = "https://auth.example.com/token"
+	seed.save(serverURL, saved)
+
+	h := newMCPOAuthHandler(serverURL)
+	ts, err := h.TokenSource(t.Context())
+	require.NoError(t, err)
+	require.NotNil(t, ts, "a saved token should produce a non-nil token source")
+
+	tok, err := ts.Token()
+	require.NoError(t, err)
+	require.Equal(t, "abc123", tok.AccessToken, "restored token source should yield the saved (unexpired) token")
 }


### PR DESCRIPTION
## Problem

HTTP MCP servers that use browser-based OAuth (e.g. Cairn at `https://cairn.stump.rocks/mcp`) fail with `Unauthorized` because Crush's MCP HTTP client only supports static bearer tokens via `headers`. There is no OAuth flow, no token refresh, and no browser-based authentication.

Other harnesses (Claude Code, etc.) detect when an OIDC HTTP MCP is no longer authorized and trigger a browser open. This brings Crush to parity.

## Solution

The MCP Go SDK (`github.com/modelcontextprotocol/go-sdk`) already has a built-in `OAuthHandler` interface on `StreamableClientTransport`. When the transport receives a 401/403, it calls `Authorize()` on the handler, then retries the request. The SDK's `auth.AuthorizationCodeHandler` implements the full OAuth flow:

1. Parses `WWW-Authenticate` from the 401 response
2. Fetches Protected Resource Metadata (RFC 9728) to discover authorization servers
3. Gets Authorization Server Metadata (`.well-known/openid-configuration`)
4. Dynamically registers a client (RFC 7591)
5. Generates a PKCE challenge and opens the browser for authorization
6. Captures the callback on a local HTTP server (`http://localhost:<port>/callback`)
7. Exchanges the authorization code for a token
8. Automatically refreshes expired tokens via `oauth2.TokenSource`

## Changes

- **`internal/agent/tools/mcp/oauth.go`** (new): 
  - `mcpOAuthHandler` — implements `auth.OAuthHandler`, wraps the SDK's `AuthorizationCodeHandler`
  - `tokenStore` — persists OAuth tokens per-server to `~/.config/crush/mcp-oauth-tokens.json` (mode 0600)
  - `openBrowserAndCapture` — opens the browser and listens for the OAuth callback redirect
  - Token persistence: saved tokens are loaded on startup to avoid re-auth on every restart

- **`internal/agent/tools/mcp/init.go`**:
  - `createTransport` now sets `OAuthHandler` on `StreamableClientTransport` for HTTP servers without a static `Authorization` header
  - `hasAuthHeader` helper — servers with static auth keep using headers; servers without get OAuth

## Behavior

| Config | Auth method |
|--------|------------|
| `headers: {"Authorization": "Bearer ..."}` | Static (unchanged) |
| No `Authorization` header | OAuth (new) — browser opens on 401 |

Servers that don't require auth are unaffected — the OAuth handler is never triggered (no 401).

## Testing

- `TestTokenStore_SaveLoad` — verifies token round-trip through JSON
- `TestTokenStore_FilePermissions` — verifies token file is mode 0600
- `TestHasAuthHeader` — verifies case-insensitive Authorization header detection (7 sub-tests)
- `TestMCPOAuthHandler_TokenSourceEmptyByDefault` — verifies nil token source triggers the 401 flow

Fixes #58

💘 Generated with Crush