### PR TITLE
Apply review fixes to PR #3328

### DIFF
--- a/internal/agent/tools/mcp/init.go
+++ b/internal/agent/tools/mcp/init.go
@@ -58,7 +58,45 @@ var (
 	broker   = pubsub.NewBroker[Event]()
 	initOnce sync.Once
 	initDone = make(chan struct{})
+
+	// initStarted records whether Initialize has been armed. WaitForInit only
+	// blocks once initialization is expected; coordinators built outside app
+	// startup never arm it and so must not wait forever.
+	initMu      sync.Mutex
+	initStarted bool
+
+	// renewMus serializes lazy session renewals per server so concurrent tool
+	// calls cannot race to rebuild the same session.
+	renewMusMu sync.Mutex
+	renewMus   = map[string]*sync.Mutex{}
+
+	// newSession creates a client session. It is a seam so tests can exercise
+	// renewal concurrency without spawning a real transport.
+	newSession = createSession
 )
+
+// ArmInit marks that MCP initialization is expected so WaitForInit blocks
+// until it completes. Call this synchronously before launching Initialize in a
+// goroutine; otherwise WaitForInit could observe the not-yet-started state and
+// return early, letting the tool list be read before MCP tools register.
+func ArmInit() {
+	initMu.Lock()
+	initStarted = true
+	initMu.Unlock()
+}
+
+// renewLock returns the per-server mutex used to serialize session renewals,
+// creating it on first use.
+func renewLock(name string) *sync.Mutex {
+	renewMusMu.Lock()
+	defer renewMusMu.Unlock()
+	mu, ok := renewMus[name]
+	if !ok {
+		mu = &sync.Mutex{}
+		renewMus[name] = mu
+	}
+	return mu
+}
 
 // State represents the current state of an MCP client
 type State int
@@ -164,6 +202,7 @@ func Close(ctx context.Context) error {
 
 // Initialize initializes MCP clients based on the provided configuration.
 func Initialize(ctx context.Context, permissions permission.Service, cfg *config.ConfigStore) {
+	ArmInit()
 	slog.Info("Initializing MCP clients")
 	var wg sync.WaitGroup
 	// Initialize states for all configured MCPs
@@ -204,12 +243,17 @@ func Initialize(ctx context.Context, permissions permission.Service, cfg *config
 }
 
 // WaitForInit blocks until MCP initialization is complete, i.e. until
-// Initialize has finished and closed initDone. If Initialize is never called,
-// initDone is never closed, so this blocks until ctx is cancelled and then
-// returns ctx.Err(). Callers must therefore pass a context that is eventually
-// cancelled (Initialize is spawned unconditionally during app startup, so in
-// practice initDone always closes).
+// Initialize has finished and closed initDone. If initialization was never
+// armed (ArmInit was not called, e.g. a coordinator built outside app
+// startup), there is nothing to wait for and this returns nil immediately
+// rather than blocking until ctx is cancelled.
 func WaitForInit(ctx context.Context) error {
+	initMu.Lock()
+	started := initStarted
+	initMu.Unlock()
+	if !started {
+		return nil
+	}
 	select {
 	case <-initDone:
 		return nil
@@ -290,43 +334,94 @@ func DisableSingle(cfg *config.ConfigStore, name string) error {
 }
 
 func getOrRenewClient(ctx context.Context, cfg *config.ConfigStore, name string) (*ClientSession, error) {
+	m := cfg.Config().MCP[name]
+	timeout := mcpTimeout(m)
+
+	// Fast path: reuse a healthy session without taking the renewal lock.
+	if sess, ok := sessions.Get(name); ok {
+		if err := pingSession(ctx, sess, timeout); err == nil {
+			return sess, nil
+		}
+	}
+
+	// Serialize renewals per server. Two concurrent tool calls can both
+	// observe a dead session and race to rebuild it: one may close the
+	// session the other just registered, or overwrite and leak a live
+	// replacement. Under this lock only the first arrival rebuilds; later
+	// arrivals re-check and reuse the healthy result.
+	mu := renewLock(name)
+	mu.Lock()
+	defer mu.Unlock()
+
+	// Under the lock the map is stable: any in-flight renewal has finished and
+	// either re-registered its session or failed and left none. A renewal
+	// removes the session transiently (StateError takes it before rebuilding),
+	// so this check must happen here rather than before the lock — otherwise a
+	// caller arriving mid-renewal sees no session and wrongly reports the
+	// server unavailable.
 	sess, ok := sessions.Get(name)
 	if !ok {
 		return nil, fmt.Errorf("mcp '%s' not available", name)
 	}
 
-	m := cfg.Config().MCP[name]
-	state, _ := states.Get(name)
-
-	timeout := mcpTimeout(m)
-	pingCtx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
-	err := sess.Ping(pingCtx, nil)
-	if err == nil {
+	// A concurrent goroutine may have already renewed the session while we
+	// waited for the lock. Reuse it if it is now healthy.
+	pingErr := pingSession(ctx, sess, timeout)
+	if pingErr == nil {
 		return sess, nil
 	}
-	updateState(name, StateError, maybeTimeoutErr(err, timeout), nil, state.Counts)
 
-	sess, err = createSession(ctx, name, m, cfg.Resolver())
+	state, _ := states.Get(name)
+	// StateError closes the dead session and clears its tools, prompts, and
+	// resources from the registry.
+	updateState(name, StateError, maybeTimeoutErr(pingErr, timeout), nil, state.Counts)
+
+	newSess, err := newSession(ctx, name, m, cfg.Resolver())
 	if err != nil {
 		return nil, err
 	}
 
-	// The StateError transition above cleared this server's tools from the
-	// registry (and closed the dead session). Re-list and re-register them on
-	// the fresh session; otherwise the agent reconnects but the LLM's tool
-	// list stays empty and the next call fails with "tool not found".
-	counts := state.Counts
-	counts.Tools, err = registerSessionTools(ctx, cfg, name, sess)
+	// StateError cleared this server's tools, prompts, and resources from the
+	// registry. Re-list and re-register them all on the fresh session and
+	// recompute the counts from what actually registered; otherwise the agent
+	// reconnects but the registries stay empty (the next tool call fails with
+	// "tool not found") while the reported counts still advertise capabilities
+	// that are no longer there.
+	var counts Counts
+	counts.Tools, err = registerSessionTools(ctx, cfg, name, newSess)
 	if err != nil {
-		updateState(name, StateError, err, nil, state.Counts)
-		closeSession(name, sess)
+		updateState(name, StateError, err, nil, Counts{})
+		closeSession(name, newSess)
 		return nil, err
 	}
 
-	sessions.Set(name, sess)
-	updateState(name, StateConnected, nil, sess, counts)
-	return sess, nil
+	prompts, err := getPrompts(ctx, newSess)
+	if err != nil {
+		updateState(name, StateError, err, nil, Counts{})
+		closeSession(name, newSess)
+		return nil, err
+	}
+	updatePrompts(name, prompts)
+	counts.Prompts = len(prompts)
+
+	resources, err := getResources(ctx, newSess)
+	if err != nil {
+		updateState(name, StateError, err, nil, Counts{})
+		closeSession(name, newSess)
+		return nil, err
+	}
+	counts.Resources = updateResources(name, resources)
+
+	sessions.Set(name, newSess)
+	updateState(name, StateConnected, nil, newSess, counts)
+	return newSess, nil
+}
+
+// pingSession pings a session with the server's configured timeout.
+func pingSession(ctx context.Context, s *ClientSession, timeout time.Duration) error {
+	pingCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	return s.Ping(pingCtx, nil)
 }
 
 // closeSession closes an MCP session, logging only unexpected errors. EOF,
@@ -364,7 +459,13 @@ func updateState(name string, state State, err error, client *ClientSession, cou
 		if old, ok := sessions.Take(name); ok {
 			closeSession(name, old)
 		}
+		// Drop every registry entry for the dead server. Leaving prompts or
+		// resources behind lets a disconnected server keep advertising
+		// capabilities the agent can no longer fulfil, the same divergence the
+		// tool clear prevents.
 		allTools.Del(name)
+		allPrompts.Del(name)
+		allResources.Del(name)
 	}
 	states.Set(name, info)
 

--- a/internal/agent/tools/mcp/lifecycle_test.go
+++ b/internal/agent/tools/mcp/lifecycle_test.go
@@ -3,6 +3,8 @@ package mcp
 import (
 	"context"
 	"errors"
+	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/charmbracelet/crush/internal/config"
@@ -38,6 +40,45 @@ func liveSession(t *testing.T, toolName string) (*ClientSession, context.Context
 	require.NoError(t, err)
 
 	return &ClientSession{ClientSession: clientSession, cancel: cancel}, ctx
+}
+
+// liveSessionWithCapabilities is like liveSession but the server also exposes a
+// prompt and a resource, so tests can assert those registries are populated on
+// (re)connect.
+func liveSessionWithCapabilities(t *testing.T, toolName, promptName, resourceURI string) *ClientSession {
+	t.Helper()
+
+	serverTransport, clientTransport := mcp.NewInMemoryTransports()
+	server := mcp.NewServer(&mcp.Implementation{Name: "srv"}, nil)
+	mcp.AddTool(
+		server,
+		&mcp.Tool{Name: toolName, Description: "test tool"},
+		func(context.Context, *mcp.CallToolRequest, struct{}) (*mcp.CallToolResult, any, error) {
+			return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: "ok"}}}, nil, nil
+		},
+	)
+	server.AddPrompt(
+		&mcp.Prompt{Name: promptName},
+		func(context.Context, *mcp.GetPromptRequest) (*mcp.GetPromptResult, error) {
+			return &mcp.GetPromptResult{}, nil
+		},
+	)
+	server.AddResource(
+		&mcp.Resource{Name: "res", URI: resourceURI},
+		func(context.Context, *mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
+			return &mcp.ReadResourceResult{}, nil
+		},
+	)
+	serverSession, err := server.Connect(context.Background(), serverTransport, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = serverSession.Close() })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	client := mcp.NewClient(&mcp.Implementation{Name: "crush-test"}, nil)
+	clientSession, err := client.Connect(ctx, clientTransport, nil)
+	require.NoError(t, err)
+
+	return &ClientSession{ClientSession: clientSession, cancel: cancel}
 }
 
 // TestUpdateState_ErrorClosesSessionAndClearsTools pins the primary fix: a
@@ -80,6 +121,107 @@ func TestUpdateState_ErrorClosesSessionAndClearsTools(t *testing.T) {
 	info, ok := GetState(name)
 	require.True(t, ok)
 	require.Equal(t, StateError, info.State)
+}
+
+// TestUpdateState_ErrorClearsPromptsAndResources pins that a StateError
+// transition also drops the dead server's prompts and resources, not just its
+// tools. Leaving them registered lets a disconnected server keep advertising
+// capabilities the agent can no longer fulfil — the same state/registry
+// divergence the tool clear exists to prevent.
+func TestUpdateState_ErrorClearsPromptsAndResources(t *testing.T) {
+	const name = "test-error-clears-all"
+	t.Cleanup(func() {
+		sessions.Del(name)
+		allTools.Del(name)
+		allPrompts.Del(name)
+		allResources.Del(name)
+		states.Del(name)
+	})
+
+	allTools.Set(name, []*Tool{{Name: "do_thing"}})
+	allPrompts.Set(name, []*Prompt{{Name: "a_prompt"}})
+	allResources.Set(name, []*Resource{{Name: "a_resource"}})
+
+	updateState(name, StateError, errors.New("pipe broke"), nil, Counts{})
+
+	_, ok := allTools.Get(name)
+	require.False(t, ok, "errored session's tools must be cleared")
+	_, ok = allPrompts.Get(name)
+	require.False(t, ok, "errored session's prompts must be cleared")
+	_, ok = allResources.Get(name)
+	require.False(t, ok, "errored session's resources must be cleared")
+}
+
+// TestGetOrRenewClient_SerializesConcurrentRenewals is the concurrency
+// regression the production renew path needs: when several tool calls observe
+// the same dead session at once they must not each rebuild it. Without
+// serialization, concurrent renewals close a session another goroutine just
+// registered or overwrite and leak a live replacement. With the per-server
+// lock only the first arrival rebuilds; the rest re-check and reuse the
+// healthy session, so exactly one new session is created.
+func TestGetOrRenewClient_SerializesConcurrentRenewals(t *testing.T) {
+	const name = "test-renew-concurrency"
+	const workers = 8
+
+	t.Cleanup(func() {
+		if s, ok := sessions.Take(name); ok {
+			_ = s.Close()
+		}
+		allTools.Del(name)
+		states.Del(name)
+	})
+
+	cfg := config.NewTestStore(&config.Config{MCP: config.MCPs{name: {Type: config.MCPStdio}}})
+
+	// Seed a dead session so the first ping fails and every worker attempts a
+	// renewal.
+	dead, _ := liveSession(t, "send_message")
+	require.NoError(t, dead.Close())
+	sessions.Set(name, dead)
+
+	// Pre-build enough live replacements that the buggy (unserialized) path
+	// could consume more than one; the fix must consume exactly one.
+	replacements := make(chan *ClientSession, workers)
+	for range workers {
+		s, _ := liveSession(t, "send_message")
+		replacements <- s
+	}
+	close(replacements)
+	t.Cleanup(func() {
+		for s := range replacements {
+			_ = s.Close()
+		}
+	})
+
+	var created atomic.Int32
+	origNewSession := newSession
+	newSession = func(context.Context, string, config.MCPConfig, config.VariableResolver) (*ClientSession, error) {
+		created.Add(1)
+		return <-replacements, nil
+	}
+	t.Cleanup(func() { newSession = origNewSession })
+
+	var wg sync.WaitGroup
+	results := make([]*ClientSession, workers)
+	errs := make([]error, workers)
+	for i := range workers {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			results[i], errs[i] = getOrRenewClient(context.Background(), cfg, name)
+		}(i)
+	}
+	wg.Wait()
+
+	require.Equal(t, int32(1), created.Load(),
+		"exactly one renewal must occur; concurrent callers must reuse the renewed session")
+
+	final, ok := sessions.Get(name)
+	require.True(t, ok, "a live session must remain registered after concurrent renewals")
+	for i := range workers {
+		require.NoError(t, errs[i])
+		require.Same(t, final, results[i], "every caller must observe the same renewed session")
+	}
 }
 
 // TestRegisterSessionTools_PopulatesRegistry pins that registerSessionTools —
@@ -152,4 +294,60 @@ func TestSessionErrorThenRenew_RestoresTools(t *testing.T) {
 	require.True(t, ok, "tools must be restored after the session is renewed")
 	require.Len(t, got, 1)
 	require.Equal(t, "send_message", got[0].Name)
+}
+
+// TestGetOrRenewClient_RestoresPromptsAndResources pins that a renewal
+// repopulates every registry and reports counts that match. StateError clears
+// tools, prompts, and resources; if renewal restored only tools while keeping
+// the old prompt/resource counts, GetState would again advertise capabilities
+// absent from the registries.
+func TestGetOrRenewClient_RestoresPromptsAndResources(t *testing.T) {
+	const name = "test-renew-prompts-resources"
+	t.Cleanup(func() {
+		if s, ok := sessions.Take(name); ok {
+			_ = s.Close()
+		}
+		allTools.Del(name)
+		allPrompts.Del(name)
+		allResources.Del(name)
+		states.Del(name)
+	})
+
+	cfg := config.NewTestStore(&config.Config{MCP: config.MCPs{name: {Type: config.MCPStdio}}})
+
+	// Seed a dead session so the renewal path runs.
+	dead, _ := liveSession(t, "send_message")
+	require.NoError(t, dead.Close())
+	sessions.Set(name, dead)
+	// Stale counts that must be recomputed, not preserved.
+	updateState(name, StateConnected, nil, dead, Counts{Tools: 1, Prompts: 1, Resources: 1})
+
+	replacement := liveSessionWithCapabilities(t, "send_message", "a_prompt", "res://thing")
+	origNewSession := newSession
+	newSession = func(context.Context, string, config.MCPConfig, config.VariableResolver) (*ClientSession, error) {
+		return replacement, nil
+	}
+	t.Cleanup(func() { newSession = origNewSession })
+
+	sess, err := getOrRenewClient(context.Background(), cfg, name)
+	require.NoError(t, err)
+	require.Same(t, replacement, sess)
+
+	tools, ok := allTools.Get(name)
+	require.True(t, ok, "tools must be restored on renewal")
+	require.Len(t, tools, 1)
+
+	prompts, ok := allPrompts.Get(name)
+	require.True(t, ok, "prompts must be restored on renewal")
+	require.Len(t, prompts, 1)
+
+	resources, ok := allResources.Get(name)
+	require.True(t, ok, "resources must be restored on renewal")
+	require.Len(t, resources, 1)
+
+	info, ok := GetState(name)
+	require.True(t, ok)
+	require.Equal(t, StateConnected, info.State)
+	require.Equal(t, Counts{Tools: 1, Prompts: 1, Resources: 1}, info.Counts,
+		"reported counts must match the restored registries")
 }

--- a/internal/agent/tools/mcp/waitforinit_test.go
+++ b/internal/agent/tools/mcp/waitforinit_test.go
@@ -19,7 +19,18 @@ func swapInitGate(t *testing.T) chan struct{} {
 	t.Helper()
 	orig := initDone
 	initDone = make(chan struct{})
-	t.Cleanup(func() { initDone = orig })
+
+	initMu.Lock()
+	origStarted := initStarted
+	initStarted = true
+	initMu.Unlock()
+
+	t.Cleanup(func() {
+		initDone = orig
+		initMu.Lock()
+		initStarted = origStarted
+		initMu.Unlock()
+	})
 	return initDone
 }
 
@@ -41,6 +52,29 @@ func TestWaitForInit_BlocksUntilInitCompletes(t *testing.T) {
 	close(gate)
 	require.NoError(t, WaitForInit(context.Background()),
 		"WaitForInit must return once initialization has completed")
+}
+
+// TestWaitForInit_ReturnsWhenNotArmed is the regression test for coordinators
+// built outside app startup. Those paths never call mcp.Initialize (which is
+// what arms the gate), so WaitForInit must return immediately instead of
+// blocking on a channel that will never close. Before the fix it blocked until
+// ctx was cancelled, hanging coordinator.run's readyWg forever.
+func TestWaitForInit_ReturnsWhenNotArmed(t *testing.T) {
+	// Ensure the gate looks unarmed regardless of test ordering.
+	initMu.Lock()
+	orig := initStarted
+	initStarted = false
+	initMu.Unlock()
+	t.Cleanup(func() {
+		initMu.Lock()
+		initStarted = orig
+		initMu.Unlock()
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	require.NoError(t, WaitForInit(ctx),
+		"WaitForInit must return immediately when initialization was never armed")
 }
 
 // TestWaitForInit_ToolsVisibleAfterInit is the regression test for the bug the

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -140,6 +140,10 @@ func New(ctx context.Context, conn *sql.DB, store *config.ConfigStore, skillsMgr
 	// Check for updates in the background.
 	go app.checkForUpdates(ctx)
 
+	// Arm initialization synchronously before launching it so WaitForInit
+	// blocks for the in-flight init instead of racing the goroutine and
+	// returning before any MCP tools register.
+	mcp.ArmInit()
 	go mcp.Initialize(ctx, app.Permissions, store)
 
 	// Start herdr integration when running inside a herdr pane.


### PR DESCRIPTION
These are the review fixes for PR #3328 (see review on charmbracelet/crush#3328).

- `WaitForInit` no longer hangs coordinators built outside app startup: `ArmInit` marks initialization as expected, so the app path blocks until init completes while standalone paths return immediately.
- `getOrRenewClient` serializes per-server renewals and re-checks the session under the lock, so concurrent callers can't race to rebuild the same session or leak a replacement.
- Renewal re-lists/re-registers prompts and resources (not just tools) and recomputes counts, keeping `StateError`'s clear and the restore symmetric.

Adds regression tests for the not-armed init gate, concurrent renewals, and prompt/resource restoration on renew.

Merge this into the PR branch and #3328 will be updated.

Generated with Crush