### PR TITLE
feat(ui): framed-square glyph for image attachment icon

### DIFF
--- a/internal/ui/styles/styles.go
+++ b/internal/ui/styles/styles.go
@@ -41,7 +41,7 @@ const (
 	TodoPendingIcon    string = "•"
 	TodoInProgressIcon string = "→"
 
-	ImageIcon string = "■"
+	ImageIcon string = "▣"
 	TextIcon  string = "≡"
 	SkillIcon string = "▲"
 


### PR DESCRIPTION
## TUI uplift — images get better treatment

Replace the plain black square (`■`) used for image attachments with a framed square containing an inner filled square (`▣`), which reads more clearly as "image/picture" at a glance.

- `internal/ui/styles/styles.go` — `ImageIcon` glyph `■` → `▣`

### Packaging note
Repackages previously-merged work (originally #119) as its own small, self-contained PR. Base branch is `claude/crush-fork-pr-reorg-iu7e2m` (pre-attachment `main`).

> Note: this touches the same `styles.go` const block as the ✕ remove-button PR. They're independent; whichever merges second needs a trivial one-line conflict resolution on the icon constants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01V7CNwo12K2nJXtmKUMZ3QQ)_