### PR TITLE
fix: include allow-commands overrides in first-wins mismatch log

### DIFF
--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -751,10 +751,13 @@ func workspaceToProto(ws *Workspace) proto.Workspace {
 // while the first set one will still log the mismatch.
 func logFirstWinsMismatch(existing *Workspace, args proto.Workspace) {
 	existingCfg := existing.Cfg.Config()
-	existingYOLO := existing.Cfg.Overrides().SkipPermissionRequests
+	existingOverrides := existing.Cfg.Overrides()
+	existingYOLO := existingOverrides.SkipPermissionRequests
 	if existingYOLO == args.YOLO &&
 		existingCfg.Options.Debug == args.Debug &&
 		existingCfg.Options.DataDirectory == args.DataDir &&
+		existingOverrides.AllowAllCommands == args.AllowAllCommands &&
+		stringSlicesEqual(existingOverrides.AllowedCommands, args.AllowedCommands) &&
 		stringSlicesEqual(existing.Env, args.Env) {
 		return
 	}
@@ -768,6 +771,10 @@ func logFirstWinsMismatch(existing *Workspace, args proto.Workspace) {
 		"requested_debug", args.Debug,
 		"existing_data_dir", existingCfg.Options.DataDirectory,
 		"requested_data_dir", args.DataDir,
+		"existing_allow_all_commands", existingOverrides.AllowAllCommands,
+		"requested_allow_all_commands", args.AllowAllCommands,
+		"existing_allowed_commands", existingOverrides.AllowedCommands,
+		"requested_allowed_commands", args.AllowedCommands,
 		"existing_env", existing.Env,
 		"requested_env", args.Env,
 	)

--- a/internal/backend/backend_test.go
+++ b/internal/backend/backend_test.go
@@ -711,6 +711,14 @@ func TestFirstWinsMismatch_LogsOnFlagDifferences(t *testing.T) {
 			name:   "env",
 			mutate: func(p *proto.Workspace) { p.Env = []string{"NEW=val"} },
 		},
+		{
+			name:   "allow-all-commands",
+			mutate: func(p *proto.Workspace) { p.AllowAllCommands = true },
+		},
+		{
+			name:   "allowed-commands",
+			mutate: func(p *proto.Workspace) { p.AllowedCommands = []string{"ssh"} },
+		},
 	}
 
 	for _, tc := range tests {
@@ -745,6 +753,8 @@ func TestFirstWinsMismatch_LogsOnFlagDifferences(t *testing.T) {
 			// Existing workspace's YOLO and Debug must not change.
 			require.Equal(t, originalYOLO, wsA.Cfg.Overrides().SkipPermissionRequests, "YOLO must be immutable on first-wins")
 			require.Equal(t, originalDebug, wsA.Cfg.Config().Options.Debug, "Debug must be immutable on first-wins")
+			require.False(t, wsA.Cfg.Overrides().AllowAllCommands, "AllowAllCommands must be immutable on first-wins")
+			require.Empty(t, wsA.Cfg.Overrides().AllowedCommands, "AllowedCommands must be immutable on first-wins")
 		})
 	}
 }


### PR DESCRIPTION
Follow-up from the review of #159, which was merged by another session while the review fix was in flight (the commit landed on the PR branch a minute after the merge, so it never reached `main`).

`CreateWorkspace` ignores a second client's flags on attach-to-existing (first-wins), and `logFirstWinsMismatch` exists to make that visible for debugging. The `AllowAllCommands`/`AllowedCommands` args added in #159 were left out of the comparison, so a client attaching with a different bash allowlist than the running workspace got no mismatch log at all — worse than YOLO/Debug, given these are security-relevant (a client requesting the default blocklist could silently land in an `--allow-all-commands` workspace). Adds both fields to the comparison and the log line, plus test cases asserting the log fires and the existing workspace's overrides stay immutable.

`go build ./...` ✓, `go test ./internal/backend/ -run TestFirstWinsMismatch` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)