### PR TITLE
fix(ui): sidebar focus/help/height correctness; palette sub-menu resize reset

### DIFF
--- a/internal/ui/dialog/commands.go
+++ b/internal/ui/dialog/commands.go
@@ -311,7 +311,13 @@ func (c *Commands) Draw(scr uv.Screen, area uv.Rectangle) *tea.Cursor {
 	if area.Dx() != c.windowWidth && c.selected == SystemCommands {
 		c.windowWidth = area.Dx()
 		// since some items in the list depend on width (e.g. toggle sidebar command),
-		// we need to reset the command items when width changes
+		// we need to reset the command items when width changes. Repopulating
+		// replaces the list with top-level items, so any open sub-menu must be
+		// abandoned too — resetting to the top level is simpler than re-deriving
+		// the open sub-menu's children against the regenerated item set, and
+		// keeps the list, menu stack, and breadcrumb consistent.
+		c.menuStack = nil
+		c.breadcrumb = nil
 		c.setCommandItems(c.selected)
 	}
 
@@ -352,19 +358,26 @@ func (c *Commands) Draw(scr uv.Screen, area uv.Rectangle) *tea.Cursor {
 
 // ShortHelp implements [help.KeyMap].
 func (c *Commands) ShortHelp() []key.Binding {
-	return []key.Binding{
+	binds := []key.Binding{
 		c.keyMap.Tab,
 		c.keyMap.UpDown,
 		c.keyMap.Select,
-		c.keyMap.Close,
 	}
+	if c.inSubMenu() {
+		binds = append(binds, c.keyMap.Back)
+	}
+	return append(binds, c.keyMap.Close)
 }
 
 // FullHelp implements [help.KeyMap].
 func (c *Commands) FullHelp() [][]key.Binding {
+	second := []key.Binding{c.keyMap.Close}
+	if c.inSubMenu() {
+		second = append([]key.Binding{c.keyMap.Back}, second...)
+	}
 	return [][]key.Binding{
 		{c.keyMap.Select, c.keyMap.Next, c.keyMap.Previous, c.keyMap.Tab},
-		{c.keyMap.Close},
+		second,
 	}
 }
 

--- a/internal/ui/dialog/commands_test.go
+++ b/internal/ui/dialog/commands_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/charmbracelet/crush/internal/ui/list"
 	"github.com/charmbracelet/crush/internal/ui/styles"
 	"github.com/charmbracelet/crush/internal/workspace"
+	uv "github.com/charmbracelet/ultraviolet"
 	"github.com/stretchr/testify/require"
 )
 
@@ -234,6 +235,87 @@ func TestCommands_BackspaceEditsTopLevelFilter(t *testing.T) {
 	c.HandleMsg(tea.KeyPressMsg{Code: tea.KeyBackspace})
 	require.False(t, c.inSubMenu())
 	require.Equal(t, "mc", c.input.Value(), "backspace should delete a char from the top-level filter")
+}
+
+// TestCommands_ResizeInSubMenuResetsToTopLevel verifies that when Draw
+// repopulates the command items because the width changed, any open sub-menu
+// is abandoned along with it — otherwise the list would show top-level items
+// while inSubMenu() is still true and the breadcrumb is stale.
+func TestCommands_ResizeInSubMenuResetsToTopLevel(t *testing.T) {
+	t.Parallel()
+
+	c := newTestCommands(t)
+
+	// Establish an initial window width via a first Draw.
+	scr := uv.NewScreenBuffer(120, 40)
+	c.Draw(scr, uv.Rect(0, 0, 120, 40))
+	require.False(t, c.inSubMenu())
+
+	// There are no production sub-menus yet, so inject a parent with a child
+	// and enter its sub-menu.
+	leaf := NewCommandItem(c.com.Styles, "leaf", "Leaf", "", ActionNewSession{})
+	parent := NewCommandItem(c.com.Styles, "parent", "Parent", "", nil).WithChildren(leaf)
+	items := []list.FilterableItem{parent}
+	c.list.SetItems(items...)
+	c.list.SetSelected(0)
+	c.HandleMsg(tea.KeyPressMsg{Code: tea.KeyEnter})
+	require.True(t, c.inSubMenu())
+	require.Equal(t, []string{"Parent"}, c.breadcrumb)
+
+	// A redraw at the same width must not reset the menu.
+	c.Draw(scr, uv.Rect(0, 0, 120, 40))
+	require.True(t, c.inSubMenu(), "same-width draws must preserve the sub-menu")
+
+	// A redraw at a different width repopulates the top-level items, so the
+	// menu stack and breadcrumb must reset with them.
+	scr2 := uv.NewScreenBuffer(140, 40)
+	c.Draw(scr2, uv.Rect(0, 0, 140, 40))
+	require.False(t, c.inSubMenu(), "width change must reset the sub-menu state")
+	require.Empty(t, c.menuStack)
+	require.Empty(t, c.breadcrumb)
+
+	// And the visible items are top-level commands again, not the sub-menu's
+	// children.
+	for _, item := range c.list.FilteredItems() {
+		if ci, ok := item.(*CommandItem); ok {
+			require.NotEqual(t, "leaf", ci.id, "sub-menu children must not remain in the list")
+		}
+	}
+}
+
+// TestCommands_SubMenuHelpShowsBack verifies the Back binding is advertised
+// in the help views only while inside a sub-menu.
+func TestCommands_SubMenuHelpShowsBack(t *testing.T) {
+	t.Parallel()
+
+	c := setupMenuHierarchy(t)
+
+	shortHasBack := func() bool {
+		for _, b := range c.ShortHelp() {
+			if b.Help().Desc == "back" {
+				return true
+			}
+		}
+		return false
+	}
+	fullHasBack := func() bool {
+		for _, row := range c.FullHelp() {
+			for _, b := range row {
+				if b.Help().Desc == "back" {
+					return true
+				}
+			}
+		}
+		return false
+	}
+
+	require.False(t, shortHasBack(), "Back must not show in ShortHelp at the top level")
+	require.False(t, fullHasBack(), "Back must not show in FullHelp at the top level")
+
+	c.HandleMsg(tea.KeyPressMsg{Code: tea.KeyEnter})
+	require.True(t, c.inSubMenu())
+	require.True(t, shortHasBack(), "Back must show in ShortHelp inside a sub-menu")
+	require.True(t, fullHasBack(), "Back must show in FullHelp inside a sub-menu")
 }
 
 func setupMenuHierarchy(t *testing.T) *Commands {

--- a/internal/ui/model/sidebar.go
+++ b/internal/ui/model/sidebar.go
@@ -228,7 +228,6 @@ func (m *UI) drawSidebar(scr uv.Screen, area uv.Rectangle) {
 		layout.Len(lipgloss.Height(sidebarHeader)),
 		layout.Fill(1),
 	).Split(m.layout.sidebar).Assign(new(image.Rectangle), &remainingHeightArea)
-	remainingHeight := remainingHeightArea.Dy() - 6
 	filesCount := 0
 	for _, f := range m.sessionFiles {
 		if f.Additions == 0 && f.Deletions == 0 {
@@ -248,6 +247,15 @@ func (m *UI) drawSidebar(scr uv.Screen, area uv.Rectangle) {
 
 	skillsCount := len(m.skillStatusItems())
 	channelsCount := len(m.channelStatusItems())
+
+	// Each section below the header renders a title line plus a blank line
+	// before its items, and adjacent sections are joined with one blank
+	// separator line (see fullContent below). That overhead must come out
+	// of the height before budgeting item lines, or the bottom section is
+	// silently clipped by the MaxHeight applied at the end.
+	sectionCounts := []int{filesCount, lspsCount, mcpsCount, skillsCount, channelsCount}
+	sectionOverhead := len(sectionCounts)*2 + len(sectionCounts) - 1
+	remainingHeight := remainingHeightArea.Dy() - sectionOverhead
 
 	maxFiles, maxLSPs, maxMCPs, maxSkills, maxChannels := getDynamicHeightLimits(remainingHeight, filesCount, lspsCount, mcpsCount, skillsCount, channelsCount)
 

--- a/internal/ui/model/sidebar_focus_test.go
+++ b/internal/ui/model/sidebar_focus_test.go
@@ -85,6 +85,28 @@ func TestSidebarMouseWheelScrollsInChatDirection(t *testing.T) {
 	require.False(t, handled, "wheel outside the sidebar should not be handled by it")
 }
 
+// TestCompactModeResizeReturnsFocusToEditor verifies that when a resize flips
+// the UI into compact mode while the sidebar has focus, focus returns to the
+// editor. The sidebar is not drawn in compact mode, so leaving focus on it
+// would swallow keys and keep showing sidebar help bindings.
+func TestCompactModeResizeReturnsFocusToEditor(t *testing.T) {
+	t.Parallel()
+	m := newTestUI() // 140x45 is a non-compact chat layout
+	m.updateLayoutAndSize()
+	require.False(t, m.isCompact)
+
+	m.focusSidebar()
+	require.Equal(t, uiFocusSidebar, m.focus)
+
+	// Shrink below the compact width breakpoint, as a WindowSizeMsg would.
+	m.width = compactModeWidthBreakpoint - 1
+	m.updateLayoutAndSize()
+
+	require.True(t, m.isCompact)
+	require.Equal(t, uiFocusEditor, m.focus, "focus must not remain on the hidden sidebar")
+	require.True(t, m.textarea.Focused(), "the editor should be refocused")
+}
+
 // TestSidebarFocusEnumExists documents the three-state non-compact cycle.
 func TestSidebarFocusEnumExists(t *testing.T) {
 	t.Parallel()

--- a/internal/ui/model/sidebar_height_test.go
+++ b/internal/ui/model/sidebar_height_test.go
@@ -1,0 +1,117 @@
+package model
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/charmbracelet/crush/internal/agent/tools/mcp"
+	"github.com/charmbracelet/crush/internal/config"
+	"github.com/charmbracelet/crush/internal/history"
+	"github.com/charmbracelet/crush/internal/lsp"
+	"github.com/charmbracelet/crush/internal/session"
+	"github.com/charmbracelet/crush/internal/skills"
+	"github.com/charmbracelet/crush/internal/ui/common"
+	"github.com/charmbracelet/crush/internal/ui/styles"
+	"github.com/charmbracelet/crush/internal/workspace"
+	uv "github.com/charmbracelet/ultraviolet"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/stretchr/testify/require"
+)
+
+// sidebarHeightTestWorkspace implements just enough of [workspace.Workspace]
+// for drawSidebar.
+type sidebarHeightTestWorkspace struct {
+	workspace.Workspace
+	cfg *config.Config
+}
+
+func (w *sidebarHeightTestWorkspace) Config() *config.Config { return w.cfg }
+func (w *sidebarHeightTestWorkspace) WorkingDir() string     { return "/tmp/project" }
+func (w *sidebarHeightTestWorkspace) AgentIsReady() bool     { return false }
+func (w *sidebarHeightTestWorkspace) LSPGetDiagnosticCounts(string) lsp.DiagnosticCounts {
+	return lsp.DiagnosticCounts{}
+}
+
+// newSidebarHeightTestUI builds a UI whose sidebar has every section
+// populated with more items than the dynamic limits will allow, so the
+// height budget arithmetic — not the item counts — decides what is visible.
+func newSidebarHeightTestUI(t *testing.T) *UI {
+	t.Helper()
+
+	mcps := config.MCPs{}
+	mcpStates := map[string]mcp.ClientInfo{}
+	for i := range 4 {
+		name := fmt.Sprintf("mcp-%d", i)
+		mcps[name] = config.MCPConfig{}
+		mcpStates[name] = mcp.ClientInfo{Name: name, State: mcp.StateConnected}
+
+		chName := fmt.Sprintf("chan-%d", i)
+		mcps[chName] = config.MCPConfig{}
+		mcpStates[chName] = mcp.ClientInfo{Name: chName, State: mcp.StateConnected, Channel: true}
+	}
+
+	var files []SessionFile
+	for i := range 4 {
+		files = append(files, SessionFile{
+			FirstVersion: history.File{Path: fmt.Sprintf("/tmp/project/file-%d.go", i)},
+			Additions:    1,
+		})
+	}
+
+	lspStates := map[string]workspace.LSPClientInfo{}
+	for i := range 4 {
+		name := fmt.Sprintf("lsp-%d", i)
+		lspStates[name] = workspace.LSPClientInfo{Name: name}
+	}
+
+	var skillStates []*skills.SkillState
+	for i := range 4 {
+		name := fmt.Sprintf("skill-%d", i)
+		skillStates = append(skillStates, &skills.SkillState{
+			Name: name,
+			Path: fmt.Sprintf("/skills/%s/SKILL.md", name),
+		})
+	}
+
+	s := styles.CharmtonePantera()
+	return &UI{
+		com: &common.Common{
+			Workspace: &sidebarHeightTestWorkspace{cfg: &config.Config{MCP: mcps, Options: &config.Options{}}},
+			Styles:    &s,
+		},
+		state:        uiChat,
+		focus:        uiFocusEditor, // unfocused sidebar: dynamic limits apply
+		session:      &session.Session{ID: "s1", Title: "Test Session"},
+		sessionFiles: files,
+		lspStates:    lspStates,
+		mcpStates:    mcpStates,
+		skillStates:  skillStates,
+	}
+}
+
+// TestSidebarAllSectionTitlesVisibleAtTightHeight pins the sidebar height
+// budget: at a height where every section holds only its minimum items, all
+// five section titles (Modified Files, LSPs, MCPs, Skills, Channels) must be
+// visible. The old budget subtracted an overhead constant sized for four
+// sections, so the item allocation overshot the space and the MaxHeight clip
+// silently swallowed the bottom (Channels) section.
+func TestSidebarAllSectionTitlesVisibleAtTightHeight(t *testing.T) {
+	t.Parallel()
+
+	m := newSidebarHeightTestUI(t)
+
+	// Header is 7 lines (logo, title, blank, cwd, blank, model info, blank).
+	// The five sections at minimum need 2 title+blank lines each, 4 blank
+	// separators, and 2 item lines each: 7 + (5*2 + 4) + 5*2 = 31.
+	const width, height = 32, 31
+	m.layout.sidebar = uv.Rect(0, 0, width, height)
+
+	scr := uv.NewScreenBuffer(width, height)
+	m.drawSidebar(scr, m.layout.sidebar)
+	out := ansi.Strip(scr.Render())
+
+	for _, title := range []string{"Modified Files", "LSPs", "MCPs", "Skills", "Channels"} {
+		require.Contains(t, out, title,
+			"section title %q must be visible at height %d", title, height)
+	}
+}

--- a/internal/ui/model/sidebar_help_test.go
+++ b/internal/ui/model/sidebar_help_test.go
@@ -4,6 +4,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/charmbracelet/crush/internal/config"
+	"github.com/charmbracelet/crush/internal/session"
 	"github.com/charmbracelet/crush/internal/ui/attachments"
 	"github.com/stretchr/testify/require"
 )
@@ -77,6 +79,43 @@ func TestFullHelpSidebarHidesCommandOptions(t *testing.T) {
 
 	for _, key := range []string{"ctrl+p", "ctrl+l", "ctrl+m", "ctrl+g", "/ or ctrl+p"} {
 		require.False(t, helpKeys[key], "key %q should NOT appear in FullHelp when sidebar is focused", key)
+	}
+}
+
+// TestFullHelpSidebarHidesUnroutedKeys verifies that FullHelp under sidebar
+// focus does not advertise sessions (ctrl+s), yolo (ctrl+y), or new session
+// (ctrl+n) — the sidebar key handler never routes them, so they are dead keys
+// while it has focus.
+func TestFullHelpSidebarHidesUnroutedKeys(t *testing.T) {
+	t.Parallel()
+
+	collectKeys := func(m *UI) map[string]bool {
+		out := make(map[string]bool)
+		for _, row := range m.FullHelp() {
+			for _, b := range row {
+				out[b.Help().Key] = true
+			}
+		}
+		return out
+	}
+
+	m := newSidebarTestUI()
+	m.attachments = attachments.New(nil, attachments.Keymap{})
+	// The editor-focus branch consults the model config and agent state, so
+	// give the UI a workspace stub with an empty config.
+	m.com.Workspace = &sidebarHeightTestWorkspace{cfg: &config.Config{}}
+	m.session = &session.Session{ID: "s1"} // so NewSession would otherwise be listed
+	m.focus = uiFocusSidebar
+	keys := collectKeys(m)
+	for _, key := range []string{"ctrl+s", "ctrl+y", "ctrl+n"} {
+		require.False(t, keys[key], "key %q should NOT appear in FullHelp when sidebar is focused", key)
+	}
+
+	// The same keys stay advertised for the editor, where they are routed.
+	m.focus = uiFocusEditor
+	keys = collectKeys(m)
+	for _, key := range []string{"ctrl+s", "ctrl+y", "ctrl+n"} {
+		require.True(t, keys[key], "key %q should appear in FullHelp when the editor is focused", key)
 	}
 }
 

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -2792,14 +2792,12 @@ func (m *UI) FullHelp() [][]key.Binding {
 			tab,
 		)
 		if !isSidebar {
-			mainBinds = append(mainBinds, commands, k.Models)
-		}
-		mainBinds = append(mainBinds,
-			k.Sessions,
-			k.ToggleYolo,
-		)
-		if hasSession {
-			mainBinds = append(mainBinds, k.Chat.NewSession)
+			// The sidebar key handler only routes focus/scroll keys, so
+			// don't advertise bindings that are inert while it's focused.
+			mainBinds = append(mainBinds, commands, k.Models, k.Sessions, k.ToggleYolo)
+			if hasSession {
+				mainBinds = append(mainBinds, k.Chat.NewSession)
+			}
 		}
 
 		binds = append(binds, mainBinds)
@@ -2941,6 +2939,14 @@ func (m *UI) updateLayoutAndSize() {
 			m.isCompact = true
 		} else {
 			m.isCompact = false
+		}
+		// The sidebar isn't drawn in compact mode; if it kept focus, its key
+		// handler would keep swallowing input and help would keep showing
+		// sidebar bindings. Return focus to the editor, mirroring the
+		// sidebar's esc handler.
+		if m.isCompact && m.focus == uiFocusSidebar {
+			m.focus = uiFocusEditor
+			m.textarea.Focus()
 		}
 	}
 


### PR DESCRIPTION
Audit batch: UI focus/help/layout (4 MINOR).

## 1. Help advertised dead keys under sidebar focus

With `focus == uiFocusSidebar`, FullHelp still listed ctrl+s (sessions), ctrl+y (yolo), ctrl+n (new session) — but the sidebar key handler never routes them, so all three were inert. Now excluded under sidebar focus; `sidebar_help_test.go` pins them hidden there and still shown under editor focus.

## 2. Focus stranded on a hidden sidebar

Shrinking into compact mode didn't reset focus: with the sidebar focused, it stopped being drawn but kept focus — typing swallowed, arrows scrolling an invisible panel, footer showing sidebar help for a pane that doesn't exist. Entering compact with sidebar focus now returns focus to the editor (mirrors the esc handler).

## 3. Sidebar height budget didn't account for the 5th section

`remainingHeight - 6` was upstream's overhead allowance for **4** sections; the fork added Channels, making real overhead 14 lines (5 title+blank pairs + 4 separators) — the bottom section was silently clipped at tight heights. The overhead is now **derived from the section count** instead of a magic number. New test pins all five section titles visible at a height where the old constant clipped "Channels" (verified failing pre-fix).

## 4. Palette sub-menu desync on resize

`Draw` repopulates top-level items on any width change without clearing `menuStack`/`breadcrumb` — inside a sub-menu, a resize produced top-level items under a stale "Commands ▸ Parent" title, with Esc "popping" into a stale snapshot. Resize now resets to top level (documented choice). Also: the `Back` binding now appears in Short/FullHelp when in a sub-menu. (Latent today — no production item uses `WithChildren` yet — but this code is also headed upstream in the open submenu PR, so worth fixing at the source.)

Every fix negative-checked (each test fails with its fix reverted).

```
go build ./... ✓   go vet ./internal/ui/... ✓   gofmt ✓   go test ./internal/ui/... ✓
```

---
_Generated by [Claude Code](https://claude.ai/code/session_01AtvfVcwLAeVKk9SkRjb7GN)_