### PR TITLE
feat: add configurable allowed_commands for bash tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -582,6 +582,44 @@ permissions. Use this with care.
 You can also skip all permission prompts entirely by running Crush with the
 `--yolo` flag. Be very, very careful with this feature.
 
+### Allowing Blocked Commands
+
+The `bash` tool blocks a set of potentially dangerous commands by default (for
+example `ssh`, `curl`, `systemctl`, and various package managers). You can
+selectively remove commands from that blocklist with `options.allowed_commands`:
+
+```json
+{
+  "$schema": "https://charm.land/crush.json",
+  "options": {
+    "allowed_commands": ["ssh", "curl", "scp"]
+  }
+}
+```
+
+The same can be set for a single session via CLI flags or environment variables
+(flags take precedence over the environment variables):
+
+```bash
+# Allow specific commands (repeatable flag, or a comma-separated env var).
+crush --allow-commands ssh --allow-commands curl
+CRUSH_ALLOW_COMMANDS="ssh,curl,scp" crush
+
+# Remove every command restriction (dangerous).
+crush --allow-all-commands
+CRUSH_ALLOW_ALL_COMMANDS=1 crush
+```
+
+Two things to keep in mind:
+
+- `allowed_commands` only removes commands from the exact-command blocklist. It
+  does **not** unlock the package-manager argument blocks (such as `apt install`
+  or `npm -g`); use `allow_all_commands` (or `--allow-all-commands`) to remove
+  those as well.
+- Allowing a command does not auto-approve it. Blocked commands are simply a
+  hard filter in front of the normal permission flow, so an allowed command is
+  still subject to the usual permission prompt unless you also enable `--yolo`.
+
 ### Disabling Built-In Tools
 
 If you'd like to prevent Crush from using certain built-in tools entirely, you

--- a/internal/agent/common_test.go
+++ b/internal/agent/common_test.go
@@ -167,7 +167,7 @@ func coderAgent(r *vcr.Recorder, env fakeEnv, large, small fantasy.LanguageModel
 	}
 
 	allTools := []fantasy.AgentTool{
-		tools.NewBashTool(env.permissions, env.workingDir, cfg.Config().Options.Attribution, modelName, cfg.Config().Options),
+		tools.NewBashTool(env.permissions, env.workingDir, cfg.Config().Options.Attribution, modelName, cfg.Config().Options.AllowedCommands, cfg.Config().Options.AllowAllCommands),
 		tools.NewDownloadTool(env.permissions, env.workingDir, r.GetDefaultClient()),
 		tools.NewEditTool(nil, env.permissions, env.history, *env.filetracker, env.workingDir),
 		tools.NewMultiEditTool(nil, env.permissions, env.history, *env.filetracker, env.workingDir),

--- a/internal/agent/common_test.go
+++ b/internal/agent/common_test.go
@@ -167,7 +167,7 @@ func coderAgent(r *vcr.Recorder, env fakeEnv, large, small fantasy.LanguageModel
 	}
 
 	allTools := []fantasy.AgentTool{
-		tools.NewBashTool(env.permissions, env.workingDir, cfg.Config().Options.Attribution, modelName),
+		tools.NewBashTool(env.permissions, env.workingDir, cfg.Config().Options.Attribution, modelName, cfg.Config().Options),
 		tools.NewDownloadTool(env.permissions, env.workingDir, r.GetDefaultClient()),
 		tools.NewEditTool(nil, env.permissions, env.history, *env.filetracker, env.workingDir),
 		tools.NewMultiEditTool(nil, env.permissions, env.history, *env.filetracker, env.workingDir),

--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -644,6 +644,15 @@ func (c *coordinator) buildTools(ctx context.Context, agent config.Agent, isSubA
 
 	logFile := filepath.Join(c.cfg.Config().Options.DataDirectory, "logs", "crush.log")
 
+	// Effective bash allow-list: config-file values plus any runtime overrides
+	// from --allow-commands / --allow-all-commands (or their env vars). The
+	// overrides live on the store rather than in Options so they survive the
+	// config reloads triggered by MCP reconnects and model changes.
+	bashOpts := c.cfg.Config().Options
+	bashOverrides := c.cfg.Overrides()
+	allowedCommands := append(append([]string{}, bashOpts.AllowedCommands...), bashOverrides.AllowedCommands...)
+	allowAllCommands := bashOpts.AllowAllCommands || bashOverrides.AllowAllCommands
+
 	// Build hook runner if PreToolUse hooks are configured.
 	var hookRunner *hooks.Runner
 	if preToolHooks := c.cfg.Config().Hooks[hooks.EventPreToolUse]; len(preToolHooks) > 0 {
@@ -652,7 +661,7 @@ func (c *coordinator) buildTools(ctx context.Context, agent config.Agent, isSubA
 
 	allTools = append(
 		allTools,
-		tools.NewBashTool(c.permissions, c.cfg.WorkingDir(), c.cfg.Config().Options.Attribution, modelID, c.cfg.Config().Options),
+		tools.NewBashTool(c.permissions, c.cfg.WorkingDir(), c.cfg.Config().Options.Attribution, modelID, allowedCommands, allowAllCommands),
 		tools.NewCrushInfoTool(c.cfg, c.lspManager, c.allSkills, c.activeSkills, c.skillTracker),
 		tools.NewCrushLogsTool(logFile),
 		tools.NewJobOutputTool(),

--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -652,7 +652,7 @@ func (c *coordinator) buildTools(ctx context.Context, agent config.Agent, isSubA
 
 	allTools = append(
 		allTools,
-		tools.NewBashTool(c.permissions, c.cfg.WorkingDir(), c.cfg.Config().Options.Attribution, modelID),
+		tools.NewBashTool(c.permissions, c.cfg.WorkingDir(), c.cfg.Config().Options.Attribution, modelID, c.cfg.Config().Options),
 		tools.NewCrushInfoTool(c.cfg, c.lspManager, c.allSkills, c.activeSkills, c.skillTracker),
 		tools.NewCrushLogsTool(logFile),
 		tools.NewJobOutputTool(),

--- a/internal/agent/tools/bash.go
+++ b/internal/agent/tools/bash.go
@@ -145,8 +145,24 @@ var bannedCommands = []string{
 	"ufw",
 }
 
-func bashDescription(attribution *config.Attribution, modelID string) string {
-	bannedCommandsStr := strings.Join(bannedCommands, ", ")
+func bashDescription(attribution *config.Attribution, modelID string, allowedCommands []string, allowAllCommands bool) string {
+	// Build effective banned list for display
+	var bannedCommandsStr string
+	if allowAllCommands {
+		bannedCommandsStr = "(none - all commands allowed)"
+	} else {
+		effectiveBanned := make([]string, 0, len(bannedCommands))
+		allowedSet := make(map[string]bool, len(allowedCommands))
+		for _, cmd := range allowedCommands {
+			allowedSet[cmd] = true
+		}
+		for _, cmd := range bannedCommands {
+			if !allowedSet[cmd] {
+				effectiveBanned = append(effectiveBanned, cmd)
+			}
+		}
+		bannedCommandsStr = strings.Join(effectiveBanned, ", ")
+	}
 	var out bytes.Buffer
 	if err := bashDescriptionTpl.Execute(&out, bashDescriptionData{
 		BannedCommands:  bannedCommandsStr,
@@ -162,9 +178,26 @@ func bashDescription(attribution *config.Attribution, modelID string) string {
 	return out.String()
 }
 
-func blockFuncs() []shell.BlockFunc {
+func blockFuncs(allowedCommands []string, allowAllCommands bool) []shell.BlockFunc {
+	// If allowAllCommands is set, don't block any commands
+	if allowAllCommands {
+		return []shell.BlockFunc{}
+	}
+
+	// Build effective banned list by removing allowed commands from the defaults
+	effectiveBanned := make([]string, 0, len(bannedCommands))
+	allowedSet := make(map[string]bool, len(allowedCommands))
+	for _, cmd := range allowedCommands {
+		allowedSet[cmd] = true
+	}
+	for _, cmd := range bannedCommands {
+		if !allowedSet[cmd] {
+			effectiveBanned = append(effectiveBanned, cmd)
+		}
+	}
+
 	return []shell.BlockFunc{
-		shell.CommandsBlocker(bannedCommands),
+		shell.CommandsBlocker(effectiveBanned),
 
 		// System package managers
 		shell.ArgumentsBlocker("apk", []string{"add"}, nil),
@@ -194,10 +227,16 @@ func blockFuncs() []shell.BlockFunc {
 	}
 }
 
-func NewBashTool(permissions permission.Service, workingDir string, attribution *config.Attribution, modelID string) fantasy.AgentTool {
+func NewBashTool(permissions permission.Service, workingDir string, attribution *config.Attribution, modelID string, opts *config.Options) fantasy.AgentTool {
+	var allowedCommands []string
+	var allowAllCommands bool
+	if opts != nil {
+		allowedCommands = opts.AllowedCommands
+		allowAllCommands = opts.AllowAllCommands
+	}
 	return fantasy.NewAgentTool(
 		BashToolName,
-		string(bashDescription(attribution, modelID)),
+		string(bashDescription(attribution, modelID, allowedCommands, allowAllCommands)),
 		func(ctx context.Context, params BashParams, call fantasy.ToolCall) (fantasy.ToolResponse, error) {
 			if params.Command == "" {
 				return fantasy.NewTextErrorResponse("missing command"), nil
@@ -251,7 +290,7 @@ func NewBashTool(permissions permission.Service, workingDir string, attribution 
 				bgManager := shell.GetBackgroundShellManager()
 				bgManager.Cleanup()
 				// Use background context so it continues after tool returns
-				bgShell, err := bgManager.Start(context.Background(), execWorkingDir, blockFuncs(), params.Command, params.Description)
+				bgShell, err := bgManager.Start(context.Background(), execWorkingDir, blockFuncs(allowedCommands, allowAllCommands), params.Command, params.Description)
 				if err != nil {
 					return fantasy.ToolResponse{}, fmt.Errorf("error starting background shell: %w", err)
 				}
@@ -306,7 +345,7 @@ func NewBashTool(permissions permission.Service, workingDir string, attribution 
 			// Start with detached context so it can survive if moved to background
 			bgManager := shell.GetBackgroundShellManager()
 			bgManager.Cleanup()
-			bgShell, err := bgManager.Start(context.Background(), execWorkingDir, blockFuncs(), params.Command, params.Description)
+			bgShell, err := bgManager.Start(context.Background(), execWorkingDir, blockFuncs(allowedCommands, allowAllCommands), params.Command, params.Description)
 			if err != nil {
 				return fantasy.ToolResponse{}, fmt.Errorf("error starting shell: %w", err)
 			}

--- a/internal/agent/tools/bash.go
+++ b/internal/agent/tools/bash.go
@@ -145,23 +145,46 @@ var bannedCommands = []string{
 	"ufw",
 }
 
+// effectiveBannedCommands returns the default banned command list with any
+// entries in allowed removed. The order of the defaults is preserved so the
+// tool description and the enforcement layer never drift apart.
+func effectiveBannedCommands(allowed []string) []string {
+	allowedSet := make(map[string]struct{}, len(allowed))
+	for _, cmd := range allowed {
+		allowedSet[cmd] = struct{}{}
+	}
+	effective := make([]string, 0, len(bannedCommands))
+	for _, cmd := range bannedCommands {
+		if _, ok := allowedSet[cmd]; !ok {
+			effective = append(effective, cmd)
+		}
+	}
+	return effective
+}
+
+// UnknownAllowedCommands returns the entries in allowed that are not present
+// in the default banned list. Such entries subtract nothing from the block
+// list and usually indicate a typo, so callers can warn about them.
+func UnknownAllowedCommands(allowed []string) []string {
+	bannedSet := make(map[string]struct{}, len(bannedCommands))
+	for _, cmd := range bannedCommands {
+		bannedSet[cmd] = struct{}{}
+	}
+	var unknown []string
+	for _, cmd := range allowed {
+		if _, ok := bannedSet[cmd]; !ok {
+			unknown = append(unknown, cmd)
+		}
+	}
+	return unknown
+}
+
 func bashDescription(attribution *config.Attribution, modelID string, allowedCommands []string, allowAllCommands bool) string {
-	// Build effective banned list for display
-	var bannedCommandsStr string
-	if allowAllCommands {
-		bannedCommandsStr = "(none - all commands allowed)"
-	} else {
-		effectiveBanned := make([]string, 0, len(bannedCommands))
-		allowedSet := make(map[string]bool, len(allowedCommands))
-		for _, cmd := range allowedCommands {
-			allowedSet[cmd] = true
-		}
-		for _, cmd := range bannedCommands {
-			if !allowedSet[cmd] {
-				effectiveBanned = append(effectiveBanned, cmd)
-			}
-		}
-		bannedCommandsStr = strings.Join(effectiveBanned, ", ")
+	// Build the effective banned list for display. When every command is
+	// allowed the block list is empty.
+	bannedCommandsStr := "(none - all commands allowed)"
+	if !allowAllCommands {
+		bannedCommandsStr = strings.Join(effectiveBannedCommands(allowedCommands), ", ")
 	}
 	var out bytes.Buffer
 	if err := bashDescriptionTpl.Execute(&out, bashDescriptionData{
@@ -179,25 +202,15 @@ func bashDescription(attribution *config.Attribution, modelID string, allowedCom
 }
 
 func blockFuncs(allowedCommands []string, allowAllCommands bool) []shell.BlockFunc {
-	// If allowAllCommands is set, don't block any commands
+	// If allowAllCommands is set, don't block any commands. Note this also
+	// removes the argument-level blockers below (apt install, npm -g, ...);
+	// allowed_commands only subtracts from the exact-command block list.
 	if allowAllCommands {
 		return []shell.BlockFunc{}
 	}
 
-	// Build effective banned list by removing allowed commands from the defaults
-	effectiveBanned := make([]string, 0, len(bannedCommands))
-	allowedSet := make(map[string]bool, len(allowedCommands))
-	for _, cmd := range allowedCommands {
-		allowedSet[cmd] = true
-	}
-	for _, cmd := range bannedCommands {
-		if !allowedSet[cmd] {
-			effectiveBanned = append(effectiveBanned, cmd)
-		}
-	}
-
 	return []shell.BlockFunc{
-		shell.CommandsBlocker(effectiveBanned),
+		shell.CommandsBlocker(effectiveBannedCommands(allowedCommands)),
 
 		// System package managers
 		shell.ArgumentsBlocker("apk", []string{"add"}, nil),
@@ -227,13 +240,7 @@ func blockFuncs(allowedCommands []string, allowAllCommands bool) []shell.BlockFu
 	}
 }
 
-func NewBashTool(permissions permission.Service, workingDir string, attribution *config.Attribution, modelID string, opts *config.Options) fantasy.AgentTool {
-	var allowedCommands []string
-	var allowAllCommands bool
-	if opts != nil {
-		allowedCommands = opts.AllowedCommands
-		allowAllCommands = opts.AllowAllCommands
-	}
+func NewBashTool(permissions permission.Service, workingDir string, attribution *config.Attribution, modelID string, allowedCommands []string, allowAllCommands bool) fantasy.AgentTool {
 	return fantasy.NewAgentTool(
 		BashToolName,
 		string(bashDescription(attribution, modelID, allowedCommands, allowAllCommands)),

--- a/internal/agent/tools/bash_test.go
+++ b/internal/agent/tools/bash_test.go
@@ -117,7 +117,7 @@ func (m *recordingPermissionService) SubscribeNotifications(ctx context.Context)
 func newBashToolForTest(workingDir string) fantasy.AgentTool {
 	permissions := &mockBashPermissionService{Broker: pubsub.NewBroker[permission.PermissionRequest]()}
 	attribution := &config.Attribution{TrailerStyle: config.TrailerStyleNone}
-	return NewBashTool(permissions, workingDir, attribution, "test-model", nil)
+	return NewBashTool(permissions, workingDir, attribution, "test-model", nil, false)
 }
 
 func newBashToolWithRecordingPerms(workingDir string, allow bool) (fantasy.AgentTool, *recordingPermissionService) {
@@ -126,7 +126,7 @@ func newBashToolWithRecordingPerms(workingDir string, allow bool) (fantasy.Agent
 		allow:  allow,
 	}
 	attribution := &config.Attribution{TrailerStyle: config.TrailerStyleNone}
-	return NewBashTool(perms, workingDir, attribution, "test-model", nil), perms
+	return NewBashTool(perms, workingDir, attribution, "test-model", nil, false), perms
 }
 
 func TestBashTool_ChainedCommandsRequirePermission(t *testing.T) {
@@ -210,4 +210,55 @@ func TestTruncateOutputEmoji(t *testing.T) {
 	out := TruncateOutput(content)
 	require.True(t, utf8.ValidString(out), "truncated output must stay valid UTF-8")
 	require.Contains(t, out, "lines truncated")
+}
+
+func TestEffectiveBannedCommands(t *testing.T) {
+	t.Parallel()
+
+	// No allowances: the effective list matches the defaults exactly.
+	require.Equal(t, bannedCommands, effectiveBannedCommands(nil))
+
+	// Allowing a banned command removes it while preserving order and the
+	// rest of the list.
+	effective := effectiveBannedCommands([]string{"ssh", "curl"})
+	require.NotContains(t, effective, "ssh")
+	require.NotContains(t, effective, "curl")
+	require.Contains(t, effective, "systemctl")
+	require.Len(t, effective, len(bannedCommands)-2)
+
+	// Unknown allowances subtract nothing.
+	require.Equal(t, bannedCommands, effectiveBannedCommands([]string{"definitely-not-banned"}))
+}
+
+func TestUnknownAllowedCommands(t *testing.T) {
+	t.Parallel()
+
+	require.Empty(t, UnknownAllowedCommands(nil))
+	require.Empty(t, UnknownAllowedCommands([]string{"ssh", "curl"}))
+	require.Equal(t, []string{"shh"}, UnknownAllowedCommands([]string{"ssh", "shh"}))
+}
+
+func TestBlockFuncs_AllowedCommandNotBlocked(t *testing.T) {
+	t.Parallel()
+
+	// By default, ssh is blocked by the first (commands) blocker.
+	require.True(t, blockFuncs(nil, false)[0]([]string{"ssh"}))
+
+	// Allowing ssh unblocks it, but a still-banned command stays blocked.
+	allowed := blockFuncs([]string{"ssh"}, false)
+	require.False(t, allowed[0]([]string{"ssh"}))
+	require.True(t, allowed[0]([]string{"systemctl"}))
+
+	// Allowing ssh does not touch the argument-level blockers (apt install).
+	stillBlocksAptInstall := false
+	for _, fn := range allowed {
+		if fn([]string{"apt", "install", "cowsay"}) {
+			stillBlocksAptInstall = true
+			break
+		}
+	}
+	require.True(t, stillBlocksAptInstall, "allowed_commands must not unlock package-manager argument blocks")
+
+	// allowAllCommands drops every blocker, including argument-level ones.
+	require.Empty(t, blockFuncs(nil, true))
 }

--- a/internal/agent/tools/bash_test.go
+++ b/internal/agent/tools/bash_test.go
@@ -117,7 +117,7 @@ func (m *recordingPermissionService) SubscribeNotifications(ctx context.Context)
 func newBashToolForTest(workingDir string) fantasy.AgentTool {
 	permissions := &mockBashPermissionService{Broker: pubsub.NewBroker[permission.PermissionRequest]()}
 	attribution := &config.Attribution{TrailerStyle: config.TrailerStyleNone}
-	return NewBashTool(permissions, workingDir, attribution, "test-model")
+	return NewBashTool(permissions, workingDir, attribution, "test-model", nil)
 }
 
 func newBashToolWithRecordingPerms(workingDir string, allow bool) (fantasy.AgentTool, *recordingPermissionService) {
@@ -126,7 +126,7 @@ func newBashToolWithRecordingPerms(workingDir string, allow bool) (fantasy.Agent
 		allow:  allow,
 	}
 	attribution := &config.Attribution{TrailerStyle: config.TrailerStyleNone}
-	return NewBashTool(perms, workingDir, attribution, "test-model"), perms
+	return NewBashTool(perms, workingDir, attribution, "test-model", nil), perms
 }
 
 func TestBashTool_ChainedCommandsRequirePermission(t *testing.T) {

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -13,6 +13,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/charmbracelet/crush/internal/agent/tools"
 	"github.com/charmbracelet/crush/internal/app"
 	"github.com/charmbracelet/crush/internal/config"
 	"github.com/charmbracelet/crush/internal/csync"
@@ -277,6 +278,11 @@ func (b *Backend) CreateWorkspace(args proto.Workspace) (*Workspace, proto.Works
 
 	cfg.Overrides().SkipPermissionRequests = args.YOLO
 	cfg.Overrides().EnabledChannels = args.Channels
+	cfg.Overrides().AllowAllCommands = args.AllowAllCommands
+	cfg.Overrides().AllowedCommands = args.AllowedCommands
+	if unknown := tools.UnknownAllowedCommands(append(append([]string{}, cfg.Config().Options.AllowedCommands...), args.AllowedCommands...)); len(unknown) > 0 {
+		slog.Warn("Ignoring allow-commands entries not in the default banned list", "commands", unknown)
+	}
 
 	if err := createDotCrushDir(cfg.Config().Options.DataDirectory); err != nil {
 		return nil, proto.Workspace{}, fmt.Errorf("failed to create data directory: %w", err)
@@ -716,15 +722,17 @@ func validateClientID(id string) (string, error) {
 func workspaceToProto(ws *Workspace) proto.Workspace {
 	cfg := ws.Cfg.Config()
 	out := proto.Workspace{
-		ID:       ws.ID,
-		Path:     ws.Path,
-		YOLO:     ws.Cfg.Overrides().SkipPermissionRequests,
-		Channels: ws.Cfg.Overrides().EnabledChannels,
-		DataDir:  cfg.Options.DataDirectory,
-		Debug:    cfg.Options.Debug,
-		Config:   cfg,
-		Env:      ws.Env,
-		Version:  version.Version,
+		ID:               ws.ID,
+		Path:             ws.Path,
+		YOLO:             ws.Cfg.Overrides().SkipPermissionRequests,
+		Channels:         ws.Cfg.Overrides().EnabledChannels,
+		AllowAllCommands: ws.Cfg.Overrides().AllowAllCommands,
+		AllowedCommands:  ws.Cfg.Overrides().AllowedCommands,
+		DataDir:          cfg.Options.DataDirectory,
+		Debug:            cfg.Options.Debug,
+		Config:           cfg,
+		Env:              ws.Env,
+		Version:          version.Version,
 	}
 	if ws.Skills != nil {
 		out.Skills = skillStatesToProto(ws.Skills.States())

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -24,6 +24,7 @@ import (
 	fang "charm.land/fang/v2"
 	"charm.land/lipgloss/v2"
 	"github.com/charmbracelet/colorprofile"
+	"github.com/charmbracelet/crush/internal/agent/tools"
 	"github.com/charmbracelet/crush/internal/app"
 	"github.com/charmbracelet/crush/internal/client"
 	"github.com/charmbracelet/crush/internal/config"
@@ -60,8 +61,8 @@ func init() {
 	rootCmd.Flags().StringSlice("channels", nil, "MCP servers to enable as channels (repeatable), e.g. --channels server:webhook")
 	rootCmd.Flags().StringP("session", "s", "", "Continue a previous session by ID")
 	rootCmd.Flags().BoolP("continue", "C", false, "Continue the most recent session")
-	rootCmd.Flags().StringSlice("allow-commands", nil, "Allow commands that are normally banned (repeatable), e.g. --allow-commands ssh --allow-commands curl")
-	rootCmd.Flags().Bool("allow-all-commands", false, "Allow all commands that are normally banned (removes all blocklist restrictions)")
+	rootCmd.Flags().StringSlice("allow-commands", nil, "Allow specific commands from the default bash blocklist (repeatable); does not affect package-manager argument blocks like 'apt install'. Env: CRUSH_ALLOW_COMMANDS (comma-separated)")
+	rootCmd.Flags().Bool("allow-all-commands", false, "Remove all bash blocklist restrictions, including package-manager blocks (dangerous). Env: CRUSH_ALLOW_ALL_COMMANDS")
 	rootCmd.MarkFlagsMutuallyExclusive("session", "continue")
 
 	rootCmd.AddCommand(
@@ -248,19 +249,14 @@ func setupWorkspace(cmd *cobra.Command) (workspace.Workspace, func(), error) {
 	return setupLocalWorkspace(cmd)
 }
 
-// setupLocalWorkspace creates an in-process app.App and wraps it in an
-// AppWorkspace.
-func setupLocalWorkspace(cmd *cobra.Command) (workspace.Workspace, func(), error) {
-	debug, _ := cmd.Flags().GetBool("debug")
-	yolo, _ := cmd.Flags().GetBool("yolo")
-	channels, _ := cmd.Flags().GetStringSlice("channels")
-	allowCommands, _ := cmd.Flags().GetStringSlice("allow-commands")
-	allowAllCommands, _ := cmd.Flags().GetBool("allow-all-commands")
-	dataDir, _ := cmd.Flags().GetString("data-dir")
-	ctx := cmd.Context()
+// resolveAllowCommands returns the bash allow-command settings from flags,
+// falling back to the CRUSH_ALLOW_COMMANDS / CRUSH_ALLOW_ALL_COMMANDS
+// environment variables for 12-factor compliance. CLI flags take precedence
+// over env vars. Comma-separated env entries are trimmed and empties dropped.
+func resolveAllowCommands(cmd *cobra.Command) (allowCommands []string, allowAllCommands bool) {
+	allowCommands, _ = cmd.Flags().GetStringSlice("allow-commands")
+	allowAllCommands, _ = cmd.Flags().GetBool("allow-all-commands")
 
-	// Support environment variables for 12-factor app compliance
-	// CLI flags take precedence over env vars
 	if !allowAllCommands {
 		if v := os.Getenv("CRUSH_ALLOW_ALL_COMMANDS"); v != "" {
 			allowAllCommands = strings.EqualFold(v, "true") || v == "1"
@@ -268,9 +264,37 @@ func setupLocalWorkspace(cmd *cobra.Command) (workspace.Workspace, func(), error
 	}
 	if len(allowCommands) == 0 {
 		if v := os.Getenv("CRUSH_ALLOW_COMMANDS"); v != "" {
-			allowCommands = strings.Split(v, ",")
+			for _, c := range strings.Split(v, ",") {
+				if c = strings.TrimSpace(c); c != "" {
+					allowCommands = append(allowCommands, c)
+				}
+			}
 		}
 	}
+	return allowCommands, allowAllCommands
+}
+
+// warnUnknownAllowedCommands logs a startup warning for allow-command entries
+// (from config and flags/env) that aren't in the default banned list, since
+// they subtract nothing and usually indicate a typo.
+func warnUnknownAllowedCommands(configAllowed, flagAllowed []string) {
+	combined := make([]string, 0, len(configAllowed)+len(flagAllowed))
+	combined = append(combined, configAllowed...)
+	combined = append(combined, flagAllowed...)
+	if unknown := tools.UnknownAllowedCommands(combined); len(unknown) > 0 {
+		slog.Warn("Ignoring allow-commands entries not in the default banned list", "commands", unknown)
+	}
+}
+
+// setupLocalWorkspace creates an in-process app.App and wraps it in an
+// AppWorkspace.
+func setupLocalWorkspace(cmd *cobra.Command) (workspace.Workspace, func(), error) {
+	debug, _ := cmd.Flags().GetBool("debug")
+	yolo, _ := cmd.Flags().GetBool("yolo")
+	channels, _ := cmd.Flags().GetStringSlice("channels")
+	allowCommands, allowAllCommands := resolveAllowCommands(cmd)
+	dataDir, _ := cmd.Flags().GetString("data-dir")
+	ctx := cmd.Context()
 
 	cwd, err := ResolveCwd(cmd)
 	if err != nil {
@@ -285,15 +309,11 @@ func setupLocalWorkspace(cmd *cobra.Command) (workspace.Workspace, func(), error
 	cfg := store.Config()
 	store.Overrides().SkipPermissionRequests = yolo
 	store.Overrides().EnabledChannels = channels
-
-	// Handle --allow-all-commands and --allow-commands flags
-	if allowAllCommands || len(allowCommands) > 0 {
-		if cfg.Options == nil {
-			cfg.Options = &config.Options{}
-		}
-		cfg.Options.AllowAllCommands = allowAllCommands
-		cfg.Options.AllowedCommands = append(cfg.Options.AllowedCommands, allowCommands...)
-	}
+	// Held as runtime overrides (not written into Options) so they survive the
+	// config reloads triggered by MCP reconnects and model changes.
+	store.Overrides().AllowAllCommands = allowAllCommands
+	store.Overrides().AllowedCommands = allowCommands
+	warnUnknownAllowedCommands(cfg.Options.AllowedCommands, allowCommands)
 
 	if err := os.MkdirAll(cfg.Options.DataDirectory, 0o700); err != nil {
 		return nil, nil, fmt.Errorf("failed to create data directory: %q %w", cfg.Options.DataDirectory, err)
@@ -402,6 +422,7 @@ func connectToServer(cmd *cobra.Command) (*client.Client, *proto.Workspace, func
 	debug, _ := cmd.Flags().GetBool("debug")
 	yolo, _ := cmd.Flags().GetBool("yolo")
 	channels, _ := cmd.Flags().GetStringSlice("channels")
+	allowCommands, allowAllCommands := resolveAllowCommands(cmd)
 	dataDir, _ := cmd.Flags().GetString("data-dir")
 	ctx := cmd.Context()
 
@@ -416,13 +437,15 @@ func connectToServer(cmd *cobra.Command) (*client.Client, *proto.Workspace, func
 	}
 
 	wsReq := proto.Workspace{
-		Path:     cwd,
-		DataDir:  dataDir,
-		Debug:    debug,
-		YOLO:     yolo,
-		Channels: channels,
-		Version:  version.Version,
-		Env:      os.Environ(),
+		Path:             cwd,
+		DataDir:          dataDir,
+		Debug:            debug,
+		YOLO:             yolo,
+		Channels:         channels,
+		AllowAllCommands: allowAllCommands,
+		AllowedCommands:  allowCommands,
+		Version:          version.Version,
+		Env:              os.Environ(),
 	}
 
 	ws, err := c.CreateWorkspace(ctx, wsReq)

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -60,6 +60,8 @@ func init() {
 	rootCmd.Flags().StringSlice("channels", nil, "MCP servers to enable as channels (repeatable), e.g. --channels server:webhook")
 	rootCmd.Flags().StringP("session", "s", "", "Continue a previous session by ID")
 	rootCmd.Flags().BoolP("continue", "C", false, "Continue the most recent session")
+	rootCmd.Flags().StringSlice("allow-commands", nil, "Allow commands that are normally banned (repeatable), e.g. --allow-commands ssh --allow-commands curl")
+	rootCmd.Flags().Bool("allow-all-commands", false, "Allow all commands that are normally banned (removes all blocklist restrictions)")
 	rootCmd.MarkFlagsMutuallyExclusive("session", "continue")
 
 	rootCmd.AddCommand(
@@ -252,8 +254,23 @@ func setupLocalWorkspace(cmd *cobra.Command) (workspace.Workspace, func(), error
 	debug, _ := cmd.Flags().GetBool("debug")
 	yolo, _ := cmd.Flags().GetBool("yolo")
 	channels, _ := cmd.Flags().GetStringSlice("channels")
+	allowCommands, _ := cmd.Flags().GetStringSlice("allow-commands")
+	allowAllCommands, _ := cmd.Flags().GetBool("allow-all-commands")
 	dataDir, _ := cmd.Flags().GetString("data-dir")
 	ctx := cmd.Context()
+
+	// Support environment variables for 12-factor app compliance
+	// CLI flags take precedence over env vars
+	if !allowAllCommands {
+		if v := os.Getenv("CRUSH_ALLOW_ALL_COMMANDS"); v != "" {
+			allowAllCommands = strings.EqualFold(v, "true") || v == "1"
+		}
+	}
+	if len(allowCommands) == 0 {
+		if v := os.Getenv("CRUSH_ALLOW_COMMANDS"); v != "" {
+			allowCommands = strings.Split(v, ",")
+		}
+	}
 
 	cwd, err := ResolveCwd(cmd)
 	if err != nil {
@@ -268,6 +285,15 @@ func setupLocalWorkspace(cmd *cobra.Command) (workspace.Workspace, func(), error
 	cfg := store.Config()
 	store.Overrides().SkipPermissionRequests = yolo
 	store.Overrides().EnabledChannels = channels
+
+	// Handle --allow-all-commands and --allow-commands flags
+	if allowAllCommands || len(allowCommands) > 0 {
+		if cfg.Options == nil {
+			cfg.Options = &config.Options{}
+		}
+		cfg.Options.AllowAllCommands = allowAllCommands
+		cfg.Options.AllowedCommands = append(cfg.Options.AllowedCommands, allowCommands...)
+	}
 
 	if err := os.MkdirAll(cfg.Options.DataDirectory, 0o700); err != nil {
 		return nil, nil, fmt.Errorf("failed to create data directory: %q %w", cfg.Options.DataDirectory, err)

--- a/internal/cmd/root_allow_commands_test.go
+++ b/internal/cmd/root_allow_commands_test.go
@@ -1,0 +1,59 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+)
+
+func newAllowCommandsTestCmd() *cobra.Command {
+	cmd := &cobra.Command{}
+	cmd.Flags().StringSlice("allow-commands", nil, "")
+	cmd.Flags().Bool("allow-all-commands", false, "")
+	return cmd
+}
+
+func TestResolveAllowCommands_EnvTrimsWhitespaceAndDropsEmpties(t *testing.T) {
+	t.Setenv("CRUSH_ALLOW_COMMANDS", "ssh, curl ,,scp ")
+	t.Setenv("CRUSH_ALLOW_ALL_COMMANDS", "")
+
+	allow, all := resolveAllowCommands(newAllowCommandsTestCmd())
+	require.False(t, all)
+	require.Equal(t, []string{"ssh", "curl", "scp"}, allow)
+}
+
+func TestResolveAllowCommands_FlagsTakePrecedenceOverEnv(t *testing.T) {
+	t.Setenv("CRUSH_ALLOW_COMMANDS", "curl")
+	t.Setenv("CRUSH_ALLOW_ALL_COMMANDS", "true")
+
+	cmd := newAllowCommandsTestCmd()
+	require.NoError(t, cmd.Flags().Set("allow-commands", "ssh"))
+
+	allow, all := resolveAllowCommands(cmd)
+	// Flag was provided, so env is ignored for allow-commands.
+	require.Equal(t, []string{"ssh"}, allow)
+	// allow-all-commands flag was not set, so it falls back to the env var.
+	require.True(t, all)
+}
+
+func TestResolveAllowCommands_AllCommandsEnvVariants(t *testing.T) {
+	for _, tc := range []struct {
+		val  string
+		want bool
+	}{
+		{"true", true},
+		{"TRUE", true},
+		{"1", true},
+		{"false", false},
+		{"0", false},
+		{"", false},
+	} {
+		t.Run(tc.val, func(t *testing.T) {
+			t.Setenv("CRUSH_ALLOW_ALL_COMMANDS", tc.val)
+			t.Setenv("CRUSH_ALLOW_COMMANDS", "")
+			_, all := resolveAllowCommands(newAllowCommandsTestCmd())
+			require.Equal(t, tc.want, all)
+		})
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -301,12 +301,16 @@ type Options struct {
 	// AllowedCommands specifies commands that should be removed from the default
 	// banned commands list, allowing the agent to execute them via the bash tool.
 	// This provides a way to selectively enable commands like "ssh" or "curl"
-	// that are blocked by default for security reasons.
-	AllowedCommands []string `json:"allowed_commands,omitempty" jsonschema:"description=List of commands to allow that are normally banned,example=ssh,example=curl,example=scp"`
+	// that are blocked by default for security reasons. It only subtracts from
+	// the exact-command block list; package-manager argument blocks such as
+	// "apt install" or "npm -g" are unaffected. Allowed commands are still
+	// subject to the normal permission prompt (they are not auto-approved).
+	AllowedCommands []string `json:"allowed_commands,omitempty" jsonschema:"description=List of commands to allow that are normally banned. Only affects the exact-command block list; package-manager argument blocks (e.g. 'apt install') are unaffected. Allowed commands still require permission approval.,example=ssh,example=curl,example=scp"`
 	// AllowAllCommands removes all restrictions from the banned commands list,
-	// allowing the agent to execute any command via the bash tool.
+	// allowing the agent to execute any command via the bash tool. Unlike
+	// allowed_commands, this also removes the package-manager argument blocks.
 	// This is a dangerous option and should be used with caution.
-	AllowAllCommands bool `json:"allow_all_commands,omitempty" jsonschema:"description=Remove all command restrictions from the bash tool (dangerous),default=false"`
+	AllowAllCommands bool `json:"allow_all_commands,omitempty" jsonschema:"description=Remove all command restrictions from the bash tool, including package-manager argument blocks (dangerous). Commands still require permission approval unless yolo mode is enabled.,default=false"`
 }
 
 type MCPs map[string]MCPConfig

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -298,6 +298,15 @@ type Options struct {
 	NotificationStyle         string       `json:"notification_style,omitempty" jsonschema:"description=Notification style to use. Options: auto (default), native, osc, bell, disabled. Auto selects based on environment: native for local sessions, osc for SSH (with automatic OSC 99/777 detection).,enum=auto,enum=native,enum=osc,enum=bell,enum=disabled,default=auto"`
 	DisabledSkills            []string     `json:"disabled_skills,omitempty" jsonschema:"description=List of skill names to disable and hide from the agent,example=crush-config"`
 	DisableA2UI               bool         `json:"disable_a2ui,omitempty" jsonschema:"description=Disable the A2UI prompt section that invites the model to emit renderable <a2ui-json> UI surfaces in chat,default=false"`
+	// AllowedCommands specifies commands that should be removed from the default
+	// banned commands list, allowing the agent to execute them via the bash tool.
+	// This provides a way to selectively enable commands like "ssh" or "curl"
+	// that are blocked by default for security reasons.
+	AllowedCommands []string `json:"allowed_commands,omitempty" jsonschema:"description=List of commands to allow that are normally banned,example=ssh,example=curl,example=scp"`
+	// AllowAllCommands removes all restrictions from the banned commands list,
+	// allowing the agent to execute any command via the bash tool.
+	// This is a dangerous option and should be used with caution.
+	AllowAllCommands bool `json:"allow_all_commands,omitempty" jsonschema:"description=Remove all command restrictions from the bash tool (dangerous),default=false"`
 }
 
 type MCPs map[string]MCPConfig

--- a/internal/config/store.go
+++ b/internal/config/store.go
@@ -55,6 +55,15 @@ type RuntimeOverrides struct {
 	// pushes channel events when it also appears here. Entries may be written
 	// as "server:<name>" or as a bare "<name>".
 	EnabledChannels []string
+	// AllowAllCommands, when true, removes every bash-tool command block for
+	// this session (via the --allow-all-commands flag or CRUSH_ALLOW_ALL_COMMANDS).
+	AllowAllCommands bool
+	// AllowedCommands lists commands to drop from the bash tool's default
+	// banned list for this session (via the --allow-commands flag or
+	// CRUSH_ALLOW_COMMANDS). It is merged with options.allowed_commands from
+	// the config file. Held here rather than in Options so it survives config
+	// reloads.
+	AllowedCommands []string
 }
 
 // ConfigStore is the single entry point for all config access. It owns the

--- a/internal/proto/proto.go
+++ b/internal/proto/proto.go
@@ -25,6 +25,13 @@ type Workspace struct {
 	// Channels lists the MCP servers opted in as channels for this workspace
 	// (from the --channels flag).
 	Channels []string `json:"channels,omitempty"`
+	// AllowAllCommands removes every bash-tool command block for this
+	// workspace (from the --allow-all-commands flag or CRUSH_ALLOW_ALL_COMMANDS).
+	AllowAllCommands bool `json:"allow_all_commands,omitempty"`
+	// AllowedCommands lists commands to drop from the bash tool's default
+	// banned list for this workspace (from the --allow-commands flag or
+	// CRUSH_ALLOW_COMMANDS).
+	AllowedCommands []string `json:"allowed_commands,omitempty"`
 	// Skills carries the snapshot of skill discovery state at workspace
 	// creation time. Subsequent updates flow through the SSE event
 	// stream.


### PR DESCRIPTION
## Summary

Adds ability to selectively remove commands from the default banned list via `crush.json` config or CLI flag.

## Changes

- Add `AllowedCommands` field to `config.Options`
- Add `--allow-commands` CLI flag (repeatable)
- Refactor bash tool to accept `allowedCommands` parameter
- Generate effective banned list at runtime by removing allowed commands

## Backward Compatibility

Fully backward compatible - default `bannedCommands` remain unchanged.

## Usage Examples

**Via crush.json:**
```json
{
  "options": {
    "allowed_commands": ["ssh", "curl", "scp"]
  }
}
```

**Via CLI:**
```bash
crush --allow-commands ssh --allow-commands curl
```

## Testing

All existing bash tool tests pass.

---

💘 Generated with Crush