### PR TITLE
fix: small audit batch — channel case-fold, server reconnect reload, session-scoped slash busy, log levels

### DIFF
--- a/internal/agent/tools/mcp/channel.go
+++ b/internal/agent/tools/mcp/channel.go
@@ -162,7 +162,7 @@ func hasChannelCapability(res *mcp.InitializeResult) bool {
 func ChannelEnabled(enabled []string, name string) bool {
 	for _, e := range enabled {
 		e = strings.TrimSpace(e)
-		if e == name {
+		if strings.EqualFold(e, name) {
 			return true
 		}
 		if strings.EqualFold(e, "server:"+name) {

--- a/internal/agent/tools/mcp/channel_test.go
+++ b/internal/agent/tools/mcp/channel_test.go
@@ -300,6 +300,9 @@ func TestChannelEnabled(t *testing.T) {
 		{[]string{"other"}, "webhook", false},
 		{nil, "webhook", false},
 		{[]string{"SERVER:webhook"}, "webhook", true},
+		{[]string{"Webhook"}, "webhook", true},
+		{[]string{"WEBHOOK"}, "webhook", true},
+		{[]string{"  Webhook  "}, "webhook", true},
 	}
 	for _, tt := range tests {
 		if got := ChannelEnabled(tt.enabled, tt.name); got != tt.want {

--- a/internal/backend/config.go
+++ b/internal/backend/config.go
@@ -343,6 +343,11 @@ func (b *Backend) MCPReconnect(ctx context.Context, workspaceID, name string) er
 	}
 	if err := ws.Cfg.ReloadFromDisk(ctx); err != nil {
 		slog.Warn("Failed to reload config from disk before reconnecting MCP; using existing config", "name", name, "error", err)
+	} else {
+		// Remote clients render from a cached config snapshot that only
+		// refreshes on ConfigChanged, so a reload that picked up on-disk
+		// edits must be published like every other config mutation here.
+		publishConfigChanged(ws)
 	}
 	return mcptools.InitializeSingle(ctx, name, ws.Cfg)
 }

--- a/internal/backend/config.go
+++ b/internal/backend/config.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 
 	"github.com/charmbracelet/crush/internal/agent"
 	mcptools "github.com/charmbracelet/crush/internal/agent/tools/mcp"
@@ -339,6 +340,9 @@ func (b *Backend) MCPReconnect(ctx context.Context, workspaceID, name string) er
 	}
 	if err := mcptools.DisableSingle(ws.Cfg, name); err != nil {
 		return fmt.Errorf("failed to disconnect MCP %q: %w", name, err)
+	}
+	if err := ws.Cfg.ReloadFromDisk(ctx); err != nil {
+		slog.Warn("Failed to reload config from disk before reconnecting MCP; using existing config", "name", name, "error", err)
 	}
 	return mcptools.InitializeSingle(ctx, name, ws.Cfg)
 }

--- a/internal/backend/config_test.go
+++ b/internal/backend/config_test.go
@@ -284,3 +284,26 @@ func TestMCPReconnect_ReloadsConfigFromDisk(t *testing.T) {
 		_ = mcptools.DisableSingle(ws.Cfg, "added-server")
 	})
 }
+
+// TestMCPReconnect_PublishesConfigChanged verifies that a reconnect whose
+// disk reload succeeded publishes ConfigChanged, so remote clients refresh
+// their cached config snapshot and render the reloaded MCP list. Not
+// parallel: newPublishingWorkspace uses t.Setenv via xdgIsolated.
+func TestMCPReconnect_PublishesConfigChanged(t *testing.T) {
+	b, ws, evc := newPublishingWorkspace(t)
+
+	// Put a disabled stdio server on disk so the reload succeeds with an
+	// explicit provider and InitializeSingle marks the server
+	// StateDisabled without spawning a process.
+	writeReconnectConfig(t, filepath.Join(ws.Path, "crush.json"), map[string]any{
+		"added-server": map[string]any{"type": "stdio", "command": "echo", "disabled": true},
+	})
+	drainEvents(evc, 100*time.Millisecond)
+
+	require.NoError(t, b.MCPReconnect(context.Background(), ws.ID, "added-server"))
+	awaitConfigChanged(t, evc, ws.ID)
+
+	t.Cleanup(func() {
+		_ = mcptools.DisableSingle(ws.Cfg, "added-server")
+	})
+}

--- a/internal/backend/config_test.go
+++ b/internal/backend/config_test.go
@@ -2,10 +2,14 @@ package backend
 
 import (
 	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
 	tea "charm.land/bubbletea/v2"
+	mcptools "github.com/charmbracelet/crush/internal/agent/tools/mcp"
 	"github.com/charmbracelet/crush/internal/config"
 	"github.com/charmbracelet/crush/internal/proto"
 	"github.com/charmbracelet/crush/internal/pubsub"
@@ -204,4 +208,79 @@ func TestPublishConfigChanged_NilWorkspaceSafe(t *testing.T) {
 	t.Parallel()
 	require.NotPanics(t, func() { publishConfigChanged(nil) })
 	require.NotPanics(t, func() { publishConfigChanged(&Workspace{}) })
+}
+
+// writeReconnectConfig writes a crush.json with a valid provider/model
+// selection (so ReloadFromDisk's provider setup succeeds) plus the given
+// MCP section. A nil mcp writes a config with no MCP servers.
+func writeReconnectConfig(t *testing.T, path string, mcp map[string]any) {
+	t.Helper()
+	cfg := map[string]any{
+		"providers": map[string]any{
+			"openai": map[string]any{
+				"api_key": "test-key",
+				"models":  []any{map[string]any{"id": "gpt-4", "name": "GPT-4"}},
+			},
+		},
+		"models": map[string]any{
+			"large": map[string]any{"provider": "openai", "model": "gpt-4"},
+		},
+	}
+	if mcp != nil {
+		cfg["mcp"] = mcp
+	}
+	data, err := json.Marshal(cfg)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(path, data, 0o644))
+}
+
+// TestMCPReconnect_ReloadsConfigFromDisk verifies that the server
+// backend's MCPReconnect reloads crush.json before re-initialising the
+// server, matching AppWorkspace.MCPReconnect and the Workspace interface
+// contract: a server added to the on-disk config after startup must be
+// picked up by a reconnect. Not parallel: uses t.Setenv via xdgIsolated.
+func TestMCPReconnect_ReloadsConfigFromDisk(t *testing.T) {
+	xdgIsolated(t)
+	b, _ := newTestBackend(t)
+
+	wd := t.TempDir()
+	configPath := filepath.Join(wd, "crush.json")
+
+	// Load the store from a config that has no MCP servers yet.
+	writeReconnectConfig(t, configPath, nil)
+	cfg, err := config.Init(wd, "", false)
+	require.NoError(t, err)
+
+	ws := &Workspace{
+		ID:           uuid.New().String(),
+		Path:         wd,
+		Cfg:          cfg,
+		resolvedPath: wd,
+		clients:      make(map[string]*clientState),
+		shutdownFn:   func() {},
+	}
+	ws.ctx, ws.cancel = context.WithCancel(b.ctx)
+	b.mu.Lock()
+	b.workspaces.Set(ws.ID, ws)
+	b.pathIndex[ws.resolvedPath] = ws.ID
+	b.mu.Unlock()
+
+	require.NotContains(t, cfg.Config().MCP, "added-server",
+		"added-server should not be in the initially-loaded config")
+
+	// Add a disabled stdio server on disk after the store was loaded —
+	// disabled so InitializeSingle marks it StateDisabled without
+	// spawning a process.
+	writeReconnectConfig(t, configPath, map[string]any{
+		"added-server": map[string]any{"type": "stdio", "command": "echo", "disabled": true},
+	})
+
+	err = b.MCPReconnect(context.Background(), ws.ID, "added-server")
+	require.NoError(t, err, "MCPReconnect should reload config from disk and find the new server")
+	require.Contains(t, ws.Cfg.Config().MCP, "added-server",
+		"added-server should be in the live config after the disk reload")
+
+	t.Cleanup(func() {
+		_ = mcptools.DisableSingle(ws.Cfg, "added-server")
+	})
 }

--- a/internal/ui/dialog/mcp_servers_test.go
+++ b/internal/ui/dialog/mcp_servers_test.go
@@ -37,12 +37,13 @@ func TestMCPServers_EnterReconnectsSelectedServer(t *testing.T) {
 	}
 	d := newTestMCPServers(t, states)
 
-	// Select the first server and press Enter — should fire reconnect for that server.
+	// Select the first server and press Enter — should fire reconnect for
+	// that server. serverItems sorts by name, so index 0 is "cairn".
 	action := d.HandleMsg(tea.KeyPressMsg{Code: tea.KeyEnter})
 
 	reconnect, ok := action.(ActionMCPReconnect)
 	require.True(t, ok, "expected ActionMCPReconnect")
-	require.Contains(t, []string{"signal", "cairn"}, reconnect.ServerName)
+	require.Equal(t, "cairn", reconnect.ServerName)
 }
 
 func TestMCPServers_EscClosesDialog(t *testing.T) {

--- a/internal/ui/model/slash_command_test.go
+++ b/internal/ui/model/slash_command_test.go
@@ -5,10 +5,13 @@ import (
 	"testing"
 
 	"charm.land/bubbles/v2/textarea"
+	tea "charm.land/bubbletea/v2"
 
 	"github.com/charmbracelet/crush/internal/config"
 	"github.com/charmbracelet/crush/internal/session"
+	"github.com/charmbracelet/crush/internal/ui/attachments"
 	"github.com/charmbracelet/crush/internal/ui/common"
+	"github.com/charmbracelet/crush/internal/ui/dialog"
 	"github.com/charmbracelet/crush/internal/workspace"
 )
 
@@ -41,6 +44,12 @@ func (w *slashCommandWorkspace) Config() *config.Config { return nil }
 func (w *slashCommandWorkspace) AgentSummarize(_ context.Context, sessionID string) error {
 	w.summCall = sessionID
 	return w.summErr
+}
+
+func (w *slashCommandWorkspace) PermissionSkipRequests() bool { return false }
+
+func (w *slashCommandWorkspace) CreateSession(context.Context, string) (session.Session, error) {
+	return session.Session{}, nil
 }
 
 func newSlashCommandUI(ws *slashCommandWorkspace) *UI {
@@ -100,9 +109,9 @@ func TestSlashClearBlockedWhenAgentBusy(t *testing.T) {
 
 	m := newSlashCommandUI(&slashCommandWorkspace{ready: true, busy: map[string]bool{"s1": true}})
 	m.session = &session.Session{ID: "s1"}
-	// isAgentBusy is a pure cache read (workspace probes happen off-thread);
-	// seed the memoized busy state the way a refresh would.
-	m.agentBusyCache.set(true)
+	// The gate is a pure cache read of the session-scoped busy state
+	// (workspace probes happen off-thread); seed it the way a refresh would.
+	m.sessionBusyCache.setForSession(true, "s1")
 	m.promptHistory.index = 3
 	m.promptHistory.draft = "wip"
 
@@ -115,6 +124,29 @@ func TestSlashClearBlockedWhenAgentBusy(t *testing.T) {
 	}
 	if m.promptHistory.index != -1 || m.promptHistory.draft != "" {
 		t.Fatalf("prompt history not reset on busy /clear: index=%d draft=%q", m.promptHistory.index, m.promptHistory.draft)
+	}
+}
+
+// TestSlashClearNotBlockedByOtherSessionBusy verifies the busy gate is
+// session-scoped: agent activity in a different session must not block
+// /clear for the session the user is viewing.
+func TestSlashClearNotBlockedByOtherSessionBusy(t *testing.T) {
+	t.Parallel()
+
+	m := newSlashCommandUI(&slashCommandWorkspace{ready: true, busy: map[string]bool{"other": true}})
+	m.session = &session.Session{ID: "s1"}
+	// A busy value cached for a DIFFERENT session must not gate this one.
+	m.sessionBusyCache.setForSession(true, "other")
+
+	_, ok := m.handleSlashCommand("/clear")
+	if !ok {
+		t.Fatal("handleSlashCommand(/clear) should match")
+	}
+	if m.session != nil {
+		t.Fatal("busy state of another session must not block /clear")
+	}
+	if m.state != uiLanding {
+		t.Fatal("expected state to be uiLanding after /clear")
 	}
 }
 
@@ -173,6 +205,54 @@ func TestSlashCompactNoSession(t *testing.T) {
 	}
 }
 
+// TestSlashCompactNotBlockedByOtherSessionBusy verifies the busy gate is
+// session-scoped: agent activity in a different session must not block
+// /compact for the session the user is viewing.
+func TestSlashCompactNotBlockedByOtherSessionBusy(t *testing.T) {
+	t.Parallel()
+
+	ws := &slashCommandWorkspace{ready: true, busy: map[string]bool{"other": true}}
+	m := newSlashCommandUI(ws)
+	m.session = &session.Session{ID: "s1"}
+	// A busy value cached for a DIFFERENT session must not gate this one.
+	m.sessionBusyCache.setForSession(true, "other")
+
+	cmd, ok := m.handleSlashCommand("/compact")
+	if !ok {
+		t.Fatal("handleSlashCommand(/compact) should match")
+	}
+	if cmd == nil {
+		t.Fatal("expected a summarize command despite another session being busy")
+	}
+	cmd()
+	if ws.summCall != "s1" {
+		t.Fatalf("expected AgentSummarize called with s1, got %q", ws.summCall)
+	}
+}
+
+// TestBangModeWinsOverSlashCommands verifies that in bang (!) shell mode a
+// command that is literally "/clear" is executed in the shell instead of
+// being hijacked by the slash-command handler.
+func TestBangModeWinsOverSlashCommands(t *testing.T) {
+	t.Parallel()
+
+	m := newSlashCommandUI(&slashCommandWorkspace{ready: true})
+	m.keyMap = DefaultKeyMap()
+	m.dialog = dialog.NewOverlay()
+	m.attachments = attachments.New(nil, attachments.Keymap{})
+	m.bangMode = true
+	m.textarea.SetValue("/clear")
+
+	m.handleKeyPressMsg(tea.KeyPressMsg{Code: tea.KeyEnter})
+
+	if m.bangMode {
+		t.Fatal("bang mode should be consumed by Enter")
+	}
+	if m.pendingBangCommand != "/clear" {
+		t.Fatalf("bang-mode input should run as a shell command, got pending %q", m.pendingBangCommand)
+	}
+}
+
 // TestSlashCompactBlockedWhenAgentBusy verifies /compact warns when busy and
 // does not call AgentSummarize even if the returned cmd is executed.
 func TestSlashCompactBlockedWhenAgentBusy(t *testing.T) {
@@ -181,9 +261,9 @@ func TestSlashCompactBlockedWhenAgentBusy(t *testing.T) {
 	ws := &slashCommandWorkspace{ready: true, busy: map[string]bool{"s1": true}}
 	m := newSlashCommandUI(ws)
 	m.session = &session.Session{ID: "s1"}
-	// isAgentBusy is a pure cache read (workspace probes happen off-thread);
-	// seed the memoized busy state the way a refresh would.
-	m.agentBusyCache.set(true)
+	// The gate is a pure cache read of the session-scoped busy state
+	// (workspace probes happen off-thread); seed it the way a refresh would.
+	m.sessionBusyCache.setForSession(true, "s1")
 
 	cmd, ok := m.handleSlashCommand("/compact")
 	if !ok {

--- a/internal/ui/model/slash_command_test.go
+++ b/internal/ui/model/slash_command_test.go
@@ -230,6 +230,30 @@ func TestSlashCompactNotBlockedByOtherSessionBusy(t *testing.T) {
 	}
 }
 
+// TestNewSessionKeyNotBlockedByOtherSessionBusy verifies the ctrl+n
+// new-session gate is session-scoped like /clear (both run newSession):
+// agent activity in a different session must not block it.
+func TestNewSessionKeyNotBlockedByOtherSessionBusy(t *testing.T) {
+	t.Parallel()
+
+	m := newSlashCommandUI(&slashCommandWorkspace{ready: true, busy: map[string]bool{"other": true}})
+	m.keyMap = DefaultKeyMap()
+	m.dialog = dialog.NewOverlay()
+	m.attachments = attachments.New(nil, attachments.Keymap{})
+	m.session = &session.Session{ID: "s1"}
+	// A busy value cached for a DIFFERENT session must not gate this one.
+	m.sessionBusyCache.setForSession(true, "other")
+
+	m.handleKeyPressMsg(tea.KeyPressMsg{Code: 'n', Mod: tea.ModCtrl})
+
+	if m.session != nil {
+		t.Fatal("busy state of another session must not block ctrl+n new session")
+	}
+	if m.state != uiLanding {
+		t.Fatal("expected state to be uiLanding after new session")
+	}
+}
+
 // TestBangModeWinsOverSlashCommands verifies that in bang (!) shell mode a
 // command that is literally "/clear" is executed in the shell instead of
 // being hijacked by the slash-command handler.

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -2340,7 +2340,7 @@ func (m *UI) handleKeyPressMsg(msg tea.KeyPressMsg) tea.Cmd {
 				if !m.hasSession() {
 					break
 				}
-				if m.isAgentBusy() {
+				if m.isCurrentSessionBusy() {
 					cmds = append(cmds, util.ReportWarn("Agent is busy, please wait before starting a new session..."))
 					break
 				}
@@ -2514,7 +2514,7 @@ func (m *UI) handleKeyPressMsg(msg tea.KeyPressMsg) tea.Cmd {
 				if !m.hasSession() {
 					break
 				}
-				if m.isAgentBusy() {
+				if m.isCurrentSessionBusy() {
 					cmds = append(cmds, util.ReportWarn("Agent is busy, please wait before starting a new session..."))
 					break
 				}

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -2311,16 +2311,19 @@ func (m *UI) handleKeyPressMsg(msg tea.KeyPressMsg) tea.Cmd {
 					return m.openQuitDialog()
 				}
 
-				if cmd, ok := m.handleSlashCommand(value); ok {
-					return cmd
-				}
-
+				// Bang mode wins over slash commands: a shell command that
+				// happens to start with "/clear" or "/compact" must run in
+				// the shell, not be hijacked as a slash command.
 				if m.bangMode && value != "" {
 					m.bangMode = false
 					m.setEditorPrompt(m.yoloModeCached())
 					m.randomizePlaceholders()
 					m.historyReset()
 					return tea.Batch(m.runShellCommand(value))
+				}
+
+				if cmd, ok := m.handleSlashCommand(value); ok {
+					return cmd
 				}
 
 				attachments := m.attachments.List()
@@ -3862,7 +3865,7 @@ func (m *UI) handleChannelMessage(ev mcp.Event) tea.Cmd {
 	}
 	loadCmd, err := m.ensureSession()
 	if err != nil {
-		slog.Debug("Failed to create session for channel message", "error", err)
+		slog.Warn("Failed to create session for channel message", "error", err)
 		return nil
 	}
 	if !m.hasSession() {
@@ -3870,7 +3873,7 @@ func (m *UI) handleChannelMessage(ev mcp.Event) tea.Cmd {
 	}
 	updatedSession, err := m.com.Workspace.SetSessionChannel(context.Background(), m.session.ID, ev.Name)
 	if err != nil {
-		slog.Debug("Failed to set session channel", "error", err, "session", m.session.ID, "channel", ev.Name)
+		slog.Warn("Failed to set session channel", "error", err, "session", m.session.ID, "channel", ev.Name)
 		return loadCmd
 	}
 	m.session = &updatedSession
@@ -3879,8 +3882,7 @@ func (m *UI) handleChannelMessage(ev mcp.Event) tea.Cmd {
 	content := ev.ChannelMessage
 	runCmd := func() tea.Msg {
 		if err := m.com.Workspace.AgentRunChannel(context.Background(), channel, sessionID, content); err != nil {
-			slog.Debug("Failed to inject channel message", "error", err, "session", sessionID)
-			return nil
+			slog.Warn("Failed to inject channel message", "error", err, "session", sessionID)
 		}
 		// The prompt may have been enqueued behind a running turn;
 		// re-fetch busy/queue state.
@@ -4341,7 +4343,7 @@ func (m *UI) handleSlashCommand(value string) (tea.Cmd, bool) {
 	switch value {
 	case "/clear":
 		m.randomizePlaceholders()
-		if m.isAgentBusy() {
+		if m.isCurrentSessionBusy() {
 			m.historyReset()
 			return util.ReportWarn("Agent is busy, please wait before starting a new session..."), true
 		}
@@ -4357,7 +4359,7 @@ func (m *UI) handleSlashCommand(value string) (tea.Cmd, bool) {
 	case "/compact":
 		m.randomizePlaceholders()
 		m.historyReset()
-		if m.isAgentBusy() {
+		if m.isCurrentSessionBusy() {
 			return util.ReportWarn("Agent is busy, please wait before summarizing session..."), true
 		}
 		if !m.hasSession() {


### PR DESCRIPTION
Audit batch: six small independent fixes, one commit.

1. **`ChannelEnabled` case-fold** — bare entries compared case-sensitively while `server:<name>` used `EqualFold`: `--channels Signal` failed where `--channels server:Signal` matched. Bare entries now fold too (+tests).
2. **Server-mode `MCPReconnect` skipped the config reload** the `Workspace` interface doc promises: `Backend.MCPReconnect` did Disable→Initialize with no `ReloadFromDisk`, so in `crush serve` mode, editing `crush.json` and hitting "reconnect" in the `/mcp` dialog used **stale config** — contradicting #125's whole point. Now mirrors `AppWorkspace` (Disable → Reload → Initialize). New `TestMCPReconnect_ReloadsConfigFromDisk` proves a server added on disk after load is visible post-reconnect.
3. **`TestMCPServers_EnterReconnectsSelectedServer` couldn't fail on wrong selection** — it asserted the reconnect target was *either* of the two servers. `serverItems` sorts by name, so index 0 is deterministically `cairn`; now pinned exactly.
4. **Channel-message drop paths logged at Debug** despite the "a pushed event is never silently dropped" contract; raised to Warn (matches the server-side router).
5. **`/clear` and `/compact` gated on global busy** — a run in *another* session blocked them, contradicting the fork's own session-scoping of busy state. Both now use the session-scoped check; new tests prove another session's activity no longer blocks either.
6. **Bang-mode hijack** — the slash-command check ran before the bang-mode branch, so in `!` shell mode a command literally named `/clear` was hijacked by the slash handler. Bang mode now wins; test drives a real Enter keypress with `bangMode=true` and asserts the shell command is executed.

```
go build ./... ✓   gofmt ✓   go test ./internal/ui/... ./internal/config/ ./internal/agent/tools/mcp/ ./internal/backend/ ✓
```

(Note: `go vet ./internal/csync` fails on clean main — pre-existing upstream `JSONSchemaAlias passes lock by value`; untouched by this PR.)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AtvfVcwLAeVKk9SkRjb7GN)_