### PR TITLE
fix(config): resolve provider base URL before custom validation

### DIFF
--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -435,11 +435,13 @@ func (c *Config) configureProviders(ctx context.Context, store *ConfigStore, env
 			c.Providers.Del(id)
 			continue
 		}
-		if providerConfig.APIKey == "" {
+		apiKey, err := resolver.ResolveValue(providerConfig.APIKey)
+		if apiKey == "" || err != nil {
 			slog.Warn("Provider is missing API key, this might be OK for local providers", "provider", id)
 		}
-		if providerConfig.BaseURL == "" {
-			slog.Warn("Skipping custom provider due to missing API endpoint", "provider", id)
+		baseURL, err := resolver.ResolveValue(providerConfig.BaseURL)
+		if baseURL == "" || err != nil {
+			slog.Warn("Skipping custom provider due to missing API endpoint", "provider", id, "error", err)
 			c.Providers.Del(id)
 			continue
 		}
@@ -461,17 +463,6 @@ func (c *Config) configureProviders(ctx context.Context, store *ConfigStore, env
 
 		if len(providerConfig.Models) == 0 {
 			slog.Warn("Skipping custom provider because the provider has no models", "provider", id)
-			c.Providers.Del(id)
-			continue
-		}
-
-		apiKey, err := resolver.ResolveValue(providerConfig.APIKey)
-		if apiKey == "" || err != nil {
-			slog.Warn("Provider is missing API key, this might be OK for local providers", "provider", id)
-		}
-		baseURL, err := resolver.ResolveValue(providerConfig.BaseURL)
-		if baseURL == "" || err != nil {
-			slog.Warn("Skipping custom provider due to missing API endpoint", "provider", id, "error", err)
 			c.Providers.Del(id)
 			continue
 		}


### PR DESCRIPTION
Fixes a provider setup bug when `disable_default_providers` is enabled and provider fields are shell-expanded.

The custom-provider validation path previously checked `providerConfig.BaseURL == ""` before running `resolver.ResolveValue(...)`, which could incorrectly reject providers whose endpoint was supplied via shell expansion syntax in config values. This change validates using the resolved value.

## Validation

- `go build ./internal/config/...`
- `go test ./internal/config -run TestConfig_configureProvidersDisableDefaultProviders -count=1`

Note: `go test ./internal/config/...` currently has unrelated failing store auto-reload tests in this workspace due to global config state.

💘 Generated with Crush