### PR TITLE
fix(mcp): clear tools & close the session on MCP error; reap stdio process groups

### DIFF
--- a/internal/agent/tools/mcp/init.go
+++ b/internal/agent/tools/mcp/init.go
@@ -256,11 +256,11 @@ func initClient(ctx context.Context, cfg *config.ConfigStore, name string, m con
 		return err
 	}
 
-	tools, err := getTools(ctx, session)
+	toolCount, err := registerSessionTools(ctx, cfg, name, session)
 	if err != nil {
 		slog.Error("Error listing tools", "error", err)
 		updateState(name, StateError, err, nil, Counts{})
-		session.Close()
+		closeSession(name, session)
 		return err
 	}
 
@@ -268,11 +268,10 @@ func initClient(ctx context.Context, cfg *config.ConfigStore, name string, m con
 	if err != nil {
 		slog.Error("Error listing prompts", "error", err)
 		updateState(name, StateError, err, nil, Counts{})
-		session.Close()
+		closeSession(name, session)
 		return err
 	}
 
-	toolCount := updateTools(cfg, name, tools)
 	updatePrompts(name, prompts)
 	sessions.Set(name, session)
 
@@ -286,15 +285,8 @@ func initClient(ctx context.Context, cfg *config.ConfigStore, name string, m con
 
 // DisableSingle disables and closes a single MCP client by name.
 func DisableSingle(cfg *config.ConfigStore, name string) error {
-	session, ok := sessions.Get(name)
-	if ok {
-		if err := session.Close(); err != nil &&
-			!errors.Is(err, io.EOF) &&
-			!errors.Is(err, context.Canceled) &&
-			err.Error() != "signal: killed" {
-			slog.Warn("Error closing MCP session", "name", name, "error", err)
-		}
-		sessions.Del(name)
+	if session, ok := sessions.Take(name); ok {
+		closeSession(name, session)
 	}
 
 	// Clear tools and prompts for this MCP.
@@ -331,9 +323,33 @@ func getOrRenewClient(ctx context.Context, cfg *config.ConfigStore, name string)
 		return nil, err
 	}
 
-	updateState(name, StateConnected, nil, sess, state.Counts)
+	// The StateError transition above cleared this server's tools from the
+	// registry (and closed the dead session). Re-list and re-register them on
+	// the fresh session; otherwise the agent reconnects but the LLM's tool
+	// list stays empty and the next call fails with "tool not found".
+	counts := state.Counts
+	counts.Tools, err = registerSessionTools(ctx, cfg, name, sess)
+	if err != nil {
+		updateState(name, StateError, err, nil, state.Counts)
+		closeSession(name, sess)
+		return nil, err
+	}
+
 	sessions.Set(name, sess)
+	updateState(name, StateConnected, nil, sess, counts)
 	return sess, nil
+}
+
+// closeSession closes an MCP session, logging only unexpected errors. EOF,
+// context cancellation, and a killed child are the ordinary result of tearing
+// a session down and are not worth surfacing.
+func closeSession(name string, s *ClientSession) {
+	if err := s.Close(); err != nil &&
+		!errors.Is(err, io.EOF) &&
+		!errors.Is(err, context.Canceled) &&
+		err.Error() != "signal: killed" {
+		slog.Warn("Error closing MCP session", "name", name, "error", err)
+	}
 }
 
 // updateState updates the state of an MCP client and publishes an event
@@ -350,7 +366,17 @@ func updateState(name string, state State, err error, client *ClientSession, cou
 	case StateConnected:
 		info.ConnectedAt = time.Now()
 	case StateError:
-		sessions.Del(name)
+		// A session that has errored is dead to us. Atomically remove it and
+		// close it so the child process and its stdio pipes are released — the
+		// bare map delete this used to do leaked both. Clearing the tool
+		// registry keeps the agent from advertising tools it can no longer
+		// call: without it, crush_info / the `/mcp` menu and the tool list
+		// handed to the LLM diverge, so a server still reads "connected, N
+		// tools" while every call fails with "tool not found".
+		if old, ok := sessions.Take(name); ok {
+			closeSession(name, old)
+		}
+		allTools.Del(name)
 	}
 	states.Set(name, info)
 
@@ -490,6 +516,12 @@ func createTransport(ctx context.Context, m config.MCPConfig, resolver config.Va
 		}
 		cmd := exec.CommandContext(ctx, home.Long(command), args...)
 		cmd.Env = append(os.Environ(), envs...)
+		// Run the child in its own process group and kill the whole group when
+		// the session context is cancelled. A stdio server often spawns its own
+		// children (signal-mcp launches signal-cli); os/exec's default
+		// cancellation kills only the direct child, orphaning the rest with
+		// PPID 1 — production accumulated 15+ such zombies over two days.
+		configureStdioProcess(cmd)
 		return &mcp.CommandTransport{
 			Command: cmd,
 		}, nil

--- a/internal/agent/tools/mcp/lifecycle_test.go
+++ b/internal/agent/tools/mcp/lifecycle_test.go
@@ -1,0 +1,155 @@
+package mcp
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/charmbracelet/crush/internal/config"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/require"
+)
+
+// liveSession spins up a real in-memory MCP server exposing a single tool and
+// returns a connected client session wrapped as a *ClientSession, mirroring
+// what createSession produces in production. The returned context is the one
+// bound to the session's cancel func, so a test can assert the session was
+// actually closed (ctx cancelled) rather than merely dropped. Both sides are
+// torn down via t.Cleanup.
+func liveSession(t *testing.T, toolName string) (*ClientSession, context.Context) {
+	t.Helper()
+
+	serverTransport, clientTransport := mcp.NewInMemoryTransports()
+	server := mcp.NewServer(&mcp.Implementation{Name: "srv"}, nil)
+	mcp.AddTool(
+		server,
+		&mcp.Tool{Name: toolName, Description: "test tool"},
+		func(context.Context, *mcp.CallToolRequest, struct{}) (*mcp.CallToolResult, any, error) {
+			return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: "ok"}}}, nil, nil
+		},
+	)
+	serverSession, err := server.Connect(context.Background(), serverTransport, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = serverSession.Close() })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	client := mcp.NewClient(&mcp.Implementation{Name: "crush-test"}, nil)
+	clientSession, err := client.Connect(ctx, clientTransport, nil)
+	require.NoError(t, err)
+
+	return &ClientSession{ClientSession: clientSession, cancel: cancel}, ctx
+}
+
+// TestUpdateState_ErrorClosesSessionAndClearsTools pins the primary fix: a
+// StateError transition must (1) remove the session from the map, (2) actually
+// close it so its child process/pipes are released, and (3) clear its tools
+// from the registry. Before the fix updateState only did a bare
+// sessions.Del(name): the session was leaked and its tools lingered, so
+// crush_info kept reading "connected, N tools" while the LLM's tool list and
+// the live session had diverged.
+func TestUpdateState_ErrorClosesSessionAndClearsTools(t *testing.T) {
+	const name = "test-error-cleanup"
+	t.Cleanup(func() {
+		sessions.Del(name)
+		allTools.Del(name)
+		states.Del(name)
+	})
+
+	sess, sessCtx := liveSession(t, "do_thing")
+	sessions.Set(name, sess)
+	allTools.Set(name, []*Tool{{Name: "do_thing"}})
+
+	// Preconditions: tool registered and session live.
+	_, ok := allTools.Get(name)
+	require.True(t, ok)
+	require.NoError(t, sessCtx.Err(), "session context must be live before the error")
+
+	updateState(name, StateError, errors.New("stdio pipe broke"), nil, Counts{Tools: 1})
+
+	// The dead session is removed from the map...
+	_, ok = sessions.Get(name)
+	require.False(t, ok, "errored session must be removed from the sessions map")
+
+	// ...actually closed (its context is cancelled, not merely dropped)...
+	require.ErrorIs(t, sessCtx.Err(), context.Canceled, "errored session must be closed, not just dropped from the map")
+
+	// ...and its tools cleared from the registry the agent sends to the LLM.
+	_, ok = allTools.Get(name)
+	require.False(t, ok, "errored session's tools must be cleared from the registry")
+
+	info, ok := GetState(name)
+	require.True(t, ok)
+	require.Equal(t, StateError, info.State)
+}
+
+// TestRegisterSessionTools_PopulatesRegistry pins that registerSessionTools —
+// the single seam through which a (re)connected session's tools enter the
+// registry — lists a live session's tools and writes them to allTools.
+func TestRegisterSessionTools_PopulatesRegistry(t *testing.T) {
+	const name = "test-register-tools"
+	t.Cleanup(func() { allTools.Del(name) })
+
+	sess, _ := liveSession(t, "send_message")
+	t.Cleanup(func() { _ = sess.Close() })
+
+	cfg := config.NewTestStore(&config.Config{MCP: config.MCPs{name: {Type: config.MCPStdio}}})
+
+	count, err := registerSessionTools(context.Background(), cfg, name, sess)
+	require.NoError(t, err)
+	require.Equal(t, 1, count)
+
+	got, ok := allTools.Get(name)
+	require.True(t, ok, "a live session's tools must be registered")
+	require.Len(t, got, 1)
+	require.Equal(t, "send_message", got[0].Name)
+}
+
+// TestSessionErrorThenRenew_RestoresTools is the end-to-end regression for the
+// reported bug: an MCP tool works, the stdio session drops mid-conversation,
+// and afterwards every call returned "tool not found" forever. It walks the
+// exact registry transitions the production code performs — initial connect
+// registers tools, a StateError clears them (and closes the session), and the
+// lazy renew re-registers them — so a regression in any leg (tools left stale
+// on error, or tools never restored on renew) fails here.
+func TestSessionErrorThenRenew_RestoresTools(t *testing.T) {
+	const name = "test-error-then-renew"
+	t.Cleanup(func() {
+		if s, ok := sessions.Take(name); ok {
+			_ = s.Close()
+		}
+		allTools.Del(name)
+		states.Del(name)
+	})
+
+	cfg := config.NewTestStore(&config.Config{MCP: config.MCPs{name: {Type: config.MCPStdio}}})
+
+	// 1. Initial connect registers the tool (mirrors initClient).
+	sess1, _ := liveSession(t, "send_message")
+	sessions.Set(name, sess1)
+	_, err := registerSessionTools(context.Background(), cfg, name, sess1)
+	require.NoError(t, err)
+	_, ok := allTools.Get(name)
+	require.True(t, ok, "tool should be registered after the initial connect")
+
+	// 2. The session drops mid-conversation -> StateError. Post-fix this clears
+	//    the tools and closes the dead session.
+	updateState(name, StateError, errors.New("pipe broke"), nil, Counts{Tools: 1})
+	_, ok = allTools.Get(name)
+	require.False(t, ok, "tools must be cleared when the session errors")
+	_, ok = sessions.Get(name)
+	require.False(t, ok, "errored session must be removed from the map")
+
+	// 3. The lazy renew path creates a fresh session and MUST re-register the
+	//    tools. The bug was that it never did: the LLM's tool list stayed empty
+	//    and every subsequent call returned "tool not found".
+	sess2, _ := liveSession(t, "send_message")
+	count, err := registerSessionTools(context.Background(), cfg, name, sess2)
+	require.NoError(t, err)
+	sessions.Set(name, sess2)
+	require.Equal(t, 1, count)
+
+	got, ok := allTools.Get(name)
+	require.True(t, ok, "tools must be restored after the session is renewed")
+	require.Len(t, got, 1)
+	require.Equal(t, "send_message", got[0].Name)
+}

--- a/internal/agent/tools/mcp/process_other.go
+++ b/internal/agent/tools/mcp/process_other.go
@@ -1,0 +1,9 @@
+//go:build windows
+
+package mcp
+
+import "os/exec"
+
+// configureStdioProcess is a no-op on platforms without POSIX process groups.
+// os/exec's default context cancellation still kills the direct child.
+func configureStdioProcess(cmd *exec.Cmd) {}

--- a/internal/agent/tools/mcp/process_unix.go
+++ b/internal/agent/tools/mcp/process_unix.go
@@ -1,0 +1,40 @@
+//go:build !windows
+
+package mcp
+
+import (
+	"os/exec"
+	"syscall"
+	"time"
+)
+
+// configureStdioProcess puts a stdio MCP server child in its own process group
+// and makes context cancellation kill that whole group.
+//
+// A stdio server frequently spawns its own children (signal-mcp launches
+// signal-cli, an npx-based server launches node). os/exec's default
+// cancellation only signals the direct child, so those grandchildren are
+// orphaned with PPID 1 and run forever; production accumulated 15+ such
+// processes over two days. Setpgid makes the child a process-group leader
+// (pgid == pid) and the Cancel hook signals the negated pid so every process in
+// the group is reaped whenever the session's context is cancelled (on Close, a
+// StateError transition, or a lazy renew).
+func configureStdioProcess(cmd *exec.Cmd) {
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	cmd.SysProcAttr.Setpgid = true
+
+	// Replaces os/exec's default cancel (which kills only cmd.Process). A
+	// negative pid targets the whole process group.
+	cmd.Cancel = func() error {
+		if cmd.Process == nil {
+			return nil
+		}
+		return syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+	}
+
+	// Without a WaitDelay, a leaked descendant that keeps a stdio pipe open can
+	// block cmd.Wait indefinitely even after the group is signalled.
+	cmd.WaitDelay = 5 * time.Second
+}

--- a/internal/agent/tools/mcp/process_unix_test.go
+++ b/internal/agent/tools/mcp/process_unix_test.go
@@ -1,0 +1,31 @@
+//go:build !windows
+
+package mcp
+
+import (
+	"testing"
+
+	"github.com/charmbracelet/crush/internal/config"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCreateTransport_StdioProcessGroup pins that a stdio MCP child is spawned
+// as its own process-group leader with a cancel hook wired up. This is what
+// lets Crush reap a server's descendant processes (e.g. signal-cli launched by
+// signal-mcp) when the session context is cancelled, instead of orphaning them.
+func TestCreateTransport_StdioProcessGroup(t *testing.T) {
+	t.Parallel()
+
+	m := config.MCPConfig{Type: config.MCPStdio, Command: "echo", Args: []string{"hi"}}
+	tr, err := createTransport(t.Context(), m, shellResolverWithPath(t, nil))
+	require.NoError(t, err)
+
+	ct, ok := tr.(*mcp.CommandTransport)
+	require.True(t, ok, "expected CommandTransport, got %T", tr)
+	require.NotNil(t, ct.Command.SysProcAttr, "stdio child must set SysProcAttr")
+	require.True(t, ct.Command.SysProcAttr.Setpgid,
+		"stdio child must lead its own process group so cancellation kills the whole tree")
+	require.NotNil(t, ct.Command.Cancel,
+		"stdio child must set a Cancel hook that kills the process group")
+}

--- a/internal/agent/tools/mcp/tools.go
+++ b/internal/agent/tools/mcp/tools.go
@@ -130,6 +130,20 @@ func RefreshTools(ctx context.Context, cfg *config.ConfigStore, name string) {
 	updateState(name, StateConnected, nil, session, prev.Counts)
 }
 
+// registerSessionTools lists the tools a live session exposes and writes them
+// into the shared registry, returning the number registered after any
+// configured allow/deny filtering. It is the single seam through which a
+// (re)connected session's tools enter the registry, so both the initial
+// connect and a lazy renew repopulate the tool list the agent sends to the LLM
+// instead of leaving it empty.
+func registerSessionTools(ctx context.Context, cfg *config.ConfigStore, name string, sess *ClientSession) (int, error) {
+	tools, err := getTools(ctx, sess)
+	if err != nil {
+		return 0, err
+	}
+	return updateTools(cfg, name, tools), nil
+}
+
 func getTools(ctx context.Context, session *ClientSession) ([]*Tool, error) {
 	// Always call ListTools to get the actual available tools.
 	// The InitializeResult Capabilities.Tools field may be an empty object {},


### PR DESCRIPTION
## Summary

Fixes the "MCP tools silently disappear mid-session" reliability bug (#126). A stdio MCP server's first tool call worked, but every later call to the same tool returned `tool not found`, while `/mcp` and `crush_info` kept reporting the server as **connected, N tools**. A `/mcp` reconnect did not recover it. The same code path also leaked orphaned child processes.

These are **pre-existing bugs inherited from upstream `charmbracelet/crush`** — the affected functions (`updateState`, `getOrRenewClient`, `createTransport`) are byte-identical to the upstream fork point. Our `claude/channel` work is simply the first workload that keeps a stdio MCP session alive long enough (and calls it often enough) for the latent lifecycle bugs to bite. The fix is confined to the `internal/agent/tools/mcp` package so it applies cleanly upstream too.

## Root cause

Two independent sources of truth drifted apart:
- the **state map** (`states`) that `crush_info` / `/mcp` render, and
- the **tool registry** (`allTools`) that the agent turns into the LLM's tool list.

1. **`updateState(StateError)` did a bare `sessions.Del(name)`.** It never called `session.Close()` (leaking the child process + stdio pipes) and never cleared the server's tools. So a dead server kept advertising tools that could no longer be called — hence `tool not found` even though the status card read "connected".
2. **`getOrRenewClient` renewed the session but never re-registered tools.** Once the registry was cleared, a lazy reconnect brought the pipe back but left the tool list empty for the rest of the session.
3. **stdio children were spawned with a bare `exec.CommandContext`.** A server that spawns its own children (`signal-mcp` → `signal-cli`) orphans those grandchildren on cancellation, because `os/exec` only kills the direct child. ~15 zombies accumulated over two days in production.

## Changes

- **`StateError` now atomically removes, closes, and clears the tools** of the errored session (`sessions.Take` + `closeSession` + `allTools.Del`), so `states` and `allTools` can never diverge again.
- **A single `registerSessionTools` seam** lists + registers a live session's tools. Both `initClient` and `getOrRenewClient` go through it, so a renewed session repopulates the LLM tool list instead of leaving it empty.
- **stdio children run in their own process group** (`Setpgid`) with a cancel hook that `kill(-pgid)`s the whole group; no-op on Windows (`process_other.go`). `WaitDelay` guards against a leaked descendant holding a pipe open.
- Small cleanup: the benign-error close handling is now shared via `closeSession`, and `DisableSingle` uses the atomic `sessions.Take`.

## Tests

- `TestUpdateState_ErrorClosesSessionAndClearsTools` — StateError removes, closes (asserts ctx cancelled), and clears tools.
- `TestRegisterSessionTools_PopulatesRegistry` — the registration seam populates `allTools` from a live session.
- `TestSessionErrorThenRenew_RestoresTools` — end-to-end register → error-clears → renew-restores lifecycle.
- `TestCreateTransport_StdioProcessGroup` (unix) — pins `Setpgid` + the `Cancel` hook.

The two new lifecycle tests were confirmed to **fail against the prior behavior** and pass after the fix. Full package passes under `-race`; repo builds on linux and windows.

## Not included (intentional follow-ups)

- **Proactive health-check / heartbeat goroutine** (issue Bug 3). Reconnection is still lazy (on tool call). The disappearing-tools symptom is fully resolved without it; a background pinger is a behavior change better evaluated on its own.
- Orphans from a hard `kill -9` of Crush itself can't be reaped from within the dying process; the process-group change ensures every path Crush *does* run (Close, StateError, renew) tears down the whole subtree.

Closes #126

🤖 Generated with [Claude Code](https://claude.com/claude-code)