### PR TITLE
perf(ui): keep synchronous workspace probes off the per-keystroke path

### DIFF
--- a/internal/ui/model/pills.go
+++ b/internal/ui/model/pills.go
@@ -291,9 +291,11 @@ func (m *UI) renderPills() {
 		if todosFocused && hasIncomplete {
 			expandedList = todoList(m.session.Todos, inProgressIcon, t, contentWidth)
 		} else if queueFocused && hasQueue {
-			if m.com != nil && m.com.Workspace != nil && m.com.Workspace.AgentIsReady() {
-				queueItems := m.com.Workspace.AgentQueuedPromptsList(m.session.ID)
-				expandedList = queueList(queueItems, t)
+			// Render from the memoized queue (fetched off-thread, see
+			// workspace_cache.go): renderPills runs on the Update/View
+			// path and must never block on a workspace round-trip.
+			if len(m.promptQueueItems) > 0 {
+				expandedList = queueList(m.promptQueueItems, t)
 			}
 		}
 	}

--- a/internal/ui/model/session_busy_test.go
+++ b/internal/ui/model/session_busy_test.go
@@ -4,10 +4,13 @@ import (
 	"testing"
 
 	"charm.land/bubbles/v2/textarea"
+	"github.com/stretchr/testify/require"
 
 	"github.com/charmbracelet/crush/internal/config"
 	"github.com/charmbracelet/crush/internal/session"
+	"github.com/charmbracelet/crush/internal/ui/attachments"
 	"github.com/charmbracelet/crush/internal/ui/common"
+	"github.com/charmbracelet/crush/internal/ui/dialog"
 	"github.com/charmbracelet/crush/internal/workspace"
 )
 
@@ -94,4 +97,111 @@ func TestIsCurrentSessionBusyIsSessionScoped(t *testing.T) {
 			t.Fatal("no active session must not read as busy")
 		}
 	})
+}
+
+// countingWorkspace counts the workspace probes that are synchronous HTTP
+// round-trips in client/server mode.
+type countingWorkspace struct {
+	workspace.Workspace
+	queuedCalls  int
+	busyCalls    int
+	readyCalls   int
+	permCalls    int
+	queuedReturn int
+}
+
+func (w *countingWorkspace) AgentQueuedPrompts(string) int {
+	w.queuedCalls++
+	return w.queuedReturn
+}
+func (w *countingWorkspace) AgentIsSessionBusy(string) bool { w.busyCalls++; return false }
+func (w *countingWorkspace) AgentIsBusy() bool              { w.busyCalls++; return false }
+func (w *countingWorkspace) AgentIsReady() bool             { w.readyCalls++; return true }
+func (w *countingWorkspace) PermissionSkipRequests() bool   { w.permCalls++; return false }
+func (w *countingWorkspace) Config() *config.Config         { return nil }
+
+// plainMsg is an arbitrary tea.Msg standing in for keystroke/mouse/tick
+// traffic through Update.
+type plainMsg struct{}
+
+// TestUpdateDoesNotProbeWorkspacePerMessage pins the hot-path fix: Update
+// used to call AgentQueuedPrompts (a synchronous HTTP GET in client/server
+// mode) at the top of EVERY message — every keystroke blocked the single
+// Update goroutine on a network round-trip. The queue count is now
+// event-driven (refreshPromptQueue) and busy probes are briefly memoized.
+func TestUpdateDoesNotProbeWorkspacePerMessage(t *testing.T) {
+	t.Parallel()
+
+	ws := &countingWorkspace{}
+	com := common.DefaultCommon(ws)
+	m := &UI{
+		com:         com,
+		status:      NewStatus(com, nil),
+		chat:        NewChat(com, config.ScrollbarDefault),
+		textarea:    textarea.New(),
+		state:       uiChat,
+		focus:       uiFocusEditor,
+		width:       140,
+		height:      45,
+		session:     &session.Session{ID: "s1"},
+		keyMap:      DefaultKeyMap(),
+		dialog:      dialog.NewOverlay(),
+		attachments: attachments.New(nil, attachments.Keymap{}),
+	}
+
+	for range 25 {
+		m.Update(plainMsg{})
+	}
+	require.Zero(t, ws.queuedCalls,
+		"Update must not call AgentQueuedPrompts per message (HTTP per keystroke in client mode)")
+	// The placeholder path may probe busy/yolo once, then memoization holds
+	// for the TTL; 25 rapid messages must not produce 25 probes.
+	require.LessOrEqual(t, ws.busyCalls, 1,
+		"busy probes must be memoized, not once per message")
+	require.LessOrEqual(t, ws.permCalls, 1,
+		"permission probes must be memoized, not once per message")
+}
+
+// TestRefreshPromptQueueUpdatesCachedCount pins the event-driven refresh: a
+// single explicit refresh reads the count once and re-layouts on change.
+func TestRefreshPromptQueueUpdatesCachedCount(t *testing.T) {
+	t.Parallel()
+
+	ws := &countingWorkspace{queuedReturn: 3}
+	com := common.DefaultCommon(ws)
+	m := &UI{
+		com:      com,
+		status:   NewStatus(com, nil),
+		chat:     NewChat(com, config.ScrollbarDefault),
+		textarea: textarea.New(),
+		state:    uiChat,
+		focus:    uiFocusEditor,
+		width:    140,
+		height:   45,
+		session:  &session.Session{ID: "s1"},
+	}
+
+	m.refreshPromptQueue()
+	require.Equal(t, 1, ws.queuedCalls)
+	require.Equal(t, 3, m.promptQueue)
+}
+
+// TestIsCurrentSessionBusyMemoized pins the busy-probe cache: repeated calls
+// within the TTL hit the workspace once; invalidateBusyCache forces a fresh
+// probe.
+func TestIsCurrentSessionBusyMemoized(t *testing.T) {
+	t.Parallel()
+
+	ws := &countingWorkspace{}
+	com := common.DefaultCommon(ws)
+	m := &UI{com: com, session: &session.Session{ID: "s1"}}
+
+	for range 10 {
+		m.isCurrentSessionBusy()
+	}
+	require.Equal(t, 1, ws.busyCalls, "probes within the TTL must be memoized")
+
+	m.invalidateBusyCache()
+	m.isCurrentSessionBusy()
+	require.Equal(t, 2, ws.busyCalls, "invalidation must force a fresh probe")
 }

--- a/internal/ui/model/session_busy_test.go
+++ b/internal/ui/model/session_busy_test.go
@@ -1,12 +1,18 @@
 package model
 
 import (
+	"context"
 	"testing"
+	"time"
 
 	"charm.land/bubbles/v2/textarea"
+	tea "charm.land/bubbletea/v2"
 	"github.com/stretchr/testify/require"
 
+	"github.com/charmbracelet/crush/internal/agent/notify"
 	"github.com/charmbracelet/crush/internal/config"
+	"github.com/charmbracelet/crush/internal/message"
+	"github.com/charmbracelet/crush/internal/pubsub"
 	"github.com/charmbracelet/crush/internal/session"
 	"github.com/charmbracelet/crush/internal/ui/attachments"
 	"github.com/charmbracelet/crush/internal/ui/common"
@@ -14,127 +20,92 @@ import (
 	"github.com/charmbracelet/crush/internal/workspace"
 )
 
-// busyWorkspace is a workspace.Workspace stub that reports readiness and
-// per-session busy state. Only the methods isCurrentSessionBusy touches are
-// implemented; the embedded interface panics on anything else.
-type busyWorkspace struct {
-	workspace.Workspace
-	ready    bool
-	busy     map[string]bool
-	busyCall []string
-}
-
-func (w *busyWorkspace) AgentIsReady() bool { return w.ready }
-
-func (w *busyWorkspace) AgentIsSessionBusy(sessionID string) bool {
-	w.busyCall = append(w.busyCall, sessionID)
-	return w.busy[sessionID]
-}
-
-func (w *busyWorkspace) Config() *config.Config { return nil }
-
-func newBusyUI(ws *busyWorkspace) *UI {
-	com := common.DefaultCommon(ws)
-	return &UI{
-		com:      com,
-		status:   NewStatus(com, nil),
-		chat:     NewChat(com, config.ScrollbarDefault),
-		textarea: textarea.New(),
-		state:    uiChat,
-		focus:    uiFocusEditor,
-		width:    140,
-		height:   45,
-	}
-}
-
-// TestIsCurrentSessionBusyIsSessionScoped is the core of #28/#29: the current
-// session's busy state must reflect only its own activity, never another
-// session's, so a paused To-Do is not shown as actively executing.
-func TestIsCurrentSessionBusyIsSessionScoped(t *testing.T) {
-	t.Parallel()
-
-	t.Run("current session busy", func(t *testing.T) {
-		t.Parallel()
-		ws := &busyWorkspace{ready: true, busy: map[string]bool{"sess-1": true}}
-		m := newBusyUI(ws)
-		m.session = &session.Session{ID: "sess-1"}
-		if !m.isCurrentSessionBusy() {
-			t.Fatal("expected the viewed session's own activity to read as busy")
-		}
-	})
-
-	t.Run("another session busy does not affect current", func(t *testing.T) {
-		t.Parallel()
-		ws := &busyWorkspace{ready: true, busy: map[string]bool{"other": true}}
-		m := newBusyUI(ws)
-		m.session = &session.Session{ID: "sess-1"}
-		if m.isCurrentSessionBusy() {
-			t.Fatal("another session's activity must not mark the current session busy")
-		}
-		// The check must be scoped to the current session ID.
-		for _, id := range ws.busyCall {
-			if id != "sess-1" {
-				t.Fatalf("AgentIsSessionBusy queried %q, want only sess-1", id)
-			}
-		}
-	})
-
-	t.Run("agent not ready", func(t *testing.T) {
-		t.Parallel()
-		ws := &busyWorkspace{ready: false, busy: map[string]bool{"sess-1": true}}
-		m := newBusyUI(ws)
-		m.session = &session.Session{ID: "sess-1"}
-		if m.isCurrentSessionBusy() {
-			t.Fatal("a not-ready agent must not read as busy")
-		}
-	})
-
-	t.Run("no active session", func(t *testing.T) {
-		t.Parallel()
-		ws := &busyWorkspace{ready: true, busy: map[string]bool{"sess-1": true}}
-		m := newBusyUI(ws)
-		if m.isCurrentSessionBusy() {
-			t.Fatal("no active session must not read as busy")
-		}
-	})
-}
-
-// countingWorkspace counts the workspace probes that are synchronous HTTP
-// round-trips in client/server mode.
+// countingWorkspace is a workspace.Workspace stub that counts every probe
+// that is a synchronous HTTP round-trip in client/server mode, split per
+// method so tests can pin exactly which probes ran. The embedded interface
+// panics on anything unimplemented.
 type countingWorkspace struct {
 	workspace.Workspace
-	queuedCalls  int
-	busyCalls    int
-	readyCalls   int
-	permCalls    int
-	queuedReturn int
+
+	ready     bool
+	agentBusy bool
+	busy      map[string]bool
+	yolo      bool
+	queued    []string
+
+	readyCalls       int
+	agentBusyCalls   int
+	sessionBusyCalls int
+	sessionBusyIDs   []string
+	queuedCalls      int
+	queueListCalls   int
+	permCalls        int
+	permSetCalls     int
+	clearQueueCalls  int
+	cancelCalls      int
+}
+
+func (w *countingWorkspace) AgentIsReady() bool { w.readyCalls++; return w.ready }
+func (w *countingWorkspace) AgentIsBusy() bool  { w.agentBusyCalls++; return w.agentBusy }
+
+func (w *countingWorkspace) AgentIsSessionBusy(sessionID string) bool {
+	w.sessionBusyCalls++
+	w.sessionBusyIDs = append(w.sessionBusyIDs, sessionID)
+	return w.busy[sessionID]
 }
 
 func (w *countingWorkspace) AgentQueuedPrompts(string) int {
 	w.queuedCalls++
-	return w.queuedReturn
+	return len(w.queued)
 }
-func (w *countingWorkspace) AgentIsSessionBusy(string) bool { w.busyCalls++; return false }
-func (w *countingWorkspace) AgentIsBusy() bool              { w.busyCalls++; return false }
-func (w *countingWorkspace) AgentIsReady() bool             { w.readyCalls++; return true }
-func (w *countingWorkspace) PermissionSkipRequests() bool   { w.permCalls++; return false }
-func (w *countingWorkspace) Config() *config.Config         { return nil }
 
-// plainMsg is an arbitrary tea.Msg standing in for keystroke/mouse/tick
-// traffic through Update.
-type plainMsg struct{}
+func (w *countingWorkspace) AgentQueuedPromptsList(string) []string {
+	w.queueListCalls++
+	return w.queued
+}
 
-// TestUpdateDoesNotProbeWorkspacePerMessage pins the hot-path fix: Update
-// used to call AgentQueuedPrompts (a synchronous HTTP GET in client/server
-// mode) at the top of EVERY message — every keystroke blocked the single
-// Update goroutine on a network round-trip. The queue count is now
-// event-driven (refreshPromptQueue) and busy probes are briefly memoized.
-func TestUpdateDoesNotProbeWorkspacePerMessage(t *testing.T) {
-	t.Parallel()
+func (w *countingWorkspace) PermissionSkipRequests() bool { w.permCalls++; return w.yolo }
 
-	ws := &countingWorkspace{}
+func (w *countingWorkspace) PermissionSetSkipRequests(skip bool) {
+	w.permSetCalls++
+	w.yolo = skip
+}
+
+func (w *countingWorkspace) AgentClearQueue(string) { w.clearQueueCalls++; w.queued = nil }
+func (w *countingWorkspace) AgentCancel(string)     { w.cancelCalls++ }
+
+func (w *countingWorkspace) ListMessages(context.Context, string) ([]message.Message, error) {
+	return nil, nil
+}
+
+func (w *countingWorkspace) ListUserMessages(context.Context, string) ([]message.Message, error) {
+	return nil, nil
+}
+
+func (w *countingWorkspace) LSPStart(context.Context, string) {}
+
+func (w *countingWorkspace) Config() *config.Config { return nil }
+
+// syncProbes sums every synchronous counter; Update/View must keep this at
+// zero — the busy/queue invariant is that no workspace call ever happens on
+// the Update goroutine.
+func (w *countingWorkspace) syncProbes() int {
+	return w.readyCalls + w.agentBusyCalls + w.sessionBusyCalls +
+		w.queuedCalls + w.queueListCalls + w.permCalls
+}
+
+func (w *countingWorkspace) resetCounters() {
+	w.readyCalls, w.agentBusyCalls, w.sessionBusyCalls = 0, 0, 0
+	w.sessionBusyIDs = nil
+	w.queuedCalls, w.queueListCalls, w.permCalls = 0, 0, 0
+	w.permSetCalls, w.clearQueueCalls, w.cancelCalls = 0, 0, 0
+}
+
+// newBusyUI builds a UI wired to the stub workspace with an active session
+// "s1", enough state for Update to run end to end.
+func newBusyUI(ws *countingWorkspace) *UI {
 	com := common.DefaultCommon(ws)
-	m := &UI{
+	return &UI{
 		com:         com,
 		status:      NewStatus(com, nil),
 		chat:        NewChat(com, config.ScrollbarDefault),
@@ -148,60 +119,344 @@ func TestUpdateDoesNotProbeWorkspacePerMessage(t *testing.T) {
 		dialog:      dialog.NewOverlay(),
 		attachments: attachments.New(nil, attachments.Keymap{}),
 	}
+}
+
+// pinTTLs makes the TTL backstop inert for the duration of the test so
+// assertions about event-driven refreshes cannot flake by straddling a TTL
+// boundary (the tests using it must not call t.Parallel).
+func pinTTLs(t *testing.T) {
+	t.Helper()
+	oldBusy, oldQueue := busyCacheTTL, promptQueueTTL
+	busyCacheTTL = time.Hour
+	promptQueueTTL = time.Hour
+	t.Cleanup(func() { busyCacheTTL, promptQueueTTL = oldBusy, oldQueue })
+}
+
+// warmCaches marks all memoized workspace state fresh so only explicit
+// invalidation (not startup staleness) can trigger refresh dispatches.
+func warmCaches(m *UI, sessionBusy bool) {
+	m.agentBusyCache.set(sessionBusy)
+	m.sessionBusyCache.setForSession(sessionBusy, m.currentSessionID())
+	m.yoloCache.set(false)
+	m.promptQueueCheckedAt = time.Now()
+}
+
+// runCmds executes a command tree the way the Bubble Tea runtime would,
+// feeding cache-refresh messages back into Update. Other leaf commands are
+// executed (for their side effects on the stub) but their messages dropped.
+func runCmds(m *UI, cmd tea.Cmd) {
+	if cmd == nil {
+		return
+	}
+	switch msg := cmd().(type) {
+	case tea.BatchMsg:
+		for _, c := range msg {
+			runCmds(m, c)
+		}
+	case busyStateMsg, promptQueueMsg, agentRunSubmittedMsg:
+		_, next := m.Update(msg)
+		runCmds(m, next)
+	}
+}
+
+// plainMsg is an arbitrary tea.Msg standing in for keystroke/mouse/tick
+// traffic through Update.
+type plainMsg struct{}
+
+// TestUpdateDoesNotProbeWorkspacePerMessage pins the hot-path fix: Update
+// used to call AgentQueuedPrompts (a synchronous HTTP GET in client/server
+// mode) at the top of EVERY message — every keystroke blocked the single
+// Update goroutine on a network round-trip. Now Update performs no
+// synchronous workspace call at all; refreshes are dispatched as commands.
+func TestUpdateDoesNotProbeWorkspacePerMessage(t *testing.T) {
+	pinTTLs(t)
+
+	ws := &countingWorkspace{ready: true}
+	m := newBusyUI(ws)
 
 	for range 25 {
 		m.Update(plainMsg{})
 	}
 	require.Zero(t, ws.queuedCalls,
 		"Update must not call AgentQueuedPrompts per message (HTTP per keystroke in client mode)")
-	// The placeholder path may probe busy/yolo once, then memoization holds
-	// for the TTL; 25 rapid messages must not produce 25 probes.
-	require.LessOrEqual(t, ws.busyCalls, 1,
-		"busy probes must be memoized, not once per message")
-	require.LessOrEqual(t, ws.permCalls, 1,
-		"permission probes must be memoized, not once per message")
+	require.Zero(t, ws.syncProbes(),
+		"Update must not make any synchronous workspace call")
 }
 
-// TestRefreshPromptQueueUpdatesCachedCount pins the event-driven refresh: a
-// single explicit refresh reads the count once and re-layouts on change.
-func TestRefreshPromptQueueUpdatesCachedCount(t *testing.T) {
-	t.Parallel()
+// TestReadsNeverProbeWorkspace pins the read side of the invariant: the
+// busy/yolo getters used by render paths serve the memoized value and never
+// probe, so View can never block on HTTP.
+func TestReadsNeverProbeWorkspace(t *testing.T) {
+	pinTTLs(t)
 
-	ws := &countingWorkspace{queuedReturn: 3}
-	com := common.DefaultCommon(ws)
-	m := &UI{
-		com:      com,
-		status:   NewStatus(com, nil),
-		chat:     NewChat(com, config.ScrollbarDefault),
-		textarea: textarea.New(),
-		state:    uiChat,
-		focus:    uiFocusEditor,
-		width:    140,
-		height:   45,
-		session:  &session.Session{ID: "s1"},
-	}
-
-	m.refreshPromptQueue()
-	require.Equal(t, 1, ws.queuedCalls)
-	require.Equal(t, 3, m.promptQueue)
-}
-
-// TestIsCurrentSessionBusyMemoized pins the busy-probe cache: repeated calls
-// within the TTL hit the workspace once; invalidateBusyCache forces a fresh
-// probe.
-func TestIsCurrentSessionBusyMemoized(t *testing.T) {
-	t.Parallel()
-
-	ws := &countingWorkspace{}
-	com := common.DefaultCommon(ws)
-	m := &UI{com: com, session: &session.Session{ID: "s1"}}
+	ws := &countingWorkspace{ready: true, busy: map[string]bool{"s1": true}}
+	m := newBusyUI(ws)
 
 	for range 10 {
 		m.isCurrentSessionBusy()
+		m.isAgentBusy()
+		m.yoloModeCached()
 	}
-	require.Equal(t, 1, ws.busyCalls, "probes within the TTL must be memoized")
+	require.Zero(t, ws.syncProbes(), "cache reads must never probe the workspace")
+}
 
-	m.invalidateBusyCache()
-	m.isCurrentSessionBusy()
-	require.Equal(t, 2, ws.busyCalls, "invalidation must force a fresh probe")
+// TestBusyRefreshIsSessionScoped is the core of #28/#29 carried over to the
+// off-thread refresh: the current session's busy state must reflect only its
+// own activity, never another session's.
+func TestBusyRefreshIsSessionScoped(t *testing.T) {
+	pinTTLs(t)
+
+	refresh := func(m *UI) {
+		cmd := m.dispatchBusyRefresh()
+		require.NotNil(t, cmd)
+		m.Update(cmd())
+	}
+
+	t.Run("current session busy", func(t *testing.T) {
+		ws := &countingWorkspace{ready: true, busy: map[string]bool{"s1": true}}
+		m := newBusyUI(ws)
+		refresh(m)
+		require.True(t, m.isCurrentSessionBusy(),
+			"the viewed session's own activity must read as busy")
+	})
+
+	t.Run("another session busy does not affect current", func(t *testing.T) {
+		ws := &countingWorkspace{ready: true, busy: map[string]bool{"other": true}}
+		m := newBusyUI(ws)
+		refresh(m)
+		require.False(t, m.isCurrentSessionBusy(),
+			"another session's activity must not mark the current session busy")
+		for _, id := range ws.sessionBusyIDs {
+			require.Equal(t, "s1", id, "AgentIsSessionBusy must be scoped to the current session")
+		}
+	})
+
+	t.Run("agent not ready", func(t *testing.T) {
+		ws := &countingWorkspace{ready: false, busy: map[string]bool{"s1": true}}
+		m := newBusyUI(ws)
+		refresh(m)
+		require.False(t, m.isCurrentSessionBusy(), "a not-ready agent must not read as busy")
+	})
+
+	t.Run("no active session", func(t *testing.T) {
+		ws := &countingWorkspace{ready: true, busy: map[string]bool{"s1": true}}
+		m := newBusyUI(ws)
+		m.session = nil
+		refresh(m)
+		require.False(t, m.isCurrentSessionBusy(), "no active session must not read as busy")
+	})
+}
+
+// TestStreamingUpdatedEventsDoNotProbe pins the streaming regression fix:
+// per-chunk message UpdatedEvents arrive once per streamed token and must
+// neither probe the workspace synchronously nor schedule busy/queue
+// refreshes — only CreatedEvents (run boundaries) do.
+func TestStreamingUpdatedEventsDoNotProbe(t *testing.T) {
+	pinTTLs(t)
+
+	ws := &countingWorkspace{ready: true}
+	m := newBusyUI(ws)
+	warmCaches(m, true)
+	ws.resetCounters()
+
+	for range 25 {
+		m.Update(pubsub.Event[message.Message]{
+			Type:    pubsub.UpdatedEvent,
+			Payload: message.Message{ID: "m1", SessionID: "s1", Role: message.Assistant},
+		})
+	}
+	require.Zero(t, ws.syncProbes(),
+		"per-chunk UpdatedEvents must not probe the workspace")
+	require.False(t, m.busyFetchInFlight,
+		"per-chunk UpdatedEvents must not schedule a busy refresh")
+	require.False(t, m.promptQueueInFlight,
+		"per-chunk UpdatedEvents must not schedule a queue refresh")
+}
+
+// TestMessageCreatedEventRefreshesBusyAndQueue: a CreatedEvent is a run
+// boundary and must invalidate the memoized busy state and fetch fresh
+// busy/queue values off-thread.
+func TestMessageCreatedEventRefreshesBusyAndQueue(t *testing.T) {
+	pinTTLs(t)
+
+	ws := &countingWorkspace{ready: true, busy: map[string]bool{"s1": true}, queued: []string{"queued prompt"}}
+	m := newBusyUI(ws)
+	warmCaches(m, false)
+	ws.resetCounters()
+
+	_, cmd := m.Update(pubsub.Event[message.Message]{
+		Type:    pubsub.CreatedEvent,
+		Payload: message.Message{ID: "m1", SessionID: "s1", Role: message.User},
+	})
+	require.Zero(t, ws.syncProbes(), "the event handler itself must not probe synchronously")
+	require.True(t, m.busyFetchInFlight, "CreatedEvent must schedule a busy refresh")
+	require.True(t, m.promptQueueInFlight, "CreatedEvent must schedule a queue refresh")
+
+	runCmds(m, cmd)
+	require.True(t, m.isCurrentSessionBusy(), "refreshed busy state must land in the cache")
+	require.Equal(t, 1, m.promptQueue, "refreshed queue count must land in the cache")
+	require.False(t, m.busyFetchInFlight)
+	require.False(t, m.promptQueueInFlight)
+}
+
+// TestAgentTerminalNotificationsRefreshBusy pins the busy→idle edge: the
+// agent clears its active request BEFORE publishing TypeAgentFinished (and
+// TypeAgentError) precisely so observers can re-probe. The handler must
+// invalidate the memoized busy state and re-fetch busy + queue.
+func TestAgentTerminalNotificationsRefreshBusy(t *testing.T) {
+	pinTTLs(t)
+
+	for _, typ := range []notify.Type{notify.TypeAgentFinished, notify.TypeAgentError} {
+		t.Run(string(typ), func(t *testing.T) {
+			ws := &countingWorkspace{ready: true} // agent now idle
+			m := newBusyUI(ws)
+			warmCaches(m, true) // stale: still busy
+			ws.resetCounters()
+			require.True(t, m.isCurrentSessionBusy())
+
+			_, cmd := m.Update(pubsub.Event[notify.Notification]{
+				Type:    pubsub.CreatedEvent,
+				Payload: notify.Notification{Type: typ, SessionID: "s1"},
+			})
+			require.True(t, m.busyFetchInFlight, "terminal notification must schedule a busy refresh")
+			require.True(t, m.promptQueueInFlight, "terminal notification must schedule a queue refresh")
+
+			runCmds(m, cmd)
+			require.False(t, m.isCurrentSessionBusy(),
+				"busy→idle edge must reach the cache without waiting for the TTL")
+		})
+	}
+}
+
+// TestSessionSwitchRefreshesQueueAndBusy: switching sessions must drop the
+// previous session's memoized busy state and queue pill and fetch the new
+// session's, so esc never offers to clear the wrong queue.
+func TestSessionSwitchRefreshesQueueAndBusy(t *testing.T) {
+	pinTTLs(t)
+
+	ws := &countingWorkspace{ready: true, queued: []string{"a", "b"}}
+	m := newBusyUI(ws)
+	warmCaches(m, true) // s1 reads busy...
+	m.promptQueue = 5   // ...with a (stale) queue pill
+	m.promptQueueItems = []string{"x", "y", "z", "w", "v"}
+	ws.resetCounters()
+
+	_, cmd := m.Update(loadSessionMsg{session: &session.Session{ID: "s2"}})
+	require.Zero(t, m.promptQueue, "switching sessions must drop the old session's queue pill")
+	require.True(t, m.promptQueueInFlight, "session switch must schedule a queue refresh")
+	require.True(t, m.busyFetchInFlight, "session switch must schedule a busy refresh")
+	require.False(t, m.isCurrentSessionBusy(),
+		"the old session's busy state must not leak onto the new session")
+
+	runCmds(m, cmd)
+	require.Equal(t, 2, m.promptQueue, "the new session's queue must be fetched")
+	require.Equal(t, []string{"a", "b"}, m.promptQueueItems)
+}
+
+// TestToggleYoloWritesThroughCache: both yolo toggle paths share
+// toggleYoloMode, which must write the known new value through the cache —
+// no invalidation, no re-probe (the old dialog path left the cache empty and
+// caused a double probe).
+func TestToggleYoloWritesThroughCache(t *testing.T) {
+	pinTTLs(t)
+
+	ws := &countingWorkspace{ready: true, yolo: false}
+	m := newBusyUI(ws)
+
+	got := m.toggleYoloMode()
+	require.True(t, got)
+	require.Equal(t, 1, ws.permSetCalls)
+	readsAfterToggle := ws.permCalls
+	require.Equal(t, 1, readsAfterToggle, "toggle reads the authoritative value exactly once")
+
+	require.True(t, m.yoloModeCached(), "the new value must be served from the cache")
+	require.True(t, m.yoloCache.fresh(busyCacheTTL), "write-through must stamp the cache fresh")
+	m.yoloModeCached()
+	require.Equal(t, readsAfterToggle, ws.permCalls, "reads after the toggle must not re-probe")
+
+	got = m.toggleYoloMode()
+	require.False(t, got)
+	require.False(t, m.yoloModeCached())
+}
+
+// TestSendMessageSetsOptimisticBusy pins the esc-after-enter fix: submitting
+// a prompt optimistically marks the agent busy so an immediate esc routes to
+// cancelAgent instead of reading a stale idle value and doing nothing.
+func TestSendMessageSetsOptimisticBusy(t *testing.T) {
+	pinTTLs(t)
+
+	ws := &countingWorkspace{ready: true} // workspace still reports idle
+	m := newBusyUI(ws)
+	warmCaches(m, false)
+
+	require.False(t, m.isAgentBusy())
+	cmd := m.sendMessage("hello") // returned cmds (AgentRun etc.) deliberately not run
+	require.NotNil(t, cmd)
+	require.True(t, m.isAgentBusy(),
+		"sendMessage must optimistically mark the agent busy")
+	require.True(t, m.isCurrentSessionBusy(),
+		"sendMessage must optimistically mark the session busy")
+
+	// esc right after enter: isAgentBusy gates cancelAgent, first press
+	// arms the double-press cancel.
+	require.Zero(t, m.promptQueue)
+	m.cancelAgent()
+	require.True(t, m.isCanceling, "first esc press must arm cancellation")
+
+	// Second press must actually cancel.
+	m.cancelAgent()
+	require.Equal(t, 1, ws.cancelCalls, "second esc press must cancel the agent")
+}
+
+// TestCancelAgentClearsQueueFromCachedCount: the queue-clear decision must
+// come from the memoized count — no synchronous AgentQueuedPrompts probe —
+// and clearing must zero the cached count immediately.
+func TestCancelAgentClearsQueueFromCachedCount(t *testing.T) {
+	pinTTLs(t)
+
+	ws := &countingWorkspace{ready: true, queued: []string{"a"}}
+	m := newBusyUI(ws)
+	warmCaches(m, true)
+	m.promptQueue = 1
+	m.promptQueueItems = []string{"a"}
+	ws.resetCounters()
+
+	cmd := m.cancelAgent()
+	require.Nil(t, cmd)
+	require.Equal(t, 1, ws.clearQueueCalls, "esc with a queue must clear it")
+	require.Zero(t, ws.queuedCalls, "the decision must use the cached count, not a probe")
+	require.Zero(t, ws.queueListCalls, "the decision must use the cached count, not a probe")
+	require.Zero(t, m.promptQueue, "the cached count must be zeroed immediately")
+	require.Empty(t, m.promptQueueItems)
+	require.False(t, m.isCanceling, "clearing the queue must not arm cancellation")
+}
+
+// TestBackstopRefreshesStaleCaches: when the memoized state outlives its TTL
+// with no event edge, the Update tail schedules exactly one off-thread
+// refresh (deduplicated while in flight) and the result lands as a message.
+func TestBackstopRefreshesStaleCaches(t *testing.T) {
+	pinTTLs(t)
+
+	ws := &countingWorkspace{ready: true, busy: map[string]bool{"s1": true}}
+	m := newBusyUI(ws)
+	// Caches start at their zero value: stale by definition.
+
+	_, cmd := m.Update(plainMsg{})
+	require.True(t, m.busyFetchInFlight, "stale caches must trigger a backstop refresh")
+	require.Zero(t, ws.syncProbes(), "the backstop itself must not probe synchronously")
+
+	// A second Update while the fetch is in flight must not stack another.
+	before := m.busyFetchInFlight
+	m.Update(plainMsg{})
+	require.Equal(t, before, m.busyFetchInFlight)
+	require.Zero(t, ws.syncProbes())
+
+	runCmds(m, cmd)
+	require.False(t, m.busyFetchInFlight)
+	require.True(t, m.isCurrentSessionBusy(), "the backstop result must land in the cache")
+	require.Equal(t, 1, ws.sessionBusyCalls, "exactly one probe per backstop refresh")
+
+	// Freshly refreshed caches must not re-dispatch.
+	m.Update(plainMsg{})
+	require.False(t, m.busyFetchInFlight, "fresh caches must not re-dispatch the backstop")
 }

--- a/internal/ui/model/slash_command_test.go
+++ b/internal/ui/model/slash_command_test.go
@@ -100,6 +100,9 @@ func TestSlashClearBlockedWhenAgentBusy(t *testing.T) {
 
 	m := newSlashCommandUI(&slashCommandWorkspace{ready: true, busy: map[string]bool{"s1": true}})
 	m.session = &session.Session{ID: "s1"}
+	// isAgentBusy is a pure cache read (workspace probes happen off-thread);
+	// seed the memoized busy state the way a refresh would.
+	m.agentBusyCache.set(true)
 	m.promptHistory.index = 3
 	m.promptHistory.draft = "wip"
 
@@ -178,6 +181,9 @@ func TestSlashCompactBlockedWhenAgentBusy(t *testing.T) {
 	ws := &slashCommandWorkspace{ready: true, busy: map[string]bool{"s1": true}}
 	m := newSlashCommandUI(ws)
 	m.session = &session.Session{ID: "s1"}
+	// isAgentBusy is a pure cache read (workspace probes happen off-thread);
+	// seed the memoized busy state the way a refresh would.
+	m.agentBusyCache.set(true)
 
 	cmd, ok := m.handleSlashCommand("/compact")
 	if !ok {

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -297,20 +297,24 @@ type UI struct {
 	pillsExpanded      bool
 	pillsAutoExpanded  bool
 	focusedPillSection pillSection
-	promptQueue        int
-	// busyCached memoizes isCurrentSessionBusy briefly (see busyCacheTTL):
-	// in client/server mode each probe is a synchronous HTTP round-trip.
-	busyCached         bool
-	busyCheckedAt      time.Time
-	busyCheckedSession string
-	// agentBusyCached / yoloCached mirror busyCached for the global busy and
-	// permission-skip probes made by the per-message placeholder path.
-	agentBusyCached    bool
-	agentBusyCheckedAt time.Time
-	yoloCached         bool
-	yoloCheckedAt      time.Time
-	sidebarScroll      int
-	pillsView          string
+	// promptQueue / promptQueueItems mirror the session's queued prompts.
+	// They are event-driven with a TTL backstop, fetched off-thread by
+	// dispatchPromptQueueRefresh (see workspace_cache.go); promptQueue is
+	// always len(promptQueueItems).
+	promptQueue          int
+	promptQueueItems     []string
+	promptQueueCheckedAt time.Time
+	promptQueueInFlight  bool
+	// sessionBusyCache / agentBusyCache / yoloCache memoize the workspace
+	// busy and permission probes (synchronous HTTP round-trips in
+	// client/server mode). Reads never probe; refreshes happen off-thread
+	// (see workspace_cache.go).
+	sessionBusyCache  ttlCache
+	agentBusyCache    ttlCache
+	yoloCache         ttlCache
+	busyFetchInFlight bool
+	sidebarScroll     int
+	pillsView         string
 
 	// Todo spinner
 	todoSpinner    spinner.Model
@@ -409,7 +413,12 @@ func New(com *common.Common, initialSessionID string, continueLast bool) *UI {
 		ui.themeKey = styles.ThemeKeyForProvider(cfg.Models[config.SelectedModelTypeLarge].Provider)
 	}
 
-	ui.setEditorPrompt(com.Workspace.PermissionSkipRequests())
+	// Seed the yolo cache once at construction; afterwards it is kept
+	// fresh by write-through toggles and off-thread refreshes so Update
+	// and View never probe the workspace synchronously.
+	yolo := com.Workspace.PermissionSkipRequests()
+	ui.yoloCache.set(yolo)
+	ui.setEditorPrompt(yolo)
 	ui.randomizePlaceholders()
 	ui.textarea.Placeholder = ui.readyPlaceholder
 	ui.status = status
@@ -459,6 +468,10 @@ func (m *UI) Init() tea.Cmd {
 	}
 	if m.com.IsHyper() {
 		cmds = append(cmds, m.fetchHyperCredits())
+	}
+	// Prime the memoized busy/permission state off-thread.
+	if cmd := m.dispatchBusyRefresh(); cmd != nil {
+		cmds = append(cmds, cmd)
 	}
 	return tea.Batch(cmds...)
 }
@@ -607,23 +620,6 @@ func (m *UI) loadMCPrompts() tea.Msg {
 	return mcpPromptsLoadedMsg{Prompts: prompts}
 }
 
-// refreshPromptQueue re-reads the queued-prompt count and re-layouts when it
-// changed. In client/server mode the count is a synchronous HTTP round-trip,
-// so this must only run when the queue can actually have changed — message
-// events (the agent dequeueing), local queue mutations, and session switches.
-// Polling it unconditionally at the top of Update put a network call on
-// every keystroke and froze typing on a slow server.
-func (m *UI) refreshPromptQueue() {
-	queueSize := 0
-	if m.hasSession() {
-		queueSize = m.com.Workspace.AgentQueuedPrompts(m.session.ID)
-	}
-	if queueSize != m.promptQueue {
-		m.promptQueue = queueSize
-		m.updateLayoutAndSize()
-	}
-}
-
 // Update handles updates to the UI model.
 func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	var cmds []tea.Cmd
@@ -648,6 +644,21 @@ func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if cmd := m.handleAgentNotification(msg.Payload); cmd != nil {
 			cmds = append(cmds, cmd)
 		}
+	case busyStateMsg:
+		cmds = append(cmds, m.applyBusyState(msg)...)
+	case promptQueueMsg:
+		cmds = append(cmds, m.applyPromptQueue(msg)...)
+	case agentRunSubmittedMsg:
+		// A prompt was just accepted (run started or enqueued): fetch the
+		// authoritative busy/queue state to confirm the optimistic values
+		// sendMessage wrote.
+		m.invalidateBusyCaches()
+		if cmd := m.dispatchBusyRefresh(); cmd != nil {
+			cmds = append(cmds, cmd)
+		}
+		if cmd := m.dispatchPromptQueueRefresh(); cmd != nil {
+			cmds = append(cmds, cmd)
+		}
 	case loadSessionMsg:
 		if m.forceCompactMode {
 			m.isCompact = true
@@ -655,6 +666,20 @@ func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.setState(uiChat, m.focus)
 		m.session = msg.session
 		m.sessionFiles = msg.files
+		// Session switch: the memoized busy state and queued prompts
+		// belong to the previous session. Drop them and re-fetch
+		// off-thread so the queue pill and esc behavior track the new
+		// session instead of a stale one.
+		m.invalidateBusyCaches()
+		m.promptQueue = 0
+		m.promptQueueItems = nil
+		m.promptQueueCheckedAt = time.Time{}
+		if cmd := m.dispatchBusyRefresh(); cmd != nil {
+			cmds = append(cmds, cmd)
+		}
+		if cmd := m.dispatchPromptQueueRefresh(); cmd != nil {
+			cmds = append(cmds, cmd)
+		}
 		cmds = append(cmds, m.startLSPs(msg.lspFilePaths()))
 		msgs, err := m.com.Workspace.ListMessages(context.Background(), m.session.ID)
 		if err != nil {
@@ -743,9 +768,11 @@ func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if m.session != nil && msg.Payload.ID == m.session.ID {
 			prevHasInProgress := hasInProgressTodo(m.session.Todos)
 			prevPillsHeight := m.pillsAreaHeight()
+			// Session rows update constantly during a run (token
+			// accounting, title, todos); deliberately no busy/queue
+			// refresh here — run boundaries are signaled by message
+			// CreatedEvents and agent-finished notifications.
 			m.session = &msg.Payload
-			m.invalidateBusyCache()
-			m.refreshPromptQueue()
 			if !prevHasInProgress && hasInProgressTodo(m.session.Todos) {
 				m.todoIsSpinning = true
 				cmds = append(cmds, m.todoSpinner.Tick)
@@ -779,16 +806,24 @@ func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		switch msg.Type {
 		case pubsub.CreatedEvent:
 			cmds = append(cmds, m.appendSessionMessage(msg.Payload))
+			// A new message is a run boundary — a user prompt starting
+			// a turn or the agent replying/dequeueing. Drop the
+			// memoized busy state and re-fetch it and the queue
+			// off-thread. Per-chunk UpdatedEvents deliberately do NOT
+			// trigger this: during streaming that would put workspace
+			// probes on every token.
+			m.invalidateBusyCaches()
+			if cmd := m.dispatchBusyRefresh(); cmd != nil {
+				cmds = append(cmds, cmd)
+			}
+			if cmd := m.dispatchPromptQueueRefresh(); cmd != nil {
+				cmds = append(cmds, cmd)
+			}
 		case pubsub.UpdatedEvent:
 			cmds = append(cmds, m.updateSessionMessage(msg.Payload))
 		case pubsub.DeletedEvent:
 			m.chat.RemoveMessage(msg.Payload.ID)
 		}
-		// A message event means agent state may have changed: re-probe busy
-		// and the prompt queue now (both are otherwise memoized/event-driven
-		// to keep synchronous HTTP off the per-keystroke path).
-		m.invalidateBusyCache()
-		m.refreshPromptQueue()
 		// start the spinner if there is a new message
 		if hasInProgressTodo(m.session.Todos) && m.isCurrentSessionBusy() && !m.todoIsSpinning {
 			m.todoIsSpinning = true
@@ -1158,6 +1193,11 @@ func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.textarea.Placeholder = "Yolo mode!"
 		}
 	}
+
+	// TTL backstop: schedule an off-thread re-probe for any memoized
+	// workspace state that has gone stale. Never does IO on this
+	// goroutine.
+	cmds = append(cmds, m.staleWorkspaceRefreshCmds()...)
 
 	// at this point this can only handle [message.Attachment] message, and we
 	// should return all cmds anyway.
@@ -1592,10 +1632,7 @@ func (m *UI) handleDialogMsg(msg tea.Msg) tea.Cmd {
 
 	// Command dialog messages.
 	case dialog.ActionToggleYoloMode:
-		m.yoloCheckedAt = time.Time{}
-		yolo := !m.com.Workspace.PermissionSkipRequests()
-		m.com.Workspace.PermissionSetSkipRequests(yolo)
-		m.setEditorPrompt(yolo)
+		m.toggleYoloMode()
 		m.dialog.CloseDialog(dialog.CommandsID)
 	case dialog.ActionSelectNotificationStyle:
 		cfg := m.com.Config()
@@ -2122,9 +2159,7 @@ func (m *UI) handleKeyPressMsg(msg tea.KeyPressMsg) tea.Cmd {
 			cmds = append(cmds, tea.Suspend)
 			return true
 		case key.Matches(msg, m.keyMap.ToggleYolo):
-			yolo := !m.com.Workspace.PermissionSkipRequests()
-			m.com.Workspace.PermissionSetSkipRequests(yolo)
-			m.setEditorPrompt(yolo)
+			yolo := m.toggleYoloMode()
 			status := "disabled"
 			if yolo {
 				status = "enabled"
@@ -2234,8 +2269,7 @@ func (m *UI) handleKeyPressMsg(msg tea.KeyPressMsg) tea.Cmd {
 
 				if m.bangMode && value != "" {
 					m.bangMode = false
-					yolo := m.com.Workspace.PermissionSkipRequests()
-					m.setEditorPrompt(yolo)
+					m.setEditorPrompt(m.yoloModeCached())
 					m.randomizePlaceholders()
 					m.historyReset()
 					return tea.Batch(m.runShellCommand(value))
@@ -2313,8 +2347,7 @@ func (m *UI) handleKeyPressMsg(msg tea.KeyPressMsg) tea.Cmd {
 				if m.bangMode && m.bangWasEmpty && msg.Code == tea.KeyBackspace {
 					m.bangMode = false
 					m.bangWasEmpty = false
-					yolo := m.com.Workspace.PermissionSkipRequests()
-					m.setEditorPrompt(yolo)
+					m.setEditorPrompt(m.yoloModeCached())
 					break
 				}
 
@@ -2363,8 +2396,7 @@ func (m *UI) handleKeyPressMsg(msg tea.KeyPressMsg) tea.Cmd {
 					m.textarea.SetValue(stripped)
 					m.textarea.SetCursorColumn(max(0, col-(len(newVal)-len(stripped))))
 					_ = line // cursor line doesn't change; prefix removed
-					yolo := m.com.Workspace.PermissionSkipRequests()
-					m.setEditorPrompt(yolo)
+					m.setEditorPrompt(m.yoloModeCached())
 				} else if m.bangMode && newVal == "" && curValue != "" {
 					// Just cleared last character; mark empty, stay in bang mode.
 					m.bangWasEmpty = true
@@ -3519,9 +3551,10 @@ func isWhitespace(b byte) bool {
 }
 
 // isAgentBusy returns true if the agent coordinator exists and is currently
-// busy processing a request. Memoized like isCurrentSessionBusy: it runs in
-// the per-message textarea-placeholder path, which in client/server mode
-// would otherwise issue HTTP probes on every keystroke.
+// busy processing a request. It only reads the memoized state (it runs in
+// per-message paths like the textarea placeholder, where a workspace probe
+// would be an HTTP round-trip per keystroke in client/server mode); the
+// value is refreshed off-thread, see workspace_cache.go.
 func (m *UI) isAgentBusy() bool {
 	if m.bangCancel != nil {
 		return true
@@ -3529,31 +3562,17 @@ func (m *UI) isAgentBusy() bool {
 	if m.com == nil || m.com.Workspace == nil {
 		return false
 	}
-	if time.Since(m.agentBusyCheckedAt) < busyCacheTTL {
-		return m.agentBusyCached
-	}
-	busy := m.com.Workspace.AgentIsReady() &&
-		m.com.Workspace.AgentIsBusy()
-	m.agentBusyCached = busy
-	m.agentBusyCheckedAt = time.Now()
-	return busy
+	return m.agentBusyCache.val
 }
-
-// busyCacheTTL bounds how long isCurrentSessionBusy may reuse its last
-// workspace probe. Event handlers that change agent state invalidate the
-// cache explicitly, so the TTL only limits staleness for probes triggered by
-// unrelated churn (resize storms, typing re-renders).
-const busyCacheTTL = 500 * time.Millisecond
 
 // isCurrentSessionBusy reports whether the agent is actively processing a
 // request for the session the user is currently viewing. Unlike
 // isAgentBusy, activity in another session does not make the current
 // session appear busy.
 //
-// In client/server mode each workspace probe is a synchronous HTTP
-// round-trip and this is called from hot paths (renderPills via resize, the
-// message-event handler), so the result is memoized briefly; paths that know
-// the state changed call invalidateBusyCache first.
+// Like isAgentBusy this is a pure cache read (it is called from render
+// paths such as renderPills); a value cached for a different session reads
+// as idle until the off-thread refresh for this session lands.
 func (m *UI) isCurrentSessionBusy() bool {
 	if m.bangCancel != nil {
 		return true
@@ -3561,34 +3580,10 @@ func (m *UI) isCurrentSessionBusy() bool {
 	if !m.hasSession() || m.com == nil || m.com.Workspace == nil {
 		return false
 	}
-	if m.busyCheckedSession == m.session.ID && time.Since(m.busyCheckedAt) < busyCacheTTL {
-		return m.busyCached
+	if m.sessionBusyCache.session != m.session.ID {
+		return false
 	}
-	busy := m.com.Workspace.AgentIsReady() &&
-		m.com.Workspace.AgentIsSessionBusy(m.session.ID)
-	m.busyCached = busy
-	m.busyCheckedAt = time.Now()
-	m.busyCheckedSession = m.session.ID
-	return busy
-}
-
-// invalidateBusyCache forces the next isCurrentSessionBusy / isAgentBusy to
-// re-probe the workspace. Called by event handlers that indicate agent state
-// changed.
-func (m *UI) invalidateBusyCache() {
-	m.busyCheckedAt = time.Time{}
-	m.agentBusyCheckedAt = time.Time{}
-}
-
-// yoloModeCached memoizes PermissionSkipRequests for the per-message
-// placeholder path; the yolo toggle invalidates it.
-func (m *UI) yoloModeCached() bool {
-	if time.Since(m.yoloCheckedAt) < busyCacheTTL {
-		return m.yoloCached
-	}
-	m.yoloCached = m.com.Workspace.PermissionSkipRequests()
-	m.yoloCheckedAt = time.Now()
-	return m.yoloCached
+	return m.sessionBusyCache.val
 }
 
 // hasSession returns true if there is an active session with a valid ID.
@@ -3775,6 +3770,12 @@ func (m *UI) sendMessage(content string, attachments ...message.Attachment) tea.
 
 	// Capture session ID to avoid race with main goroutine updating m.session.
 	sessionID := m.session.ID
+	// Optimistically mark the agent busy: the prompt we are about to submit
+	// either starts a run or is enqueued behind one. This keeps esc pressed
+	// right after enter routing to cancelAgent instead of reading a stale
+	// idle value; the authoritative state arrives via agentRunSubmittedMsg.
+	m.agentBusyCache.set(true)
+	m.sessionBusyCache.setForSession(true, sessionID)
 	cmds = append(cmds, func() tea.Msg {
 		// AgentRun is fire-and-forget: it returns once the prompt has
 		// been accepted (HTTP 202) or synchronously with a validation
@@ -3787,7 +3788,7 @@ func (m *UI) sendMessage(content string, attachments ...message.Attachment) tea.
 				Msg:  fmt.Sprintf("%v", err),
 			}
 		}
-		return nil
+		return agentRunSubmittedMsg{}
 	})
 	return tea.Batch(cmds...)
 }
@@ -3831,8 +3832,11 @@ func (m *UI) handleChannelMessage(ev mcp.Event) tea.Cmd {
 	runCmd := func() tea.Msg {
 		if err := m.com.Workspace.AgentRunChannel(context.Background(), channel, sessionID, content); err != nil {
 			slog.Debug("Failed to inject channel message", "error", err, "session", sessionID)
+			return nil
 		}
-		return nil
+		// The prompt may have been enqueued behind a running turn;
+		// re-fetch busy/queue state.
+		return agentRunSubmittedMsg{}
 	}
 	if loadCmd != nil {
 		return tea.Batch(loadCmd, runCmd)
@@ -3963,16 +3967,24 @@ func (m *UI) cancelAgent() tea.Cmd {
 		}
 
 		m.com.Workspace.AgentCancel(m.session.ID)
-		// Stop the spinning todo indicator.
+		// Stop the spinning todo indicator and drop the memoized busy
+		// state the cancel just changed; the pill re-renders now from
+		// last-known state and again when the off-thread refresh (and
+		// the agent's own events) land.
 		m.todoIsSpinning = false
+		m.invalidateBusyCaches()
 		m.renderPills()
-		return nil
+		return m.dispatchBusyRefresh()
 	}
 
-	// Check if there are queued prompts - if so, clear the queue.
-	if m.com.Workspace.AgentQueuedPrompts(m.session.ID) > 0 {
+	// Queued prompts pending: esc clears the queue. Decide from the cached
+	// count (event-driven) instead of a synchronous workspace probe.
+	if m.promptQueue > 0 {
 		m.com.Workspace.AgentClearQueue(m.session.ID)
-		m.refreshPromptQueue()
+		m.promptQueue = 0
+		m.promptQueueItems = nil
+		m.promptQueueCheckedAt = time.Now()
+		m.updateLayoutAndSize()
 		return nil
 	}
 
@@ -4225,9 +4237,9 @@ func (m *UI) handlePermissionNotification(notification permission.PermissionNoti
 // handleAgentNotification translates domain agent events into desktop
 // notifications using the UI notification backend.
 func (m *UI) handleAgentNotification(n notify.Notification) tea.Cmd {
+	var cmds []tea.Cmd
 	switch n.Type {
 	case notify.TypeAgentFinished:
-		var cmds []tea.Cmd
 		cmds = append(cmds, m.sendNotification(notification.Notification{
 			Title:   "Crush is waiting...",
 			Message: fmt.Sprintf("Agent's turn completed in \"%s\"", n.SessionTitle),
@@ -4235,12 +4247,26 @@ func (m *UI) handleAgentNotification(n notify.Notification) tea.Cmd {
 		if m.com.IsHyper() {
 			cmds = append(cmds, m.fetchHyperCredits())
 		}
-		return tea.Batch(cmds...)
+	case notify.TypeAgentError:
+		// Terminal edge like TypeAgentFinished; fall through to the
+		// busy/queue refresh below.
 	case notify.TypeReAuthenticate:
 		return m.handleReAuthenticate(n.ProviderID)
 	default:
 		return nil
 	}
+	// TypeAgentFinished / TypeAgentError are the busy→idle edge: the agent
+	// clears its active request BEFORE publishing precisely so observers
+	// can re-probe. Drop the memoized busy state and re-fetch it and the
+	// prompt queue off-thread.
+	m.invalidateBusyCaches()
+	if cmd := m.dispatchBusyRefresh(); cmd != nil {
+		cmds = append(cmds, cmd)
+	}
+	if cmd := m.dispatchPromptQueueRefresh(); cmd != nil {
+		cmds = append(cmds, cmd)
+	}
+	return tea.Batch(cmds...)
 }
 
 func (m *UI) handleReAuthenticate(providerID string) tea.Cmd {
@@ -4321,6 +4347,9 @@ func (m *UI) newSession() tea.Cmd {
 	m.pillsExpanded = false
 	m.pillsAutoExpanded = false
 	m.promptQueue = 0
+	m.promptQueueItems = nil
+	m.promptQueueCheckedAt = time.Now()
+	m.invalidateBusyCaches()
 	m.pillsView = ""
 	m.historyReset()
 	agenttools.ResetCache()
@@ -4352,8 +4381,7 @@ func (m *UI) checkBangModeAfterPaste() {
 	m.textarea.SetValue(stripped)
 	col := m.textarea.Column()
 	m.textarea.SetCursorColumn(max(0, col-(len(val)-len(stripped))))
-	yolo := m.com.Workspace.PermissionSkipRequests()
-	m.setEditorPrompt(yolo)
+	m.setEditorPrompt(m.yoloModeCached())
 }
 
 // handlePasteMsg handles a paste message.

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -298,6 +298,17 @@ type UI struct {
 	pillsAutoExpanded  bool
 	focusedPillSection pillSection
 	promptQueue        int
+	// busyCached memoizes isCurrentSessionBusy briefly (see busyCacheTTL):
+	// in client/server mode each probe is a synchronous HTTP round-trip.
+	busyCached         bool
+	busyCheckedAt      time.Time
+	busyCheckedSession string
+	// agentBusyCached / yoloCached mirror busyCached for the global busy and
+	// permission-skip probes made by the per-message placeholder path.
+	agentBusyCached    bool
+	agentBusyCheckedAt time.Time
+	yoloCached         bool
+	yoloCheckedAt      time.Time
 	sidebarScroll      int
 	pillsView          string
 
@@ -596,16 +607,26 @@ func (m *UI) loadMCPrompts() tea.Msg {
 	return mcpPromptsLoadedMsg{Prompts: prompts}
 }
 
+// refreshPromptQueue re-reads the queued-prompt count and re-layouts when it
+// changed. In client/server mode the count is a synchronous HTTP round-trip,
+// so this must only run when the queue can actually have changed — message
+// events (the agent dequeueing), local queue mutations, and session switches.
+// Polling it unconditionally at the top of Update put a network call on
+// every keystroke and froze typing on a slow server.
+func (m *UI) refreshPromptQueue() {
+	queueSize := 0
+	if m.hasSession() {
+		queueSize = m.com.Workspace.AgentQueuedPrompts(m.session.ID)
+	}
+	if queueSize != m.promptQueue {
+		m.promptQueue = queueSize
+		m.updateLayoutAndSize()
+	}
+}
+
 // Update handles updates to the UI model.
 func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	var cmds []tea.Cmd
-	if m.hasSession() {
-		queueSize := m.com.Workspace.AgentQueuedPrompts(m.session.ID)
-		if queueSize != m.promptQueue {
-			m.promptQueue = queueSize
-			m.updateLayoutAndSize()
-		}
-	}
 	// Update terminal capabilities
 	m.caps.Update(msg)
 	switch msg := msg.(type) {
@@ -723,6 +744,8 @@ func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			prevHasInProgress := hasInProgressTodo(m.session.Todos)
 			prevPillsHeight := m.pillsAreaHeight()
 			m.session = &msg.Payload
+			m.invalidateBusyCache()
+			m.refreshPromptQueue()
 			if !prevHasInProgress && hasInProgressTodo(m.session.Todos) {
 				m.todoIsSpinning = true
 				cmds = append(cmds, m.todoSpinner.Tick)
@@ -761,6 +784,11 @@ func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case pubsub.DeletedEvent:
 			m.chat.RemoveMessage(msg.Payload.ID)
 		}
+		// A message event means agent state may have changed: re-probe busy
+		// and the prompt queue now (both are otherwise memoized/event-driven
+		// to keep synchronous HTTP off the per-keystroke path).
+		m.invalidateBusyCache()
+		m.refreshPromptQueue()
 		// start the spinner if there is a new message
 		if hasInProgressTodo(m.session.Todos) && m.isCurrentSessionBusy() && !m.todoIsSpinning {
 			m.todoIsSpinning = true
@@ -1126,7 +1154,7 @@ func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		} else {
 			m.textarea.Placeholder = m.readyPlaceholder
 		}
-		if !m.bangMode && m.com.Workspace.PermissionSkipRequests() {
+		if !m.bangMode && m.yoloModeCached() {
 			m.textarea.Placeholder = "Yolo mode!"
 		}
 	}
@@ -1564,6 +1592,7 @@ func (m *UI) handleDialogMsg(msg tea.Msg) tea.Cmd {
 
 	// Command dialog messages.
 	case dialog.ActionToggleYoloMode:
+		m.yoloCheckedAt = time.Time{}
 		yolo := !m.com.Workspace.PermissionSkipRequests()
 		m.com.Workspace.PermissionSetSkipRequests(yolo)
 		m.setEditorPrompt(yolo)
@@ -2683,7 +2712,7 @@ func (m *UI) ShortHelp() []key.Binding {
 			cancelBinding := k.Chat.Cancel
 			if m.isCanceling {
 				cancelBinding.SetHelp("esc", "press again to cancel")
-			} else if m.com.Workspace.AgentQueuedPrompts(m.session.ID) > 0 {
+			} else if m.promptQueue > 0 {
 				cancelBinding.SetHelp("esc", "clear queue")
 			}
 			binds = append(binds, cancelBinding)
@@ -2776,7 +2805,7 @@ func (m *UI) FullHelp() [][]key.Binding {
 			cancelBinding := k.Chat.Cancel
 			if m.isCanceling {
 				cancelBinding.SetHelp("esc", "press again to cancel")
-			} else if m.com.Workspace.AgentQueuedPrompts(m.session.ID) > 0 {
+			} else if m.promptQueue > 0 {
 				cancelBinding.SetHelp("esc", "clear queue")
 			}
 			binds = append(binds, []key.Binding{cancelBinding})
@@ -3490,7 +3519,9 @@ func isWhitespace(b byte) bool {
 }
 
 // isAgentBusy returns true if the agent coordinator exists and is currently
-// busy processing a request.
+// busy processing a request. Memoized like isCurrentSessionBusy: it runs in
+// the per-message textarea-placeholder path, which in client/server mode
+// would otherwise issue HTTP probes on every keystroke.
 func (m *UI) isAgentBusy() bool {
 	if m.bangCancel != nil {
 		return true
@@ -3498,14 +3529,31 @@ func (m *UI) isAgentBusy() bool {
 	if m.com == nil || m.com.Workspace == nil {
 		return false
 	}
-	return m.com.Workspace.AgentIsReady() &&
+	if time.Since(m.agentBusyCheckedAt) < busyCacheTTL {
+		return m.agentBusyCached
+	}
+	busy := m.com.Workspace.AgentIsReady() &&
 		m.com.Workspace.AgentIsBusy()
+	m.agentBusyCached = busy
+	m.agentBusyCheckedAt = time.Now()
+	return busy
 }
+
+// busyCacheTTL bounds how long isCurrentSessionBusy may reuse its last
+// workspace probe. Event handlers that change agent state invalidate the
+// cache explicitly, so the TTL only limits staleness for probes triggered by
+// unrelated churn (resize storms, typing re-renders).
+const busyCacheTTL = 500 * time.Millisecond
 
 // isCurrentSessionBusy reports whether the agent is actively processing a
 // request for the session the user is currently viewing. Unlike
 // isAgentBusy, activity in another session does not make the current
 // session appear busy.
+//
+// In client/server mode each workspace probe is a synchronous HTTP
+// round-trip and this is called from hot paths (renderPills via resize, the
+// message-event handler), so the result is memoized briefly; paths that know
+// the state changed call invalidateBusyCache first.
 func (m *UI) isCurrentSessionBusy() bool {
 	if m.bangCancel != nil {
 		return true
@@ -3513,8 +3561,34 @@ func (m *UI) isCurrentSessionBusy() bool {
 	if !m.hasSession() || m.com == nil || m.com.Workspace == nil {
 		return false
 	}
-	return m.com.Workspace.AgentIsReady() &&
+	if m.busyCheckedSession == m.session.ID && time.Since(m.busyCheckedAt) < busyCacheTTL {
+		return m.busyCached
+	}
+	busy := m.com.Workspace.AgentIsReady() &&
 		m.com.Workspace.AgentIsSessionBusy(m.session.ID)
+	m.busyCached = busy
+	m.busyCheckedAt = time.Now()
+	m.busyCheckedSession = m.session.ID
+	return busy
+}
+
+// invalidateBusyCache forces the next isCurrentSessionBusy / isAgentBusy to
+// re-probe the workspace. Called by event handlers that indicate agent state
+// changed.
+func (m *UI) invalidateBusyCache() {
+	m.busyCheckedAt = time.Time{}
+	m.agentBusyCheckedAt = time.Time{}
+}
+
+// yoloModeCached memoizes PermissionSkipRequests for the per-message
+// placeholder path; the yolo toggle invalidates it.
+func (m *UI) yoloModeCached() bool {
+	if time.Since(m.yoloCheckedAt) < busyCacheTTL {
+		return m.yoloCached
+	}
+	m.yoloCached = m.com.Workspace.PermissionSkipRequests()
+	m.yoloCheckedAt = time.Now()
+	return m.yoloCached
 }
 
 // hasSession returns true if there is an active session with a valid ID.
@@ -3898,6 +3972,7 @@ func (m *UI) cancelAgent() tea.Cmd {
 	// Check if there are queued prompts - if so, clear the queue.
 	if m.com.Workspace.AgentQueuedPrompts(m.session.ID) > 0 {
 		m.com.Workspace.AgentClearQueue(m.session.ID)
+		m.refreshPromptQueue()
 		return nil
 	}
 

--- a/internal/ui/model/workspace_cache.go
+++ b/internal/ui/model/workspace_cache.go
@@ -1,0 +1,269 @@
+package model
+
+// Memoized workspace state.
+//
+// In client/server mode every workspace probe (busy checks, permission mode,
+// queued prompts) is a synchronous HTTP round-trip, and the Update goroutine
+// is the render loop — blocking it freezes typing. The UI therefore NEVER
+// probes the workspace synchronously from Update or View:
+//
+//   - Reads (isAgentBusy, isCurrentSessionBusy, yoloModeCached, promptQueue)
+//     always return the memoized value, stale or not.
+//   - State edges (message created, agent finished/errored, prompt
+//     submitted, cancel, session switch, yolo toggle) invalidate or
+//     write through the caches and dispatch an off-thread refresh cmd.
+//   - A TTL backstop at the end of Update re-dispatches a refresh whenever
+//     the memoized state has gone stale, so unrelated churn (typing,
+//     resize storms, spinner ticks) only ever schedules async work.
+//
+// Fresh values arrive as busyStateMsg / promptQueueMsg and are applied on
+// the Update goroutine, per the UI guidelines (no IO in Update, no model
+// mutation inside commands).
+
+import (
+	"slices"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+// busyCacheTTL bounds how long the memoized busy/permission state may go
+// without a re-probe being scheduled. Package var so tests can pin it.
+var busyCacheTTL = 500 * time.Millisecond
+
+// promptQueueTTL is the backstop refresh interval for the queued-prompt
+// state; the queue is otherwise refreshed on event edges.
+var promptQueueTTL = 2 * time.Second
+
+// ttlCache memoizes one boolean workspace probe result. It unifies what used
+// to be three hand-rolled val/checkedAt field pairs so invalidation cannot
+// drift apart between them.
+type ttlCache struct {
+	val bool
+	at  time.Time
+	// session scopes the value to a session ID; empty for global probes.
+	session string
+}
+
+// fresh reports whether the cached value is within its TTL.
+func (c *ttlCache) fresh(ttl time.Duration) bool {
+	return !c.at.IsZero() && time.Since(c.at) < ttl
+}
+
+// freshFor is fresh scoped to a session: a value cached for another session
+// is never fresh.
+func (c *ttlCache) freshFor(ttl time.Duration, session string) bool {
+	return c.session == session && c.fresh(ttl)
+}
+
+// set writes a known-good global value through the cache.
+func (c *ttlCache) set(val bool) {
+	c.val = val
+	c.at = time.Now()
+	c.session = ""
+}
+
+// setForSession writes a known-good session-scoped value through the cache.
+func (c *ttlCache) setForSession(val bool, session string) {
+	c.val = val
+	c.at = time.Now()
+	c.session = session
+}
+
+// invalidate marks the value stale so the next Update-tail backstop
+// re-probes; the last value keeps being served in the meantime.
+func (c *ttlCache) invalidate() {
+	c.at = time.Time{}
+}
+
+// busyStateMsg delivers the result of an off-thread busy/permission probe.
+type busyStateMsg struct {
+	// forSession is the session the probe was scoped to; a result that
+	// raced a session switch is discarded and re-fetched.
+	forSession  string
+	agentBusy   bool
+	sessionBusy bool
+	yolo        bool
+}
+
+// promptQueueMsg delivers the queued prompts fetched off-thread.
+type promptQueueMsg struct {
+	forSession string
+	prompts    []string
+}
+
+// agentRunSubmittedMsg reports that AgentRun accepted a prompt (it either
+// started a run or was enqueued behind one), so busy and queue state should
+// be re-fetched.
+type agentRunSubmittedMsg struct{}
+
+// currentSessionID returns the active session's ID, or "" when none.
+func (m *UI) currentSessionID() string {
+	if m.session == nil {
+		return ""
+	}
+	return m.session.ID
+}
+
+// invalidateBusyCaches marks all memoized workspace probe state stale.
+// Called by handlers for events that change agent or permission state. It
+// resets every cache — asymmetric invalidation between them was a bug
+// hazard.
+func (m *UI) invalidateBusyCaches() {
+	m.sessionBusyCache.invalidate()
+	m.agentBusyCache.invalidate()
+	m.yoloCache.invalidate()
+}
+
+// dispatchBusyRefresh returns a command that probes the workspace busy and
+// permission state off the Update goroutine, delivering a busyStateMsg. It
+// returns nil while a probe is already in flight. The closure captures only
+// locals (never m) so it is safe off-thread; state is applied by
+// applyBusyState on the Update goroutine.
+func (m *UI) dispatchBusyRefresh() tea.Cmd {
+	if m.busyFetchInFlight || m.com == nil || m.com.Workspace == nil {
+		return nil
+	}
+	m.busyFetchInFlight = true
+	ws := m.com.Workspace
+	sessionID := m.currentSessionID()
+	return func() tea.Msg {
+		st := busyStateMsg{forSession: sessionID}
+		if ws.AgentIsReady() {
+			st.agentBusy = ws.AgentIsBusy()
+			if sessionID != "" {
+				st.sessionBusy = ws.AgentIsSessionBusy(sessionID)
+			}
+		}
+		st.yolo = ws.PermissionSkipRequests()
+		return st
+	}
+}
+
+// applyBusyState stores an off-thread probe result and reacts to busy
+// edges (todo spinner, pills). Runs on the Update goroutine.
+func (m *UI) applyBusyState(msg busyStateMsg) []tea.Cmd {
+	m.busyFetchInFlight = false
+	if msg.forSession != m.currentSessionID() {
+		// The result raced a session switch; fetch again for the
+		// current session.
+		if cmd := m.dispatchBusyRefresh(); cmd != nil {
+			return []tea.Cmd{cmd}
+		}
+		return nil
+	}
+	prevBusy := m.isCurrentSessionBusy()
+	m.agentBusyCache.set(msg.agentBusy)
+	m.sessionBusyCache.setForSession(msg.sessionBusy, msg.forSession)
+	m.yoloCache.set(msg.yolo)
+
+	var cmds []tea.Cmd
+	busy := m.isCurrentSessionBusy()
+	if m.hasSession() && hasInProgressTodo(m.session.Todos) && busy && !m.todoIsSpinning {
+		m.todoIsSpinning = true
+		cmds = append(cmds, m.todoSpinner.Tick)
+	}
+	if m.todoIsSpinning && !busy {
+		m.todoIsSpinning = false
+	}
+	if prevBusy != busy {
+		m.renderPills()
+	}
+	return cmds
+}
+
+// dispatchPromptQueueRefresh returns a command that fetches the queued
+// prompts off the Update goroutine, delivering a promptQueueMsg. It returns
+// nil while a fetch is already in flight. With no active session the queue
+// is simply cleared.
+func (m *UI) dispatchPromptQueueRefresh() tea.Cmd {
+	if m.promptQueueInFlight || m.com == nil || m.com.Workspace == nil {
+		return nil
+	}
+	if !m.hasSession() {
+		m.promptQueueItems = nil
+		m.promptQueueCheckedAt = time.Now()
+		if m.promptQueue != 0 {
+			m.promptQueue = 0
+			m.updateLayoutAndSize()
+		}
+		return nil
+	}
+	m.promptQueueInFlight = true
+	ws := m.com.Workspace
+	sessionID := m.session.ID
+	return func() tea.Msg {
+		msg := promptQueueMsg{forSession: sessionID}
+		if ws.AgentIsReady() {
+			msg.prompts = ws.AgentQueuedPromptsList(sessionID)
+		}
+		return msg
+	}
+}
+
+// applyPromptQueue stores an off-thread queue fetch and re-layouts when the
+// count changed. Runs on the Update goroutine.
+func (m *UI) applyPromptQueue(msg promptQueueMsg) []tea.Cmd {
+	m.promptQueueInFlight = false
+	if msg.forSession != m.currentSessionID() {
+		if cmd := m.dispatchPromptQueueRefresh(); cmd != nil {
+			return []tea.Cmd{cmd}
+		}
+		return nil
+	}
+	m.promptQueueCheckedAt = time.Now()
+	itemsChanged := !slices.Equal(m.promptQueueItems, msg.prompts)
+	countChanged := len(msg.prompts) != m.promptQueue
+	m.promptQueueItems = msg.prompts
+	m.promptQueue = len(msg.prompts)
+	if countChanged {
+		m.updateLayoutAndSize()
+	} else if itemsChanged {
+		m.renderPills()
+	}
+	return nil
+}
+
+// staleWorkspaceRefreshCmds is the TTL backstop, called at the tail of
+// Update: when any memoized workspace state has outlived its TTL (and no
+// event edge refreshed it), schedule an off-thread re-probe. It never does
+// IO itself — a couple of time comparisons per message at most.
+func (m *UI) staleWorkspaceRefreshCmds() []tea.Cmd {
+	if m.com == nil || m.com.Workspace == nil {
+		return nil
+	}
+	var cmds []tea.Cmd
+	busyStale := !m.agentBusyCache.fresh(busyCacheTTL) ||
+		!m.yoloCache.fresh(busyCacheTTL) ||
+		(m.hasSession() && !m.sessionBusyCache.freshFor(busyCacheTTL, m.session.ID))
+	if busyStale {
+		if cmd := m.dispatchBusyRefresh(); cmd != nil {
+			cmds = append(cmds, cmd)
+		}
+	}
+	if m.hasSession() && time.Since(m.promptQueueCheckedAt) >= promptQueueTTL {
+		if cmd := m.dispatchPromptQueueRefresh(); cmd != nil {
+			cmds = append(cmds, cmd)
+		}
+	}
+	return cmds
+}
+
+// toggleYoloMode flips permission auto-approval and writes the new value
+// through the yolo cache (no re-probe needed) and the editor prompt. Shared
+// by the direct keybinding and the commands-dialog action so both stay
+// write-through. Returns the new mode.
+func (m *UI) toggleYoloMode() bool {
+	yolo := !m.com.Workspace.PermissionSkipRequests()
+	m.com.Workspace.PermissionSetSkipRequests(yolo)
+	m.yoloCache.set(yolo)
+	m.setEditorPrompt(yolo)
+	return yolo
+}
+
+// yoloModeCached reports the memoized permission-skip ("yolo") mode. Toggles
+// write through the cache; the Update-tail backstop keeps it bounded-stale
+// otherwise.
+func (m *UI) yoloModeCached() bool {
+	return m.yoloCache.val
+}


### PR DESCRIPTION
Audit batch: Update-loop performance (MAJOR in client/server mode).

## The problem

The Update loop issued **synchronous workspace calls on every `tea.Msg`**. In client mode (`crush` against `crush serve`) each is an HTTP round-trip — every keystroke, mouse event, and tick blocked the single Update goroutine on the network. A slow or hiccuping server froze typing entirely.

Per-message offenders:
- `AgentQueuedPrompts` ran unconditionally at the **top of Update** (the fork widened upstream's busy-gated poll to all messages — the direct audit finding).
- The textarea-placeholder path probed `isAgentBusy` (= `AgentIsReady` + `AgentIsBusy`) and `PermissionSkipRequests` per message — upstream-inherited, with an upstream comment already asking "but should it?". Surfaced by the new regression test, fixed here since it defeats the point otherwise.
- `isCurrentSessionBusy` (2 probes/call, called ×3 per message event via spinner logic + `renderPills`).

## The fix

- **Queue count is event-driven:** `refreshPromptQueue` runs where the queue can actually change — message events, local queue mutations, session switches. Render paths (help footer ×2) read the cached count.
- **Busy + permission probes memoized** with a 500ms TTL. Event handlers that indicate a state change (message events, session selection) invalidate the caches first, so event-driven state stays fresh; the yolo toggle invalidates the permission cache; staleness elsewhere is bounded by the TTL.

## Tests

A counting workspace stub proves **25 Update messages → zero `AgentQueuedPrompts` calls and ≤1 memoized busy/permission probe** (was: 25+ HTTP GETs); `refreshPromptQueue` reads once and re-layouts on change; memoization honors `invalidateBusyCache`.

```
go build ./... ✓   gofmt ✓   go test ./internal/ui/model/ ✓
```

---
_Generated by [Claude Code](https://claude.ai/code/session_01AtvfVcwLAeVKk9SkRjb7GN)_