### PR TITLE
fix(chat): A2UI alerts agree with the parser, gate on finished, keep fences

### DIFF
--- a/internal/ui/chat/a2ui.go
+++ b/internal/ui/chat/a2ui.go
@@ -1,7 +1,6 @@
 package chat
 
 import (
-	"encoding/json"
 	"fmt"
 	"regexp"
 	"strings"
@@ -76,9 +75,18 @@ func contentHasUnclosedA2UI(content string) bool {
 }
 
 // countDroppedTaggedBlocks scans content for complete
-// <a2ui-json>...</a2ui-json> pairs whose JSON body cannot be unmarshalled —
-// blocks a2tea silently drops. This is independent of bare-JSON parts, which
-// must not mask the alert (#7).
+// <a2ui-json>...</a2ui-json> pairs that yield no A2UI messages — blocks the
+// parser drops. This is independent of bare-JSON parts, which must not mask
+// the alert (#7).
+//
+// Each block is judged by running it through the SAME parser Scan uses, so
+// this check agrees with rendering by construction. The previous
+// implementation unmarshalled the body as a single JSON object, which
+// disagreed with the parser in both directions: valid-but-unrecognized JSON
+// ({"foo":1}) is silently dropped by the parser but unmarshals fine (missed
+// alert), while array-wrapped or multiple newline-delimited messages render
+// fine but fail a single-object unmarshal (false alert beside a working
+// surface).
 func countDroppedTaggedBlocks(content string) int {
 	const openTag, closeTag = "<a2ui-json>", "</a2ui-json>"
 	var dropped int
@@ -93,10 +101,16 @@ func countDroppedTaggedBlocks(content string) int {
 		if j < 0 {
 			break
 		}
-		body := strings.TrimSpace(s[:j])
+		body := s[:j]
 		s = s[j+len(closeTag):]
-		var raw map[string]any
-		if json.Unmarshal([]byte(body), &raw) != nil {
+
+		messages := 0
+		if parts, err := a2tea.Scan(openTag + body + closeTag); err == nil {
+			for _, p := range parts {
+				messages += len(p.Messages)
+			}
+		}
+		if messages == 0 {
 			dropped++
 		}
 	}
@@ -117,7 +131,7 @@ func countDroppedTaggedBlocks(content string) int {
 // This deliberately bypasses the streaming-markdown prefix cache (which assumes
 // a single glamour render per item) and renders each segment directly. The
 // renderer is shared, so the whole multi-render sequence holds its lock.
-func (a *AssistantMessageItem) renderContentWithA2UI(content string, width int) string {
+func (a *AssistantMessageItem) renderContentWithA2UI(content string, width int, finished bool) string {
 	masked, fenceReps := maskFencedCode(content)
 
 	parts, err := a2tea.Scan(masked)
@@ -175,8 +189,11 @@ func (a *AssistantMessageItem) renderContentWithA2UI(content string, width int) 
 
 	// Alert when a complete tag pair was dropped by the parser (#7) —
 	// checked directly so bare-JSON parts cannot mask the count — or when
-	// generation was truncated mid-block (#5).
-	if countDroppedTaggedBlocks(masked) > 0 || hasUnclosedA2UITag(masked) {
+	// generation was truncated mid-block (#5). Only for finished messages:
+	// while streaming, an "unclosed" tag usually just means the close tag
+	// hasn't arrived yet, and flashing a red alert between flushes that then
+	// vanishes reads as a glitch.
+	if finished && (countDroppedTaggedBlocks(masked) > 0 || hasUnclosedA2UITag(masked)) {
 		writeChunk(a.renderA2UIAlert(width))
 	}
 
@@ -189,12 +206,15 @@ func (a *AssistantMessageItem) renderContentWithA2UI(content string, width int) 
 // surfaced through the standard A2UI alert instead of leaving a wall of raw
 // JSON.
 func (a *AssistantMessageItem) renderTruncatedA2UI(content string, width int) string {
-	stripped := stripFencedCode(content)
-	idx := strings.Index(stripped, "<a2ui-json>")
+	// Mask (not strip) fences: a fence containing an <a2ui-json> example must
+	// not be mistaken for the truncation point, but the fence's code must
+	// stay in the rendered prose — stripping deleted it from the message.
+	masked, fenceReps := maskFencedCode(content)
+	idx := strings.Index(masked, "<a2ui-json>")
 
 	var b strings.Builder
 	if idx > 0 {
-		prose := stripped[:idx]
+		prose := unmaskFencedCode(masked[:idx], fenceReps)
 		if strings.TrimSpace(prose) != "" {
 			b.WriteString(a.renderMarkdown(prose, width))
 		}

--- a/internal/ui/chat/a2ui_test.go
+++ b/internal/ui/chat/a2ui_test.go
@@ -37,7 +37,7 @@ func TestRenderContentWithA2UIFencedCodeNotLiveSurface(t *testing.T) {
 	item := &AssistantMessageItem{sty: &sty}
 
 	content := "Example:\n\n```json\n" + a2uiSurface + "\n```\n\nAnd some text."
-	out := item.renderContentWithA2UI(content, 80)
+	out := item.renderContentWithA2UI(content, 80, true)
 	plain := ansi.Strip(out)
 
 	// The fenced example is rendered as code — the raw tags and JSON are
@@ -59,7 +59,7 @@ func TestRenderContentWithA2UIRealSurfaceNextToFencedExample(t *testing.T) {
 	// A real surface followed by a fenced example: both should render
 	// correctly — the real surface as live, the fenced example as code.
 	content := "Real: " + a2uiSurface + "\n\nExample:\n\n```json\n" + a2uiSurface + "\n```"
-	out := item.renderContentWithA2UI(content, 80)
+	out := item.renderContentWithA2UI(content, 80, true)
 	plain := ansi.Strip(out)
 
 	require.Contains(t, plain, "Hello from A2UI") // real surface rendered
@@ -107,7 +107,7 @@ func TestRenderContentWithA2UIMalformedShowsAlert(t *testing.T) {
 	// Malformed JSON inside the tags: a2uistream drops it (no messages), so
 	// crush must alert rather than silently losing the block.
 	content := "Look: <a2ui-json>{not valid json}</a2ui-json>"
-	out := item.renderContentWithA2UI(content, 80)
+	out := item.renderContentWithA2UI(content, 80, true)
 	plain := ansi.Strip(out)
 
 	require.Contains(t, plain, "A2UI")
@@ -128,7 +128,7 @@ func TestRenderContentWithA2UIMalformedNotMaskedByBareJSON(t *testing.T) {
 	bareJSON := `{"version":"v0.9","updateComponents":{"surfaceId":"s","components":[` +
 		`{"component":"Text","id":"t","text":"bare"}]}}`
 	content := "<a2ui-json>{not valid json}</a2ui-json>\n\n" + bareJSON
-	out := item.renderContentWithA2UI(content, 80)
+	out := item.renderContentWithA2UI(content, 80, true)
 	plain := ansi.Strip(out)
 
 	require.Contains(t, plain, "couldn't render") // the malformed tagged block alerted
@@ -143,7 +143,7 @@ func TestRenderContentWithA2UI(t *testing.T) {
 	item := &AssistantMessageItem{sty: &sty}
 
 	content := "Here is a card:\n\n" + a2uiSurface + "\n\nAnything else?"
-	out := item.renderContentWithA2UI(content, 80)
+	out := item.renderContentWithA2UI(content, 80, true)
 	plain := ansi.Strip(out)
 
 	// The A2UI surface renders (text pulled from the card's Text component)...
@@ -167,9 +167,94 @@ func TestRenderContentWithA2UIMixedGoodAndBadAlerts(t *testing.T) {
 	// One valid surface plus one malformed block: the good one renders AND the
 	// dropped one is still surfaced via an alert (not silently lost).
 	content := "ok: " + a2uiSurface + " bad: <a2ui-json>{nope}</a2ui-json>"
-	out := item.renderContentWithA2UI(content, 80)
+	out := item.renderContentWithA2UI(content, 80, true)
 	plain := ansi.Strip(out)
 
 	require.Contains(t, plain, "Hello from A2UI") // the good surface rendered
 	require.Contains(t, plain, "couldn't render") // the bad block alerted
+}
+
+// TestDroppedBlockAlert_UnrecognizedValidJSON pins the parser-agreement fix:
+// {"foo":1} is valid JSON — the old single-object unmarshal check passed it —
+// but the A2UI parser silently drops it (no recognized message), so the user
+// lost the block with no alert. The dropped-block check now runs each block
+// through the same parser rendering uses.
+func TestDroppedBlockAlert_UnrecognizedValidJSON(t *testing.T) {
+	t.Parallel()
+
+	sty := styles.CharmtonePantera()
+	item := &AssistantMessageItem{sty: &sty}
+
+	content := `Look: <a2ui-json>{"foo": 1}</a2ui-json>`
+	out := item.renderContentWithA2UI(content, 80, true)
+	plain := ansi.Strip(out)
+
+	require.Contains(t, plain, "couldn't render",
+		"valid-but-unrecognized JSON is dropped by the parser and must alert")
+}
+
+// TestNoDroppedBlockAlert_MultiMessageBody pins the other direction: a tagged
+// body carrying multiple newline-delimited A2UI messages renders fine, so no
+// alert may appear beside the working surface (the old single-object
+// unmarshal false-positived here).
+func TestNoDroppedBlockAlert_MultiMessageBody(t *testing.T) {
+	t.Parallel()
+
+	sty := styles.CharmtonePantera()
+	item := &AssistantMessageItem{sty: &sty}
+
+	body := `{"version":"v0.9","updateComponents":{"surfaceId":"s","components":[{"component":"Text","id":"root","text":"First"}]}}
+{"version":"v0.9","updateDataModel":{"surfaceId":"s","path":"/x","value":"y"}}`
+	content := "Here: <a2ui-json>" + body + "</a2ui-json>"
+
+	// Sanity: the parser really does yield messages for this body.
+	require.Zero(t, countDroppedTaggedBlocks(content),
+		"multi-message body must not count as dropped")
+
+	out := item.renderContentWithA2UI(content, 80, true)
+	plain := ansi.Strip(out)
+	require.Contains(t, plain, "First", "the surface must render")
+	require.NotContains(t, plain, "couldn't render",
+		"no alert may appear next to a successfully rendered surface")
+}
+
+// TestNoAlertWhileStreaming pins the streaming gate: with one complete
+// surface rendered and a second block still open (its close tag not yet
+// arrived), an unfinished message must NOT flash the alert; the same content
+// on a finished message must show it.
+func TestNoAlertWhileStreaming(t *testing.T) {
+	t.Parallel()
+
+	sty := styles.CharmtonePantera()
+	item := &AssistantMessageItem{sty: &sty}
+
+	content := `<a2ui-json>{"version":"v0.9","updateComponents":{"surfaceId":"s","components":[{"component":"Text","id":"root","text":"Done"}]}}</a2ui-json>
+And a second one: <a2ui-json>{"version":"v0.9","updateComp`
+
+	streaming := ansi.Strip(item.renderContentWithA2UI(content, 80, false))
+	require.Contains(t, streaming, "Done", "the complete surface renders mid-stream")
+	require.NotContains(t, streaming, "couldn't render",
+		"no alert while the close tag simply hasn't arrived yet")
+
+	finished := ansi.Strip(item.renderContentWithA2UI(content, 80, true))
+	require.Contains(t, finished, "couldn't render",
+		"a finished message with a dangling open tag must alert")
+}
+
+// TestRenderTruncatedA2UIPreservesFencedCode pins the fence fix: prose before
+// the truncated block may contain fenced code, which must survive rendering —
+// the old implementation stripped fences from the whole message, deleting the
+// user-visible code block.
+func TestRenderTruncatedA2UIPreservesFencedCode(t *testing.T) {
+	t.Parallel()
+
+	sty := styles.CharmtonePantera()
+	item := &AssistantMessageItem{sty: &sty}
+
+	content := "Example:\n\n```go\nfunc keepMe() {}\n```\n\nForm: <a2ui-json>{\"version\":\"v0.9\",\"updateComp"
+	out := ansi.Strip(item.renderTruncatedA2UI(content, 80))
+
+	require.Contains(t, out, "keepMe", "fenced code before the truncated block must be preserved")
+	require.Contains(t, out, "couldn't render")
+	require.NotContains(t, out, "updateComp", "raw truncated JSON must not leak")
 }

--- a/internal/ui/chat/a2ui_test.go
+++ b/internal/ui/chat/a2ui_test.go
@@ -3,6 +3,8 @@ package chat
 import (
 	"testing"
 
+	"github.com/charmbracelet/crush/internal/message"
+
 	"github.com/charmbracelet/crush/internal/ui/styles"
 	"github.com/charmbracelet/x/ansi"
 	"github.com/stretchr/testify/require"
@@ -257,4 +259,43 @@ func TestRenderTruncatedA2UIPreservesFencedCode(t *testing.T) {
 	require.Contains(t, out, "keepMe", "fenced code before the truncated block must be preserved")
 	require.Contains(t, out, "couldn't render")
 	require.NotContains(t, out, "updateComp", "raw truncated JSON must not leak")
+}
+
+// TestContentCache_FinishedRenderNotServedFromStreamingEntry pins the cache
+// key folding in the finish state: the last streaming delta and the Finish
+// part often carry byte-identical text, so without finish state in the key
+// the no-alert render cached mid-stream would be served forever and the
+// dropped-block alert the finished gate promises could never appear.
+func TestContentCache_FinishedRenderNotServedFromStreamingEntry(t *testing.T) {
+	t.Parallel()
+
+	sty := styles.CharmtonePantera()
+	item := &AssistantMessageItem{sty: &sty}
+
+	content := `<a2ui-json>{"version":"v0.9","updateComponents":{"surfaceId":"s","components":[{"component":"Text","id":"root","text":"Done"}]}}</a2ui-json>
+And a second one: <a2ui-json>{"version":"v0.9","updateComp`
+
+	// Final content delta arrives while the message is still streaming;
+	// the no-alert render lands in the section cache.
+	item.message = &message.Message{
+		ID:    "m-finish-key",
+		Role:  message.Assistant,
+		Parts: []message.ContentPart{message.TextContent{Text: content}},
+	}
+	streaming := ansi.Strip(item.cachedContent(80))
+	require.NotContains(t, streaming, "couldn't render", "no alert while streaming")
+
+	// The Finish part lands with the text unchanged. The finished render
+	// must re-render and alert, not serve the streaming cache entry.
+	item.message = &message.Message{
+		ID:   "m-finish-key",
+		Role: message.Assistant,
+		Parts: []message.ContentPart{
+			message.TextContent{Text: content},
+			message.Finish{Reason: message.FinishReasonEndTurn},
+		},
+	}
+	finished := ansi.Strip(item.cachedContent(80))
+	require.Contains(t, finished, "couldn't render",
+		"finished message with a dangling block must alert even when its text matches the cached streaming render")
 }

--- a/internal/ui/chat/assistant.go
+++ b/internal/ui/chat/assistant.go
@@ -386,9 +386,17 @@ func (a *AssistantMessageItem) thinkingKey() (uint64, uint64) {
 }
 
 // contentKey returns the (srcHash, extra) cache key components for the
-// main content section.
+// main content section. Finish state is folded into the key because the
+// rendered output depends on IsFinished() (A2UI alert gating and the
+// truncated-block branch): the last streaming delta and the finished
+// message often carry byte-identical text, and the finished render must
+// not be served from a cache entry stored while streaming.
 func (a *AssistantMessageItem) contentKey() (uint64, uint64) {
-	return fnv64(a.message.Content().Text), 0
+	var fin uint64
+	if a.message.IsFinished() {
+		fin = 1
+	}
+	return fnv64(a.message.Content().Text), fin
 }
 
 // errorKey returns the (srcHash, extra) cache key components for the

--- a/internal/ui/chat/assistant.go
+++ b/internal/ui/chat/assistant.go
@@ -434,7 +434,7 @@ func (a *AssistantMessageItem) cachedContent(width int) string {
 	if contentHasA2UI(text) {
 		// The reply carries an A2UI document — route it through a2tea instead
 		// of rendering the raw JSON as a markdown code block.
-		out = a.renderContentWithA2UI(text, width)
+		out = a.renderContentWithA2UI(text, width, a.message.IsFinished())
 	} else if a.message.IsFinished() && contentHasUnclosedA2UI(text) {
 		// Generation was truncated mid-block: an <a2ui-json> tag never got
 		// its closing partner. Show the alert instead of raw partial JSON.


### PR DESCRIPTION
Audit batch: A2UI chat rendering alerts (1 MAJOR + 2 MINOR).

## 1. Alert check disagreed with the parser — both directions (MAJOR)

`countDroppedTaggedBlocks` judged each `<a2ui-json>` block by a **single-object `json.Unmarshal`**, while the real parser brace-scans multiple objects, accepts array-wrapped bodies, and silently drops valid-but-unrecognized JSON:

- **Missed alert:** `{"foo":1}` unmarshals fine → no alert — but the parser drops it, so the user silently lost the block. This defeats the check's stated purpose (issue #7).
- **False alert:** multiple newline-delimited messages in one block render fine → red "couldn't render" appears **next to a working surface**.

**Fix:** each block now runs through the same parser `Scan` uses (count of yielded messages), so the check agrees with rendering **by construction**. Both regression tests fail against the old code — verified.

## 2. Alert flashed during streaming (MINOR)

`hasUnclosedA2UITag`'s own doc says it's "only meaningful for finished messages", but the alert ran on every mid-stream flush — surface 1 complete + surface 2 still streaming = red alert flashing until the close tag arrives. Now gated on `IsFinished()` (threaded as a parameter; the truncated-render path was already gated).

## 3. Truncated-render deleted fenced code (MINOR)

`renderTruncatedA2UI` used `stripFencedCode` — so prose like "Example: \`\`\`go …\`\`\` Form: `<a2ui-json>{trunc…`" rendered **without the code block**. Now masks/unmasks fences like the main path (an in-fence `<a2ui-json>` example still can't be mistaken for the truncation point).

## Tests

Unrecognized-valid-JSON alerts (**failed before**), multi-message body no false positive (**failed before**), streaming-vs-finished alert gating, fence preservation in truncated render.

```
go build ./... ✓   go vet ✓   gofmt ✓   go test ./internal/ui/chat/ ✓
```

---
_Generated by [Claude Code](https://claude.ai/code/session_01AtvfVcwLAeVKk9SkRjb7GN)_