### PR TITLE
fix(mcp): wait for MCP init before building tool list

### DIFF
--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -22,6 +22,7 @@ import (
 	"github.com/charmbracelet/crush/internal/agent/notify"
 	"github.com/charmbracelet/crush/internal/agent/prompt"
 	"github.com/charmbracelet/crush/internal/agent/tools"
+	"github.com/charmbracelet/crush/internal/agent/tools/mcp"
 	"github.com/charmbracelet/crush/internal/config"
 	"github.com/charmbracelet/crush/internal/discover"
 	"github.com/charmbracelet/crush/internal/event"
@@ -212,6 +213,15 @@ func (c *coordinator) RunAccepted(ctx context.Context, accept *AcceptedRun, sess
 func (c *coordinator) run(ctx context.Context, accept *AcceptedRun, sessionID string, prompt string, attachments ...message.Attachment) (*fantasy.AgentResult, error) {
 	if err := c.readyWg.Wait(); err != nil {
 		return nil, err
+	}
+
+	// Wait for MCP initialization to complete before building the tool list.
+	// Without this, slow-to-start MCP servers (e.g. stdio Python via uv) may
+	// not have registered their tools yet when buildTools reads the registry,
+	// so their tools silently never appear in the LLM tool palette — even
+	// though crush_info reports them as connected.
+	if err := mcp.WaitForInit(ctx); err != nil {
+		return nil, fmt.Errorf("failed to wait for MCP initialization: %w", err)
 	}
 
 	// refresh models before each run
@@ -605,6 +615,13 @@ func (c *coordinator) buildAgent(ctx context.Context, prompt *prompt.Prompt, age
 	})
 
 	c.readyWg.Go(func() error {
+		// Wait for MCP servers to finish registering their tools before
+		// building the initial tool list. This ensures the first tool set
+		// (used if anything reads it before run() rebuilds) includes all
+		// MCP tools, not just fast-to-init ones.
+		if err := mcp.WaitForInit(ctx); err != nil {
+			return err
+		}
 		tools, err := c.buildTools(ctx, agent, isSubAgent)
 		if err != nil {
 			return err

--- a/internal/agent/tools/mcp/waitforinit_test.go
+++ b/internal/agent/tools/mcp/waitforinit_test.go
@@ -1,0 +1,180 @@
+package mcp
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/charmbracelet/crush/internal/config"
+	"github.com/stretchr/testify/require"
+)
+
+// TestWaitForInit_BlocksBeforeInitialize verifies that WaitForInit blocks
+// when Initialize has not yet been called (or has not yet completed).
+// This is the foundation of the fix: the coordinator must call WaitForInit
+// before reading the tool registry so that slow-to-start MCP servers
+// (e.g. stdio Python via uv) have time to register their tools.
+//
+// initDone is a package-global one-shot channel. If another test in this
+// package has already triggered Initialize (closing initDone), this test
+// is a no-op — the contract is already satisfied. Otherwise, it verifies
+// that a context with a short deadline expires while waiting, proving
+// WaitForInit actually blocks.
+func TestWaitForInit_BlocksBeforeInitialize(t *testing.T) {
+	// If initDone was already closed by a prior Initialize call, the
+	// blocking contract can't be tested in this process. Verify it
+	// returns immediately and skip the blocking assertion.
+	select {
+	case <-initDone:
+		// Already initialized — WaitForInit returns immediately.
+		// This is fine; the point is that in a fresh process it blocks.
+		err := WaitForInit(context.Background())
+		require.NoError(t, err)
+		return
+	default:
+	}
+
+	// initDone is still open. WaitForInit must block until the context
+	// expires (since we are not calling Initialize in this test).
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	err := WaitForInit(ctx)
+	require.ErrorIs(t, err, context.DeadlineExceeded,
+		"WaitForInit must block when Initialize has not completed")
+}
+
+// TestWaitForInit_ReturnsAfterInitialize verifies that WaitForInit returns
+// without error once Initialize completes. It also verifies that tools
+// registered during initialization are visible in the allTools registry
+// after WaitForInit returns — the core invariant the coordinator relies on.
+//
+// Because initDone and initOnce are package-global one-shots, this test
+// triggers Initialize exactly once for the entire test binary. It uses
+// an in-memory MCP server so no external processes are spawned.
+func TestWaitForInit_ReturnsAfterInitialize(t *testing.T) {
+	// If Initialize was already called by a prior test, initDone is
+	// closed and WaitForInit returns immediately. We can still verify
+	// the tool-visibility invariant using the registry directly.
+	select {
+	case <-initDone:
+		// Already initialized; verify WaitForInit returns promptly.
+		err := WaitForInit(context.Background())
+		require.NoError(t, err)
+		return
+	default:
+	}
+
+	// Set up an in-memory MCP server with a tool, then use a config
+	// that points to it via a fake transport. Since Initialize uses
+	// createSession → createTransport which requires real stdio/http
+	// transports, we simulate the init completion by directly closing
+	// initDone after registering tools — mirroring what Initialize does
+	// internally (wg.Wait() then close(initDone)).
+	const name = "test-waitforinit"
+	t.Cleanup(func() {
+		allTools.Del(name)
+		states.Del(name)
+	})
+
+	// Simulate a slow MCP server: register tools after a delay, then
+	// signal init completion (close initDone).
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		time.Sleep(20 * time.Millisecond)
+
+		sess, _ := liveSession(t, "slow_tool")
+		sessions.Set(name, sess)
+		allTools.Set(name, []*Tool{{Name: "slow_tool"}})
+		updateState(name, StateConnected, nil, sess, Counts{Tools: 1})
+	}()
+
+	// In production, Initialize does wg.Wait() then close(initDone).
+	// We replicate that sequencing here.
+	go func() {
+		wg.Wait()
+		initOnce.Do(func() { close(initDone) })
+	}()
+
+	// WaitForInit must block until the simulated init completes.
+	err := WaitForInit(context.Background())
+	require.NoError(t, err)
+
+	// After WaitForInit returns, the slow server's tools must be visible.
+	tools, ok := allTools.Get(name)
+	require.True(t, ok, "tools from a slow MCP server must be registered after WaitForInit")
+	require.Len(t, tools, 1)
+	require.Equal(t, "slow_tool", tools[0].Name)
+}
+
+// TestWaitForInit_ToolsVisibleAfterInit is the regression test for the
+// specific bug: buildTools reads allTools concurrently with MCP
+// initialization. Without WaitForInit as a gate, a race exists where
+// buildTools runs before slow MCP servers register their tools, so the
+// LLM's tool palette silently omits them even though crush_info later
+// reports the server as "connected, N tools".
+//
+// This test simulates the race: a reader goroutine checks allTools before
+// and after WaitForInit. Before WaitForInit the tools may or may not be
+// present (that's the race), but after WaitForInit they MUST be present.
+func TestWaitForInit_ToolsVisibleAfterInit(t *testing.T) {
+	const name = "test-race-visibility"
+	t.Cleanup(func() {
+		allTools.Del(name)
+		states.Del(name)
+	})
+
+	cfg := config.NewTestStore(&config.Config{})
+
+	_ = cfg // suppress unused var if config isn't needed for this test
+
+	// If initDone is already closed (prior test called Initialize),
+	// we can't test the before/after gating. Just verify tools are visible.
+	select {
+	case <-initDone:
+		// Register tools and verify they're visible.
+		sess, _ := liveSession(t, "post_init_tool")
+		sessions.Set(name, sess)
+		allTools.Set(name, []*Tool{{Name: "post_init_tool"}})
+
+		err := WaitForInit(context.Background())
+		require.NoError(t, err)
+
+		tools, ok := allTools.Get(name)
+		require.True(t, ok)
+		require.Len(t, tools, 1)
+		return
+	default:
+	}
+
+	// Fresh process: simulate a slow MCP that registers tools after a delay.
+	registered := make(chan struct{})
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		sess, _ := liveSession(t, "gated_tool")
+		sessions.Set(name, sess)
+		allTools.Set(name, []*Tool{{Name: "gated_tool"}})
+		updateState(name, StateConnected, nil, sess, Counts{Tools: 1})
+		close(registered)
+	}()
+
+	go func() {
+		<-registered
+		initOnce.Do(func() { close(initDone) })
+	}()
+
+	// WaitForInit must block until init completes.
+	err := WaitForInit(context.Background())
+	require.NoError(t, err)
+
+	// Tools MUST be visible after WaitForInit returns.
+	tools, ok := allTools.Get(name)
+	require.True(t, ok,
+		"tools must be visible after WaitForInit — this is the regression: "+
+			"buildTools must call WaitForInit before reading allTools")
+	require.Len(t, tools, 1)
+	require.Equal(t, "gated_tool", tools[0].Name)
+}


### PR DESCRIPTION
## Summary

Fixes a race condition where MCP tools from slow-to-start servers silently never appear in the LLM's tool palette in the **interactive/TUI** path.

The non-interactive path (`RunNonInteractive` in `app.go`) already called `mcp.WaitForInit(ctx)` before rebuilding tools. The interactive path (`run()` in `coordinator.go`) did **not** — so `buildTools` read the `allTools` registry concurrently with MCP server initialization. Fast MCP servers (HTTP, quick stdio) had their tools ready in time, but slow stdio servers (e.g. Python via `uv run`) did not. Their tools were registered in `allTools` *later* (hence `crush_info` reported them as "connected, N tools"), but `buildTools` had already snapshotted the tool list and never re-read it.

This manifested in production as the Signal MCP's 7 tools showing as connected in `/mcp` and `crush_info`, but the LLM returning `tool not found` for every `mcp_signal_*` call.

Related to #130 (which fixed tools disappearing *after* an MCP error). This fixes the complementary case: tools never appearing because MCP *init* hadn't completed yet.

## Changes

- **`coordinator.go:run()`** — Added `mcp.WaitForInit(ctx)` before `UpdateModels`, mirroring the non-interactive path in `app.go`.
- **`coordinator.go:buildAgent()`** — Added `mcp.WaitForInit(ctx)` in the initial `buildTools` goroutine, so the first tool set is complete even if something reads it before `run()` rebuilds.
- **`waitforinit_test.go`** — Three regression tests covering the `WaitForInit` contract: blocks before init completes, returns after, and tools are visible after the gate.

## Testing

```
go test ./internal/agent/tools/mcp/ -run TestWaitForInit -v -count=1
go test ./internal/agent/tools/mcp/ -count=1
go test ./internal/agent/ -count=1
go vet ./internal/agent/...
```

All pass.


💘 Generated with Crush