### PR TITLE
fix(mcp): make OAuth persistence actually survive restarts

### DIFF
--- a/internal/agent/tools/mcp/oauth.go
+++ b/internal/agent/tools/mcp/oauth.go
@@ -24,15 +24,19 @@ import (
 // tokenFileName is the file where MCP OAuth tokens are persisted.
 const tokenFileName = "mcp-oauth-tokens.json"
 
+// oauthEndpoints holds the authorization-server endpoints persisted alongside
+// a token so the token source can be rebuilt on restart.
+type oauthEndpoints struct {
+	AuthURL  string `json:"auth_url"`
+	TokenURL string `json:"token_url"`
+}
+
 // mcptoken stores a serialised OAuth token plus the client registration
 // info needed to refresh it.
 type mcptoken struct {
-	Token     *oauth2.Token `json:"token"`
-	ClientID  string        `json:"client_id,omitempty"`
-	Endpoints struct {
-		AuthURL  string `json:"auth_url"`
-		TokenURL string `json:"token_url"`
-	} `json:"endpoints"`
+	Token     *oauth2.Token  `json:"token"`
+	ClientID  string         `json:"client_id,omitempty"`
+	Endpoints oauthEndpoints `json:"endpoints"`
 }
 
 // tokenStore persists MCP OAuth tokens keyed by server URL. It is safe
@@ -75,6 +79,21 @@ func (s *tokenStore) get(serverURL string) (mcptoken, bool) {
 func (s *tokenStore) save(serverURL string, t mcptoken) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	// Merge with what's on disk before rewriting the file. Each HTTP MCP
+	// server gets its own handler with its own store snapshot; without the
+	// merge, server B's save rewrote the whole file from a snapshot that
+	// never saw server A's token, erasing it. Disk wins for every server
+	// except the one being saved now.
+	if b, err := os.ReadFile(s.path); err == nil {
+		var onDisk map[string]mcptoken
+		if json.Unmarshal(b, &onDisk) == nil {
+			for k, v := range onDisk {
+				if k != serverURL {
+					s.data[k] = v
+				}
+			}
+		}
+	}
 	s.data[serverURL] = t
 	b, err := json.MarshalIndent(s.data, "", "  ")
 	if err != nil {
@@ -92,6 +111,16 @@ type mcpOAuthHandler struct {
 	inner     *auth.AuthorizationCodeHandler
 	mu        sync.Mutex
 	tokenSrc  oauth2.TokenSource
+	// clientID is the dynamically registered OAuth client ID, captured from
+	// the authorization URL (the only place the SDK surfaces it). It is
+	// persisted so token refresh keeps working across restarts — a public
+	// client (TokenEndpointAuthMethod "none") must send client_id on every
+	// refresh, so a restart without it re-prompts the browser flow as soon
+	// as the access token expires.
+	clientID string
+	// endpoints caches the discovered authorization-server endpoints so
+	// re-persisting a refreshed token doesn't re-run network discovery.
+	endpoints oauthEndpoints
 }
 
 var _ auth.OAuthHandler = (*mcpOAuthHandler)(nil)
@@ -106,6 +135,8 @@ func newMCPOAuthHandler(serverURL string) *mcpOAuthHandler {
 	// Restore any saved token so we can skip the browser flow on
 	// subsequent startups.
 	if saved, ok := store.get(serverURL); ok && saved.Token != nil {
+		h.clientID = saved.ClientID
+		h.endpoints = saved.Endpoints
 		cfg := &oauth2.Config{
 			ClientID: saved.ClientID,
 			Endpoint: oauth2.Endpoint{
@@ -113,11 +144,46 @@ func newMCPOAuthHandler(serverURL string) *mcpOAuthHandler {
 				TokenURL: saved.Endpoints.TokenURL,
 			},
 		}
-		h.tokenSrc = cfg.TokenSource(context.Background(), saved.Token)
+		// Wrap the source so refreshes are re-persisted: OAuth 2.1 public
+		// clients rotate the refresh token on use, so a refresh that only
+		// lives in memory invalidates the one on disk and the NEXT restart
+		// falls back to the browser flow.
+		h.tokenSrc = &persistingTokenSource{
+			h:    h,
+			src:  cfg.TokenSource(context.Background(), saved.Token),
+			last: saved.Token,
+		}
 	} else {
 		slog.Debug("No saved MCP OAuth token found", "server", serverURL)
 	}
 	return h
+}
+
+// persistingTokenSource wraps a TokenSource and re-persists the token
+// whenever it changes (refresh, rotation), keeping the on-disk copy usable
+// across restarts.
+type persistingTokenSource struct {
+	h    *mcpOAuthHandler
+	src  oauth2.TokenSource
+	mu   sync.Mutex
+	last *oauth2.Token
+}
+
+func (p *persistingTokenSource) Token() (*oauth2.Token, error) {
+	tok, err := p.src.Token()
+	if err != nil {
+		return nil, err
+	}
+	p.mu.Lock()
+	changed := p.last == nil ||
+		p.last.AccessToken != tok.AccessToken ||
+		p.last.RefreshToken != tok.RefreshToken
+	p.last = tok
+	p.mu.Unlock()
+	if changed {
+		p.h.persistToken(tok)
+	}
+	return tok, nil
 }
 
 // TokenSource implements auth.OAuthHandler.
@@ -131,38 +197,48 @@ func (h *mcpOAuthHandler) TokenSource(_ context.Context) (oauth2.TokenSource, er
 // authorization-code flow (discovery, registration, browser, PKCE,
 // token exchange) then persists the resulting token.
 func (h *mcpOAuthHandler) Authorize(ctx context.Context, req *http.Request, resp *http.Response) error {
-	inner, err := h.buildInner()
+	inner, ln, err := h.buildInner()
 	if err != nil {
 		resp.Body.Close()
 		return err
 	}
+	// The callback server closes ln when it shuts down; this extra Close is
+	// a no-op then, and the cleanup path when Authorize fails before the
+	// fetcher ever runs.
+	defer func() { _ = ln.Close() }()
 	if err := inner.Authorize(ctx, req, resp); err != nil {
 		return err
 	}
 	// After a successful Authorize the inner handler holds a fresh
-	// token source. Cache it and persist to disk.
+	// token source. Cache it (wrapped so refreshes re-persist) and
+	// persist the initial token to disk.
 	ts, _ := inner.TokenSource(ctx)
-	h.mu.Lock()
-	h.tokenSrc = ts
-	h.inner = inner
-	h.mu.Unlock()
+	var wrapped oauth2.TokenSource
 	if ts != nil {
+		var last *oauth2.Token
 		if tok, err := ts.Token(); err == nil {
 			h.persistToken(tok)
+			last = tok
 		}
+		wrapped = &persistingTokenSource{h: h, src: ts, last: last}
 	}
+	h.mu.Lock()
+	h.tokenSrc = wrapped
+	h.inner = inner
+	h.mu.Unlock()
 	return nil
 }
 
-// buildInner lazily creates the SDK AuthorizationCodeHandler. The
-// redirect URL is allocated on first use because we need a free port.
-func (h *mcpOAuthHandler) buildInner() (*auth.AuthorizationCodeHandler, error) {
+// buildInner lazily creates the SDK AuthorizationCodeHandler along with the
+// live callback listener. The listener is allocated once and handed to the
+// callback server directly — allocating a port, closing it, and re-listening
+// later would let another process steal the port in between.
+func (h *mcpOAuthHandler) buildInner() (*auth.AuthorizationCodeHandler, net.Listener, error) {
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
-		return nil, fmt.Errorf("failed to allocate callback port: %w", err)
+		return nil, nil, fmt.Errorf("failed to allocate callback port: %w", err)
 	}
 	port := ln.Addr().(*net.TCPAddr).Port
-	_ = ln.Close() // the handler's callback server will re-listen
 	redirectURL := fmt.Sprintf("http://localhost:%d/callback", port)
 
 	cfg := &auth.AuthorizationCodeHandlerConfig{
@@ -178,28 +254,67 @@ func (h *mcpOAuthHandler) buildInner() (*auth.AuthorizationCodeHandler, error) {
 		},
 		RedirectURL: redirectURL,
 		AuthorizationCodeFetcher: func(fetchCtx context.Context, args *auth.AuthorizationArgs) (*auth.AuthorizationResult, error) {
-			return openBrowserAndCapture(fetchCtx, args.URL, port, h.serverURL)
+			// The authorization URL is the only place the SDK surfaces the
+			// dynamically registered client_id; capture it (and the auth
+			// endpoint) for persistence before opening the browser.
+			h.captureFromAuthURL(args.URL)
+			return openBrowserAndCapture(fetchCtx, args.URL, ln, h.serverURL)
 		},
 	}
-	return auth.NewAuthorizationCodeHandler(cfg)
+	handler, err := auth.NewAuthorizationCodeHandler(cfg)
+	if err != nil {
+		_ = ln.Close()
+		return nil, nil, err
+	}
+	return handler, ln, nil
 }
 
-// persistToken saves the current token to the store. It is called
-// after Authorize succeeds and lazily captures the endpoint/client info
-// from the inner handler.
+// captureFromAuthURL records the registered client_id and the authorization
+// endpoint from the authorization URL the SDK built. persistToken saves both
+// so the token source — and, critically, token refresh for this public
+// client — can be reconstructed after a restart.
+func (h *mcpOAuthHandler) captureFromAuthURL(authURL string) {
+	u, err := url.Parse(authURL)
+	if err != nil {
+		return
+	}
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if cid := u.Query().Get("client_id"); cid != "" {
+		h.clientID = cid
+	}
+	if h.endpoints.AuthURL == "" {
+		base := *u
+		base.RawQuery = ""
+		base.Fragment = ""
+		h.endpoints.AuthURL = base.String()
+	}
+}
+
+// persistToken saves the current token to the store, together with the
+// registered client ID (captured from the authorization URL) and the
+// authorization-server endpoints — everything a restart needs to rebuild a
+// refreshable token source. Endpoints are cached on the handler so token
+// refreshes don't re-run network discovery.
 func (h *mcpOAuthHandler) persistToken(tok *oauth2.Token) {
 	entry := mcptoken{Token: tok}
 	h.mu.Lock()
-	inner := h.inner
+	entry.ClientID = h.clientID
+	entry.Endpoints = h.endpoints
 	h.mu.Unlock()
-	if inner != nil {
-		// Best-effort: the inner handler doesn't expose its config, so
-		// we fetch the metadata endpoints now to persist them for use
-		// on the next startup.
-		endpoints, clientID := h.discoverEndpoints(context.Background(), h.serverURL)
-		entry.Endpoints.AuthURL = endpoints.AuthURL
-		entry.Endpoints.TokenURL = endpoints.TokenURL
-		entry.ClientID = clientID
+	if entry.Endpoints.TokenURL == "" {
+		// Best-effort: the inner handler doesn't expose its config, so fetch
+		// the metadata endpoints once and cache them.
+		endpoints := h.discoverEndpoints(context.Background(), h.serverURL)
+		h.mu.Lock()
+		if endpoints.AuthURL != "" {
+			h.endpoints.AuthURL = endpoints.AuthURL
+		}
+		if endpoints.TokenURL != "" {
+			h.endpoints.TokenURL = endpoints.TokenURL
+		}
+		entry.Endpoints = h.endpoints
+		h.mu.Unlock()
 	}
 	h.store.save(h.serverURL, entry)
 }
@@ -207,11 +322,11 @@ func (h *mcpOAuthHandler) persistToken(tok *oauth2.Token) {
 // discoverEndpoints fetches the OAuth metadata for the server URL to
 // extract the authorization and token endpoints. This is used to
 // persist enough info to restore the token source on restart.
-func (h *mcpOAuthHandler) discoverEndpoints(ctx context.Context, serverURL string) (struct{ AuthURL, TokenURL string }, string) {
-	result := struct{ AuthURL, TokenURL string }{}
+func (h *mcpOAuthHandler) discoverEndpoints(ctx context.Context, serverURL string) oauthEndpoints {
+	result := oauthEndpoints{}
 	u, err := url.Parse(serverURL)
 	if err != nil {
-		return result, ""
+		return result
 	}
 	// Try RFC 9728 protected resource metadata.
 	prmURLs := []string{
@@ -230,7 +345,7 @@ func (h *mcpOAuthHandler) discoverEndpoints(ctx context.Context, serverURL strin
 		}
 		result.AuthURL = asm.AuthorizationEndpoint
 		result.TokenURL = asm.TokenEndpoint
-		return result, ""
+		return result
 	}
 	// Fallback: server root as authorization server.
 	authServer := fmt.Sprintf("%s://%s", u.Scheme, u.Host)
@@ -239,17 +354,18 @@ func (h *mcpOAuthHandler) discoverEndpoints(ctx context.Context, serverURL strin
 		result.AuthURL = asm.AuthorizationEndpoint
 		result.TokenURL = asm.TokenEndpoint
 	}
-	return result, ""
+	return result
 }
 
-// openBrowserAndCapture opens the authorization URL in the user's
-// browser and listens on the given port for the OAuth callback redirect.
-func openBrowserAndCapture(ctx context.Context, authURL string, port int, serverName string) (*auth.AuthorizationResult, error) {
-	resultCh := make(chan auth.AuthorizationResult, 1)
-	errCh := make(chan error, 1)
-
-	mux := http.NewServeMux()
-	mux.HandleFunc("/callback", func(w http.ResponseWriter, r *http.Request) {
+// callbackHandler builds the /callback handler used during the OAuth flow.
+// Sends are non-blocking one-shots: the channels are buffered (capacity 1)
+// and anything beyond the first delivery is dropped. A duplicate callback
+// hit — browser refresh, link prefetcher, AS retry — used to block its
+// handler goroutine forever on the full channel, which then wedged
+// srv.Shutdown (it waits for active handlers) and leaked the whole
+// authorization flow.
+func callbackHandler(resultCh chan auth.AuthorizationResult, errCh chan error) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
 		q := r.URL.Query()
 		if codeErr := q.Get("error"); codeErr != "" {
 			desc := q.Get("error_description")
@@ -257,25 +373,42 @@ func openBrowserAndCapture(ctx context.Context, authURL string, port int, server
 				desc = codeErr
 			}
 			fmt.Fprintf(w, "Authorization failed: %s", desc)
-			errCh <- fmt.Errorf("authorization error: %s", desc)
+			select {
+			case errCh <- fmt.Errorf("authorization error: %s", desc):
+			default:
+			}
 			return
 		}
 		code := q.Get("code")
 		state := q.Get("state")
 		if code == "" {
 			http.Error(w, "missing code parameter", http.StatusBadRequest)
-			errCh <- fmt.Errorf("callback missing code parameter")
+			select {
+			case errCh <- fmt.Errorf("callback missing code parameter"):
+			default:
+			}
 			return
 		}
 		fmt.Fprint(w, "Authorization successful. You can close this tab and return to Crush.")
-		resultCh <- auth.AuthorizationResult{Code: code, State: state}
-	})
+		select {
+		case resultCh <- auth.AuthorizationResult{Code: code, State: state}:
+		default:
+		}
+	}
+}
+
+// openBrowserAndCapture opens the authorization URL in the user's browser
+// and serves the OAuth callback redirect on the provided listener (the one
+// whose port is baked into the redirect URL — reusing it avoids the
+// close-and-relisten window in which another process could steal the port).
+func openBrowserAndCapture(ctx context.Context, authURL string, ln net.Listener, serverName string) (*auth.AuthorizationResult, error) {
+	resultCh := make(chan auth.AuthorizationResult, 1)
+	errCh := make(chan error, 1)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/callback", callbackHandler(resultCh, errCh))
 
 	srv := &http.Server{Handler: mux}
-	ln, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
-	if err != nil {
-		return nil, fmt.Errorf("failed to listen on callback port: %w", err)
-	}
 	go srv.Serve(ln)
 	defer srv.Shutdown(context.Background())
 

--- a/internal/agent/tools/mcp/oauth.go
+++ b/internal/agent/tools/mcp/oauth.go
@@ -39,6 +39,15 @@ type mcptoken struct {
 	Endpoints oauthEndpoints `json:"endpoints"`
 }
 
+// tokenFileMu serializes token-file access across ALL tokenStore
+// instances. Each HTTP MCP server's handler owns its own store; with only
+// the per-store mutex, two handlers refreshing concurrently could both
+// read the file before either wrote it, and the last writer erased the
+// other's just-saved token — with OAuth 2.1 refresh-token rotation the
+// surviving on-disk copy is the invalidated one, forcing a browser
+// re-auth on the next restart.
+var tokenFileMu sync.Mutex
+
 // tokenStore persists MCP OAuth tokens keyed by server URL. It is safe
 // for concurrent access.
 type tokenStore struct {
@@ -60,6 +69,8 @@ func newTokenStore() *tokenStore {
 }
 
 func (s *tokenStore) load() {
+	tokenFileMu.Lock()
+	defer tokenFileMu.Unlock()
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	b, err := os.ReadFile(s.path)
@@ -77,6 +88,8 @@ func (s *tokenStore) get(serverURL string) (mcptoken, bool) {
 }
 
 func (s *tokenStore) save(serverURL string, t mcptoken) {
+	tokenFileMu.Lock()
+	defer tokenFileMu.Unlock()
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	// Merge with what's on disk before rewriting the file. Each HTTP MCP
@@ -108,7 +121,6 @@ func (s *tokenStore) save(serverURL string, t mcptoken) {
 type mcpOAuthHandler struct {
 	serverURL string
 	store     *tokenStore
-	inner     *auth.AuthorizationCodeHandler
 	mu        sync.Mutex
 	tokenSrc  oauth2.TokenSource
 	// clientID is the dynamically registered OAuth client ID, captured from
@@ -174,12 +186,16 @@ func (p *persistingTokenSource) Token() (*oauth2.Token, error) {
 	if err != nil {
 		return nil, err
 	}
+	// Persist while holding p.mu: two Token() calls straddling an expiry
+	// could otherwise interleave so the earlier (rotated-out) token is
+	// persisted after the newer one. Lock order p.mu -> h.mu -> store.mu
+	// has no reverse path.
 	p.mu.Lock()
+	defer p.mu.Unlock()
 	changed := p.last == nil ||
 		p.last.AccessToken != tok.AccessToken ||
 		p.last.RefreshToken != tok.RefreshToken
 	p.last = tok
-	p.mu.Unlock()
 	if changed {
 		p.h.persistToken(tok)
 	}
@@ -197,6 +213,14 @@ func (h *mcpOAuthHandler) TokenSource(_ context.Context) (oauth2.TokenSource, er
 // authorization-code flow (discovery, registration, browser, PKCE,
 // token exchange) then persists the resulting token.
 func (h *mcpOAuthHandler) Authorize(ctx context.Context, req *http.Request, resp *http.Response) error {
+	// A full re-authorization means the cached endpoints may be stale
+	// (the server may have moved them — often why we are re-authorizing
+	// at all). Clear the token endpoint so the post-auth persistToken
+	// re-runs discovery; captureFromAuthURL refreshes the auth endpoint.
+	h.mu.Lock()
+	h.endpoints.TokenURL = ""
+	h.mu.Unlock()
+
 	inner, ln, err := h.buildInner()
 	if err != nil {
 		resp.Body.Close()
@@ -224,7 +248,6 @@ func (h *mcpOAuthHandler) Authorize(ctx context.Context, req *http.Request, resp
 	}
 	h.mu.Lock()
 	h.tokenSrc = wrapped
-	h.inner = inner
 	h.mu.Unlock()
 	return nil
 }
@@ -283,12 +306,13 @@ func (h *mcpOAuthHandler) captureFromAuthURL(authURL string) {
 	if cid := u.Query().Get("client_id"); cid != "" {
 		h.clientID = cid
 	}
-	if h.endpoints.AuthURL == "" {
-		base := *u
-		base.RawQuery = ""
-		base.Fragment = ""
-		h.endpoints.AuthURL = base.String()
-	}
+	// Overwrite unconditionally: this runs during a live authorization,
+	// which is the freshest possible source. Keeping a cached value here
+	// would pin a stale endpoint forever after the AS moves.
+	base := *u
+	base.RawQuery = ""
+	base.Fragment = ""
+	h.endpoints.AuthURL = base.String()
 }
 
 // persistToken saves the current token to the store, together with the

--- a/internal/agent/tools/mcp/oauth_test.go
+++ b/internal/agent/tools/mcp/oauth_test.go
@@ -1,12 +1,15 @@
 package mcp
 
 import (
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"runtime"
 	"testing"
+	"time"
 
 	"github.com/charmbracelet/crush/internal/config"
+	"github.com/modelcontextprotocol/go-sdk/auth"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/oauth2"
 )
@@ -167,4 +170,126 @@ func TestMCPOAuthHandler_RestoresSavedToken(t *testing.T) {
 	tok, err := ts.Token()
 	require.NoError(t, err)
 	require.Equal(t, "abc123", tok.AccessToken, "restored token source should yield the saved (unexpired) token")
+}
+
+// TestTokenStore_SaveMergesWithDisk pins the multi-server persistence fix:
+// each HTTP MCP server gets its own handler with its own store snapshot, and
+// a save used to rewrite the whole file from that snapshot — server B's save
+// erased server A's token. Save now merges with what's on disk.
+func TestTokenStore_SaveMergesWithDisk(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "tokens.json")
+
+	// Handler A's store saves server A.
+	storeA := &tokenStore{path: path, data: make(map[string]mcptoken)}
+	storeA.load()
+	storeA.save("https://a.example.com/mcp", mcptoken{Token: &oauth2.Token{AccessToken: "tok-a"}})
+
+	// Handler B's store loaded before/without A's save (its own snapshot).
+	storeB := &tokenStore{path: path, data: make(map[string]mcptoken)}
+	storeB.save("https://b.example.com/mcp", mcptoken{Token: &oauth2.Token{AccessToken: "tok-b"}})
+
+	// Both tokens must survive on disk.
+	check := &tokenStore{path: path, data: make(map[string]mcptoken)}
+	check.load()
+	gotA, okA := check.get("https://a.example.com/mcp")
+	require.True(t, okA, "server A's token was erased by server B's save")
+	require.Equal(t, "tok-a", gotA.Token.AccessToken)
+	gotB, okB := check.get("https://b.example.com/mcp")
+	require.True(t, okB)
+	require.Equal(t, "tok-b", gotB.Token.AccessToken)
+}
+
+// TestPersistingTokenSource_RepersistsRotatedToken pins the refresh fix:
+// OAuth 2.1 public clients rotate the refresh token on use; a refresh that
+// stayed only in memory invalidated the copy on disk, so the NEXT restart
+// fell back to the browser flow. The wrapping source re-persists on change.
+func TestPersistingTokenSource_RepersistsRotatedToken(t *testing.T) {
+	globalDir := t.TempDir()
+	t.Setenv("CRUSH_GLOBAL_CONFIG", globalDir)
+
+	serverURL := "https://rotate.example.com/mcp"
+	h := newMCPOAuthHandler(serverURL)
+	h.clientID = "client-1"
+	h.endpoints = oauthEndpoints{AuthURL: "https://as.example.com/auth", TokenURL: "https://as.example.com/token"}
+
+	rotated := &oauth2.Token{AccessToken: "new-access", RefreshToken: "new-refresh"}
+	src := &persistingTokenSource{
+		h:    h,
+		src:  oauth2.StaticTokenSource(rotated),
+		last: &oauth2.Token{AccessToken: "old-access", RefreshToken: "old-refresh"},
+	}
+
+	tok, err := src.Token()
+	require.NoError(t, err)
+	require.Equal(t, "new-access", tok.AccessToken)
+
+	// The rotated token must be on disk, with the client ID and endpoints.
+	check := newTokenStore()
+	check.load()
+	got, ok := check.get(serverURL)
+	require.True(t, ok, "rotated token was not re-persisted")
+	require.Equal(t, "new-access", got.Token.AccessToken)
+	require.Equal(t, "new-refresh", got.Token.RefreshToken)
+	require.Equal(t, "client-1", got.ClientID)
+	require.Equal(t, "https://as.example.com/token", got.Endpoints.TokenURL)
+}
+
+// TestCaptureFromAuthURL pins the client-ID persistence fix: the SDK never
+// exposes the dynamically registered client ID, but it necessarily appears
+// as client_id in the authorization URL handed to the code fetcher. Before
+// the fix, ClientID was persisted as "" on every path, so refresh after
+// restart could never work (a public client must send client_id).
+func TestCaptureFromAuthURL(t *testing.T) {
+	t.Setenv("CRUSH_GLOBAL_CONFIG", t.TempDir())
+	h := newMCPOAuthHandler("https://cap.example.com/mcp")
+
+	h.captureFromAuthURL("https://as.example.com/authorize?client_id=dyn-client-42&response_type=code&state=xyz")
+
+	require.Equal(t, "dyn-client-42", h.clientID)
+	require.Equal(t, "https://as.example.com/authorize", h.endpoints.AuthURL)
+
+	// persistToken must write the captured ID (TokenURL pre-set so the
+	// test performs no network discovery).
+	h.endpoints.TokenURL = "https://as.example.com/token"
+	h.persistToken(&oauth2.Token{AccessToken: "t"})
+	check := newTokenStore()
+	check.load()
+	got, ok := check.get("https://cap.example.com/mcp")
+	require.True(t, ok)
+	require.Equal(t, "dyn-client-42", got.ClientID, "registered client ID must be persisted")
+}
+
+// TestCallbackHandler_DuplicateHitDoesNotBlock pins the wedge fix: a second
+// /callback request (browser refresh, prefetcher, AS retry) used to block
+// its handler goroutine forever on the full capacity-1 channel; the deferred
+// srv.Shutdown then waited for that handler indefinitely and the whole
+// authorization flow leaked.
+func TestCallbackHandler_DuplicateHitDoesNotBlock(t *testing.T) {
+	t.Parallel()
+	resultCh := make(chan auth.AuthorizationResult, 1)
+	errCh := make(chan error, 1)
+	handler := callbackHandler(resultCh, errCh)
+
+	hit := func() {
+		req := httptest.NewRequest("GET", "/callback?code=abc&state=s1", nil)
+		handler(httptest.NewRecorder(), req)
+	}
+
+	hit() // first delivery fills the channel
+
+	done := make(chan struct{})
+	go func() {
+		hit() // duplicate — must not block
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("duplicate callback hit blocked (would wedge srv.Shutdown and leak the auth flow)")
+	}
+
+	require.Len(t, resultCh, 1, "exactly one result delivered")
+	got := <-resultCh
+	require.Equal(t, "abc", got.Code)
 }

--- a/internal/agent/tools/mcp/oauth_test.go
+++ b/internal/agent/tools/mcp/oauth_test.go
@@ -1,10 +1,12 @@
 package mcp
 
 import (
+	"fmt"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"runtime"
+	"sync"
 	"testing"
 	"time"
 
@@ -292,4 +294,56 @@ func TestCallbackHandler_DuplicateHitDoesNotBlock(t *testing.T) {
 	require.Len(t, resultCh, 1, "exactly one result delivered")
 	got := <-resultCh
 	require.Equal(t, "abc", got.Code)
+}
+
+// TestTokenStore_ConcurrentCrossStoreSavesKeepAllTokens pins that saves
+// racing across DIFFERENT store instances (one per HTTP MCP handler in
+// production) cannot erase each other's entries. With only the per-store
+// mutex, both stores could read the file before either wrote it, and the
+// last writer dropped the other's token; the shared file mutex serializes
+// them so the read-merge-write in save always sees the previous winner.
+func TestTokenStore_ConcurrentCrossStoreSavesKeepAllTokens(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "tokens.json")
+	const n = 8
+
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	for i := range n {
+		store := &tokenStore{path: path, data: make(map[string]mcptoken)}
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			store.save(
+				fmt.Sprintf("https://mcp%d.example.com/mcp", i),
+				mcptoken{Token: &oauth2.Token{AccessToken: fmt.Sprintf("tok-%d", i)}},
+			)
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	check := &tokenStore{path: path, data: make(map[string]mcptoken)}
+	check.load()
+	for i := range n {
+		_, ok := check.get(fmt.Sprintf("https://mcp%d.example.com/mcp", i))
+		require.True(t, ok, "server %d's token was erased by a concurrent save from another store", i)
+	}
+}
+
+// TestCaptureFromAuthURL_OverwritesStaleAuthEndpoint pins the re-authorize
+// healing path: a live authorization is the freshest source of the auth
+// endpoint, so a previously cached (possibly stale) value must be replaced,
+// not kept forever.
+func TestCaptureFromAuthURL_OverwritesStaleAuthEndpoint(t *testing.T) {
+	t.Setenv("CRUSH_GLOBAL_CONFIG", t.TempDir())
+	h := newMCPOAuthHandler("https://stale.example.com/mcp")
+	h.endpoints.AuthURL = "https://old-as.example.com/authorize"
+	h.endpoints.TokenURL = "https://old-as.example.com/token"
+
+	h.captureFromAuthURL("https://new-as.example.com/authorize?client_id=cid&response_type=code")
+
+	require.Equal(t, "https://new-as.example.com/authorize", h.endpoints.AuthURL,
+		"a live authorization must replace the cached auth endpoint")
 }


### PR DESCRIPTION
Audit batch: MCP OAuth persistence (MAJOR ×3 + callback wedge). The persistence feature added in #122 looked complete but was broken end-to-end beyond a single unexpired access token — the existing test asserted a `ClientID` round-trip using data production never wrote.

## 1. Registered client ID was never captured

`discoverEndpoints` returned `""` for the client ID on **every** path (the second return was dead code), so `persistToken` always saved `ClientID: ""`. On restart, the rebuilt `oauth2.Config` had no client ID — and this is a **public client** (`TokenEndpointAuthMethod: "none"`), which must send `client_id` on every refresh — so any spec-compliant AS rejected the refresh. Net: browser re-auth on every restart after token expiry; persistence only helped while the access token was still fresh.

**Fix:** the SDK never exposes the dynamically registered ID, but it necessarily appears as `client_id` in the authorization URL handed to our `AuthorizationCodeFetcher`. `captureFromAuthURL` records it (plus the auth endpoint) there; `persistToken` saves it.

## 2. Refreshed/rotated tokens never re-persisted

`persistToken` ran only from `Authorize`. OAuth 2.1 public clients rotate the refresh token on use — an in-memory refresh invalidated the on-disk copy, so the *next* restart hit the browser flow even with fix 1. Both restored and post-Authorize sources are now wrapped in a `persistingTokenSource` that re-saves on change.

## 3. Second server's save erased the first server's token

Each HTTP server's handler loads its own whole-file snapshot at transport creation; `save` rewrote the entire file from that snapshot. Authorize A, then authorize B → file contains only B. `save` now merges with on-disk contents (disk wins for every server but the one being saved).

## 4. Duplicate callback hit wedged the flow

A second `/callback` request (browser refresh, prefetcher, AS retry) blocked forever on the full capacity-1 channel; the deferred `srv.Shutdown` waits for active handlers → the connect goroutine leaked and reconnect wedged. Sends are now non-blocking one-shots. Also: the callback listener is allocated once and handed to the server directly, closing the port-stealing TOCTOU between the old allocate→close→re-listen sequence.

## Tests

- `TestTokenStore_SaveMergesWithDisk` — server A's token survives server B's save
- `TestPersistingTokenSource_RepersistsRotatedToken` — rotation reaches disk with client ID + endpoints
- `TestCaptureFromAuthURL` — ID captured from the auth URL and persisted end-to-end
- `TestCallbackHandler_DuplicateHitDoesNotBlock` — duplicate hit completes; exactly one delivery

```
go build ./... ✓   go vet ✓   gofmt ✓   go test -race ./internal/agent/tools/mcp/ ✓
```

File format unchanged (`oauthEndpoints` keeps the same JSON shape). Legacy entries with `ClientID: ""` heal on the next full authorize.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AtvfVcwLAeVKk9SkRjb7GN)_