### PR TITLE
fix(ui): skills dialog error states — no phantom rows, no empty-name toggles

### DIFF
--- a/internal/ui/dialog/skills.go
+++ b/internal/ui/dialog/skills.go
@@ -2,6 +2,7 @@ package dialog
 
 import (
 	"context"
+	"path/filepath"
 	"strings"
 
 	"charm.land/bubbles/v2/help"
@@ -13,6 +14,7 @@ import (
 	"github.com/charmbracelet/crush/internal/ui/common"
 	"github.com/charmbracelet/crush/internal/ui/list"
 	"github.com/charmbracelet/crush/internal/ui/styles"
+	"github.com/charmbracelet/crush/internal/ui/util"
 	"github.com/charmbracelet/crush/internal/workspace"
 	uv "github.com/charmbracelet/ultraviolet"
 	"github.com/sahilm/fuzzy"
@@ -96,10 +98,12 @@ func (s *SkillItem) Render(width int) string {
 	var parts []string
 	parts = append(parts, string(s.entry.Source))
 
-	if s.disabled {
-		parts = append(parts, "off")
-	} else if s.state != nil && s.state.State == skills.StateError {
+	// Error wins over disabled: a broken skill must surface as broken, not
+	// as merely switched off.
+	if s.state != nil && s.state.State == skills.StateError {
 		parts = append(parts, "error")
+	} else if s.disabled {
+		parts = append(parts, "off")
 	} else {
 		parts = append(parts, "on")
 	}
@@ -217,6 +221,20 @@ func (d *Skills) skillItems() []list.FilterableItem {
 
 	// Add skills that are discovered but disabled (not in the active catalog).
 	for _, st := range states {
+		if st.Name == "" {
+			// Walk/parse errors produce states with no name. Show them with a
+			// directory-derived fallback name (like the status sidebar does)
+			// so the breakage stays visible, keyed by path so multiple broken
+			// files don't collapse into duplicate empty IDs. These rows are
+			// not toggleable: there is no skill name to persist.
+			entry := skills.CatalogEntry{
+				ID:     st.Path,
+				Name:   filepath.Base(filepath.Dir(st.Path)),
+				Source: skills.SourceProject,
+			}
+			items = append(items, NewSkillItem(d.com.Styles, entry, st, false))
+			continue
+		}
 		if seenNames[st.Name] {
 			continue
 		}
@@ -262,6 +280,15 @@ func (d *Skills) HandleMsg(msg tea.Msg) Action {
 			return ActionSkillsReload{}
 		case key.Matches(msg, d.keyMap.Toggle):
 			if item := d.selectedSkill(); item != nil {
+				if item.state != nil && item.state.Name == "" {
+					// A broken skill file has no real name to toggle;
+					// surface its error instead of persisting an empty (or
+					// fallback) name to config.
+					if item.state.Err != nil {
+						return ActionCmd{util.ReportWarn(item.state.Err.Error())}
+					}
+					return nil
+				}
 				return ActionSkillToggle{SkillName: item.entry.Name}
 			}
 		default:

--- a/internal/ui/dialog/skills_test.go
+++ b/internal/ui/dialog/skills_test.go
@@ -258,6 +258,88 @@ func TestSkillsDialog_ListSkillsErrorRendersEmpty(t *testing.T) {
 	require.True(t, ok, "reload should still fire even when the list is empty")
 }
 
+func TestSkillsDialog_BrokenSkillRendersFallbackName(t *testing.T) {
+	t.Parallel()
+
+	// Walk/parse errors produce states with an empty Name. Those must not
+	// become blank rows with duplicate empty IDs: they render with a
+	// directory-derived fallback name and an error indicator.
+	d := newTestSkillsDialog(
+		t,
+		[]skills.CatalogEntry{{ID: "/skills/alpha/SKILL.md", Name: "Alpha", Source: skills.SourceUser}},
+		[]*skills.SkillState{
+			{Name: "Alpha", State: skills.StateNormal},
+			{Name: "", Path: "/skills/broken-skill/SKILL.md", State: skills.StateError, Err: errors.New("bad frontmatter")},
+		},
+		nil,
+	)
+
+	items := d.list.FilteredItems()
+	require.Len(t, items, 2)
+	broken := items[1].(*SkillItem)
+	require.Equal(t, "broken-skill", broken.entry.Name, "fallback name should come from the skill directory")
+	require.Equal(t, "/skills/broken-skill/SKILL.md", broken.ID(), "ID should be the path, not an empty string")
+
+	rendered := broken.Render(60)
+	require.Contains(t, rendered, "broken-skill")
+	require.Contains(t, rendered, "error")
+	require.NotContains(t, rendered, "off", "a broken skill is an error, not merely off")
+}
+
+func TestSkillsDialog_BrokenSkillNotToggleable(t *testing.T) {
+	t.Parallel()
+
+	// Enter on a broken (empty-name) skill must not emit ActionSkillToggle:
+	// there is no real skill name to persist to disabled_skills.
+	d := newTestSkillsDialog(
+		t,
+		[]skills.CatalogEntry{{ID: "/skills/alpha/SKILL.md", Name: "Alpha", Source: skills.SourceUser}},
+		[]*skills.SkillState{
+			{Name: "Alpha", State: skills.StateNormal},
+			{Name: "", Path: "/skills/broken-skill/SKILL.md", State: skills.StateError, Err: errors.New("bad frontmatter")},
+		},
+		nil,
+	)
+
+	d.HandleMsg(tea.KeyPressMsg{Code: tea.KeyDown})
+	sel := d.selectedSkill()
+	require.NotNil(t, sel)
+	require.Equal(t, "broken-skill", sel.entry.Name)
+
+	action := d.HandleMsg(tea.KeyPressMsg{Code: tea.KeyEnter})
+	_, isToggle := action.(ActionSkillToggle)
+	require.False(t, isToggle, "Enter on a broken skill must not emit a toggle")
+	cmdAction, ok := action.(ActionCmd)
+	require.True(t, ok, "Enter on a broken skill should surface its error")
+	require.NotNil(t, cmdAction.Cmd)
+}
+
+func TestSkillItem_NamedErrorSkillShowsErrorNotOff(t *testing.T) {
+	t.Parallel()
+
+	// A named skill in StateError (e.g. failed validation) is excluded from
+	// the active catalog and used to render as merely "off". The error state
+	// must win over the disabled flag.
+	d := newTestSkillsDialog(
+		t,
+		[]skills.CatalogEntry{{ID: "/skills/alpha/SKILL.md", Name: "Alpha", Source: skills.SourceUser}},
+		[]*skills.SkillState{
+			{Name: "Alpha", State: skills.StateNormal},
+			{Name: "Bad", Path: "/skills/bad/SKILL.md", State: skills.StateError, Err: errors.New("validation failed")},
+		},
+		nil,
+	)
+
+	items := d.list.FilteredItems()
+	require.Len(t, items, 2)
+	bad := items[1].(*SkillItem)
+	require.Equal(t, "Bad", bad.entry.Name)
+
+	rendered := bad.Render(60)
+	require.Contains(t, rendered, "error")
+	require.NotContains(t, rendered, "off", "error state must win over the disabled flag")
+}
+
 func TestSkillsDialog_ActiveSkillNotDuplicatedByState(t *testing.T) {
 	t.Parallel()
 

--- a/internal/ui/model/skills_test.go
+++ b/internal/ui/model/skills_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/charmbracelet/crush/internal/skills"
 	"github.com/charmbracelet/crush/internal/ui/common"
 	uistyles "github.com/charmbracelet/crush/internal/ui/styles"
+	"github.com/charmbracelet/crush/internal/workspace"
 	"github.com/stretchr/testify/require"
 )
 
@@ -56,6 +57,64 @@ func TestSkillStatusItemsIncludesBuiltinSkills(t *testing.T) {
 		}
 	}
 	require.True(t, hasBuiltin)
+}
+
+// toggleSkillWorkspace records config writes and skill reloads so tests can
+// assert on what toggleSkill persists.
+type toggleSkillWorkspace struct {
+	workspace.Workspace
+	cfg         *config.Config
+	setKeys     []string
+	setValues   []any
+	reloadCalls int
+}
+
+func (w *toggleSkillWorkspace) Config() *config.Config { return w.cfg }
+
+func (w *toggleSkillWorkspace) SetConfigField(_ config.Scope, key string, value any) error {
+	w.setKeys = append(w.setKeys, key)
+	w.setValues = append(w.setValues, value)
+	return nil
+}
+
+func (w *toggleSkillWorkspace) ReloadSkills() error {
+	w.reloadCalls++
+	return nil
+}
+
+// TestToggleSkillRejectsEmptyName verifies an empty skill name (as produced
+// by broken SKILL.md files) never reaches config persistence.
+func TestToggleSkillRejectsEmptyName(t *testing.T) {
+	t.Parallel()
+
+	ws := &toggleSkillWorkspace{cfg: &config.Config{Options: &config.Options{}}}
+	ui := &UI{com: &common.Common{Workspace: ws}}
+
+	cmd := ui.toggleSkill("")
+	require.Nil(t, cmd, "toggleSkill with an empty name must be a no-op")
+	require.Empty(t, ws.setKeys, "no config field should be written")
+	require.Zero(t, ws.reloadCalls, "skills should not be reloaded")
+	require.Empty(t, ws.cfg.Options.DisabledSkills)
+}
+
+// TestToggleSkillPersistsAndRefreshes verifies a normal toggle still writes
+// disabled_skills, reloads skills, and requests a dialog refresh.
+func TestToggleSkillPersistsAndRefreshes(t *testing.T) {
+	t.Parallel()
+
+	ws := &toggleSkillWorkspace{cfg: &config.Config{Options: &config.Options{}}}
+	ui := &UI{com: &common.Common{Workspace: ws}}
+
+	cmd := ui.toggleSkill("alpha")
+	require.NotNil(t, cmd)
+
+	msg := cmd()
+	_, ok := msg.(skillsRefreshedMsg)
+	require.True(t, ok, "toggle should request a skills dialog refresh")
+	require.Equal(t, []string{"options.disabled_skills"}, ws.setKeys)
+	require.Equal(t, 1, ws.reloadCalls)
+	require.Len(t, ws.setValues, 1)
+	require.Equal(t, []string{"alpha"}, ws.setValues[0])
 }
 
 func TestSkillStatusItemsExcludesDisabledSkills(t *testing.T) {

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -153,6 +153,12 @@ type (
 	// closeDialogMsg is sent to close the current dialog.
 	closeDialogMsg struct{}
 
+	// skillsRefreshedMsg is sent after a skill reload or toggle finishes so
+	// the skills dialog (if open) can refresh in place.
+	skillsRefreshedMsg struct {
+		info string
+	}
+
 	// hyperRefreshDoneMsg is sent after a silent Hyper OAuth refresh
 	// finishes. It carries the original model-selection action so the
 	// selection can be resumed.
@@ -764,6 +770,14 @@ func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case closeDialogMsg:
 		m.dialog.CloseFrontDialog()
+
+	case skillsRefreshedMsg:
+		// Refresh the skills dialog in place (if it is still open) so the
+		// toggled/reloaded state shows up without slamming the dialog shut.
+		if skillsDialog, ok := m.dialog.Dialog(dialog.SkillsID).(*dialog.Skills); ok {
+			skillsDialog.Refresh()
+		}
+		return m, util.ReportInfo(msg.info)
 
 	case pubsub.Event[session.Session]:
 		if msg.Type == pubsub.DeletedEvent {
@@ -1820,12 +1834,10 @@ func (m *UI) handleDialogMsg(msg tea.Msg) tea.Cmd {
 			if err := m.com.Workspace.ReloadSkills(); err != nil {
 				return util.ReportError(err)()
 			}
-			return util.NewInfoMsg("Skills reloaded")
+			return skillsRefreshedMsg{info: "Skills reloaded"}
 		})
-		m.dialog.CloseDialog(dialog.SkillsID)
 	case dialog.ActionSkillToggle:
 		cmds = append(cmds, m.toggleSkill(msg.SkillName))
-		m.dialog.CloseDialog(dialog.SkillsID)
 	case dialog.ActionReloadModelDiscovery:
 		// Keep the dialog open; run discovery in the background and refresh
 		// the list when the result arrives (modelsDiscoveryReloadedMsg).
@@ -4766,6 +4778,12 @@ func (m *UI) disableDockerMCP() tea.Msg {
 // toggleSkill enables or disables a skill by name, persisting the change
 // to config and reloading skills so the change takes effect immediately.
 func (m *UI) toggleSkill(skillName string) tea.Cmd {
+	if skillName == "" {
+		// Never persist an empty name to disabled_skills. Broken skill
+		// files produce states with no name; toggling them is meaningless.
+		slog.Warn("Ignoring skill toggle with empty skill name")
+		return nil
+	}
 	return func() tea.Msg {
 		cfg := m.com.Config()
 		if cfg == nil || cfg.Options == nil {
@@ -4798,7 +4816,7 @@ func (m *UI) toggleSkill(skillName string) tea.Cmd {
 			return util.ReportError(err)()
 		}
 
-		return util.NewInfoMsg(fmt.Sprintf("Skill %q %s", skillName, action))
+		return skillsRefreshedMsg{info: fmt.Sprintf("Skill %q %s", skillName, action)}
 	}
 }
 


### PR DESCRIPTION
Audit batch: skills dialog error handling (MAJOR, confirmed by executed repro).

## The bug

The dialog's "disabled skills from states" loop had no guard for states with **empty names** (what parse/walk errors produce) and hardcoded `disabled=true`. A workspace with broken SKILL.md files showed **blank rows with duplicate empty IDs**, and pressing Enter on one fired `ActionSkillToggle{SkillName: ""}` — which `toggleSkill` then appended to `options.disabled_skills` and **persisted to global config**. Additionally, a *named* skill in `StateError` rendered as merely "off" because `Render` checked `disabled` before `StateError` — the error branch was unreachable.

## Fixes

1. Empty-name error states render with a **path-derived fallback name** (`filepath.Base(filepath.Dir(path))` — same as the sidebar, which already did this right), keyed by path (no duplicate IDs), **non-toggleable** — Enter surfaces the error message instead.
2. `SkillItem.Render` reordered: **StateError wins over disabled**, so broken skills read as errors, not "off".
3. Defense in depth: `toggleSkill("")` is a no-op + warning — nothing can persist `""` into config.
4. The documented-but-never-called `Skills.Refresh()` is now actually wired: reload/toggle refresh the open dialog **in place** instead of slamming it shut.

## Tests

Fallback-name rendering (shows the directory name + error, not a blank "off" row), non-toggleable broken rows, named error skill shows "error", `toggleSkill("")` writes nothing to config, and a positive-path toggle test (config write + reload + refresh emitted). Negative-checked against the old code.

```
go build ./... ✓   gofmt ✓   go test ./internal/ui/... ./internal/config/ ✓
```

---
_Generated by [Claude Code](https://claude.ai/code/session_01AtvfVcwLAeVKk9SkRjb7GN)_