### PR TITLE
fix(attachments): one text predicate everywhere; reject binary-sniffing files

### DIFF
--- a/internal/message/attachment.go
+++ b/internal/message/attachment.go
@@ -31,17 +31,26 @@ var textMimePrefixes = []string{
 	"application/x-graphql",
 }
 
-// IsText reports whether the attachment should be treated as text and
-// inlined into the prompt. This includes standard text/* MIME types as
-// well as common application/* types that are fundamentally text (JSON,
-// YAML, XML, etc.).
-func (a Attachment) IsText() bool {
+// IsTextMIME reports whether a MIME type should be treated as text and
+// inlined into the prompt. This includes standard text/* MIME types as well
+// as common application/* types that are fundamentally text (JSON, YAML,
+// XML, etc.). Every place that decides "inline as text vs. send as a binary
+// file part" MUST use this single predicate: when the initial send and the
+// history rebuild (ToAIMessage) disagree, a text attachment that worked on
+// turn one comes back on turn two as a bogus binary file part.
+func IsTextMIME(mimeType string) bool {
 	for _, prefix := range textMimePrefixes {
-		if strings.HasPrefix(a.MimeType, prefix) {
+		if strings.HasPrefix(mimeType, prefix) {
 			return true
 		}
 	}
 	return false
+}
+
+// IsText reports whether the attachment should be treated as text and
+// inlined into the prompt. See IsTextMIME.
+func (a Attachment) IsText() bool {
+	return IsTextMIME(a.MimeType)
 }
 
 func (a Attachment) IsImage() bool    { return strings.HasPrefix(a.MimeType, "image/") }

--- a/internal/message/attachment_test.go
+++ b/internal/message/attachment_test.go
@@ -3,6 +3,7 @@ package message
 import (
 	"testing"
 
+	"charm.land/fantasy"
 	"github.com/stretchr/testify/require"
 )
 
@@ -122,4 +123,49 @@ func TestContainsTextAttachment(t *testing.T) {
 		}
 		require.True(t, ContainsTextAttachment(attachments))
 	})
+}
+
+// TestToAIMessage_TextAttachmentSurvivesHistoryRebuild pins the audit fix:
+// IsText() was widened to application/* text types, but ToAIMessage (which
+// rebuilds prior user messages on every later turn) still inlined only
+// text/* — so an application/json attachment worked on turn one and came
+// back on turn two as a BINARY file part with media type application/json,
+// which file-part-only-accepting providers reject, wedging the session.
+// The two paths must use the same predicate.
+func TestToAIMessage_TextAttachmentSurvivesHistoryRebuild(t *testing.T) {
+	t.Parallel()
+
+	msg := &Message{Role: User}
+	msg.Parts = []ContentPart{
+		TextContent{Text: "look at this config"},
+		BinaryContent{Path: "config.json", MIMEType: "application/json", Data: []byte(`{"a":1}`)},
+	}
+
+	aiMsgs := msg.ToAIMessage()
+	require.Len(t, aiMsgs, 1)
+
+	var sawFilePart bool
+	var text string
+	for _, part := range aiMsgs[0].Content {
+		switch p := part.(type) {
+		case fantasy.TextPart:
+			text = p.Text
+		case fantasy.FilePart:
+			sawFilePart = true
+		}
+	}
+	require.False(t, sawFilePart,
+		"application/json must be inlined as text on history rebuild, not re-sent as a binary file part")
+	require.Contains(t, text, `{"a":1}`, "attachment content must be inlined into the prompt text")
+}
+
+// TestIsTextMIME_AgreesWithAttachmentIsText pins the shared predicate.
+func TestIsTextMIME_AgreesWithAttachmentIsText(t *testing.T) {
+	t.Parallel()
+	for _, mt := range []string{
+		"text/plain", "application/json", "application/yaml",
+		"image/png", "application/pdf", "application/octet-stream",
+	} {
+		require.Equal(t, Attachment{MimeType: mt}.IsText(), IsTextMIME(mt), mt)
+	}
 }

--- a/internal/message/content.go
+++ b/internal/message/content.go
@@ -504,7 +504,11 @@ func (m *Message) ToAIMessage() []fantasy.Message {
 		text := strings.TrimSpace(m.Content().Text)
 		var textAttachments []Attachment
 		for _, content := range m.BinaryContent() {
-			if !strings.HasPrefix(content.MIMEType, "text/") {
+			// Same predicate as the initial send (Attachment.IsText): the
+			// history rebuild must inline exactly what the first turn
+			// inlined, or application/* text attachments come back as
+			// binary file parts that providers reject.
+			if !IsTextMIME(content.MIMEType) {
 				continue
 			}
 			textAttachments = append(textAttachments, Attachment{
@@ -527,8 +531,9 @@ func (m *Message) ToAIMessage() []fantasy.Message {
 			parts = append(parts, fantasy.TextPart{Text: text})
 		}
 		for _, content := range m.BinaryContent() {
-			// skip text attachements
-			if strings.HasPrefix(content.MIMEType, "text/") {
+			// Skip text attachments — they were inlined above. Must mirror
+			// the inlining predicate exactly.
+			if IsTextMIME(content.MIMEType) {
 				continue
 			}
 			parts = append(parts, fantasy.FilePart{

--- a/internal/ui/common/attachments_test.go
+++ b/internal/ui/common/attachments_test.go
@@ -53,7 +53,10 @@ func TestIsAllowedAttachmentType(t *testing.T) {
 		{name: "zip", path: "archive.zip", want: false},
 		{name: "docx", path: "report.docx", want: false},
 		{name: "exe", path: "binary.exe", want: false},
-		{name: "no extension", path: "Makefile", want: false},
+		// Makefile/Dockerfile are extensionless but allowlisted by name —
+		// the ".makefile"/".dockerfile" extension entries never matched them.
+		{name: "no extension allowlisted", path: "Makefile", want: true},
+		{name: "no extension not allowlisted", path: "LICENSE", want: false},
 		{name: "mp4", path: "video.mp4", want: false},
 	}
 
@@ -106,4 +109,45 @@ func TestAllAllowedAttachmentTypes(t *testing.T) {
 
 	// Should have combined length.
 	require.Len(t, types, len(AllowedImageTypes)+len(AllowedTextFileTypes))
+}
+
+// TestIsAllowedAttachmentType_ExtensionlessNames verifies Dockerfile/Makefile
+// are attachable: suffix matching can't cover them (no dot), so the old
+// ".dockerfile"/".makefile" entries never matched the real files.
+func TestIsAllowedAttachmentType_ExtensionlessNames(t *testing.T) {
+	t.Parallel()
+	for _, path := range []string{"Dockerfile", "Makefile", "GNUmakefile", "/repo/sub/Dockerfile", "some/Makefile"} {
+		require.True(t, IsAllowedAttachmentType(path), path)
+	}
+	// The dotted variants still work for files that genuinely have them.
+	require.True(t, IsAllowedAttachmentType("build.dockerfile"))
+	// Non-allowlisted extensionless names stay rejected.
+	require.False(t, IsAllowedAttachmentType("LICENSE"))
+}
+
+// TestSniffAttachmentMIME verifies the binary-content guard: a file allowed
+// by a text extension whose content sniffs as binary (e.g. a NUL byte in the
+// first 512 bytes) must be reported not-ok instead of becoming a bogus
+// binary file part or byte soup inlined into the prompt.
+func TestSniffAttachmentMIME(t *testing.T) {
+	t.Parallel()
+
+	mt, ok := SniffAttachmentMIME([]byte("plain text content"))
+	require.True(t, ok)
+	require.Contains(t, mt, "text/plain")
+
+	// PNG magic bytes → image, ok.
+	png := []byte{0x89, 'P', 'N', 'G', 0x0D, 0x0A, 0x1A, 0x0A}
+	mt, ok = SniffAttachmentMIME(png)
+	require.True(t, ok)
+	require.Equal(t, "image/png", mt)
+
+	// NUL byte in the sniff window → application/octet-stream, not ok.
+	mt, ok = SniffAttachmentMIME([]byte("looks like a log\x00but binary"))
+	require.False(t, ok, "binary-sniffing content must be rejected")
+	require.Equal(t, "application/octet-stream", mt)
+
+	// Empty content sniffs as text; harmless.
+	_, ok = SniffAttachmentMIME(nil)
+	require.True(t, ok)
 }

--- a/internal/ui/common/common.go
+++ b/internal/ui/common/common.go
@@ -3,12 +3,15 @@ package common
 import (
 	"fmt"
 	"image"
+	"net/http"
 	"os"
+	"path/filepath"
 	"strings"
 
 	tea "charm.land/bubbletea/v2"
 	"github.com/charmbracelet/crush/internal/clipboard"
 	"github.com/charmbracelet/crush/internal/config"
+	"github.com/charmbracelet/crush/internal/message"
 	"github.com/charmbracelet/crush/internal/ui/styles"
 	"github.com/charmbracelet/crush/internal/ui/util"
 	"github.com/charmbracelet/crush/internal/workspace"
@@ -42,8 +45,14 @@ func AllAllowedAttachmentTypes() []string {
 	return result
 }
 
+// AllowedTextFileNames are extensionless file names attachable as text.
+// Suffix matching can't cover these: "Dockerfile" has no dot, so a
+// ".dockerfile" extension entry never matches it.
+var AllowedTextFileNames = []string{"dockerfile", "makefile", "gnumakefile"}
+
 // IsAllowedAttachmentType reports whether the given file path has an
-// extension that is in the allowed image or text file type list.
+// extension that is in the allowed image or text file type list, or is an
+// extensionless well-known text file (Dockerfile, Makefile).
 func IsAllowedAttachmentType(path string) bool {
 	lower := strings.ToLower(path)
 	for _, ext := range AllowedImageTypes {
@@ -56,7 +65,29 @@ func IsAllowedAttachmentType(path string) bool {
 			return true
 		}
 	}
+	base := filepath.Base(lower)
+	for _, name := range AllowedTextFileNames {
+		if base == name {
+			return true
+		}
+	}
 	return false
+}
+
+// SniffAttachmentMIME detects an attachment's MIME type from its content and
+// reports whether it is safe to attach. ok=false means the content sniffs as
+// something that is neither text nor an image — e.g. a ".log" with a NUL
+// byte in the first 512 bytes detects as application/octet-stream. Attaching
+// such a file would either inline byte soup into the prompt or send a binary
+// file part with a media type providers reject; callers should surface an
+// error instead.
+func SniffAttachmentMIME(content []byte) (string, bool) {
+	mimeBufferSize := min(512, len(content))
+	mimeType := http.DetectContentType(content[:mimeBufferSize])
+	if message.IsTextMIME(mimeType) || strings.HasPrefix(mimeType, "image/") {
+		return mimeType, true
+	}
+	return mimeType, false
 }
 
 // IsAllowedImageType reports whether the given file path has an allowed image

--- a/internal/ui/dialog/actions.go
+++ b/internal/ui/dialog/actions.go
@@ -2,7 +2,6 @@ package dialog
 
 import (
 	"fmt"
-	"net/http"
 	"os"
 	"path/filepath"
 
@@ -194,9 +193,17 @@ func (a ActionFilePickerSelected) Cmd() tea.Cmd {
 			}
 		}
 
-		mimeBufferSize := min(512, len(content))
-		mimeType := http.DetectContentType(content[:mimeBufferSize])
 		fileName := filepath.Base(path)
+		mimeType, ok := common.SniffAttachmentMIME(content)
+		if !ok {
+			// Allowed by extension but the content sniffs as binary —
+			// attaching would inline byte soup or send a file part
+			// providers reject.
+			return util.InfoMsg{
+				Type: util.InfoTypeWarn,
+				Msg:  fmt.Sprintf("%s looks binary (%s), not attaching", fileName, mimeType),
+			}
+		}
 
 		return message.Attachment{
 			FilePath: path,

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -4301,8 +4301,10 @@ func (m *UI) handlePasteMsg(msg tea.PasteMsg) tea.Cmd {
 				return util.ReportWarn("Paste is too big (>5mb)")
 			}
 			name := fmt.Sprintf("paste_%d.txt", m.pasteIdx())
-			mimeBufferSize := min(512, len(content))
-			mimeType := http.DetectContentType(content[:mimeBufferSize])
+			mimeType, ok := common.SniffAttachmentMIME(content)
+			if !ok {
+				return util.ReportWarn(fmt.Sprintf("Paste looks binary (%s), not attaching", mimeType))
+			}
 			return message.Attachment{
 				FileName: name,
 				FilePath: name,
@@ -4380,9 +4382,14 @@ func (m *UI) handleFilePathPaste(path string) tea.Cmd {
 			return util.ReportError(err)
 		}
 
-		mimeBufferSize := min(512, len(content))
-		mimeType := http.DetectContentType(content[:mimeBufferSize])
 		fileName := filepath.Base(path)
+		mimeType, ok := common.SniffAttachmentMIME(content)
+		if !ok {
+			// Allowed by extension but the content sniffs as binary —
+			// attaching would inline byte soup or send a file part
+			// providers reject.
+			return util.ReportWarn(fmt.Sprintf("%s looks binary (%s), not attaching", fileName, mimeType))
+		}
 		return message.Attachment{
 			FilePath: path,
 			FileName: fileName,

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -3400,10 +3400,18 @@ func (m *UI) insertFileCompletion(path string) tea.Cmd {
 			return nil
 		}
 
+		mimeType, ok := common.SniffAttachmentMIME(content)
+		if !ok {
+			// Content sniffs as binary: skip the attachment. The
+			// @-mention stays in the prompt, so the LLM can still
+			// read the file through tools later.
+			return nil
+		}
+
 		return message.Attachment{
 			FilePath: path,
 			FileName: filepath.Base(path),
-			MimeType: mimeOf(content),
+			MimeType: mimeType,
 			Content:  content,
 		}
 	}
@@ -4435,34 +4443,11 @@ func (m *UI) pasteImageFromClipboard() tea.Msg {
 		return util.NewInfoMsg("File type is not supported")
 	}
 
-	fileInfo, statErr := os.Stat(path)
-	if statErr != nil {
-		return util.InfoMsg{
-			Type: util.InfoTypeError,
-			Msg:  fmt.Sprintf("Unable to read file: %v", statErr),
-		}
-	}
-	if fileInfo.Size() > common.MaxAttachmentSize {
-		return util.InfoMsg{
-			Type: util.InfoTypeError,
-			Msg:  "File too large, max 5MB",
-		}
-	}
-
-	content, readErr := os.ReadFile(path)
-	if readErr != nil {
-		return util.InfoMsg{
-			Type: util.InfoTypeError,
-			Msg:  fmt.Sprintf("Unable to read file: %v", readErr),
-		}
-	}
-
-	return message.Attachment{
-		FilePath: path,
-		FileName: filepath.Base(path),
-		MimeType: mimeOf(content),
-		Content:  content,
-	}
+	// Same pipeline as pasting a path into the terminal: stat, size cap,
+	// and the binary-content sniff. Duplicating it here previously let a
+	// binary file attach through the PasteImage key that the terminal
+	// paste path would have rejected.
+	return m.handleFilePathPaste(path)()
 }
 
 var pasteRE = regexp.MustCompile(`paste_(\d+).txt`)


### PR DESCRIPTION
Audit batch: attachment MIME correctness (2 MAJOR + 1 nit).

## 1. Session-wedging history divergence (MAJOR)

#118 widened `Attachment.IsText()` to `application/*` text types — but `ToAIMessage`, which **rebuilds prior user messages on every later turn**, still inlined only `text/*` and re-emitted everything else as a binary `fantasy.FilePart`:

- Turn 1: `application/json` attachment inlined into the prompt — works.
- Turn 2+: the stored message is rebuilt via `ToAIMessage` → the same JSON is now a **binary file part** with media type `application/json` → providers that accept only image/PDF file parts reject the request. The session wedges (or the content silently vanishes).

**Fix:** single exported `message.IsTextMIME` used by `Attachment.IsText` **and** both `ToAIMessage` paths. The regression test (`application/json` stays inlined on rebuild, no FilePart) **fails against the previous code** — verified.

## 2. Text-extension files with binary content (MAJOR)

`http.DetectContentType` on a `.log`/`.csv`/`.lock` with a NUL byte in the first 512 bytes returns `application/octet-stream`; the attachment then became a bogus FilePart (provider 400) or silently evaporated on non-image models. All three attach sites (file picker, paste, clipboard file-path) now run `common.SniffAttachmentMIME` and surface **"looks binary (…), not attaching"** instead.

## 3. `Dockerfile`/`Makefile` were never attachable (nit)

`.dockerfile`/`.makefile` extension entries can't match extensionless files (suffix needs the dot). Well-known names are now allowlisted by basename; dotted variants (`build.dockerfile`) still work. The old test asserting `Makefile → rejected` was pinning this bug and is updated. (The file *picker* still lists by extension only — Dockerfile arrives via paste/drop; noted as a limitation.)

```
go build ./... ✓   gofmt ✓   go test ./internal/message/ ./internal/ui/common/ ./internal/ui/dialog/ ./internal/ui/model/ ✓
```

---
_Generated by [Claude Code](https://claude.ai/code/session_01AtvfVcwLAeVKk9SkRjb7GN)_