### PR TITLE
test(mcp): simplify WaitForInit regression tests

### DIFF
--- a/internal/agent/tools/mcp/waitforinit_test.go
+++ b/internal/agent/tools/mcp/waitforinit_test.go
@@ -2,179 +2,81 @@ package mcp
 
 import (
 	"context"
-	"sync"
 	"testing"
 	"time"
 
-	"github.com/charmbracelet/crush/internal/config"
 	"github.com/stretchr/testify/require"
 )
 
-// TestWaitForInit_BlocksBeforeInitialize verifies that WaitForInit blocks
-// when Initialize has not yet been called (or has not yet completed).
-// This is the foundation of the fix: the coordinator must call WaitForInit
-// before reading the tool registry so that slow-to-start MCP servers
-// (e.g. stdio Python via uv) have time to register their tools.
-//
-// initDone is a package-global one-shot channel. If another test in this
-// package has already triggered Initialize (closing initDone), this test
-// is a no-op — the contract is already satisfied. Otherwise, it verifies
-// that a context with a short deadline expires while waiting, proving
-// WaitForInit actually blocks.
-func TestWaitForInit_BlocksBeforeInitialize(t *testing.T) {
-	// If initDone was already closed by a prior Initialize call, the
-	// blocking contract can't be tested in this process. Verify it
-	// returns immediately and skip the blocking assertion.
-	select {
-	case <-initDone:
-		// Already initialized — WaitForInit returns immediately.
-		// This is fine; the point is that in a fresh process it blocks.
-		err := WaitForInit(context.Background())
-		require.NoError(t, err)
-		return
-	default:
-	}
-
-	// initDone is still open. WaitForInit must block until the context
-	// expires (since we are not calling Initialize in this test).
-	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
-	defer cancel()
-
-	err := WaitForInit(ctx)
-	require.ErrorIs(t, err, context.DeadlineExceeded,
-		"WaitForInit must block when Initialize has not completed")
+// swapInitGate replaces the package-global initDone channel that WaitForInit
+// waits on with a fresh, open one for the duration of the test, restoring the
+// original in cleanup. This lets each test drive WaitForInit deterministically
+// (by closing the returned channel to signal "init complete") instead of
+// branching on whether an earlier test already closed the process-wide
+// one-shot. The tests that use it are not parallel and nothing else touches the
+// gate during a unit-test run, so the swap is race-free.
+func swapInitGate(t *testing.T) chan struct{} {
+	t.Helper()
+	orig := initDone
+	initDone = make(chan struct{})
+	t.Cleanup(func() { initDone = orig })
+	return initDone
 }
 
-// TestWaitForInit_ReturnsAfterInitialize verifies that WaitForInit returns
-// without error once Initialize completes. It also verifies that tools
-// registered during initialization are visible in the allTools registry
-// after WaitForInit returns — the core invariant the coordinator relies on.
-//
-// Because initDone and initOnce are package-global one-shots, this test
-// triggers Initialize exactly once for the entire test binary. It uses
-// an in-memory MCP server so no external processes are spawned.
-func TestWaitForInit_ReturnsAfterInitialize(t *testing.T) {
-	// If Initialize was already called by a prior test, initDone is
-	// closed and WaitForInit returns immediately. We can still verify
-	// the tool-visibility invariant using the registry directly.
-	select {
-	case <-initDone:
-		// Already initialized; verify WaitForInit returns promptly.
-		err := WaitForInit(context.Background())
-		require.NoError(t, err)
-		return
-	default:
-	}
+// TestWaitForInit_BlocksUntilInitCompletes pins the contract the coordinator
+// relies on: WaitForInit blocks while MCP initialization is still in flight and
+// returns once it completes. The coordinator calls it before reading the tool
+// registry so slow-to-start servers (e.g. stdio Python via uv) have registered
+// their tools first.
+func TestWaitForInit_BlocksUntilInitCompletes(t *testing.T) {
+	gate := swapInitGate(t)
 
-	// Set up an in-memory MCP server with a tool, then use a config
-	// that points to it via a fake transport. Since Initialize uses
-	// createSession → createTransport which requires real stdio/http
-	// transports, we simulate the init completion by directly closing
-	// initDone after registering tools — mirroring what Initialize does
-	// internally (wg.Wait() then close(initDone)).
-	const name = "test-waitforinit"
+	// Init not done yet: WaitForInit must block until the context expires.
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	require.ErrorIs(t, WaitForInit(ctx), context.DeadlineExceeded,
+		"WaitForInit must block while initialization is in flight")
+
+	// Once initialization completes (the gate closes), WaitForInit returns nil.
+	close(gate)
+	require.NoError(t, WaitForInit(context.Background()),
+		"WaitForInit must return once initialization has completed")
+}
+
+// TestWaitForInit_ToolsVisibleAfterInit is the regression test for the bug the
+// coordinator fix addresses: buildTools read allTools concurrently with MCP
+// initialization, so a slow server's tools were silently missing from the LLM's
+// palette even though crush_info later reported the server as connected. Gating
+// on WaitForInit fixes it — any tool registered before initialization completes
+// must be visible once WaitForInit returns.
+func TestWaitForInit_ToolsVisibleAfterInit(t *testing.T) {
+	const name = "test-waitforinit-tools"
 	t.Cleanup(func() {
+		if s, ok := sessions.Take(name); ok {
+			_ = s.Close()
+		}
 		allTools.Del(name)
 		states.Del(name)
 	})
 
-	// Simulate a slow MCP server: register tools after a delay, then
-	// signal init completion (close initDone).
-	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		time.Sleep(20 * time.Millisecond)
+	sess, _ := liveSession(t, "slow_tool")
+	gate := swapInitGate(t)
 
-		sess, _ := liveSession(t, "slow_tool")
+	// A slow MCP server registers its tools, then initialization completes
+	// (the gate closes). close(gate) happens-after the registration, and
+	// WaitForInit returning happens-after observing the close, so the tools are
+	// guaranteed visible once WaitForInit returns.
+	go func() {
 		sessions.Set(name, sess)
 		allTools.Set(name, []*Tool{{Name: "slow_tool"}})
 		updateState(name, StateConnected, nil, sess, Counts{Tools: 1})
+		close(gate)
 	}()
 
-	// In production, Initialize does wg.Wait() then close(initDone).
-	// We replicate that sequencing here.
-	go func() {
-		wg.Wait()
-		initOnce.Do(func() { close(initDone) })
-	}()
+	require.NoError(t, WaitForInit(context.Background()))
 
-	// WaitForInit must block until the simulated init completes.
-	err := WaitForInit(context.Background())
-	require.NoError(t, err)
-
-	// After WaitForInit returns, the slow server's tools must be visible.
 	tools, ok := allTools.Get(name)
-	require.True(t, ok, "tools from a slow MCP server must be registered after WaitForInit")
+	require.True(t, ok, "a slow server's tools must be visible after WaitForInit returns")
 	require.Len(t, tools, 1)
 	require.Equal(t, "slow_tool", tools[0].Name)
-}
-
-// TestWaitForInit_ToolsVisibleAfterInit is the regression test for the
-// specific bug: buildTools reads allTools concurrently with MCP
-// initialization. Without WaitForInit as a gate, a race exists where
-// buildTools runs before slow MCP servers register their tools, so the
-// LLM's tool palette silently omits them even though crush_info later
-// reports the server as "connected, N tools".
-//
-// This test simulates the race: a reader goroutine checks allTools before
-// and after WaitForInit. Before WaitForInit the tools may or may not be
-// present (that's the race), but after WaitForInit they MUST be present.
-func TestWaitForInit_ToolsVisibleAfterInit(t *testing.T) {
-	const name = "test-race-visibility"
-	t.Cleanup(func() {
-		allTools.Del(name)
-		states.Del(name)
-	})
-
-	cfg := config.NewTestStore(&config.Config{})
-
-	_ = cfg // suppress unused var if config isn't needed for this test
-
-	// If initDone is already closed (prior test called Initialize),
-	// we can't test the before/after gating. Just verify tools are visible.
-	select {
-	case <-initDone:
-		// Register tools and verify they're visible.
-		sess, _ := liveSession(t, "post_init_tool")
-		sessions.Set(name, sess)
-		allTools.Set(name, []*Tool{{Name: "post_init_tool"}})
-
-		err := WaitForInit(context.Background())
-		require.NoError(t, err)
-
-		tools, ok := allTools.Get(name)
-		require.True(t, ok)
-		require.Len(t, tools, 1)
-		return
-	default:
-	}
-
-	// Fresh process: simulate a slow MCP that registers tools after a delay.
-	registered := make(chan struct{})
-	go func() {
-		time.Sleep(20 * time.Millisecond)
-		sess, _ := liveSession(t, "gated_tool")
-		sessions.Set(name, sess)
-		allTools.Set(name, []*Tool{{Name: "gated_tool"}})
-		updateState(name, StateConnected, nil, sess, Counts{Tools: 1})
-		close(registered)
-	}()
-
-	go func() {
-		<-registered
-		initOnce.Do(func() { close(initDone) })
-	}()
-
-	// WaitForInit must block until init completes.
-	err := WaitForInit(context.Background())
-	require.NoError(t, err)
-
-	// Tools MUST be visible after WaitForInit returns.
-	tools, ok := allTools.Get(name)
-	require.True(t, ok,
-		"tools must be visible after WaitForInit — this is the regression: "+
-			"buildTools must call WaitForInit before reading allTools")
-	require.Len(t, tools, 1)
-	require.Equal(t, "gated_tool", tools[0].Name)
 }


### PR DESCRIPTION
## Summary

Test-only cleanup of the `WaitForInit` regression tests added in #132. No production code changes.

The tests branched on whether the package-global one-shot (`initDone` / `initOnce`) had already been closed by an earlier test — a `select { case <-initDone: ...no-op... default: }` guard in each test. That made them order-dependent (only meaningful on the first one to run in the binary) and hard to read. One also carried a dead `_ = cfg` "suppress unused var" line.

## Changes

- Add a `swapInitGate` helper that swaps in a fresh, open `initDone` channel for the duration of a test and restores the original in cleanup. Each test now drives `WaitForInit` deterministically by closing the returned channel to signal "init complete" — no branching on global state, no dependence on run order.
- Collapse the three near-duplicate tests into two focused ones:
  - `TestWaitForInit_BlocksUntilInitCompletes` — blocks while init is in flight (short-deadline ctx → `DeadlineExceeded`), returns `nil` once the gate closes.
  - `TestWaitForInit_ToolsVisibleAfterInit` — the regression: a tool registered before init completes is visible once `WaitForInit` returns.
- Drop the now-unused `config` and `sync` imports and the dead `_ = cfg`.

Net: −148 / +50 in one test file.

## Testing

```
go vet ./internal/agent/tools/mcp/                              # clean (previously would flag the sync.Once copy had I kept it)
go test ./internal/agent/tools/mcp/ -run TestWaitForInit -v
go test ./internal/agent/tools/mcp/ -race -count=3              # order-independent now
go build ./...
```

All pass; `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018QwjJ7yxRMtgRidfLuv2mu)_