### PR TITLE
fix(tui): prevent stale background refreshes from overwriting UI state

### DIFF
--- a/internal/ui/model/session_busy_test.go
+++ b/internal/ui/model/session_busy_test.go
@@ -7,6 +7,7 @@ import (
 
 	"charm.land/bubbles/v2/textarea"
 	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/x/ansi"
 	"github.com/stretchr/testify/require"
 
 	"github.com/charmbracelet/crush/internal/agent/notify"
@@ -319,6 +320,35 @@ func TestToggleYoloWritesThroughCache(t *testing.T) {
 	require.False(t, m.yoloModeCached())
 }
 
+// TestLocalYoloToggleSupersedesInFlightProbe pins the generation bump in
+// toggleYoloMode: a busy/yolo probe dispatched before the toggle carries the
+// old generation. Without advancing busyFetchGen its stale result would land
+// with a still-matching generation and clobber the just-toggled value.
+func TestLocalYoloToggleSupersedesInFlightProbe(t *testing.T) {
+	pinTTLs(t)
+
+	ws := &countingWorkspace{ready: true, yolo: false}
+	m := newBusyUI(ws)
+	warmCaches(m, false)
+
+	// A busy/yolo probe carrying the pre-toggle generation is in flight.
+	m.busyFetchInFlight = true
+	staleGen := m.busyFetchGen
+
+	require.True(t, m.toggleYoloMode())
+	require.NotEqual(t, staleGen, m.busyFetchGen,
+		"toggle must advance the busy generation to supersede in-flight probes")
+	require.True(t, m.yoloModeCached(), "toggle must write the new value through the cache")
+
+	// The stale probe (old generation, old yolo=false) lands.
+	m.busyFetchInFlight = true
+	cmds := m.applyBusyState(busyStateMsg{gen: staleGen, yolo: false})
+	require.True(t, m.yoloModeCached(),
+		"stale probe must not overwrite the freshly toggled value")
+	require.NotEmpty(t, cmds, "stale probe must re-dispatch an authoritative refresh")
+	require.True(t, m.busyFetchInFlight, "re-dispatched refresh must be in flight")
+}
+
 // TestSendMessageSetsOptimisticBusy pins the esc-after-enter behavior:
 // submitting a prompt optimistically marks the agent busy so an immediate
 // esc routes to cancelAgent instead of reading a stale idle value and doing
@@ -398,4 +428,127 @@ func TestBackstopRefreshesStaleCaches(t *testing.T) {
 	// Freshly refreshed caches must not re-dispatch.
 	m.Update(plainMsg{})
 	require.False(t, m.busyFetchInFlight, "fresh caches must not re-dispatch the backstop")
+}
+
+// TestStaleBusyRefreshDiscardedAndReDispatched pins the generation guard for
+// busy/permission state: a probe started before a newer state transition
+// (here an optimistic busy write) must not overwrite the newer value when it
+// lands, and the authoritative refresh must not be lost merely because the
+// older probe was in flight — the stale result re-dispatches it.
+func TestStaleBusyRefreshDiscardedAndReDispatched(t *testing.T) {
+	pinTTLs(t)
+
+	ws := &countingWorkspace{ready: true}
+	m := newBusyUI(ws)
+	warmCaches(m, false)
+
+	// A busy probe is in flight; capture the generation it was dispatched
+	// with, then a newer transition (optimistic send) supersedes it.
+	m.busyFetchInFlight = true
+	staleGen := m.busyFetchGen
+	m.agentBusyCache.set(true) // optimistic busy
+	m.busyFetchGen++           // newer state transition
+
+	// The stale probe (agent reported idle) lands with the old generation.
+	cmds := m.applyBusyState(busyStateMsg{gen: staleGen, agentBusy: false})
+	require.True(t, m.isAgentBusy(),
+		"a stale busy result must not overwrite the newer optimistic busy state")
+	require.NotEmpty(t, cmds,
+		"a stale busy result must re-dispatch the authoritative refresh")
+	require.True(t, m.busyFetchInFlight, "the re-dispatched probe must be in flight")
+
+	// The fresh probe (matching generation) is applied normally.
+	freshGen := m.busyFetchGen
+	m.applyBusyState(busyStateMsg{gen: freshGen, agentBusy: false})
+	require.False(t, m.isAgentBusy(), "a current-generation result must land in the cache")
+}
+
+// TestStalePromptQueueDiscardedAndReDispatched pins the generation guard for
+// the queue: a fetch started before a newer transition (here a queue clear)
+// must not repopulate the cleared queue, and it must re-dispatch the
+// authoritative fetch instead of being applied.
+func TestStalePromptQueueDiscardedAndReDispatched(t *testing.T) {
+	pinTTLs(t)
+
+	ws := &countingWorkspace{ready: true, queued: []string{"real"}}
+	m := newBusyUI(ws)
+	warmCaches(m, false)
+	m.promptQueue = 1
+	m.promptQueueItems = []string{"real"}
+
+	// A fetch is in flight; capture its generation, then a newer transition
+	// (esc clears the queue) supersedes it.
+	m.promptQueueInFlight = true
+	staleGen := m.promptQueueGen
+	m.invalidatePromptQueue()
+	m.promptQueue = 0
+	m.promptQueueItems = nil
+
+	// The stale fetch (still saw one prompt) lands for the same session.
+	cmds := m.applyPromptQueue(promptQueueMsg{
+		forSession: "s1",
+		gen:        staleGen,
+		prompts:    []string{"stale"},
+	})
+	require.Zero(t, m.promptQueue,
+		"a stale queue result must not repopulate the cleared queue")
+	require.Empty(t, m.promptQueueItems)
+	require.NotEmpty(t, cmds,
+		"a stale queue result must re-dispatch the authoritative fetch")
+	require.True(t, m.promptQueueInFlight, "the re-dispatched fetch must be in flight")
+}
+
+// TestStalePromptQueuePreservesSessionScoping pins that the generation guard
+// does not weaken session scoping: a fetch scoped to a different session is
+// still discarded and re-fetched even when its generation would otherwise
+// match.
+func TestStalePromptQueuePreservesSessionScoping(t *testing.T) {
+	pinTTLs(t)
+
+	ws := &countingWorkspace{ready: true}
+	m := newBusyUI(ws) // active session "s1"
+	warmCaches(m, false)
+	m.promptQueueInFlight = true
+	gen := m.promptQueueGen
+
+	cmds := m.applyPromptQueue(promptQueueMsg{
+		forSession: "other",
+		gen:        gen,
+		prompts:    []string{"from other session"},
+	})
+	require.Zero(t, m.promptQueue,
+		"a result from a different session must never populate the queue")
+	require.NotEmpty(t, cmds, "a session-mismatched result must re-fetch for the current session")
+}
+
+// TestRemoteYoloToggleUpdatesEditorPrompt pins the second fix: when an
+// asynchronous busy-state refresh reports a yolo mode different from the
+// cached one (a remote toggle), applyBusyState must update the textarea
+// prompt function too, not just the cache — otherwise the prompt icon/style
+// keeps rendering the old mode.
+func TestRemoteYoloToggleUpdatesEditorPrompt(t *testing.T) {
+	pinTTLs(t)
+
+	ws := &countingWorkspace{ready: true}
+	m := newBusyUI(ws)
+	m.textarea.Focus()
+	m.textarea.SetWidth(40)
+	m.yoloCache.set(false)
+	m.setEditorPrompt(false)
+	normalPrompt := ansi.Strip(m.textarea.View())
+
+	// A remote toggle flips yolo on; delivered via an off-thread refresh.
+	m.applyBusyState(busyStateMsg{gen: m.busyFetchGen, yolo: true})
+	require.True(t, m.yoloModeCached(), "the refresh must write the new yolo value through the cache")
+	yoloPrompt := ansi.Strip(m.textarea.View())
+	require.NotEqual(t, normalPrompt, yoloPrompt,
+		"a remote yolo toggle must change the rendered editor prompt")
+	require.Contains(t, yoloPrompt, "Y",
+		"the yolo prompt icon must render after a remote toggle")
+
+	// Flipping back off must restore the normal prompt.
+	m.applyBusyState(busyStateMsg{gen: m.busyFetchGen, yolo: false})
+	require.False(t, m.yoloModeCached())
+	require.Equal(t, normalPrompt, ansi.Strip(m.textarea.View()),
+		"toggling yolo off must restore the normal editor prompt")
 }

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -325,13 +325,21 @@ type UI struct {
 	promptQueueItems     []string
 	promptQueueCheckedAt time.Time
 	promptQueueInFlight  bool
+	// promptQueueGen is bumped by every queue state transition; an
+	// in-flight fetch captures it at dispatch and its result is discarded
+	// if the generation has moved on (see workspace_cache.go).
+	promptQueueGen uint64
 	// agentBusyCache / yoloCache memoize the workspace busy and permission
 	// probes (synchronous HTTP round-trips in client/server mode). Reads
 	// never probe; refreshes happen off-thread (see workspace_cache.go).
 	agentBusyCache    ttlCache
 	yoloCache         ttlCache
 	busyFetchInFlight bool
-	pillsView         string
+	// busyFetchGen is bumped by every busy/permission state transition;
+	// like promptQueueGen it lets a stale in-flight probe result be
+	// discarded and re-fetched instead of clobbering newer state.
+	busyFetchGen uint64
+	pillsView    string
 
 	// Todo spinner
 	todoSpinner    spinner.Model
@@ -673,6 +681,7 @@ func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// authoritative busy/queue state to confirm the optimistic values
 		// sendMessage wrote.
 		m.invalidateBusyCaches()
+		m.invalidatePromptQueue()
 		if cmd := m.dispatchBusyRefresh(); cmd != nil {
 			cmds = append(cmds, cmd)
 		}
@@ -692,6 +701,7 @@ func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// off-thread so the queue pill and esc behavior track the new
 		// session instead of a stale one.
 		m.invalidateBusyCaches()
+		m.invalidatePromptQueue()
 		m.promptQueue = 0
 		m.promptQueueItems = nil
 		m.promptQueueCheckedAt = time.Time{}
@@ -830,6 +840,7 @@ func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// trigger this: during streaming that would put workspace
 			// probes on every token.
 			m.invalidateBusyCaches()
+			m.invalidatePromptQueue()
 			if cmd := m.dispatchBusyRefresh(); cmd != nil {
 				cmds = append(cmds, cmd)
 			}
@@ -3900,7 +3911,11 @@ func (m *UI) sendMessage(content string, attachments ...message.Attachment) tea.
 	// either starts a run or is enqueued behind one. This keeps esc pressed
 	// right after enter routing to cancelAgent instead of reading a stale
 	// idle value; the authoritative state arrives via agentRunSubmittedMsg.
+	// Bump the busy/queue generations so any probe started before this
+	// optimistic write is discarded rather than reverting us to idle.
 	m.agentBusyCache.set(true)
+	m.busyFetchGen++
+	m.invalidatePromptQueue()
 	cmds = append(cmds, func() tea.Msg {
 		// AgentRun is fire-and-forget: it returns once the prompt has
 		// been accepted (HTTP 202) or synchronously with a validation
@@ -4058,6 +4073,9 @@ func (m *UI) cancelAgent() tea.Cmd {
 		m.promptQueue = 0
 		m.promptQueueItems = nil
 		m.promptQueueCheckedAt = time.Now()
+		// Bump the queue generation so a fetch started before this clear
+		// cannot land and repopulate the pill we just emptied.
+		m.invalidatePromptQueue()
 		m.updateLayoutAndSize()
 		return nil
 	}
@@ -4355,6 +4373,7 @@ func (m *UI) handleAgentNotification(n notify.Notification) tea.Cmd {
 	// can re-probe. Drop the memoized busy state and re-fetch it and the
 	// prompt queue off-thread.
 	m.invalidateBusyCaches()
+	m.invalidatePromptQueue()
 	if cmd := m.dispatchBusyRefresh(); cmd != nil {
 		cmds = append(cmds, cmd)
 	}
@@ -4402,6 +4421,7 @@ func (m *UI) newSession() tea.Cmd {
 	m.promptQueueItems = nil
 	m.promptQueueCheckedAt = time.Now()
 	m.invalidateBusyCaches()
+	m.invalidatePromptQueue()
 	m.pillsView = ""
 	m.historyReset()
 	agenttools.ResetCache()

--- a/internal/ui/model/workspace_cache.go
+++ b/internal/ui/model/workspace_cache.go
@@ -60,6 +60,12 @@ func (c *ttlCache) invalidate() {
 
 // busyStateMsg delivers the result of an off-thread busy/permission probe.
 type busyStateMsg struct {
+	// gen is the busy generation captured when the probe was dispatched.
+	// A result whose generation no longer matches m.busyFetchGen started
+	// before a newer state transition (optimistic send, invalidation,
+	// session switch, ...) and is discarded, then re-fetched, so the
+	// authoritative refresh is never lost to an older in-flight request.
+	gen       uint64
 	agentBusy bool
 	yolo      bool
 }
@@ -69,7 +75,11 @@ type promptQueueMsg struct {
 	// forSession is the session the fetch was scoped to; a result that
 	// raced a session switch is discarded and re-fetched.
 	forSession string
-	prompts    []string
+	// gen is the queue generation captured at dispatch; like
+	// busyStateMsg.gen it guards against a stale in-flight result
+	// overwriting newer optimistic or invalidated queue state.
+	gen     uint64
+	prompts []string
 }
 
 // agentRunSubmittedMsg reports that AgentRun accepted a prompt (it either
@@ -85,11 +95,21 @@ func (m *UI) currentSessionID() string {
 	return m.session.ID
 }
 
-// invalidateBusyCaches marks all memoized workspace probe state stale.
-// Called by handlers for events that change agent or permission state.
+// invalidateBusyCaches marks all memoized workspace probe state stale and
+// bumps the busy generation so any in-flight probe result is discarded when
+// it lands. Called by handlers for events that change agent or permission
+// state.
 func (m *UI) invalidateBusyCaches() {
 	m.agentBusyCache.invalidate()
 	m.yoloCache.invalidate()
+	m.busyFetchGen++
+}
+
+// invalidatePromptQueue bumps the prompt-queue generation so any in-flight
+// queue fetch result is discarded when it lands (and re-fetched) instead of
+// overwriting newer optimistic or cleared queue state.
+func (m *UI) invalidatePromptQueue() {
+	m.promptQueueGen++
 }
 
 // dispatchBusyRefresh returns a command that probes the workspace busy and
@@ -103,8 +123,9 @@ func (m *UI) dispatchBusyRefresh() tea.Cmd {
 	}
 	m.busyFetchInFlight = true
 	ws := m.com.Workspace
+	gen := m.busyFetchGen
 	return func() tea.Msg {
-		var st busyStateMsg
+		st := busyStateMsg{gen: gen}
 		if ws.AgentIsReady() {
 			st.agentBusy = ws.AgentIsBusy()
 		}
@@ -117,9 +138,27 @@ func (m *UI) dispatchBusyRefresh() tea.Cmd {
 // edges (todo spinner, pills). Runs on the Update goroutine.
 func (m *UI) applyBusyState(msg busyStateMsg) []tea.Cmd {
 	m.busyFetchInFlight = false
+	if msg.gen != m.busyFetchGen {
+		// This probe started before a newer state transition (optimistic
+		// send, invalidation, session switch, ...). Discard its result and
+		// re-dispatch so the required authoritative refresh is not lost
+		// merely because this older request was in flight.
+		if cmd := m.dispatchBusyRefresh(); cmd != nil {
+			return []tea.Cmd{cmd}
+		}
+		return nil
+	}
 	prevBusy := m.isAgentBusy()
+	prevYolo := m.yoloModeCached()
 	m.agentBusyCache.set(msg.agentBusy)
 	m.yoloCache.set(msg.yolo)
+	if prevYolo != msg.yolo {
+		// A remote/async toggle changed yolo mode: update the editor
+		// prompt function so the prompt icon/style tracks the new mode.
+		// The cache is written above and the placeholder is refreshed by
+		// the Update tail.
+		m.setEditorPrompt(msg.yolo)
+	}
 
 	var cmds []tea.Cmd
 	busy := m.isAgentBusy()
@@ -147,6 +186,10 @@ func (m *UI) dispatchPromptQueueRefresh() tea.Cmd {
 	if !m.hasSession() {
 		m.promptQueueItems = nil
 		m.promptQueueCheckedAt = time.Now()
+		// Bump the generation so any in-flight fetch scoped to the
+		// now-departed session is discarded rather than repopulating the
+		// queue.
+		m.invalidatePromptQueue()
 		if m.promptQueue != 0 {
 			m.promptQueue = 0
 			m.updateLayoutAndSize()
@@ -156,8 +199,9 @@ func (m *UI) dispatchPromptQueueRefresh() tea.Cmd {
 	m.promptQueueInFlight = true
 	ws := m.com.Workspace
 	sessionID := m.session.ID
+	gen := m.promptQueueGen
 	return func() tea.Msg {
-		msg := promptQueueMsg{forSession: sessionID}
+		msg := promptQueueMsg{forSession: sessionID, gen: gen}
 		if ws.AgentIsReady() {
 			msg.prompts = ws.AgentQueuedPromptsList(sessionID)
 		}
@@ -169,7 +213,11 @@ func (m *UI) dispatchPromptQueueRefresh() tea.Cmd {
 // count changed. Runs on the Update goroutine.
 func (m *UI) applyPromptQueue(msg promptQueueMsg) []tea.Cmd {
 	m.promptQueueInFlight = false
-	if msg.forSession != m.currentSessionID() {
+	if msg.forSession != m.currentSessionID() || msg.gen != m.promptQueueGen {
+		// The fetch raced a session switch or a newer queue transition
+		// (submit, clear, invalidation). Discard the stale result and
+		// re-fetch so newer state is not clobbered and the authoritative
+		// refresh is not lost to this older in-flight request.
 		if cmd := m.dispatchPromptQueueRefresh(); cmd != nil {
 			return []tea.Cmd{cmd}
 		}
@@ -218,6 +266,12 @@ func (m *UI) toggleYoloMode() bool {
 	yolo := !m.com.Workspace.PermissionSkipRequests()
 	m.com.Workspace.PermissionSetSkipRequests(yolo)
 	m.yoloCache.set(yolo)
+	// Supersede any in-flight busy/yolo probe: its result carries the old
+	// generation and would otherwise overwrite the value we just wrote.
+	// Bump the generation (rather than invalidateBusyCaches, which would
+	// clear the fresh value) so applyBusyState's guard discards and
+	// re-dispatches the stale probe.
+	m.busyFetchGen++
 	m.setEditorPrompt(yolo)
 	return yolo
 }


### PR DESCRIPTION
This sits on top of https://github.com/charmbracelet/crush/pull/3363 and should be merged into that one.

Builds on the original PR’s asynchronous workspace status refreshes and fixes several real race conditions found during review:

- Prevents stale busy and prompt-queue results from overwriting newer state, which could make `esc` fail to cancel or temporarily hide queued prompts.
- Keeps the editor prompt synchronized with remote and local auto-approve mode changes.
- Adds regression coverage for stale refreshes, session switching, and auto-approve toggle races.

💘 Generated with Crush