### PR TITLE
fix(ui): keep gap between posted attachment chips; clarify WaitForInit doc

### DIFF
--- a/internal/agent/tools/mcp/init.go
+++ b/internal/agent/tools/mcp/init.go
@@ -218,8 +218,12 @@ func Initialize(ctx context.Context, permissions permission.Service, cfg *config
 	initOnce.Do(func() { close(initDone) })
 }
 
-// WaitForInit blocks until MCP initialization is complete.
-// If Initialize was never called, this returns immediately.
+// WaitForInit blocks until MCP initialization is complete, i.e. until
+// Initialize has finished and closed initDone. If Initialize is never called,
+// initDone is never closed, so this blocks until ctx is cancelled and then
+// returns ctx.Err(). Callers must therefore pass a context that is eventually
+// cancelled (Initialize is spawned unconditionally during app startup, so in
+// practice initDone always closes).
 func WaitForInit(ctx context.Context) error {
 	select {
 	case <-initDone:

--- a/internal/ui/attachments/attachments.go
+++ b/internal/ui/attachments/attachments.go
@@ -168,7 +168,16 @@ func (r *Renderer) Render(attachments []message.Attachment, deleting, showRemove
 			offset += lipgloss.Width(r.deletingStyle.Render(fmt.Sprintf("%d", i))) + lipgloss.Width(r.normalStyle.Render(filename))
 		} else {
 			iconStr := r.icon(att).String()
-			nameStr := r.normalStyle.Render(filename)
+			nameStyle := r.normalStyle
+			if !showRemove {
+				// Without a remove button there is nothing to carry the
+				// trailing margin that separates adjacent chips (the ✕'s
+				// MarginRight does this on the editor path), so put it on the
+				// filename instead. Otherwise posted messages with multiple
+				// attachments render with their chip backgrounds touching.
+				nameStyle = nameStyle.MarginRight(1)
+			}
+			nameStr := nameStyle.Render(filename)
 
 			chips = append(chips, iconStr, nameStr)
 			chipW := lipgloss.Width(iconStr) + lipgloss.Width(nameStr)

--- a/internal/ui/attachments/attachments_test.go
+++ b/internal/ui/attachments/attachments_test.go
@@ -3,6 +3,7 @@ package attachments
 import (
 	"testing"
 
+	"charm.land/lipgloss/v2"
 	"github.com/charmbracelet/crush/internal/message"
 	"github.com/charmbracelet/crush/internal/ui/styles"
 	"github.com/stretchr/testify/require"
@@ -55,6 +56,34 @@ func TestRender_ShowRemoveFalseOmitsRemoveButton(t *testing.T) {
 	require.Empty(t, r.bounds,
 		"no remove bounds should be recorded when the button is hidden")
 	require.Equal(t, -1, r.HitTestRemove(atts, 0))
+}
+
+func TestRender_ShowRemoveFalseKeepsGapBetweenChips(t *testing.T) {
+	t.Parallel()
+
+	// Regression for the #134 + #135 interaction: #134 moved the trailing
+	// margin onto the remove button, and #135 hides that button on posted
+	// messages. Together, posted messages with multiple attachments lost the
+	// margin that separated adjacent chips, so their backgrounds touched. The
+	// filename must carry the margin when the remove button is hidden.
+	//
+	// White-box width check: the visible width of the two chips without any
+	// separator is icon+filename per chip. With the fix each posted chip adds
+	// a 1-column trailing margin, so the rendered row is exactly two columns
+	// wider. Stripping ANSI can't detect this (a margin space and a
+	// background-colored padding space are both just spaces), so we measure
+	// width instead.
+	r := newTestRenderer()
+	atts := []message.Attachment{
+		{FileName: "alpha.txt"},
+		{FileName: "beta.txt"},
+	}
+	bare := lipgloss.Width(r.textStyle.String()+r.normalStyle.Render("alpha.txt")) +
+		lipgloss.Width(r.textStyle.String()+r.normalStyle.Render("beta.txt"))
+
+	got := lipgloss.Width(r.Render(atts, false, false, 200))
+	require.Equal(t, bare+2, got,
+		"each posted chip must carry a 1-col trailing margin so adjacent chip backgrounds don't touch")
 }
 
 func TestRender_MultipleChipsEachHaveRemoveButton(t *testing.T) {


### PR DESCRIPTION
## Summary

Follow-ups found while reviewing the recently merged MCP-init fix (#132) and its companion PRs (#133 test cleanup, #134 chip-gap, #135 hide-remove-on-posted). Each of those PRs is correct in isolation; the issue below only appears once #134 and #135 are both merged.

## 1. Posted attachment chips lose their separating gap (#134 × #135 interaction)

- **#134** moved the chip's trailing `MarginRight(1)` from the filename (`Attachments.Normal`) onto the remove button (`Attachments.Remove`) so the ✕ sits flush against the filename while still separating adjacent chips.
- **#135** stops rendering the ✕ on already-posted messages (`showRemove=false`).

Merged together, posted messages with **multiple** attachments have no element left to carry the trailing margin, so adjacent chips render with their colored backgrounds touching (e.g. `…alpha.png▐≡ beta.png`). This is contrary to #134's stated goal of keeping adjacent chips separated.

**Fix:** when the remove button is hidden, put the trailing `MarginRight(1)` back on the filename, so the separator is preserved on posted messages. The editor path (`showRemove=true`) is unchanged — the margin still lives on the ✕ there.

Added `TestRender_ShowRemoveFalseKeepsGapBetweenChips`, a white-box width check. ANSI-stripping can't see the difference (a plain margin space and a background-colored padding space are both just spaces), so the test measures rendered width instead — it fails (27 vs 29 cols) without the fix.

## 2. `WaitForInit` doc comment was inaccurate

The comment claimed it "returns immediately if Initialize was never called," but `initDone` is only closed by `Initialize`, so with no `Initialize` call it blocks until the context is cancelled and returns `ctx.Err()`. #132 added two new callers of this function on the interactive path, so the real contract is worth stating accurately. Doc-only change; in practice `Initialize` is spawned unconditionally at app startup, so `initDone` always closes.

## Testing

```
go build ./...
go vet ./internal/ui/attachments/ ./internal/ui/chat/ ./internal/agent/tools/mcp/
gofmt -l ...            # clean
go test ./internal/ui/attachments/ ./internal/ui/chat/ ./internal/agent/tools/mcp/ -count=1
```

All pass. The new test was confirmed to fail without the code fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017xyTkdhdZM3b8Nxmd8RCxz

---
_Generated by [Claude Code](https://claude.ai/code/session_017xyTkdhdZM3b8Nxmd8RCxz)_