### PR TITLE
fix(mcp): serialize per-server lifecycle; scope error teardown to the erroring session

### DIFF
--- a/internal/agent/tools/mcp/init.go
+++ b/internal/agent/tools/mcp/init.go
@@ -66,9 +66,13 @@ var (
 	// just-installed session, or the second success overwrites the first
 	// session without closing it. Different servers never contend.
 	nameLocks = csync.NewMap[string, *sync.Mutex]()
-	broker    = pubsub.NewBroker[Event]()
-	initOnce  sync.Once
-	initDone  = make(chan struct{})
+	// nameLocksMu makes mutex creation in nameLock atomic:
+	// csync.Map.GetOrSet is check-then-act, so two first-op callers
+	// could otherwise mint different mutexes and proceed unserialized.
+	nameLocksMu sync.Mutex
+	broker      = pubsub.NewBroker[Event]()
+	initOnce    sync.Once
+	initDone    = make(chan struct{})
 )
 
 // State represents the current state of an MCP client
@@ -258,7 +262,14 @@ func InitializeSingle(ctx context.Context, name string, cfg *config.ConfigStore)
 
 // nameLock returns the mutex serializing lifecycle mutations for one server.
 func nameLock(name string) *sync.Mutex {
-	return nameLocks.GetOrSet(name, func() *sync.Mutex { return &sync.Mutex{} })
+	nameLocksMu.Lock()
+	defer nameLocksMu.Unlock()
+	if mu, ok := nameLocks.Get(name); ok {
+		return mu
+	}
+	mu := &sync.Mutex{}
+	nameLocks.Set(name, mu)
+	return mu
 }
 
 // initClient initializes a single MCP client with the given configuration.
@@ -316,9 +327,10 @@ func DisableSingle(cfg *config.ConfigStore, name string) error {
 		closeSession(name, session)
 	}
 
-	// Clear tools and prompts for this MCP.
+	// Clear tools, prompts, and resources for this MCP.
 	updateTools(cfg, name, nil)
 	updatePrompts(name, nil)
+	updateResources(name, nil)
 
 	// Update state to disabled.
 	updateState(name, StateDisabled, nil, nil, Counts{})
@@ -427,6 +439,7 @@ func updateState(name string, state State, err error, client *ClientSession, cou
 				sessions.Del(name)
 				allTools.Del(name)
 				updatePrompts(name, nil)
+				updateResources(name, nil)
 			}
 			closeSession(name, client)
 		default:
@@ -437,6 +450,7 @@ func updateState(name string, state State, err error, client *ClientSession, cou
 			}
 			allTools.Del(name)
 			updatePrompts(name, nil)
+			updateResources(name, nil)
 		}
 		// Never publish a dead session on the state.
 		info.Client = nil

--- a/internal/agent/tools/mcp/init.go
+++ b/internal/agent/tools/mcp/init.go
@@ -59,9 +59,16 @@ func (s *ClientSession) Close() error {
 var (
 	sessions = csync.NewMap[string, *ClientSession]()
 	states   = csync.NewMap[string, ClientInfo]()
-	broker   = pubsub.NewBroker[Event]()
-	initOnce sync.Once
-	initDone = make(chan struct{})
+
+	// nameLocks serializes per-server lifecycle mutations — init, disable,
+	// renew, refresh. Without it, two concurrent renewals for the same server
+	// interleave: the loser's error path tears down the winner's healthy,
+	// just-installed session, or the second success overwrites the first
+	// session without closing it. Different servers never contend.
+	nameLocks = csync.NewMap[string, *sync.Mutex]()
+	broker    = pubsub.NewBroker[Event]()
+	initOnce  sync.Once
+	initDone  = make(chan struct{})
 )
 
 // State represents the current state of an MCP client
@@ -249,8 +256,17 @@ func InitializeSingle(ctx context.Context, name string, cfg *config.ConfigStore)
 	return initClient(ctx, cfg, name, m, cfg.Resolver())
 }
 
+// nameLock returns the mutex serializing lifecycle mutations for one server.
+func nameLock(name string) *sync.Mutex {
+	return nameLocks.GetOrSet(name, func() *sync.Mutex { return &sync.Mutex{} })
+}
+
 // initClient initializes a single MCP client with the given configuration.
 func initClient(ctx context.Context, cfg *config.ConfigStore, name string, m config.MCPConfig, resolver config.VariableResolver) error {
+	mu := nameLock(name)
+	mu.Lock()
+	defer mu.Unlock()
+
 	// Set initial starting state.
 	updateState(name, StateStarting, nil, nil, Counts{})
 
@@ -263,20 +279,23 @@ func initClient(ctx context.Context, cfg *config.ConfigStore, name string, m con
 	toolCount, err := registerSessionTools(ctx, cfg, name, session)
 	if err != nil {
 		slog.Error("Error listing tools", "error", err)
-		updateState(name, StateError, err, nil, Counts{})
-		closeSession(name, session)
+		updateState(name, StateError, err, session, Counts{})
 		return err
 	}
 
 	prompts, err := getPrompts(ctx, session)
 	if err != nil {
 		slog.Error("Error listing prompts", "error", err)
-		updateState(name, StateError, err, nil, Counts{})
-		closeSession(name, session)
+		updateState(name, StateError, err, session, Counts{})
 		return err
 	}
 
 	updatePrompts(name, prompts)
+	// A repeated init (e.g. enable called twice) must not overwrite a live
+	// session without closing it — that leaks the child process and pipes.
+	if old, ok := sessions.Take(name); ok && old != session {
+		closeSession(name, old)
+	}
 	sessions.Set(name, session)
 
 	updateState(name, StateConnected, nil, session, Counts{
@@ -289,6 +308,10 @@ func initClient(ctx context.Context, cfg *config.ConfigStore, name string, m con
 
 // DisableSingle disables and closes a single MCP client by name.
 func DisableSingle(cfg *config.ConfigStore, name string) error {
+	mu := nameLock(name)
+	mu.Lock()
+	defer mu.Unlock()
+
 	if session, ok := sessions.Take(name); ok {
 		closeSession(name, session)
 	}
@@ -305,6 +328,14 @@ func DisableSingle(cfg *config.ConfigStore, name string) error {
 }
 
 func getOrRenewClient(ctx context.Context, cfg *config.ConfigStore, name string) (*ClientSession, error) {
+	// The whole ping→renew→re-register sequence runs under the per-name lock,
+	// making renewal single-flight: a caller that raced a renewal re-pings the
+	// fresh session the winner installed and returns it, instead of tearing it
+	// down and building another.
+	mu := nameLock(name)
+	mu.Lock()
+	defer mu.Unlock()
+
 	sess, ok := sessions.Get(name)
 	if !ok {
 		return nil, fmt.Errorf("mcp '%s' not available", name)
@@ -320,34 +351,46 @@ func getOrRenewClient(ctx context.Context, cfg *config.ConfigStore, name string)
 	if err == nil {
 		return sess, nil
 	}
-	updateState(name, StateError, maybeTimeoutErr(err, timeout), nil, state.Counts)
+	// Report the failure against the exact session that failed the ping, so
+	// only that session is closed and deregistered.
+	updateState(name, StateError, maybeTimeoutErr(err, timeout), sess, state.Counts)
 
-	sess, err = createSession(ctx, name, m, cfg.Resolver(), ChannelEnabled(cfg.Overrides().EnabledChannels, name))
+	fresh, err := createSession(ctx, name, m, cfg.Resolver(), ChannelEnabled(cfg.Overrides().EnabledChannels, name))
 	if err != nil {
 		return nil, err
 	}
 
-	// The StateError transition above cleared this server's tools from the
-	// registry (and closed the dead session). Re-list and re-register them on
-	// the fresh session; otherwise the agent reconnects but the LLM's tool
-	// list stays empty and the next call fails with "tool not found".
+	// The StateError transition above cleared this server's tools and prompts
+	// from the registry (and closed the dead session). Re-list and re-register
+	// both on the fresh session; otherwise the agent reconnects but the LLM's
+	// tool list stays empty and the next call fails with "tool not found",
+	// and the commands menu keeps stale prompts.
 	counts := state.Counts
-	counts.Tools, err = registerSessionTools(ctx, cfg, name, sess)
+	counts.Tools, err = registerSessionTools(ctx, cfg, name, fresh)
 	if err != nil {
-		updateState(name, StateError, err, nil, state.Counts)
-		closeSession(name, sess)
+		updateState(name, StateError, err, fresh, state.Counts)
 		return nil, err
 	}
 
-	sessions.Set(name, sess)
-	updateState(name, StateConnected, nil, sess, counts)
-	return sess, nil
+	prompts, err := getPrompts(ctx, fresh)
+	if err != nil {
+		slog.Warn("Error re-listing prompts after MCP renewal", "name", name, "error", err)
+	}
+	updatePrompts(name, prompts)
+	counts.Prompts = len(prompts)
+
+	sessions.Set(name, fresh)
+	updateState(name, StateConnected, nil, fresh, counts)
+	return fresh, nil
 }
 
 // closeSession closes an MCP session, logging only unexpected errors. EOF,
 // context cancellation, and a killed child are the ordinary result of tearing
 // a session down and are not worth surfacing.
 func closeSession(name string, s *ClientSession) {
+	if s == nil || s.ClientSession == nil {
+		return
+	}
 	if err := s.Close(); err != nil &&
 		!errors.Is(err, io.EOF) &&
 		!errors.Is(err, context.Canceled) &&
@@ -370,17 +413,34 @@ func updateState(name string, state State, err error, client *ClientSession, cou
 	case StateConnected:
 		info.ConnectedAt = time.Now()
 	case StateError:
-		// A session that has errored is dead to us. Atomically remove it and
-		// close it so the child process and its stdio pipes are released — the
-		// bare map delete this used to do leaked both. Clearing the tool
-		// registry keeps the agent from advertising tools it can no longer
-		// call: without it, crush_info / the `/mcp` menu and the tool list
-		// handed to the LLM diverge, so a server still reads "connected, N
-		// tools" while every call fails with "tool not found".
-		if old, ok := sessions.Take(name); ok {
-			closeSession(name, old)
+		// A session that has errored is dead to us: close it so the child
+		// process and its stdio pipes are released, and clear its tool/prompt
+		// registrations so the agent stops advertising capabilities it can no
+		// longer call. Crucially, close exactly the session that errored (the
+		// client argument): if the registry already holds a DIFFERENT session
+		// — a newer, healthy one another path installed — leave it and its
+		// registrations alone. Closing "whatever is in the map" here used to
+		// let a stale error transition tear down a healthy replacement.
+		switch {
+		case client != nil:
+			if cur, ok := sessions.Get(name); ok && cur == client {
+				sessions.Del(name)
+				allTools.Del(name)
+				updatePrompts(name, nil)
+			}
+			closeSession(name, client)
+		default:
+			// No specific session errored (e.g. connect itself failed);
+			// anything still registered under this name is unusable.
+			if old, ok := sessions.Take(name); ok {
+				closeSession(name, old)
+			}
+			allTools.Del(name)
+			updatePrompts(name, nil)
 		}
-		allTools.Del(name)
+		// Never publish a dead session on the state.
+		info.Client = nil
+		info.Channel = false
 	}
 	states.Set(name, info)
 
@@ -482,6 +542,13 @@ func createSession(ctx context.Context, name string, m config.MCPConfig, resolve
 func maybeStdioErr(err error, transport mcp.Transport) error {
 	if !errors.Is(err, io.EOF) {
 		return err
+	}
+	// Every transport is wrapped in a channelTransport before Connect; the
+	// stdio transport we're probing for is the inner one. Without this unwrap
+	// the assertion below never matches and stdio startup failures report a
+	// bare EOF instead of the child's actual output.
+	if cw, ok := transport.(*channelTransport); ok {
+		transport = cw.inner
 	}
 	ct, ok := transport.(*mcp.CommandTransport)
 	if !ok {
@@ -615,7 +682,13 @@ func mcpTimeout(m config.MCPConfig) time.Duration {
 func stdioCheck(old *exec.Cmd) error {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel()
-	cmd := exec.CommandContext(ctx, old.Path, old.Args...)
+	// old.Args already includes argv0; passing it whole would duplicate the
+	// program name in the re-exec.
+	var args []string
+	if len(old.Args) > 1 {
+		args = old.Args[1:]
+	}
+	cmd := exec.CommandContext(ctx, old.Path, args...)
 	cmd.Env = old.Env
 	out, err := cmd.CombinedOutput()
 	if err == nil || errors.Is(ctx.Err(), context.DeadlineExceeded) {

--- a/internal/agent/tools/mcp/lifecycle_test.go
+++ b/internal/agent/tools/mcp/lifecycle_test.go
@@ -3,6 +3,9 @@ package mcp
 import (
 	"context"
 	"errors"
+	"io"
+	"os/exec"
+	"sync/atomic"
 	"testing"
 
 	"github.com/charmbracelet/crush/internal/config"
@@ -152,4 +155,92 @@ func TestSessionErrorThenRenew_RestoresTools(t *testing.T) {
 	require.True(t, ok, "tools must be restored after the session is renewed")
 	require.Len(t, got, 1)
 	require.Equal(t, "send_message", got[0].Name)
+}
+
+// TestUpdateState_ErrorFromStaleSessionPreservesHealthyReplacement pins the
+// audit fix: a StateError reported against a session that is NO LONGER the
+// registered one (a renewal already replaced it) must not tear down the
+// healthy replacement or its registrations. Before the fix updateState closed
+// whatever session was in the map, so a stale error transition — e.g. a slow
+// ping timing out after another path had already renewed — killed the fresh
+// session and wiped its tools.
+func TestUpdateState_ErrorFromStaleSessionPreservesHealthyReplacement(t *testing.T) {
+	const name = "test-stale-error"
+	t.Cleanup(func() {
+		sessions.Del(name)
+		allTools.Del(name)
+		allPrompts.Del(name)
+		states.Del(name)
+	})
+
+	stale, staleCtx := liveSession(t, "old_tool")
+	fresh, freshCtx := liveSession(t, "new_tool")
+
+	// The registry holds the fresh session and its registrations.
+	sessions.Set(name, fresh)
+	allTools.Set(name, []*Tool{{Name: "new_tool"}})
+	allPrompts.Set(name, []*Prompt{{Name: "new_prompt"}})
+
+	// A stale error arrives for the OLD session.
+	updateState(name, StateError, errors.New("ping timeout"), stale, Counts{})
+
+	// The fresh session must still be registered and open.
+	got, ok := sessions.Get(name)
+	require.True(t, ok, "healthy replacement session was removed")
+	require.Same(t, fresh, got)
+	require.NoError(t, freshCtx.Err(), "healthy replacement session was closed")
+	_, ok = allTools.Get(name)
+	require.True(t, ok, "healthy replacement's tools were cleared")
+	_, ok = allPrompts.Get(name)
+	require.True(t, ok, "healthy replacement's prompts were cleared")
+
+	// The stale session must have been closed.
+	require.Error(t, staleCtx.Err(), "stale session was not closed")
+}
+
+// TestUpdateState_ErrorFromCurrentSessionClearsEverything pins the complement:
+// when the erroring session IS the registered one, it is removed, closed, and
+// both tools and prompts are cleared (prompts were previously left behind —
+// dead servers kept their prompts in the commands menu).
+func TestUpdateState_ErrorFromCurrentSessionClearsEverything(t *testing.T) {
+	const name = "test-current-error"
+	t.Cleanup(func() {
+		sessions.Del(name)
+		allTools.Del(name)
+		allPrompts.Del(name)
+		states.Del(name)
+	})
+
+	sess, sessCtx := liveSession(t, "a_tool")
+	sessions.Set(name, sess)
+	allTools.Set(name, []*Tool{{Name: "a_tool"}})
+	allPrompts.Set(name, []*Prompt{{Name: "a_prompt"}})
+
+	updateState(name, StateError, errors.New("boom"), sess, Counts{})
+
+	_, ok := sessions.Get(name)
+	require.False(t, ok, "erroring session should be removed")
+	require.Error(t, sessCtx.Err(), "erroring session should be closed")
+	_, ok = allTools.Get(name)
+	require.False(t, ok, "tools should be cleared")
+	_, ok = allPrompts.Get(name)
+	require.False(t, ok, "prompts should be cleared (previously leaked)")
+
+	st, _ := states.Get(name)
+	require.Nil(t, st.Client, "error state must not publish a dead session")
+}
+
+// TestMaybeStdioErr_UnwrapsChannelTransport pins the diagnostics fix: every
+// transport is wrapped in a channelTransport before Connect, so maybeStdioErr
+// must unwrap it to find the CommandTransport. Before the fix the type
+// assertion always failed and stdio startup errors reported bare EOF with
+// none of the child's output attached.
+func TestMaybeStdioErr_UnwrapsChannelTransport(t *testing.T) {
+	cmd := exec.Command("sh", "-c", "echo boom-diagnostic >&2; exit 3")
+	inner := &mcp.CommandTransport{Command: cmd}
+	wrapped := &channelTransport{inner: inner, name: "t", gate: &atomic.Bool{}}
+
+	got := maybeStdioErr(io.EOF, wrapped)
+	require.ErrorContains(t, got, "boom-diagnostic",
+		"stdio diagnostics should surface the child's output through the channelTransport wrapper")
 }

--- a/internal/agent/tools/mcp/lifecycle_test.go
+++ b/internal/agent/tools/mcp/lifecycle_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"io"
 	"os/exec"
+	"sync"
 	"sync/atomic"
 	"testing"
 
@@ -243,4 +244,64 @@ func TestMaybeStdioErr_UnwrapsChannelTransport(t *testing.T) {
 	got := maybeStdioErr(io.EOF, wrapped)
 	require.ErrorContains(t, got, "boom-diagnostic",
 		"stdio diagnostics should surface the child's output through the channelTransport wrapper")
+}
+
+// TestNameLock_ConcurrentFirstUseReturnsOneMutex pins that the per-name
+// lifecycle lock is minted atomically: racing first-use callers must all
+// receive the same mutex, or the serialization the whole lifecycle relies
+// on silently degrades to per-caller locks.
+func TestNameLock_ConcurrentFirstUseReturnsOneMutex(t *testing.T) {
+	const name = "test-name-lock-race"
+	t.Cleanup(func() { nameLocks.Del(name) })
+
+	const n = 32
+	locks := make([]*sync.Mutex, n)
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	for i := range n {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			locks[i] = nameLock(name)
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	for i := 1; i < n; i++ {
+		require.Same(t, locks[0], locks[i], "all callers must share one lifecycle mutex")
+	}
+}
+
+// TestUpdateState_ErrorClearsResources pins that both StateError teardown
+// branches clear the resources registry alongside tools and prompts — a
+// dead server must not keep advertising resources it can no longer serve.
+func TestUpdateState_ErrorClearsResources(t *testing.T) {
+	const name = "test-error-clears-resources"
+	t.Cleanup(func() {
+		sessions.Del(name)
+		allTools.Del(name)
+		allResources.Del(name)
+		states.Del(name)
+	})
+
+	// Branch 1: the registered session itself errored (client argument).
+	sess, _ := liveSession(t, "res_tool")
+	sessions.Set(name, sess)
+	allResources.Set(name, []*Resource{{Name: "doc"}})
+
+	updateState(name, StateError, errors.New("listing broke"), sess, Counts{})
+	_, ok := allResources.Get(name)
+	require.False(t, ok, "current-session error must clear the resources registry")
+
+	// Branch 2: no specific session (connect failed); anything registered
+	// under the name is unusable.
+	sess2, _ := liveSession(t, "res_tool2")
+	sessions.Set(name, sess2)
+	allResources.Set(name, []*Resource{{Name: "doc2"}})
+
+	updateState(name, StateError, errors.New("connect broke"), nil, Counts{})
+	_, ok = allResources.Get(name)
+	require.False(t, ok, "no-session error must clear the resources registry")
 }

--- a/internal/agent/tools/mcp/prompts.go
+++ b/internal/agent/tools/mcp/prompts.go
@@ -48,6 +48,12 @@ func GetPromptMessages(ctx context.Context, cfg *config.ConfigStore, clientName,
 // RefreshPrompts gets the updated list of prompts from the MCP and updates the
 // global state.
 func RefreshPrompts(ctx context.Context, name string) {
+	// Runs under the per-name lifecycle lock so a concurrent renewal can't
+	// swap the session between our Get and the state update below.
+	mu := nameLock(name)
+	mu.Lock()
+	defer mu.Unlock()
+
 	session, ok := sessions.Get(name)
 	if !ok {
 		slog.Warn("Refresh prompts: no session", "name", name)
@@ -56,7 +62,7 @@ func RefreshPrompts(ctx context.Context, name string) {
 
 	prompts, err := getPrompts(ctx, session)
 	if err != nil {
-		updateState(name, StateError, err, nil, Counts{})
+		updateState(name, StateError, err, session, Counts{})
 		return
 	}
 

--- a/internal/agent/tools/mcp/resources.go
+++ b/internal/agent/tools/mcp/resources.go
@@ -58,6 +58,12 @@ func ReadResource(ctx context.Context, cfg *config.ConfigStore, name, uri string
 // RefreshResources gets the updated list of resources from the MCP and updates the
 // global state.
 func RefreshResources(ctx context.Context, name string) {
+	// Runs under the per-name lifecycle lock so a concurrent renewal can't
+	// swap the session between our Get and the state update below.
+	mu := nameLock(name)
+	mu.Lock()
+	defer mu.Unlock()
+
 	session, ok := sessions.Get(name)
 	if !ok {
 		slog.Warn("Refresh resources: no session", "name", name)
@@ -66,7 +72,7 @@ func RefreshResources(ctx context.Context, name string) {
 
 	resources, err := getResources(ctx, session)
 	if err != nil {
-		updateState(name, StateError, err, nil, Counts{})
+		updateState(name, StateError, err, session, Counts{})
 		return
 	}
 

--- a/internal/agent/tools/mcp/tools.go
+++ b/internal/agent/tools/mcp/tools.go
@@ -111,6 +111,12 @@ func RunTool(ctx context.Context, cfg *config.ConfigStore, name, toolName string
 // RefreshTools gets the updated list of tools from the MCP and updates the
 // global state.
 func RefreshTools(ctx context.Context, cfg *config.ConfigStore, name string) {
+	// Runs under the per-name lifecycle lock so a concurrent renewal can't
+	// swap the session between our Get and the state update below.
+	mu := nameLock(name)
+	mu.Lock()
+	defer mu.Unlock()
+
 	session, ok := sessions.Get(name)
 	if !ok {
 		slog.Warn("Refresh tools: no session", "name", name)
@@ -119,7 +125,7 @@ func RefreshTools(ctx context.Context, cfg *config.ConfigStore, name string) {
 
 	tools, err := getTools(ctx, session)
 	if err != nil {
-		updateState(name, StateError, err, nil, Counts{})
+		updateState(name, StateError, err, session, Counts{})
 		return
 	}
 


### PR DESCRIPTION
Audit batch: MCP lifecycle (MAJOR). Findings verified against the code before fixing; regression tests use the existing in-memory-MCP `liveSession` harness and pass with `-race`.

## The core bug

`updateState(StateError, …)` closed **whatever session was currently in the registry**, not the session that errored. With concurrent turns (channel + typed), two paths could renew the same server simultaneously:

- **Stale-error teardown:** turn 2's slow ping times out *after* turn 1 already renewed → the error transition tears down turn 1's healthy, just-installed session and wipes its tools. A transient timeout becomes an aborted in-flight tool call.
- **Racing renewals:** loser's error path kills the winner's session; or both succeed and the second `sessions.Set` overwrites the first without closing it — leaking the child process and stdio pipes.

## Fixes

1. **Per-name lifecycle mutex** (`nameLock`): init, disable, renew, and refresh for one server are serialized; `getOrRenewClient`'s ping→renew→re-register sequence is single-flight. Different servers never contend.
2. **Error teardown scoped by identity:** `StateError` closes exactly the erroring session (now passed by every caller) and deregisters only when it's still the registered one. Error states never publish a dead session pointer.
3. **Prompts symmetry:** error teardown cleared tools but left dead servers' **prompts** in the commands menu; both registries now clear together, and renewal re-lists prompts alongside tools (parity with `initClient`).
4. **Revived dead diagnostics:** `maybeStdioErr` never matched because every transport is wrapped in `channelTransport` before `Connect` — stdio startup failures reported bare `EOF` with none of the child's output (the classic `npx` case this code was written for). Unwrap first. Also fixed `stdioCheck` duplicating argv0 in its diagnostic re-exec.
5. Hardening: `closeSession` nil-guards; repeated `initClient` closes the session it replaces.

## Tests

- `TestUpdateState_ErrorFromStaleSessionPreservesHealthyReplacement` — the healthy replacement session, its tools, and its prompts all survive a stale error; the stale session is closed.
- `TestUpdateState_ErrorFromCurrentSessionClearsEverything` — current-session error removes/closes the session, clears tools **and prompts**, publishes no dead pointer.
- `TestMaybeStdioErr_UnwrapsChannelTransport` — child stderr (`boom-diagnostic`) surfaces through the wrapper.

```
go build ./... ✓   go vet ✓   gofmt ✓   go test -race ./internal/agent/tools/mcp/ ✓
```

---
_Generated by [Claude Code](https://claude.ai/code/session_01AtvfVcwLAeVKk9SkRjb7GN)_