### PR TITLE
feat: support text-based file attachments (JSON, YAML, Markdown, code, …)

### DIFF
--- a/internal/message/attachment.go
+++ b/internal/message/attachment.go
@@ -12,7 +12,38 @@ type Attachment struct {
 	Content  []byte
 }
 
-func (a Attachment) IsText() bool     { return strings.HasPrefix(a.MimeType, "text/") }
+// textMimePrefixes are MIME type prefixes that should be treated as text.
+var textMimePrefixes = []string{
+	"text/",
+	"application/json",
+	"application/xml",
+	"application/yaml",
+	"application/x-yaml",
+	"application/javascript",
+	"application/typescript",
+	"application/x-sh",
+	"application/x-shellscript",
+	"application/toml",
+	"application/x-toml",
+	"application/sql",
+	"application/x-sql",
+	"application/graphql",
+	"application/x-graphql",
+}
+
+// IsText reports whether the attachment should be treated as text and
+// inlined into the prompt. This includes standard text/* MIME types as
+// well as common application/* types that are fundamentally text (JSON,
+// YAML, XML, etc.).
+func (a Attachment) IsText() bool {
+	for _, prefix := range textMimePrefixes {
+		if strings.HasPrefix(a.MimeType, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
 func (a Attachment) IsImage() bool    { return strings.HasPrefix(a.MimeType, "image/") }
 func (a Attachment) IsMarkdown() bool { return a.MimeType == "text/markdown" }
 

--- a/internal/message/attachment_test.go
+++ b/internal/message/attachment_test.go
@@ -1,0 +1,125 @@
+package message
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAttachment_IsText(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		mimeType string
+		want     bool
+	}{
+		// Standard text types.
+		{name: "text/plain", mimeType: "text/plain", want: true},
+		{name: "text/html", mimeType: "text/html", want: true},
+		{name: "text/css", mimeType: "text/css", want: true},
+		{name: "text/markdown", mimeType: "text/markdown", want: true},
+		{name: "text/csv", mimeType: "text/csv", want: true},
+		{name: "text/javascript", mimeType: "text/javascript", want: true},
+		{name: "text/x-shellscript", mimeType: "text/x-shellscript", want: true},
+		{name: "text with charset", mimeType: "text/plain; charset=utf-8", want: true},
+
+		// Application types that are fundamentally text.
+		{name: "application/json", mimeType: "application/json", want: true},
+		{name: "application/xml", mimeType: "application/xml", want: true},
+		{name: "application/yaml", mimeType: "application/yaml", want: true},
+		{name: "application/x-yaml", mimeType: "application/x-yaml", want: true},
+		{name: "application/javascript", mimeType: "application/javascript", want: true},
+		{name: "application/typescript", mimeType: "application/typescript", want: true},
+		{name: "application/x-sh", mimeType: "application/x-sh", want: true},
+		{name: "application/x-shellscript", mimeType: "application/x-shellscript", want: true},
+		{name: "application/toml", mimeType: "application/toml", want: true},
+		{name: "application/x-toml", mimeType: "application/x-toml", want: true},
+		{name: "application/sql", mimeType: "application/sql", want: true},
+		{name: "application/x-sql", mimeType: "application/x-sql", want: true},
+		{name: "application/graphql", mimeType: "application/graphql", want: true},
+		{name: "application/x-graphql", mimeType: "application/x-graphql", want: true},
+
+		// Non-text types.
+		{name: "image/png", mimeType: "image/png", want: false},
+		{name: "image/jpeg", mimeType: "image/jpeg", want: false},
+		{name: "application/pdf", mimeType: "application/pdf", want: false},
+		{name: "application/zip", mimeType: "application/zip", want: false},
+		{name: "application/octet-stream", mimeType: "application/octet-stream", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			a := Attachment{MimeType: tt.mimeType}
+			require.Equal(t, tt.want, a.IsText())
+		})
+	}
+}
+
+func TestAttachment_IsImage(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		mimeType string
+		want     bool
+	}{
+		{name: "image/png", mimeType: "image/png", want: true},
+		{name: "image/jpeg", mimeType: "image/jpeg", want: true},
+		{name: "image/gif", mimeType: "image/gif", want: true},
+		{name: "text/plain", mimeType: "text/plain", want: false},
+		{name: "application/json", mimeType: "application/json", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			a := Attachment{MimeType: tt.mimeType}
+			require.Equal(t, tt.want, a.IsImage())
+		})
+	}
+}
+
+func TestAttachment_IsMarkdown(t *testing.T) {
+	t.Parallel()
+
+	require.True(t, Attachment{MimeType: "text/markdown"}.IsMarkdown())
+	require.False(t, Attachment{MimeType: "text/plain"}.IsMarkdown())
+}
+
+func TestContainsTextAttachment(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no attachments", func(t *testing.T) {
+		t.Parallel()
+		require.False(t, ContainsTextAttachment(nil))
+	})
+
+	t.Run("only image attachments", func(t *testing.T) {
+		t.Parallel()
+		attachments := []Attachment{
+			{MimeType: "image/png"},
+			{MimeType: "image/jpeg"},
+		}
+		require.False(t, ContainsTextAttachment(attachments))
+	})
+
+	t.Run("mixed attachments", func(t *testing.T) {
+		t.Parallel()
+		attachments := []Attachment{
+			{MimeType: "image/png"},
+			{MimeType: "application/json"},
+		}
+		require.True(t, ContainsTextAttachment(attachments))
+	})
+
+	t.Run("only text attachments", func(t *testing.T) {
+		t.Parallel()
+		attachments := []Attachment{
+			{MimeType: "text/plain"},
+			{MimeType: "application/yaml"},
+		}
+		require.True(t, ContainsTextAttachment(attachments))
+	})
+}

--- a/internal/ui/common/attachments_test.go
+++ b/internal/ui/common/attachments_test.go
@@ -1,0 +1,109 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsAllowedAttachmentType(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		path string
+		want bool
+	}{
+		// Image types.
+		{name: "png", path: "photo.png", want: true},
+		{name: "jpg", path: "photo.jpg", want: true},
+		{name: "jpeg", path: "photo.jpeg", want: true},
+		{name: "PNG uppercase", path: "PHOTO.PNG", want: true},
+
+		// Text file types.
+		{name: "json", path: "config.json", want: true},
+		{name: "yaml", path: "docker-compose.yaml", want: true},
+		{name: "yml", path: "docker-compose.yml", want: true},
+		{name: "md", path: "README.md", want: true},
+		{name: "txt", path: "notes.txt", want: true},
+		{name: "css", path: "style.css", want: true},
+		{name: "html", path: "index.html", want: true},
+		{name: "py", path: "main.py", want: true},
+		{name: "go", path: "main.go", want: true},
+		{name: "ts", path: "app.ts", want: true},
+		{name: "sql", path: "migration.sql", want: true},
+		{name: "toml", path: "Cargo.toml", want: true},
+		{name: "csv", path: "data.csv", want: true},
+		{name: "xml", path: "pom.xml", want: true},
+		{name: "env", path: ".env", want: true},
+		{name: "conf", path: "nginx.conf", want: true},
+		{name: "tf", path: "main.tf", want: true},
+		{name: "log", path: "app.log", want: true},
+
+		// Case insensitivity.
+		{name: "JSON uppercase", path: "CONFIG.JSON", want: true},
+		{name: "MD mixed case", path: "ReadMe.Md", want: true},
+
+		// Full paths.
+		{name: "full path", path: "/home/user/project/config.json", want: true},
+		{name: "relative path", path: "../src/main.go", want: true},
+
+		// Unsupported types.
+		{name: "pdf", path: "doc.pdf", want: false},
+		{name: "zip", path: "archive.zip", want: false},
+		{name: "docx", path: "report.docx", want: false},
+		{name: "exe", path: "binary.exe", want: false},
+		{name: "no extension", path: "Makefile", want: false},
+		{name: "mp4", path: "video.mp4", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.want, IsAllowedAttachmentType(tt.path))
+		})
+	}
+}
+
+func TestIsAllowedImageType(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		path string
+		want bool
+	}{
+		{name: "png", path: "photo.png", want: true},
+		{name: "jpg", path: "photo.jpg", want: true},
+		{name: "jpeg", path: "photo.jpeg", want: true},
+		{name: "PNG uppercase", path: "PHOTO.PNG", want: true},
+		{name: "json", path: "config.json", want: false},
+		{name: "pdf", path: "doc.pdf", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.want, IsAllowedImageType(tt.path))
+		})
+	}
+}
+
+func TestAllAllowedAttachmentTypes(t *testing.T) {
+	t.Parallel()
+
+	types := AllAllowedAttachmentTypes()
+
+	// Should include all image types.
+	for _, ext := range AllowedImageTypes {
+		require.Contains(t, types, ext)
+	}
+
+	// Should include all text file types.
+	for _, ext := range AllowedTextFileTypes {
+		require.Contains(t, types, ext)
+	}
+
+	// Should have combined length.
+	require.Len(t, types, len(AllowedImageTypes)+len(AllowedTextFileTypes))
+}

--- a/internal/ui/common/common.go
+++ b/internal/ui/common/common.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"image"
 	"os"
+	"strings"
 
 	tea "charm.land/bubbletea/v2"
 	"github.com/charmbracelet/crush/internal/clipboard"
@@ -19,6 +20,56 @@ const MaxAttachmentSize = int64(5 * 1024 * 1024)
 
 // AllowedImageTypes defines the permitted image file types.
 var AllowedImageTypes = []string{".jpg", ".jpeg", ".png"}
+
+// AllowedTextFileTypes defines text-based file types that can be attached
+// and inlined into the prompt as text attachments.
+var AllowedTextFileTypes = []string{
+	".css", ".html", ".htm", ".json", ".yaml", ".yml", ".md", ".txt",
+	".conf", ".csv", ".xml", ".js", ".ts", ".tsx", ".jsx", ".go",
+	".py", ".sh", ".bash", ".zsh", ".toml", ".ini", ".env", ".log",
+	".sql", ".rs", ".java", ".c", ".cpp", ".h", ".hpp", ".rb", ".php",
+	".swift", ".kt", ".scala", ".lua", ".r", ".dart", ".vue", ".svelte",
+	".graphql", ".gql", ".proto", ".tf", ".dockerfile", ".makefile",
+	".gitignore", ".editorconfig", ".lock", ".diff", ".patch",
+}
+
+// AllAllowedAttachmentTypes returns the combined list of image and text file
+// types that can be attached.
+func AllAllowedAttachmentTypes() []string {
+	result := make([]string, 0, len(AllowedImageTypes)+len(AllowedTextFileTypes))
+	result = append(result, AllowedImageTypes...)
+	result = append(result, AllowedTextFileTypes...)
+	return result
+}
+
+// IsAllowedAttachmentType reports whether the given file path has an
+// extension that is in the allowed image or text file type list.
+func IsAllowedAttachmentType(path string) bool {
+	lower := strings.ToLower(path)
+	for _, ext := range AllowedImageTypes {
+		if strings.HasSuffix(lower, ext) {
+			return true
+		}
+	}
+	for _, ext := range AllowedTextFileTypes {
+		if strings.HasSuffix(lower, ext) {
+			return true
+		}
+	}
+	return false
+}
+
+// IsAllowedImageType reports whether the given file path has an allowed image
+// extension.
+func IsAllowedImageType(path string) bool {
+	lower := strings.ToLower(path)
+	for _, ext := range AllowedImageTypes {
+		if strings.HasSuffix(lower, ext) {
+			return true
+		}
+	}
+	return false
+}
 
 // Common defines common UI options and configurations.
 type Common struct {

--- a/internal/ui/dialog/actions.go
+++ b/internal/ui/dialog/actions.go
@@ -176,7 +176,7 @@ func (a ActionFilePickerSelected) Cmd() tea.Cmd {
 		if err != nil {
 			return util.InfoMsg{
 				Type: util.InfoTypeError,
-				Msg:  fmt.Sprintf("unable to read the image: %v", err),
+				Msg:  fmt.Sprintf("unable to read the file: %v", err),
 			}
 		}
 		if isFileLarge {
@@ -190,7 +190,7 @@ func (a ActionFilePickerSelected) Cmd() tea.Cmd {
 		if err != nil {
 			return util.InfoMsg{
 				Type: util.InfoTypeError,
-				Msg:  fmt.Sprintf("unable to read the image: %v", err),
+				Msg:  fmt.Sprintf("unable to read the file: %v", err),
 			}
 		}
 

--- a/internal/ui/dialog/filepicker.go
+++ b/internal/ui/dialog/filepicker.go
@@ -97,7 +97,7 @@ func NewFilePicker(com *common.Common) (*FilePicker, tea.Cmd) {
 	)
 
 	fp := filepicker.New()
-	fp.AllowedTypes = common.AllowedImageTypes
+	fp.AllowedTypes = common.AllAllowedAttachmentTypes()
 	fp.ShowPermissions = false
 	fp.ShowSize = false
 	fp.AutoHeight = false
@@ -180,16 +180,10 @@ func (f *FilePicker) HandleMsg(msg tea.Msg) Action {
 	var cmd tea.Cmd
 	f.fp, cmd = f.fp.Update(msg)
 	if selFile := f.fp.HighlightedPath(); selFile != "" {
-		var allowed bool
-		for _, allowedExt := range f.fp.AllowedTypes {
-			if strings.HasSuffix(strings.ToLower(selFile), allowedExt) {
-				allowed = true
-				break
-			}
-		}
+		isImage := common.IsAllowedImageType(selFile)
 
-		f.previewingImage = allowed
-		if allowed && !fimage.HasTransmitted(selFile, f.imgPrevWidth, f.imgPrevHeight) {
+		f.previewingImage = isImage
+		if isImage && !fimage.HasTransmitted(selFile, f.imgPrevWidth, f.imgPrevHeight) {
 			f.previewingImage = false
 			img, err := loadImage(selFile)
 			if err == nil {
@@ -240,7 +234,7 @@ func (f *FilePicker) Draw(scr uv.Screen, area uv.Rectangle) *tea.Cursor {
 	t := f.com.Styles
 	rc := NewRenderContext(t, width)
 	rc.Gap = 1
-	rc.Title = "Add Image"
+	rc.Title = "Add File"
 	rc.Help = f.help.View(f)
 
 	imgPreview := t.Dialog.ImagePreview.Align(lipgloss.Center).Width(innerWidth).Render(f.imagePreview(imgPrevWidth, imgPrevHeight))

--- a/internal/ui/model/keys.go
+++ b/internal/ui/model/keys.go
@@ -121,7 +121,7 @@ func DefaultKeyMap() KeyMap {
 	)
 	km.Editor.AddImage = key.NewBinding(
 		key.WithKeys("ctrl+f"),
-		key.WithHelp("ctrl+f", "add image"),
+		key.WithHelp("ctrl+f", "add file"),
 	)
 	km.Editor.PasteImage = key.NewBinding(
 		key.WithKeys("ctrl+v", "super+v"),

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -2145,9 +2145,6 @@ func (m *UI) handleKeyPressMsg(msg tea.KeyPressMsg) tea.Cmd {
 
 			switch {
 			case key.Matches(msg, m.keyMap.Editor.AddImage):
-				if !m.currentModelSupportsImages() {
-					break
-				}
 				if cmd := m.openFilesDialog(); cmd != nil {
 					cmds = append(cmds, cmd)
 				}
@@ -2785,8 +2782,12 @@ func (m *UI) FullHelp() [][]key.Binding {
 				k.Editor.MentionFile,
 				k.Editor.OpenEditor,
 			}
+			// AddImage (ctrl+f) opens the file picker, which now accepts text
+			// files on any model, so its hint always shows. Only the clipboard
+			// image paste stays gated to image-capable models.
+			editorBinds = append(editorBinds, k.Editor.AddImage)
 			if m.currentModelSupportsImages() {
-				editorBinds = append(editorBinds, k.Editor.AddImage, k.Editor.PasteImage)
+				editorBinds = append(editorBinds, k.Editor.PasteImage)
 			}
 			binds = append(binds, editorBinds)
 			if hasAttachments {
@@ -2840,8 +2841,12 @@ func (m *UI) FullHelp() [][]key.Binding {
 				k.Editor.MentionFile,
 				k.Editor.OpenEditor,
 			}
+			// AddImage (ctrl+f) opens the file picker, which now accepts text
+			// files on any model, so its hint always shows. Only the clipboard
+			// image paste stays gated to image-capable models.
+			editorBinds = append(editorBinds, k.Editor.AddImage)
 			if m.currentModelSupportsImages() {
-				editorBinds = append(editorBinds, k.Editor.AddImage, k.Editor.PasteImage)
+				editorBinds = append(editorBinds, k.Editor.PasteImage)
 			}
 			binds = append(binds, editorBinds)
 			if hasAttachments {
@@ -4290,15 +4295,7 @@ func (m *UI) handlePasteMsg(msg tea.PasteMsg) tea.Cmd {
 				return false
 			}
 
-			lowerPath := strings.ToLower(path)
-			isValid := false
-			for _, ext := range common.AllowedImageTypes {
-				if strings.HasSuffix(lowerPath, ext) {
-					isValid = true
-					break
-				}
-			}
-			if !isValid {
+			if !common.IsAllowedAttachmentType(path) {
 				return false
 			}
 		}
@@ -4397,16 +4394,8 @@ func (m *UI) pasteImageFromClipboard() tea.Msg {
 		return nil // Clipboard does not contain an image or valid file path
 	}
 
-	lowerPath := strings.ToLower(path)
-	isAllowed := false
-	for _, ext := range common.AllowedImageTypes {
-		if strings.HasSuffix(lowerPath, ext) {
-			isAllowed = true
-			break
-		}
-	}
-	if !isAllowed {
-		return util.NewInfoMsg("File type is not a supported image format")
+	if !common.IsAllowedAttachmentType(path) {
+		return util.NewInfoMsg("File type is not supported")
 	}
 
 	fileInfo, statErr := os.Stat(path)


### PR DESCRIPTION
## TUI uplift — attach more file types

Expands the attachment system beyond images to accept common text-based file types used in development workflows (`.json`, `.yaml`, `.md`, `.go`, `.py`, `.css`, `.html`, `.ts`, `.sql`, `.toml`, …). Text attachments are inlined into the prompt via the existing `PromptWithTextAttachments` pipeline, so they work on **any** model — not just image-capable ones.

### What changed
- Add `AllowedTextFileTypes` list and `IsAllowedAttachmentType` helpers in `common.go`
- Broaden `Attachment.IsText()` to recognize `application/*` MIME types that are fundamentally text (JSON, YAML, XML, …)
- File picker shows all allowed types, dialog renamed to **"Add File"**, image preview gated to image types only
- Remove the image-support gate on <kbd>Ctrl+F</kbd> so text files work with any model, and always advertise the "add file" hint in the footer (clipboard *image* paste stays gated to image-capable models)
- Broaden paste handlers (clipboard + terminal paste) to accept text file paths
- Tests for all new functions and updated `IsText` behavior

### Packaging note
Repackages previously-merged work (originally #118) as the **"more file types"** PR, kept separate from the ✕ remove-button PR per request. Base branch is `claude/crush-fork-pr-reorg-iu7e2m` (pre-attachment `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01V7CNwo12K2nJXtmKUMZ3QQ)_