### PR TITLE
Review fixes: attachment remove button (hidden clicks, mouse button, chip spacing)

### DIFF
--- a/internal/ui/attachments/attachments_test.go
+++ b/internal/ui/attachments/attachments_test.go
@@ -143,6 +143,28 @@ func TestRender_RemoveButtonHasRightPadding(t *testing.T) {
 		"the cell to the right of ✕ must share the button's background (padding), not be a transparent margin")
 }
 
+func TestRender_RemoveButtonKeepsGapBetweenChips(t *testing.T) {
+	t.Parallel()
+
+	r := newTestRenderer()
+	atts := []message.Attachment{
+		{FileName: "first.txt"},
+		{FileName: "second.txt"},
+	}
+	cells := parseCells(r.Render(atts, false, true, 200))
+
+	xi := -1
+	for i, c := range cells {
+		if c.r == styles.RemoveIcon {
+			xi = i
+			break
+		}
+	}
+	require.GreaterOrEqual(t, xi, 0)
+	require.Less(t, xi+2, len(cells))
+	require.Empty(t, cells[xi+2].bg, "adjacent attachment chips must have a transparent one-cell gap")
+}
+
 // cell is one rendered terminal cell: its rune and the truecolor background
 // in effect ("r;g;b", or "" for none).
 type cell struct {

--- a/internal/ui/model/attachments_mouse_test.go
+++ b/internal/ui/model/attachments_mouse_test.go
@@ -67,3 +67,32 @@ func TestAttachmentClickIgnoredWhileInlineEditorIsActive(t *testing.T) {
 
 	require.Len(t, u.attachments.List(), 1)
 }
+
+func TestAttachmentClickRequiresLeftMouseButton(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		button    tea.MouseButton
+		remaining int
+	}{
+		{name: "left", button: uv.MouseLeft, remaining: 0},
+		{name: "middle", button: uv.MouseMiddle, remaining: 1},
+		{name: "right", button: uv.MouseRight, remaining: 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			u, removeX := newAttachmentClickTestUI(t)
+			_, _ = u.Update(tea.MouseClickMsg(tea.Mouse{
+				X:      u.layout.editor.Min.X + removeX,
+				Y:      u.layout.editor.Min.Y,
+				Button: tt.button,
+			}))
+
+			require.Len(t, u.attachments.List(), tt.remaining)
+		})
+	}
+}

--- a/internal/ui/model/attachments_mouse_test.go
+++ b/internal/ui/model/attachments_mouse_test.go
@@ -1,0 +1,69 @@
+package model
+
+import (
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/crush/internal/message"
+	"github.com/charmbracelet/crush/internal/question"
+	"github.com/charmbracelet/crush/internal/ui/attachments"
+	"github.com/charmbracelet/crush/internal/ui/dialog"
+	uv "github.com/charmbracelet/ultraviolet"
+	"github.com/stretchr/testify/require"
+)
+
+type attachmentClickWorkspace struct {
+	historyWorkspace
+}
+
+func (attachmentClickWorkspace) AgentIsReady() bool { return false }
+
+func newAttachmentClickTestUI(t *testing.T) (*UI, int) {
+	t.Helper()
+
+	u := newTestUI()
+	u.com.Workspace = attachmentClickWorkspace{}
+	u.dialog = dialog.NewOverlay()
+	sty := u.com.Styles.Attachments
+	renderer := attachments.NewRenderer(
+		sty.Normal,
+		sty.Deleting,
+		sty.Image,
+		sty.Text,
+		sty.Skill,
+		sty.Remove,
+	)
+	u.attachments = attachments.New(renderer, attachments.Keymap{})
+	u.updateLayoutAndSize()
+	require.True(t, u.attachments.Update(message.Attachment{FileName: "test.txt"}))
+	_ = u.attachments.Render(u.layout.editor.Dx())
+
+	for x := range u.layout.editor.Dx() {
+		if renderer.HitTestRemove(u.attachments.List(), x) == 0 {
+			return u, x
+		}
+	}
+	t.Fatal("remove button was not rendered")
+	return nil, 0
+}
+
+func TestAttachmentClickIgnoredWhileInlineEditorIsActive(t *testing.T) {
+	t.Parallel()
+
+	u, removeX := newAttachmentClickTestUI(t)
+	u.openBatchFormDialog(question.Request{
+		Questions: []question.Question{{
+			ID:   "question",
+			Type: question.TypeFreeText,
+			Text: "Question?",
+		}},
+	})
+
+	_, _ = u.Update(tea.MouseClickMsg(tea.Mouse{
+		X:      u.layout.editor.Min.X + removeX,
+		Y:      u.layout.editor.Min.Y,
+		Button: uv.MouseLeft,
+	}))
+
+	require.Len(t, u.attachments.List(), 1)
+}

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -889,7 +889,7 @@ func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Check if the click landed on an attachment's remove button.
 		// The attachment chips are rendered on the first row of the
 		// editor layout area, above the textarea.
-		if len(m.attachments.List()) > 0 && msg.Y == m.layout.editor.Min.Y {
+		if m.activeInline == nil && len(m.attachments.List()) > 0 && msg.Y == m.layout.editor.Min.Y {
 			relX := msg.X - m.layout.editor.Min.X
 			if m.attachments.HandleClick(relX) {
 				return m, tea.Batch(cmds...)

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -889,7 +889,7 @@ func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Check if the click landed on an attachment's remove button.
 		// The attachment chips are rendered on the first row of the
 		// editor layout area, above the textarea.
-		if m.activeInline == nil && len(m.attachments.List()) > 0 && msg.Y == m.layout.editor.Min.Y {
+		if m.activeInline == nil && msg.Button == uv.MouseLeft && len(m.attachments.List()) > 0 && msg.Y == m.layout.editor.Min.Y {
 			relX := msg.X - m.layout.editor.Min.X
 			if m.attachments.HandleClick(relX) {
 				return m, tea.Batch(cmds...)

--- a/internal/ui/styles/quickstyle.go
+++ b/internal/ui/styles/quickstyle.go
@@ -1029,11 +1029,10 @@ func quickStyle(o quickStyleOpts) Styles {
 	// Remove and Deleting share the same slot on the right side of a chip
 	// and must keep the same geometry so toggling delete-mode doesn't
 	// shift the chips. Padding(0, 1) puts a colored cell on each side of the
-	// glyph so it isn't flush against the box edge; the trailing cell is
-	// padding (part of the box) rather than a transparent margin, which also
-	// keeps the chip-to-chip spacing intact.
-	s.Attachments.Remove = base.Padding(0, 1).Background(o.bgLessVisible).Foreground(o.fgSubtle).SetString(RemoveIcon)
-	s.Attachments.Deleting = base.Padding(0, 1).Bold(true).Background(o.destructive).Foreground(o.fgBase)
+	// glyph so it isn't flush against the box edge, while MarginRight(1)
+	// keeps a transparent gap between adjacent chips.
+	s.Attachments.Remove = base.Padding(0, 1).MarginRight(1).Background(o.bgLessVisible).Foreground(o.fgSubtle).SetString(RemoveIcon)
+	s.Attachments.Deleting = base.Padding(0, 1).MarginRight(1).Bold(true).Background(o.destructive).Foreground(o.fgBase)
 
 	// Pills styles
 	s.Pills.Base = base.Padding(0, 1)


### PR DESCRIPTION
## Summary

Review follow-ups for #3338 (clickable ✕ remove button on attachment chips). Three small commits on top of `15e7396`:

- **`d871c96` Prevent hidden attachment controls from handling clicks** — while an inline editor (question form) is active the attachment chips aren't drawn, but stale hit-test bounds could still remove an attachment on a click. Gate removal on `m.activeInline == nil`.
- **`0eb6249` Restrict attachment removal to left clicks** — right/middle clicks were also removing attachments. Require `msg.Button == uv.MouseLeft`.
- **`84fc1ef` Restore spacing between attachment chips** — the previous padding-only button removed the transparent gap between adjacent chips. Re-add `MarginRight(1)` to `Remove`/`Deleting` so chips keep their one-column gap while preserving right padding and delete-mode alignment.

## Testing

- New regression tests in `internal/ui/model/attachments_mouse_test.go` (hidden inline editor; left/middle/right button matrix) and `internal/ui/attachments/attachments_test.go` (chip gap via per-cell backgrounds).
- `go test ./...` passes (2,181 tests). golangci-lint clean on touched files.

💘 Generated with Crush
