### PR TITLE
fix(ui): remove floating gap between attachment chip and remove button

### DIFF
--- a/internal/ui/styles/quickstyle.go
+++ b/internal/ui/styles/quickstyle.go
@@ -984,8 +984,8 @@ func quickStyle(o quickStyleOpts) Styles {
 	s.Attachments.Image = attachmentIconStyle.SetString(ImageIcon)
 	s.Attachments.Text = attachmentIconStyle.SetString(TextIcon)
 	s.Attachments.Skill = attachmentIconStyle.SetString(SkillIcon)
-	s.Attachments.Normal = base.Padding(0, 1).MarginRight(1).Background(o.fgMoreSubtle).Foreground(o.fgBase)
-	s.Attachments.Remove = base.Padding(0, 1).Background(o.bgLessVisible).Foreground(o.fgSubtle).SetString(RemoveIcon)
+	s.Attachments.Normal = base.Padding(0, 1).Background(o.fgMoreSubtle).Foreground(o.fgBase)
+	s.Attachments.Remove = base.Padding(0, 1).MarginRight(1).Background(o.bgLessVisible).Foreground(o.fgSubtle).SetString(RemoveIcon)
 	s.Attachments.Deleting = base.Padding(0, 1).Bold(true).Background(o.destructive).Foreground(o.fgBase)
 
 	// Pills styles


### PR DESCRIPTION
## Problem

The attachment remove button (✕) floats off to the side with a visible gap between it and the chip, instead of sitting tight against the chip's right edge.

The chip renders as `icon + filename + remove(✕)` joined horizontally with no separator (`internal/ui/attachments/attachments.go`), but the **filename** (`Attachments.Normal`) style carried `MarginRight(1)`. That margin lands *between* the filename and the ✕, pushing the button one column away.

## Fix

Move `MarginRight(1)` from `Attachments.Normal` to `Attachments.Remove` in `quickstyle.go`:

```go
// before
s.Attachments.Normal = base.Padding(0, 1).MarginRight(1).Background(...)
s.Attachments.Remove = base.Padding(0, 1).Background(...).SetString(RemoveIcon)

// after
s.Attachments.Normal = base.Padding(0, 1).Background(...)
s.Attachments.Remove = base.Padding(0, 1).MarginRight(1).Background(...).SetString(RemoveIcon)
```

Net effect:
- The ✕ is now flush against the filename — no floating gap.
- The margin now trails the ✕, so it still separates adjacent chips when multiple attachments are present (previously the ✕ of one chip butted directly against the icon of the next).

## Testing

- `go build ./...` — clean
- `go test ./internal/ui/attachments/...` — pass (hit-testing bounds are computed from the rendered strings, so they stay correct)
- `go vet` / `gofmt` — clean

Follow-up to the remove-button feature (#121).

🤖 Posted on behalf of `@joestump` by [Claude](https://claude.ai).
