### PR TITLE
feat(agent): auto-route replies back to originating messaging channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -454,6 +454,50 @@ A common interactive channel is [Signal MCP](https://github.com/joestump/signal-
 
 Incoming messages arrive as `<channel>` tags; use the `send_message_to_user` tool to reply.
 
+#### Channel reply routing
+
+By default a channel-originated turn only produces terminal output, so a
+person messaging you on Signal never sees the answer unless the model decides
+to call a send tool itself. Adding a `channel_reply` block to a channel
+server's MCP config makes the routing deterministic: when a turn that
+originated from that channel finishes without the model having replied through
+the channel, Crush sends the final assistant response back through the
+configured tool — to the sender for direct messages, or to the group for group
+messages.
+
+```json
+{
+  "mcp": {
+    "signal": {
+      "type": "stdio",
+      "command": "uv",
+      "args": ["run", "signal_mcp/main.py", "--operator", "+15551234567", "--channel"],
+      "channel_reply": {
+        "user": { "tool": "send_message_to_user", "target_param": "user_id" },
+        "group": { "tool": "send_message_to_group", "target_param": "group_id" },
+        "suppress_tools": ["send"]
+      }
+    }
+  }
+}
+```
+
+How it routes:
+
+- **Group pushes** (meta carries `group`) go through the `group` route;
+  **direct pushes** (meta carries `sender`) go through the `user` route.
+  `target_meta` overrides which meta attribute supplies the target;
+  `message_param` (default `message`) names the tool argument that receives
+  the reply text.
+- If the model already called a route tool — or any tool listed in
+  `suppress_tools` — during the turn, the automatic reply is skipped, so
+  richer model-driven replies aren't duplicated.
+- Local (non-channel) turns and channels without a `channel_reply` block are
+  unaffected.
+
+The same shape works for any messaging channel (Discord, Slack, …): point the
+routes at that server's send tools and the matching meta attributes.
+
 The `source` attribute is always the (trusted) server name. Payloads are
 untrusted, server-initiated input: Crush validates their structure, caps the
 body and attribute sizes, restricts `meta` keys to identifiers

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -125,6 +125,12 @@ type SessionAgentCall struct {
 	// paths treat as covered by any present mark, preserving the
 	// pre-sequence behavior.
 	acceptSeq uint64
+	// channelMeta holds the attributes of the <channel> element a
+	// channel-originated turn was started with, parsed once at Run
+	// entry. It survives the auto-summarize continuation, whose Prompt
+	// is rewritten and no longer carries the element, so the reply
+	// target is not lost when a long channel turn is summarized.
+	channelMeta map[string]string
 }
 
 func filterToolsForChannel(agentTools []fantasy.AgentTool, channel string, states map[string]mcp.ClientInfo) []fantasy.AgentTool {
@@ -175,9 +181,13 @@ type sessionAgent struct {
 	systemPrompt       *csync.Value[string]
 	tools              *csync.Slice[fantasy.AgentTool]
 
-	isSubAgent           bool
-	sessions             session.Service
-	messages             message.Service
+	isSubAgent bool
+	sessions   session.Service
+	messages   message.Service
+	// cfg backs channel reply routing (config lookup + MCP tool
+	// invocation). Nil in tests and sub-agents that never see channel
+	// turns; sendChannelReply treats nil as "routing disabled".
+	cfg                  *config.ConfigStore
 	disableAutoSummarize bool
 	isYolo               bool
 	notify               pubsub.Publisher[notify.Notification]
@@ -234,6 +244,7 @@ type SessionAgentOptions struct {
 	IsYolo               bool
 	Sessions             session.Service
 	Messages             message.Service
+	Cfg                  *config.ConfigStore
 	Tools                []fantasy.AgentTool
 	Notify               pubsub.Publisher[notify.Notification]
 	RunComplete          pubsub.Publisher[notify.RunComplete]
@@ -250,6 +261,7 @@ func NewSessionAgent(
 		isSubAgent:           opts.IsSubAgent,
 		sessions:             opts.Sessions,
 		messages:             opts.Messages,
+		cfg:                  opts.Cfg,
 		disableAutoSummarize: opts.DisableAutoSummarize,
 		tools:                csync.NewSliceFrom(opts.Tools),
 		isYolo:               opts.IsYolo,
@@ -570,6 +582,10 @@ func (a *sessionAgent) Run(ctx context.Context, call SessionAgentCall) (result *
 		return nil, err
 	}
 
+	if call.Channel != "" && call.channelMeta == nil {
+		call.channelMeta, _ = parseChannelMeta(call.Prompt)
+	}
+
 	// genCtx/cancel are the run context and its cancel func, created under
 	// the per-session dispatch mutex below so a concurrent Cancel can observe
 	// the activeRequests entry before the assistant message exists.
@@ -786,6 +802,11 @@ func (a *sessionAgent) Run(ctx context.Context, call SessionAgentCall) (result *
 	var stepMessages []fantasy.Message
 	var shouldSummarize bool
 	sanitizedToolCalls := make(map[string]bool)
+	// Full names of tool calls that completed without error this turn.
+	// Written only from the streaming callbacks (which run sequentially)
+	// and read after Stream returns, where sendChannelReply uses it to
+	// tell whether the model already replied on the originating channel.
+	completedToolCalls := make(map[string]struct{})
 	// Don't send MaxOutputTokens if 0 — some providers (e.g. LM Studio) reject it
 	var maxOutputTokens *int64
 	if call.MaxOutputTokens > 0 {
@@ -951,6 +972,9 @@ func (a *sessionAgent) Run(ctx context.Context, call SessionAgentCall) (result *
 			if sanitizedToolCalls[result.ToolCallID] {
 				toolResult.Content = "Tool call failed: arguments were not valid JSON. Please check your tool call format and try again."
 				toolResult.IsError = true
+			}
+			if !toolResult.IsError && toolResult.Name != "" {
+				completedToolCalls[toolResult.Name] = struct{}{}
 			}
 			// Use parent ctx instead of genCtx to ensure the message is created
 			// even if the request is canceled mid-stream
@@ -1171,6 +1195,16 @@ func (a *sessionAgent) Run(ctx context.Context, call SessionAgentCall) (result *
 			existing = append(existing, call)
 			a.messageQueue.Set(call.SessionID, existing)
 		}
+	}
+
+	// Route the finished turn's response back to the channel it came
+	// from, unless the turn was cut short for summarization with work
+	// still pending — the queued continuation carries the channel and
+	// replies when it actually finishes. Runs before the busy state is
+	// released so a follow-up push queued behind this turn cannot
+	// overtake its reply.
+	if currentAssistant != nil && (!shouldSummarize || len(currentAssistant.ToolCalls()) == 0) {
+		a.sendChannelReply(ctx, call, currentAssistant.Content().String(), completedToolCalls)
 	}
 
 	// Release active request before publishing the notification.

--- a/internal/agent/channelreply.go
+++ b/internal/agent/channelreply.go
@@ -1,0 +1,156 @@
+package agent
+
+import (
+	"cmp"
+	"context"
+	"encoding/json"
+	"encoding/xml"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/charmbracelet/crush/internal/agent/tools/mcp"
+	"github.com/charmbracelet/crush/internal/config"
+)
+
+// channelReplyTimeout bounds the auto-reply tool call so a wedged MCP
+// server cannot hold the finished turn (and the session's busy state)
+// open indefinitely.
+const channelReplyTimeout = 30 * time.Second
+
+// Default meta attributes identifying the reply target for each route.
+// They match the channel contract used by messaging servers (e.g. Signal
+// MCP): "sender" carries the author of a direct push, "group" is present
+// only on group pushes.
+const (
+	defaultUserTargetMeta  = "sender"
+	defaultGroupTargetMeta = "group"
+	defaultMessageParam    = "message"
+)
+
+// parseChannelMeta extracts the attributes of the <channel> element a
+// channel-originated turn was started with. The prompt of such a turn is
+// exactly the element rendered by the MCP layer (renderChannel), so this
+// is the inverse of that rendering. Returns ok=false when the prompt does
+// not start with a <channel> element.
+func parseChannelMeta(prompt string) (map[string]string, bool) {
+	dec := xml.NewDecoder(strings.NewReader(prompt))
+	for {
+		tok, err := dec.Token()
+		if err != nil {
+			return nil, false
+		}
+		switch t := tok.(type) {
+		case xml.CharData:
+			if strings.TrimSpace(string(t)) != "" {
+				return nil, false
+			}
+		case xml.StartElement:
+			if t.Name.Local != "channel" {
+				return nil, false
+			}
+			meta := make(map[string]string, len(t.Attr))
+			for _, attr := range t.Attr {
+				meta[attr.Name.Local] = attr.Value
+			}
+			return meta, true
+		default:
+			return nil, false
+		}
+	}
+}
+
+// resolveChannelReply picks the tool call that delivers a reply for a push
+// with the given meta. Group routes win over user routes when the push
+// carries the group target attribute, so a message received in a group is
+// answered in that group rather than as a DM to its author.
+func resolveChannelReply(reply *config.MCPChannelReply, meta map[string]string, text string) (tool string, args map[string]any, ok bool) {
+	msgParam := cmp.Or(reply.MessageParam, defaultMessageParam)
+	route := func(r *config.MCPChannelReplyRoute, defaultMeta string) (string, map[string]any, bool) {
+		if r == nil || r.Tool == "" || r.TargetParam == "" {
+			return "", nil, false
+		}
+		target := meta[cmp.Or(r.TargetMeta, defaultMeta)]
+		if target == "" {
+			return "", nil, false
+		}
+		return r.Tool, map[string]any{r.TargetParam: target, msgParam: text}, true
+	}
+	if tool, args, ok := route(reply.Group, defaultGroupTargetMeta); ok {
+		return tool, args, ok
+	}
+	return route(reply.User, defaultUserTargetMeta)
+}
+
+// channelReplyDelivered reports whether the model already delivered a reply
+// through the channel itself during the turn: completedTools holds the full
+// names (mcp_<server>_<tool>) of tool calls that finished without error, and
+// a call to either route tool or any configured suppress tool counts.
+func channelReplyDelivered(reply *config.MCPChannelReply, channel string, completedTools map[string]struct{}) bool {
+	names := make([]string, 0, 2+len(reply.SuppressTools))
+	if reply.User != nil {
+		names = append(names, reply.User.Tool)
+	}
+	if reply.Group != nil {
+		names = append(names, reply.Group.Tool)
+	}
+	names = append(names, reply.SuppressTools...)
+	for _, name := range names {
+		if name == "" {
+			continue
+		}
+		if _, ok := completedTools[fmt.Sprintf("mcp_%s_%s", channel, name)]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+// sendChannelReply routes the final assistant text of a channel-originated
+// turn back through the channel's configured reply tool. It is a no-op for
+// local turns, channels without a channel_reply config, empty responses,
+// and turns where the model already replied on the channel itself. Failures
+// are logged and dropped: the turn has finished and there is no caller to
+// return an error to.
+func (a *sessionAgent) sendChannelReply(ctx context.Context, call SessionAgentCall, text string, completedTools map[string]struct{}) {
+	if call.Channel == "" || a.cfg == nil {
+		return
+	}
+	mcpCfg, ok := a.cfg.Config().MCP[call.Channel]
+	if !ok || mcpCfg.ChannelReply == nil {
+		return
+	}
+	reply := mcpCfg.ChannelReply
+	if channelReplyDelivered(reply, call.Channel, completedTools) {
+		slog.Debug("Channel reply already delivered by the model", "channel", call.Channel)
+		return
+	}
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return
+	}
+	if call.channelMeta == nil {
+		slog.Warn("Channel reply skipped: prompt has no channel metadata", "channel", call.Channel)
+		return
+	}
+	tool, args, ok := resolveChannelReply(reply, call.channelMeta, text)
+	if !ok {
+		slog.Warn("Channel reply skipped: no reply route matches the push metadata", "channel", call.Channel)
+		return
+	}
+	input, err := json.Marshal(args)
+	if err != nil {
+		slog.Error("Channel reply skipped: failed to encode tool arguments", "channel", call.Channel, "tool", tool, "error", err)
+		return
+	}
+	// Detach from the run context: the turn is complete, and a cancel
+	// racing this send must not lose the reply.
+	sendCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), channelReplyTimeout)
+	defer cancel()
+	if _, err := mcp.RunTool(sendCtx, a.cfg, call.Channel, tool, string(input)); err != nil {
+		slog.Error("Channel reply failed", "channel", call.Channel, "tool", tool, "error", err)
+		return
+	}
+	slog.Info("Routed reply to originating channel", "channel", call.Channel, "tool", tool)
+}

--- a/internal/agent/channelreply_test.go
+++ b/internal/agent/channelreply_test.go
@@ -1,0 +1,143 @@
+package agent
+
+import (
+	"testing"
+
+	"github.com/charmbracelet/crush/internal/config"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseChannelMeta(t *testing.T) {
+	t.Parallel()
+
+	t.Run("channel element with attributes", func(t *testing.T) {
+		t.Parallel()
+		meta, ok := parseChannelMeta(`<channel source="signal" sender="+15551234567" sender_name="Joe">Hello?</channel>`)
+		require.True(t, ok)
+		require.Equal(t, map[string]string{
+			"source":      "signal",
+			"sender":      "+15551234567",
+			"sender_name": "Joe",
+		}, meta)
+	})
+
+	t.Run("escaped attribute values", func(t *testing.T) {
+		t.Parallel()
+		meta, ok := parseChannelMeta(`<channel source="signal" sender_name="A &amp; B">hi</channel>`)
+		require.True(t, ok)
+		require.Equal(t, "A & B", meta["sender_name"])
+	})
+
+	t.Run("leading whitespace tolerated", func(t *testing.T) {
+		t.Parallel()
+		meta, ok := parseChannelMeta("\n  <channel source=\"signal\" sender=\"+1\">x</channel>")
+		require.True(t, ok)
+		require.Equal(t, "+1", meta["sender"])
+	})
+
+	t.Run("plain prompt is not a channel push", func(t *testing.T) {
+		t.Parallel()
+		_, ok := parseChannelMeta("fix the login flow")
+		require.False(t, ok)
+	})
+
+	t.Run("other element is not a channel push", func(t *testing.T) {
+		t.Parallel()
+		_, ok := parseChannelMeta(`<task source="signal">x</task>`)
+		require.False(t, ok)
+	})
+
+	t.Run("empty prompt", func(t *testing.T) {
+		t.Parallel()
+		_, ok := parseChannelMeta("")
+		require.False(t, ok)
+	})
+}
+
+func signalChannelReply() *config.MCPChannelReply {
+	return &config.MCPChannelReply{
+		User:  &config.MCPChannelReplyRoute{Tool: "send_message_to_user", TargetParam: "user_id"},
+		Group: &config.MCPChannelReplyRoute{Tool: "send_message_to_group", TargetParam: "group_id"},
+	}
+}
+
+func TestResolveChannelReply(t *testing.T) {
+	t.Parallel()
+
+	t.Run("direct message routes to the sender", func(t *testing.T) {
+		t.Parallel()
+		tool, args, ok := resolveChannelReply(signalChannelReply(), map[string]string{"sender": "+15551234567"}, "hi")
+		require.True(t, ok)
+		require.Equal(t, "send_message_to_user", tool)
+		require.Equal(t, map[string]any{"user_id": "+15551234567", "message": "hi"}, args)
+	})
+
+	t.Run("group message routes to the group even with a sender", func(t *testing.T) {
+		t.Parallel()
+		meta := map[string]string{"sender": "+15551234567", "group": "grp=="}
+		tool, args, ok := resolveChannelReply(signalChannelReply(), meta, "hi")
+		require.True(t, ok)
+		require.Equal(t, "send_message_to_group", tool)
+		require.Equal(t, map[string]any{"group_id": "grp==", "message": "hi"}, args)
+	})
+
+	t.Run("custom target meta and message param", func(t *testing.T) {
+		t.Parallel()
+		reply := &config.MCPChannelReply{
+			MessageParam: "text",
+			User:         &config.MCPChannelReplyRoute{Tool: "post", TargetParam: "to", TargetMeta: "author"},
+		}
+		tool, args, ok := resolveChannelReply(reply, map[string]string{"author": "joe"}, "yo")
+		require.True(t, ok)
+		require.Equal(t, "post", tool)
+		require.Equal(t, map[string]any{"to": "joe", "text": "yo"}, args)
+	})
+
+	t.Run("no matching meta yields no route", func(t *testing.T) {
+		t.Parallel()
+		_, _, ok := resolveChannelReply(signalChannelReply(), map[string]string{"source": "signal"}, "hi")
+		require.False(t, ok)
+	})
+
+	t.Run("group push without a group route falls back to user", func(t *testing.T) {
+		t.Parallel()
+		reply := &config.MCPChannelReply{
+			User: &config.MCPChannelReplyRoute{Tool: "send_message_to_user", TargetParam: "user_id"},
+		}
+		meta := map[string]string{"sender": "+15551234567", "group": "grp=="}
+		tool, _, ok := resolveChannelReply(reply, meta, "hi")
+		require.True(t, ok)
+		require.Equal(t, "send_message_to_user", tool)
+	})
+
+	t.Run("incomplete route is skipped", func(t *testing.T) {
+		t.Parallel()
+		reply := &config.MCPChannelReply{
+			User: &config.MCPChannelReplyRoute{Tool: "send_message_to_user"}, // no target_param
+		}
+		_, _, ok := resolveChannelReply(reply, map[string]string{"sender": "+1"}, "hi")
+		require.False(t, ok)
+	})
+}
+
+func TestChannelReplyDelivered(t *testing.T) {
+	t.Parallel()
+	reply := signalChannelReply()
+	reply.SuppressTools = []string{"send"}
+
+	completed := func(names ...string) map[string]struct{} {
+		set := make(map[string]struct{}, len(names))
+		for _, n := range names {
+			set[n] = struct{}{}
+		}
+		return set
+	}
+
+	require.True(t, channelReplyDelivered(reply, "signal", completed("mcp_signal_send_message_to_user")))
+	require.True(t, channelReplyDelivered(reply, "signal", completed("mcp_signal_send_message_to_group")))
+	require.True(t, channelReplyDelivered(reply, "signal", completed("mcp_signal_send")))
+	require.False(t, channelReplyDelivered(reply, "signal", completed("mcp_signal_mark_read", "bash")))
+	// A same-named tool on a different server does not count as a reply.
+	require.False(t, channelReplyDelivered(reply, "signal", completed("mcp_other_send_message_to_user")))
+	require.False(t, channelReplyDelivered(reply, "signal", completed()))
+}

--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -590,6 +590,7 @@ func (c *coordinator) buildAgent(ctx context.Context, prompt *prompt.Prompt, age
 		IsYolo:               c.permissions.SkipRequests(),
 		Sessions:             c.sessions,
 		Messages:             c.messages,
+		Cfg:                  c.cfg,
 		Tools:                nil,
 		Notify:               c.notify,
 		RunComplete:          c.runComplete,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -204,6 +204,46 @@ type MCPConfig struct {
 	// omitted from the outgoing request rather than sent as
 	// "Header:".
 	Headers map[string]string `json:"headers,omitempty" jsonschema:"description=HTTP headers for HTTP/SSE MCP servers"`
+
+	// ChannelReply, when set on a server enabled as a channel, makes Crush
+	// route the final assistant response of every turn that originated from
+	// this channel back through one of the server's own tools, so a message
+	// received on the channel gets a reply on the channel even when the
+	// model only produced terminal output.
+	ChannelReply *MCPChannelReply `json:"channel_reply,omitempty" jsonschema:"description=Automatically route replies for turns originating from this channel back through one of the server's tools"`
+}
+
+// MCPChannelReply configures deterministic reply routing for an MCP server
+// acting as a channel: which of the server's tools deliver a reply for
+// direct and group pushes, and how the reply text and target are mapped
+// onto tool arguments.
+type MCPChannelReply struct {
+	// User routes replies to direct (person-to-person) channel pushes.
+	User *MCPChannelReplyRoute `json:"user,omitempty" jsonschema:"description=Reply route for direct messages"`
+	// Group routes replies to group channel pushes. It is preferred over
+	// User when the push carries the group route's meta attribute.
+	Group *MCPChannelReplyRoute `json:"group,omitempty" jsonschema:"description=Reply route for group messages"`
+	// MessageParam is the tool argument that receives the reply text.
+	MessageParam string `json:"message_param,omitempty" jsonschema:"description=Tool argument name that receives the reply text,default=message"`
+	// SuppressTools lists additional tool names (beyond the two route
+	// tools) that count as the model having already replied on the channel
+	// during the turn, e.g. an operator-shortcut send tool.
+	SuppressTools []string `json:"suppress_tools,omitempty" jsonschema:"description=Additional tool names that suppress the automatic reply when the model already called one of them during the turn,example=send"`
+}
+
+// MCPChannelReplyRoute maps one kind of inbound channel push onto the MCP
+// tool call that delivers a reply to it.
+type MCPChannelReplyRoute struct {
+	// Tool is the MCP tool (bare name, without the mcp_<server>_ prefix)
+	// invoked to deliver the reply.
+	Tool string `json:"tool" jsonschema:"required,description=MCP tool name that sends the reply,example=send_message_to_user"`
+	// TargetParam is the tool argument that receives the reply target
+	// (recipient or group ID).
+	TargetParam string `json:"target_param" jsonschema:"required,description=Tool argument name that receives the reply target,example=user_id"`
+	// TargetMeta is the <channel> meta attribute whose value identifies
+	// the reply target. Defaults to "sender" for the user route and
+	// "group" for the group route.
+	TargetMeta string `json:"target_meta,omitempty" jsonschema:"description=Channel meta attribute carrying the reply target; defaults to sender (user route) or group (group route)"`
 }
 
 type LSPConfig struct {

--- a/schema.json
+++ b/schema.json
@@ -212,6 +212,63 @@
       },
       "type": "object"
     },
+    "MCPChannelReply": {
+      "properties": {
+        "user": {
+          "$ref": "#/$defs/MCPChannelReplyRoute",
+          "description": "Reply route for direct messages"
+        },
+        "group": {
+          "$ref": "#/$defs/MCPChannelReplyRoute",
+          "description": "Reply route for group messages"
+        },
+        "message_param": {
+          "type": "string",
+          "description": "Tool argument name that receives the reply text",
+          "default": "message"
+        },
+        "suppress_tools": {
+          "items": {
+            "type": "string",
+            "examples": [
+              "send"
+            ]
+          },
+          "type": "array",
+          "description": "Additional tool names that suppress the automatic reply when the model already called one of them during the turn"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "MCPChannelReplyRoute": {
+      "properties": {
+        "tool": {
+          "type": "string",
+          "description": "MCP tool name that sends the reply",
+          "examples": [
+            "send_message_to_user"
+          ]
+        },
+        "target_param": {
+          "type": "string",
+          "description": "Tool argument name that receives the reply target",
+          "examples": [
+            "user_id"
+          ]
+        },
+        "target_meta": {
+          "type": "string",
+          "description": "Channel meta attribute carrying the reply target; defaults to sender (user route) or group (group route)"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "tool",
+        "target_param"
+      ]
+    },
     "MCPConfig": {
       "properties": {
         "command": {
@@ -294,6 +351,10 @@
           },
           "type": "object",
           "description": "HTTP headers for HTTP/SSE MCP servers"
+        },
+        "channel_reply": {
+          "$ref": "#/$defs/MCPChannelReply",
+          "description": "Automatically route replies for turns originating from this channel back through one of the server's tools"
         }
       },
       "additionalProperties": false,


### PR DESCRIPTION
Fixes #160.

## Problem

A message arriving via a messaging MCP channel (e.g. Signal) got its answer only in CLI output. Unless the model spontaneously decided to call `send_message_to_user`, the person on Signal saw nothing.

## Approach

The issue proposed hook-based routing (Option B), but Crush hooks are shell scripts that only support `PreToolUse` and cannot invoke MCP tools, so the literal design doesn't fit. This PR instead builds on the existing channel architecture (per-turn channel provenance + channel tool gating) with **config-driven deterministic routing** — still channel-generic and extensible, with zero Signal-specific logic in core:

- New optional `channel_reply` block on an MCP server's config maps direct and group pushes onto that server's reply tools (`user` / `group` routes with `tool`, `target_param`, optional `target_meta`, plus `message_param` and `suppress_tools`).
- When a channel-originated turn finishes, the agent parses the reply target from the inbound `<channel>` element's attributes (`sender` / `group` by default) and sends the final assistant text through the matching route — group route wins when the push carries a group ID.
- If the model already replied through the channel itself during the turn (called a route tool or anything in `suppress_tools`, successfully), the auto-send is skipped so replies aren't duplicated.
- The parsed channel meta is carried on the queued continuation when a long turn is cut for auto-summarization, so the reply target survives the prompt rewrite.
- The reply is sent before the session's busy state is released, so a follow-up push queued behind the turn can't overtake its reply. Sends are bounded by a 30s detached-context timeout; failures are logged and dropped.

Example config for [Signal MCP](https://github.com/joestump/signal-mcp):

```json
"channel_reply": {
  "user":  { "tool": "send_message_to_user",  "target_param": "user_id" },
  "group": { "tool": "send_message_to_group", "target_param": "group_id" },
  "suppress_tools": ["send"]
}
```

## Acceptance criteria

- ✅ Signal messages receive Signal replies automatically (deterministic, not model-dependent)
- ✅ Group messages route to the correct group ID (`group` meta → group route)
- ✅ Direct messages route to the correct sender ID (`sender` meta → user route)
- ✅ Non-channel messages continue to output to CLI only (routing keys off per-turn channel provenance)
- ✅ Configuration allows extending to other messaging channels (any server's tools/params can be mapped)

## Changes

- `internal/config/config.go`: `MCPChannelReply` / `MCPChannelReplyRoute` types, `channel_reply` field on `MCPConfig`; `schema.json` regenerated
- `internal/agent/channelreply.go`: meta parsing (inverse of the MCP layer's `renderChannel`), route resolution, suppression, tool invocation via `mcp.RunTool`
- `internal/agent/agent.go`: track successfully-completed tool calls per turn; fire `sendChannelReply` after successful turns; carry parsed channel meta across summarize continuations
- `internal/agent/coordinator.go`: pass the config store into `SessionAgentOptions`
- `README.md`: new "Channel reply routing" section
- Tests: meta parsing, route resolution (direct/group/fallback/custom mappings), suppression semantics

## Testing

`go build ./...`, new tests pass, `golangci-lint` clean on touched packages. Pre-existing environmental test failures (provider-config-dependent) reproduce identically on a clean tree.

Note: once this merges, the same fix should be forwarded to the upstream channels PR charmbracelet/crush#3345.

💘 Generated with Crush