### PR TITLE
feat(a2ui): foundational A2UI — themed container, button repair, live interactive surfaces, form submission

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -43,7 +43,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/invopop/jsonschema v0.14.0
 	github.com/itchyny/gojq v0.12.19
-	github.com/joestump-agent/a2tea v0.0.0-20260717194424-347a52e05f08
+	github.com/joestump-agent/a2tea v0.0.0-20260718201420-b797da386eaf
 	github.com/joho/godotenv v1.5.1
 	github.com/jordanella/go-ansi-paintbrush v0.0.0-20240728195301-b7ad996ecf3d
 	github.com/lucasb-eyer/go-colorful v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -256,8 +256,8 @@ github.com/jackmordaunt/icns/v3 v3.0.1 h1:xxot6aNuGrU+lNgxz5I5H0qSeCjNKp8uTXB1j8
 github.com/jackmordaunt/icns/v3 v3.0.1/go.mod h1:5sHL59nqTd2ynTnowxB/MDQFhKNqkK8X687uKNygaSQ=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
-github.com/joestump-agent/a2tea v0.0.0-20260717194424-347a52e05f08 h1:bB5h3QxxxnqYGJQoA8K5i7PjP7idMdzFBqD6MFgjuFI=
-github.com/joestump-agent/a2tea v0.0.0-20260717194424-347a52e05f08/go.mod h1:pg6ATa4oTrJfhPmfQ9a/Y/5xU9DTXZ8rGVvLj3NpEaE=
+github.com/joestump-agent/a2tea v0.0.0-20260718201420-b797da386eaf h1:Yw8XzyZXewOiewpHLd4SQPhu7CeWlFeqjpz7uE7f5as=
+github.com/joestump-agent/a2tea v0.0.0-20260718201420-b797da386eaf/go.mod h1:pg6ATa4oTrJfhPmfQ9a/Y/5xU9DTXZ8rGVvLj3NpEaE=
 github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
 github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/jordanella/go-ansi-paintbrush v0.0.0-20240728195301-b7ad996ecf3d h1:on25kP+Sx7sxUMRQiA8gdcToAGet4DK/EIA30mXre+4=

--- a/internal/skills/builtin/a2ui/SKILL.md
+++ b/internal/skills/builtin/a2ui/SKILL.md
@@ -71,11 +71,11 @@ These components render beautifully with full styling and layout:
 - `Row`: Lays out children horizontally. Expects a `children` array of IDs.
 - `List`: Lays out children as a list. Expects a `children` array of IDs.
 - `Divider`: A horizontal rule.
-- `Button`: Focusable button. Its label comes from a single `child` ID pointing at a `Text` component (there is no `label` field). Pressing Enter emits a click event to the host.
+- `Button`: Focusable button. Its label comes from a single `child` ID pointing at a `Text` component (there is no `label` field). When the user presses it, you receive a new message naming the pressed button and carrying the surface's current field values — a button whose id reads as a cancel (e.g. `btn-cancel`, `dismiss`, `close`) just dismisses the form instead.
 
-### Input Components (Read-Only Visuals)
+### Input Components (Editable)
 
-These components will render their current values, but currently do not allow the user to interactively edit them or send input back to the agent:
+These components render their current values and the user can edit them; their values (keyed by component `id`) are sent back to you when a button on the surface is pressed:
 - `TextField`
 - `CheckBox`
 - `ChoicePicker`

--- a/internal/skills/builtin/a2ui/SKILL.md
+++ b/internal/skills/builtin/a2ui/SKILL.md
@@ -101,7 +101,7 @@ These are errors that models frequently make. Read carefully.
 
 ### Buttons do NOT have a `text` or `label` field
 
-The A2UI spec has **no** `text`, `label`, or `name` field on `Button`. The label comes exclusively from a `child` Text component.
+**NEVER put `text` or `label` on a `Button`** — the A2UI spec has **no** `text`, `label`, or `name` field on `Button` in any schema version. A button's label comes exclusively from its `child` ID pointing at a separate `Text` component. A stray `text`/`label` key is dropped at parse time and the button renders unlabeled.
 
 **Wrong — the label will be empty:**
 ```json
@@ -134,6 +134,28 @@ The `"text"` key is silently ignored and the button renders with no visible labe
   "id": "btn-label",
   "text": "Submit"
 }
+```
+
+**Complete form template — copy this shape.** Two inputs and two buttons; note how *each* button gets its own child `Text` for its label:
+
+```json
+<a2ui-json>{
+  "version": "v0.9",
+  "updateComponents": {
+    "surfaceId": "form",
+    "components": [
+      {"component": "Card", "id": "root", "child": "col"},
+      {"component": "Column", "id": "col", "children": ["name", "email", "actions"]},
+      {"component": "TextField", "id": "name", "label": "Name"},
+      {"component": "TextField", "id": "email", "label": "Email"},
+      {"component": "Row", "id": "actions", "children": ["btn-send", "btn-cancel"]},
+      {"component": "Button", "id": "btn-send", "child": "btn-send-label"},
+      {"component": "Text", "id": "btn-send-label", "text": "Send"},
+      {"component": "Button", "id": "btn-cancel", "child": "btn-cancel-label"},
+      {"component": "Text", "id": "btn-cancel-label", "text": "Cancel"}
+    ]
+  }
+}</a2ui-json>
 ```
 
 ### Every `child` / `children` ID must exist in the components array

--- a/internal/ui/chat/a2ui.go
+++ b/internal/ui/chat/a2ui.go
@@ -1,12 +1,22 @@
 package chat
 
 import (
+	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"regexp"
 	"strings"
 
 	"github.com/charmbracelet/crush/internal/ui/common"
 	"github.com/joestump-agent/a2tea"
+)
+
+// a2uiOpenTag and a2uiCloseTag delimit an inline A2UI block in assistant
+// content — the wire format a2tea scans for.
+const (
+	a2uiOpenTag  = "<a2ui-json>"
+	a2uiCloseTag = "</a2ui-json>"
 )
 
 var fenceRe = regexp.MustCompile("(?s)```[^\n]*\n.*?```")
@@ -88,24 +98,23 @@ func contentHasUnclosedA2UI(content string) bool {
 // fine but fail a single-object unmarshal (false alert beside a working
 // surface).
 func countDroppedTaggedBlocks(content string) int {
-	const openTag, closeTag = "<a2ui-json>", "</a2ui-json>"
 	var dropped int
 	s := content
 	for {
-		i := strings.Index(s, openTag)
+		i := strings.Index(s, a2uiOpenTag)
 		if i < 0 {
 			break
 		}
-		s = s[i+len(openTag):]
-		j := strings.Index(s, closeTag)
+		s = s[i+len(a2uiOpenTag):]
+		j := strings.Index(s, a2uiCloseTag)
 		if j < 0 {
 			break
 		}
 		body := s[:j]
-		s = s[j+len(closeTag):]
+		s = s[j+len(a2uiCloseTag):]
 
 		messages := 0
-		if parts, err := a2tea.Scan(openTag + body + closeTag); err == nil {
+		if parts, err := a2tea.Scan(a2uiOpenTag + body + a2uiCloseTag); err == nil {
 			for _, p := range parts {
 				messages += len(p.Messages)
 			}
@@ -115,6 +124,166 @@ func countDroppedTaggedBlocks(content string) int {
 		}
 	}
 	return dropped
+}
+
+// repairA2UIButtons rewrites the raw JSON inside <a2ui-json> blocks to fix a
+// frequent model mistake (#47): a Button carrying its label in a `text` (or
+// `label`) field instead of a child Text component. A2UI's Button has no such
+// field in any schema version, so the label is silently dropped when the block
+// is parsed into typed components — which is why this repair must run on the
+// raw JSON, before a2tea.Scan.
+//
+// The repair is deliberately surgical: only a Button that has a non-empty
+// text/label AND no child is rewritten — a Text component is synthesized from
+// the stray label and the button's child pointed at it. Valid child-based
+// buttons and every other component are left untouched, and a block whose JSON
+// doesn't decode is returned verbatim so the existing error-alert path still
+// applies.
+func repairA2UIButtons(content string) string {
+	if !strings.Contains(content, a2uiOpenTag) {
+		return content
+	}
+	var b strings.Builder
+	s := content
+	for {
+		i := strings.Index(s, a2uiOpenTag)
+		if i < 0 {
+			break
+		}
+		j := strings.Index(s[i+len(a2uiOpenTag):], a2uiCloseTag)
+		if j < 0 {
+			break
+		}
+		body := s[i+len(a2uiOpenTag) : i+len(a2uiOpenTag)+j]
+		b.WriteString(s[:i+len(a2uiOpenTag)])
+		b.WriteString(repairA2UIBody(body))
+		b.WriteString(a2uiCloseTag)
+		s = s[i+len(a2uiOpenTag)+j+len(a2uiCloseTag):]
+	}
+	b.WriteString(s)
+	return b.String()
+}
+
+// repairA2UIBody repairs the JSON body of a single <a2ui-json> block. The body
+// may hold one message object, an array of messages, or several
+// newline-delimited messages — the same forms the a2tea parser accepts. If the
+// body doesn't decode, or no button needs fixing, it is returned unchanged
+// (preserving the author's formatting and the malformed-block alert path).
+func repairA2UIBody(body string) string {
+	dec := json.NewDecoder(strings.NewReader(body))
+	var vals []any
+	for {
+		var v any
+		if err := dec.Decode(&v); err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return body
+		}
+		vals = append(vals, v)
+	}
+
+	changed := false
+	for _, v := range vals {
+		switch m := v.(type) {
+		case map[string]any:
+			changed = repairA2UIMessage(m) || changed
+		case []any:
+			for _, e := range m {
+				if mm, ok := e.(map[string]any); ok {
+					changed = repairA2UIMessage(mm) || changed
+				}
+			}
+		}
+	}
+	if !changed {
+		return body
+	}
+
+	out := make([]string, 0, len(vals))
+	for _, v := range vals {
+		enc, err := json.Marshal(v)
+		if err != nil {
+			return body
+		}
+		out = append(out, string(enc))
+	}
+	return strings.Join(out, "\n")
+}
+
+// repairA2UIMessage fixes childless-but-labeled buttons inside one raw A2UI
+// message map, reporting whether it changed anything. For each such button it
+// moves the stray text/label into a new Text component (with a unique id
+// derived from the button's) and points the button's child at it.
+func repairA2UIMessage(msg map[string]any) bool {
+	uc, ok := msg["updateComponents"].(map[string]any)
+	if !ok {
+		return false
+	}
+	comps, ok := uc["components"].([]any)
+	if !ok {
+		return false
+	}
+
+	ids := make(map[string]bool, len(comps))
+	for _, c := range comps {
+		if m, ok := c.(map[string]any); ok {
+			if id, ok := m["id"].(string); ok {
+				ids[id] = true
+			}
+		}
+	}
+
+	var added []any
+	for _, c := range comps {
+		m, ok := c.(map[string]any)
+		if !ok {
+			continue
+		}
+		if typ, _ := m["component"].(string); typ != "Button" {
+			continue
+		}
+		switch child := m["child"].(type) {
+		case nil: // absent (or JSON null): childless, repairable
+		case string:
+			if child != "" {
+				continue // valid child-based button: leave untouched
+			}
+		default:
+			continue // e.g. inline-nested object: not ours to rewrite
+		}
+		label, _ := m["text"].(string)
+		if label == "" {
+			label, _ = m["label"].(string)
+		}
+		if label == "" {
+			continue
+		}
+
+		base := "label"
+		if id, _ := m["id"].(string); id != "" {
+			base = id + "-label"
+		}
+		labelID := base
+		for n := 2; ids[labelID]; n++ {
+			labelID = fmt.Sprintf("%s-%d", base, n)
+		}
+		ids[labelID] = true
+
+		m["child"] = labelID
+		delete(m, "text")
+		delete(m, "label")
+		added = append(added, map[string]any{
+			"component": "Text",
+			"id":        labelID,
+			"text":      label,
+		})
+	}
+	if len(added) == 0 {
+		return false
+	}
+	uc["components"] = append(comps, added...)
+	return true
 }
 
 // renderContentWithA2UI renders assistant content that contains A2UI. a2tea
@@ -133,6 +302,10 @@ func countDroppedTaggedBlocks(content string) int {
 // renderer is shared, so the whole multi-render sequence holds its lock.
 func (a *AssistantMessageItem) renderContentWithA2UI(content string, width int, finished bool) string {
 	masked, fenceReps := maskFencedCode(content)
+	// Repair childless-but-labeled buttons on the raw JSON before parsing —
+	// the stray label field is dropped by the typed parser (#47). Runs after
+	// masking so button examples inside fenced code stay verbatim.
+	masked = repairA2UIButtons(masked)
 
 	parts, err := a2tea.Scan(masked)
 	if err != nil {

--- a/internal/ui/chat/a2ui.go
+++ b/internal/ui/chat/a2ui.go
@@ -170,6 +170,11 @@ func (a *AssistantMessageItem) renderContentWithA2UI(content string, width int, 
 		b.WriteString(s)
 	}
 
+	// a2tea's chrome renders with terminal defaults (monochrome by design),
+	// so each surface is wrapped in a themed container to match the rest of
+	// the chat. The a2tea model is sized to the container's inner width.
+	surface := a.sty.Messages.A2UISurface
+	innerWidth := max(width-surface.GetHorizontalFrameSize(), 1)
 	for _, p := range parts {
 		writeChunk(renderMarkdown(p.Text))
 		if len(p.Messages) == 0 {
@@ -182,9 +187,10 @@ func (a *AssistantMessageItem) renderContentWithA2UI(content string, width int, 
 			continue
 		}
 		if sz, ok := model.(interface{ SetSize(width, height int) }); ok {
-			sz.SetSize(width, 0)
+			sz.SetSize(innerWidth, 0)
 		}
-		writeChunk(strings.TrimRight(model.View().Content, "\n"))
+		rendered := strings.TrimRight(model.View().Content, "\n")
+		writeChunk(surface.Width(max(width-surface.GetHorizontalBorderSize(), 1)).Render(rendered))
 	}
 
 	// Alert when a complete tag pair was dropped by the parser (#7) —

--- a/internal/ui/chat/a2ui.go
+++ b/internal/ui/chat/a2ui.go
@@ -19,42 +19,72 @@ const (
 	a2uiCloseTag = "</a2ui-json>"
 )
 
-var fenceRe = regexp.MustCompile("(?s)```[^\n]*\n.*?```")
+var (
+	fenceRe = regexp.MustCompile("(?s)```[^\n]*\n.*?```")
+	// inlineCodeRe matches markdown inline code spans on a single line:
+	// double-backtick spans first (their content may hold single backticks),
+	// then single-backtick spans.
+	inlineCodeRe = regexp.MustCompile("``[^\n]*?``|`[^`\n]+`")
+)
 
-// stripFencedCode removes markdown fenced code blocks entirely. Used for A2UI
-// detection where tags inside fences are examples, not live surfaces (#6).
-func stripFencedCode(content string) string {
-	if !strings.Contains(content, "```") {
-		return content
-	}
-	return fenceRe.ReplaceAllString(content, "")
-}
-
-// fenceReplacement tracks a masked fenced-code span for later restoration.
-type fenceReplacement struct {
+// codeReplacement tracks a masked code span for later restoration.
+type codeReplacement struct {
 	placeholder string
 	original    string
 }
 
-// maskFencedCode replaces fenced code blocks with unique placeholders so
-// a2tea's markdown-unaware scanner does not extract A2UI JSON from code
-// examples (#6). Use unmaskFencedCode to restore the originals after
-// scanning.
-func maskFencedCode(content string) (string, []fenceReplacement) {
-	if !strings.Contains(content, "```") {
-		return content, nil
-	}
-	var reps []fenceReplacement
-	masked := fenceRe.ReplaceAllStringFunc(content, func(match string) string {
-		p := fmt.Sprintf("\x00FENCE%d\x00", len(reps))
-		reps = append(reps, fenceReplacement{p, match})
+// maskMarkdownCode replaces markdown code with unique placeholders so a2tea's
+// markdown-unaware scanner does not extract A2UI from code that is
+// documentation, not live UI. Fenced code blocks are always masked (#6);
+// inline code spans are masked only when they mention A2UI markers (#96) —
+// masking every span would leak placeholders into legitimate surface JSON
+// that happens to contain backticks. Use unmaskMarkdownCode to restore the
+// originals after scanning.
+func maskMarkdownCode(content string) (string, []codeReplacement) {
+	var reps []codeReplacement
+	mask := func(match string) string {
+		p := fmt.Sprintf("\x00CODE%d\x00", len(reps))
+		reps = append(reps, codeReplacement{p, match})
 		return p
-	})
-	return masked, reps
+	}
+	if strings.Contains(content, "```") {
+		content = fenceRe.ReplaceAllStringFunc(content, mask)
+	}
+	if strings.Contains(content, "`") {
+		content = inlineCodeRe.ReplaceAllStringFunc(content, func(match string) string {
+			if !mentionsA2UI(match) {
+				return match
+			}
+			return mask(match)
+		})
+	}
+	return content, reps
 }
 
-// unmaskFencedCode restores fenced code blocks replaced by maskFencedCode.
-func unmaskFencedCode(text string, reps []fenceReplacement) string {
+// a2uiMarkers are the literals a2tea's scanner reacts to: the wire tag and
+// the quoted A2UI message-type keys used for bare-JSON detection. Inline code
+// naming any of these is documentation the scanner must not consume (#96).
+var a2uiMarkers = []string{
+	"a2ui-json",
+	`"createSurface"`,
+	`"updateComponents"`,
+	`"updateDataModel"`,
+	`"deleteSurface"`,
+}
+
+// mentionsA2UI reports whether s contains any marker the a2tea scanner
+// could mistake for live A2UI content.
+func mentionsA2UI(s string) bool {
+	for _, m := range a2uiMarkers {
+		if strings.Contains(s, m) {
+			return true
+		}
+	}
+	return false
+}
+
+// unmaskMarkdownCode restores code spans replaced by maskMarkdownCode.
+func unmaskMarkdownCode(text string, reps []codeReplacement) string {
 	for _, r := range reps {
 		text = strings.ReplaceAll(text, r.placeholder, r.original)
 	}
@@ -62,10 +92,11 @@ func unmaskFencedCode(text string, reps []fenceReplacement) string {
 }
 
 // contentHasA2UI reports whether the assistant content carries any A2UI
-// outside fenced code blocks, so the renderer only takes the a2tea path when
-// there is live UI to draw.
+// outside markdown code (fences and inline spans), so the renderer only takes
+// the a2tea path when there is live UI to draw.
 func contentHasA2UI(content string) bool {
-	return a2tea.Contains(stripFencedCode(content))
+	masked, _ := maskMarkdownCode(content)
+	return a2tea.Contains(masked)
 }
 
 // hasUnclosedA2UITag reports whether content has more opening
@@ -78,10 +109,11 @@ func hasUnclosedA2UITag(content string) bool {
 	return strings.Count(content, "<a2ui-json>") > strings.Count(content, "</a2ui-json>")
 }
 
-// contentHasUnclosedA2UI is the gate-level check (fences stripped) for
+// contentHasUnclosedA2UI is the gate-level check (markdown code masked) for
 // truncated A2UI blocks in finished messages.
 func contentHasUnclosedA2UI(content string) bool {
-	return hasUnclosedA2UITag(stripFencedCode(content))
+	masked, _ := maskMarkdownCode(content)
+	return hasUnclosedA2UITag(masked)
 }
 
 // countDroppedTaggedBlocks scans content for complete
@@ -291,8 +323,9 @@ func repairA2UIMessage(msg map[string]any) bool {
 // crush renders the prose as markdown and hands each part's messages to
 // a2tea.Render, stitching the rendered surface in place.
 //
-// Fenced code blocks are masked before scanning so that A2UI examples inside
-// code fences are not extracted as live surfaces (#6). If any complete tag
+// Markdown code (fences, and inline spans naming A2UI markers) is masked
+// before scanning so that A2UI examples in documentation prose are not
+// extracted as live surfaces (#6, #96). If any complete tag
 // pair contains malformed JSON — a block a2tea drops silently — an alert
 // element is appended (#7). An unclosed <a2ui-json> tag (truncated
 // generation) also triggers the alert (#5).
@@ -301,7 +334,7 @@ func repairA2UIMessage(msg map[string]any) bool {
 // a single glamour render per item) and renders each segment directly. The
 // renderer is shared, so the whole multi-render sequence holds its lock.
 func (a *AssistantMessageItem) renderContentWithA2UI(content string, width int, finished bool) string {
-	masked, fenceReps := maskFencedCode(content)
+	masked, codeReps := maskMarkdownCode(content)
 	// Repair childless-but-labeled buttons on the raw JSON before parsing —
 	// the stray label field is dropped by the typed parser (#47). Runs after
 	// masking so button examples inside fenced code stay verbatim.
@@ -323,8 +356,8 @@ func (a *AssistantMessageItem) renderContentWithA2UI(content string, width int, 
 		if strings.TrimSpace(text) == "" {
 			return ""
 		}
-		// Restore fenced code blocks before markdown rendering.
-		text = unmaskFencedCode(text, fenceReps)
+		// Restore masked code before markdown rendering.
+		text = unmaskMarkdownCode(text, codeReps)
 		out, err := renderer.Render(text)
 		if err != nil {
 			return strings.TrimSpace(text)
@@ -385,15 +418,16 @@ func (a *AssistantMessageItem) renderContentWithA2UI(content string, width int, 
 // surfaced through the standard A2UI alert instead of leaving a wall of raw
 // JSON.
 func (a *AssistantMessageItem) renderTruncatedA2UI(content string, width int) string {
-	// Mask (not strip) fences: a fence containing an <a2ui-json> example must
-	// not be mistaken for the truncation point, but the fence's code must
-	// stay in the rendered prose — stripping deleted it from the message.
-	masked, fenceReps := maskFencedCode(content)
+	// Mask (not strip) markdown code: a fence or inline span containing an
+	// <a2ui-json> example must not be mistaken for the truncation point, but
+	// the code must stay in the rendered prose — stripping deleted it from
+	// the message.
+	masked, codeReps := maskMarkdownCode(content)
 	idx := strings.Index(masked, "<a2ui-json>")
 
 	var b strings.Builder
 	if idx > 0 {
-		prose := unmaskFencedCode(masked[:idx], fenceReps)
+		prose := unmaskMarkdownCode(masked[:idx], codeReps)
 		if strings.TrimSpace(prose) != "" {
 			b.WriteString(a.renderMarkdown(prose, width))
 		}

--- a/internal/ui/chat/a2ui.go
+++ b/internal/ui/chat/a2ui.go
@@ -8,8 +8,10 @@ import (
 	"regexp"
 	"strings"
 
+	tea "charm.land/bubbletea/v2"
 	"github.com/charmbracelet/crush/internal/ui/common"
 	"github.com/joestump-agent/a2tea"
+	"github.com/joestump-agent/a2tea/render"
 	"github.com/tmc/a2ui/a2uistream"
 )
 
@@ -553,6 +555,145 @@ func repairA2UIMessage(msg map[string]any) bool {
 	return true
 }
 
+// syncA2UISurfaces builds — or reuses — the live a2tea models for the
+// scanned parts (#44). Surfaces are keyed by a hash of the scanned source:
+// streaming deltas rebuild them, while pure re-renders (width changes,
+// focus flips, key events) reuse the same models and preserve their
+// interaction state (focus ring position, edited field values). The slice
+// is part-indexed; parts without a renderable surface hold nil.
+func (a *AssistantMessageItem) syncA2UISurfaces(src string, parts []a2tea.Part) {
+	h := fnv64(src)
+	if a.a2uiScanned && a.a2uiSrcHash == h && len(a.a2uiSurfaces) == len(parts) {
+		return
+	}
+	surfaces := make([]render.Model, len(parts))
+	for i, p := range parts {
+		if len(p.Messages) == 0 {
+			continue
+		}
+		model, err := a2tea.Render(p.Messages)
+		if err != nil {
+			// Valid A2UI with nothing to draw (e.g. a bare data-model
+			// update). The render loop skips nil entries; the block-stats
+			// pass decides whether anything needs alerting.
+			continue
+		}
+		if rm, ok := model.(render.Model); ok {
+			surfaces[i] = rm
+		}
+	}
+	a.a2uiSurfaces = surfaces
+	a.a2uiSrcHash = h
+	a.a2uiScanned = true
+	// A rebuild replaces focused models with fresh blurred ones; re-grant
+	// focus when the item is selected so the ring survives streaming.
+	if a.focusableMessageItem.isFocused() {
+		a.focusA2UISurfaces()
+	}
+}
+
+// dropA2UISurfaces discards the live surface models, e.g. when the content
+// no longer scans as A2UI.
+func (a *AssistantMessageItem) dropA2UISurfaces() {
+	a.a2uiSurfaces = nil
+	a.a2uiSrcHash = 0
+	a.a2uiScanned = false
+}
+
+// a2uiSurfaceAt returns the live surface for scan-part i, or nil when the
+// part has none (or the index is stale).
+func (a *AssistantMessageItem) a2uiSurfaceAt(i int) render.Model {
+	if i < 0 || i >= len(a.a2uiSurfaces) {
+		return nil
+	}
+	return a.a2uiSurfaces[i]
+}
+
+// hasLiveA2UISurfaces reports whether the item holds at least one live
+// a2tea surface model. While true, the content-hash render caches are
+// bypassed so surface interaction is never served a frozen frame.
+func (a *AssistantMessageItem) hasLiveA2UISurfaces() bool {
+	for _, s := range a.a2uiSurfaces {
+		if s != nil {
+			return true
+		}
+	}
+	return false
+}
+
+// focusA2UISurfaces grants keyboard focus to the first live surface and
+// blurs the rest, honoring the a2tea composition contract of at most one
+// focused child at a time. render.Surface's Focus returns a nil cmd, so
+// dropping it here loses nothing.
+func (a *AssistantMessageItem) focusA2UISurfaces() {
+	granted := false
+	for _, s := range a.a2uiSurfaces {
+		if s == nil {
+			continue
+		}
+		if !granted {
+			_ = s.Focus()
+			granted = true
+			continue
+		}
+		s.Blur()
+	}
+}
+
+// blurA2UISurfaces revokes keyboard focus from every live surface.
+func (a *AssistantMessageItem) blurA2UISurfaces() {
+	for _, s := range a.a2uiSurfaces {
+		if s != nil {
+			s.Blur()
+		}
+	}
+}
+
+// focusedA2UISurfaceIndex returns the index of the surface currently
+// holding keyboard focus, or -1 when none does.
+func (a *AssistantMessageItem) focusedA2UISurfaceIndex() int {
+	for i, s := range a.a2uiSurfaces {
+		if s != nil && s.Focused() {
+			return i
+		}
+	}
+	return -1
+}
+
+// updateA2UISurface forwards msg into the surface's Update, stores the
+// returned model back, and bumps the item version so the list re-renders
+// the surface's new state on the next draw.
+func (a *AssistantMessageItem) updateA2UISurface(idx int, msg tea.Msg) tea.Cmd {
+	model, cmd := a.a2uiSurfaces[idx].Update(msg)
+	if rm, ok := model.(render.Model); ok {
+		a.a2uiSurfaces[idx] = rm
+	}
+	a.Bump()
+	return cmd
+}
+
+// a2uiSurfaceWantsKey reports whether a focused surface should consume the
+// key. The whitelist mirrors the keys render.Surface.Update reacts to —
+// forwarding everything would swallow host shortcuts (copy, help, quit)
+// whenever a surface item is selected. While a text-editable component is
+// being edited every key is potential input; Esc stays with the host
+// unless a modal is open to close.
+func a2uiSurfaceWantsKey(s render.Model, key tea.KeyMsg) bool {
+	k := key.String()
+	if k == "esc" {
+		m, ok := s.(interface{ HasOpenModal() bool })
+		return ok && m.HasOpenModal()
+	}
+	if e, ok := s.(interface{ EditingText() bool }); ok && e.EditingText() {
+		return true
+	}
+	switch k {
+	case "tab", "shift+tab", "enter", "space", "up", "down", "left", "right", "h", "l", "backspace":
+		return true
+	}
+	return false
+}
+
 // renderContentWithA2UI renders assistant content that contains A2UI. a2tea
 // scans the content into ordered parts of prose text and typed A2UI messages;
 // crush renders the prose as markdown and hands each part's messages to
@@ -579,8 +720,14 @@ func (a *AssistantMessageItem) renderContentWithA2UI(content string, width int, 
 	if err != nil {
 		// Not parseable as A2UI — render everything as markdown so nothing is
 		// lost.
+		a.dropA2UISurfaces()
 		return a.renderMarkdown(content, width)
 	}
+
+	// Keep the a2tea models alive on the item (rebuilt only when the source
+	// changed) so the surfaces can receive focus and key input instead of
+	// being frozen to a string (#44).
+	a.syncA2UISurfaces(masked, parts)
 
 	renderer := common.MarkdownRenderer(a.sty, width)
 	mu := common.LockMarkdownRenderer(renderer)
@@ -616,20 +763,20 @@ func (a *AssistantMessageItem) renderContentWithA2UI(content string, width int, 
 	// the chat. The a2tea model is sized to the container's inner width.
 	surface := a.sty.Messages.A2UISurface
 	innerWidth := max(width-surface.GetHorizontalFrameSize(), 1)
-	for _, p := range parts {
+	for i, p := range parts {
 		writeChunk(renderMarkdown(p.Text))
 		if len(p.Messages) == 0 {
 			continue
 		}
-		model, err := a2tea.Render(p.Messages)
-		if err != nil {
+		model := a.a2uiSurfaceAt(i)
+		if model == nil {
 			// Valid A2UI messages with nothing to draw (e.g. a data-model
 			// update). Not an error worth alarming the user about.
 			continue
 		}
-		if sz, ok := model.(interface{ SetSize(width, height int) }); ok {
-			sz.SetSize(innerWidth, 0)
-		}
+		// Render from the live model each call: its View reflects the
+		// current focus ring and edited values, not a frozen snapshot.
+		model.SetSize(innerWidth, 0)
 		rendered := strings.TrimRight(model.View().Content, "\n")
 		writeChunk(surface.Width(max(width-surface.GetHorizontalBorderSize(), 1)).Render(rendered))
 	}

--- a/internal/ui/chat/a2ui.go
+++ b/internal/ui/chat/a2ui.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/charmbracelet/crush/internal/ui/common"
 	"github.com/joestump-agent/a2tea"
+	"github.com/tmc/a2ui/a2uistream"
 )
 
 // a2uiOpenTag and a2uiCloseTag delimit an inline A2UI block in assistant
@@ -116,46 +117,280 @@ func contentHasUnclosedA2UI(content string) bool {
 	return hasUnclosedA2UITag(masked)
 }
 
-// countDroppedTaggedBlocks scans content for complete
-// <a2ui-json>...</a2ui-json> pairs that yield no A2UI messages — blocks the
-// parser drops. This is independent of bare-JSON parts, which must not mask
-// the alert (#7).
-//
-// Each block is judged by running it through the SAME parser Scan uses, so
-// this check agrees with rendering by construction. The previous
-// implementation unmarshalled the body as a single JSON object, which
-// disagreed with the parser in both directions: valid-but-unrecognized JSON
-// ({"foo":1}) is silently dropped by the parser but unmarshals fine (missed
-// alert), while array-wrapped or multiple newline-delimited messages render
-// fine but fail a single-object unmarshal (false alert beside a working
-// surface).
-func countDroppedTaggedBlocks(content string) int {
-	var dropped int
-	s := content
-	for {
-		i := strings.Index(s, a2uiOpenTag)
-		if i < 0 {
-			break
-		}
-		s = s[i+len(a2uiOpenTag):]
-		j := strings.Index(s, a2uiCloseTag)
-		if j < 0 {
-			break
-		}
-		body := s[:j]
-		s = s[j+len(a2uiCloseTag):]
+// a2uiBlockStats summarizes how the a2uistream parser treats the complete
+// <a2ui-json> blocks in content (#7, #168).
+type a2uiBlockStats struct {
+	// dropped counts blocks the parser consumed but produced nothing from —
+	// malformed JSON or objects it doesn't recognize. These lose content and
+	// must alert.
+	dropped int
+	// protocolOnly counts blocks holding only protocol messages
+	// (callFunction/actionResponse): recognized, just not drawable. These get
+	// a quiet notice, not the malformed-content alert.
+	protocolOnly int
+	// unclosed reports an open tag the parser honors as a delimiter that
+	// never got its closing partner — a truncated generation (#5).
+	unclosed bool
+}
 
-		messages := 0
-		if parts, err := a2tea.Scan(a2uiOpenTag + body + a2uiCloseTag); err == nil {
-			for _, p := range parts {
-				messages += len(p.Messages)
-			}
+// scanA2UIBlocks classifies the tagged blocks in content the way the
+// a2uistream parser does. Both the segmentation and the per-block judgment
+// derive from the parser's own rules, so this check agrees with rendering by
+// construction.
+//
+// Segmentation used to pair tag literals with a blind string scan, which
+// disagreed with the parser when a bare A2UI message's *string content*
+// mentioned the tags — the parser consumes the whole object (tag literals and
+// all) as one message, while the blind scan saw a "block" between the
+// mentions and raised a false alert beside a working surface (#168). This
+// mirrors the parser's pre-tag scan instead: a bare A2UI object opened before
+// a tag swallows it, and only a tag the parser would honor as a delimiter
+// starts a block.
+//
+// Judging each block by re-parsing it also fixes what a single-object
+// unmarshal got wrong in both directions: valid-but-unrecognized JSON
+// ({"foo":1}) is silently dropped by the parser but unmarshals fine (missed
+// alert), while multiple newline-delimited messages render fine but fail a
+// single-object unmarshal (false alert).
+func scanA2UIBlocks(content string) a2uiBlockStats {
+	var stats a2uiBlockStats
+	s := content
+scan:
+	for {
+		tagIdx := strings.Index(s, a2uiOpenTag)
+		if tagIdx < 0 {
+			return stats
 		}
-		if messages == 0 {
-			dropped++
+		// Mirror the parser's scan of the text ahead of the tag for bare
+		// A2UI JSON objects.
+		for from := 0; from < tagIdx; {
+			rel := strings.IndexByte(s[from:tagIdx], '{')
+			if rel < 0 {
+				break
+			}
+			idx := from + rel
+			if !atBareJSONBoundary(s, idx) || !possibleBareA2UIPrefix(s[idx:]) {
+				from = idx + 1
+				continue
+			}
+			end, complete := scanJSONObject(s[idx:])
+			if !complete {
+				// The parser buffers the incomplete object and everything
+				// after it as plain text; the tag never becomes a delimiter.
+				return stats
+			}
+			if acceptedBareA2UIObject(s[idx : idx+end]) {
+				// The parser consumes the object and rescans from after it —
+				// a tag literal inside the object's strings is message
+				// content, not a delimiter.
+				s = s[idx+end:]
+				continue scan
+			}
+			from = idx + 1
+		}
+		rest := s[tagIdx+len(a2uiOpenTag):]
+		j := strings.Index(rest, a2uiCloseTag)
+		if j < 0 {
+			stats.unclosed = true
+			return stats
+		}
+		messages, payloads := classifyA2UIBlock(rest[:j])
+		switch {
+		case messages > 0: // renders — nothing to report
+		case payloads > 0:
+			stats.protocolOnly++
+		default:
+			stats.dropped++
+		}
+		s = rest[j+len(a2uiCloseTag):]
+	}
+}
+
+// classifyA2UIBlock judges one complete tagged block's body with the same
+// parser rendering uses, reporting how many typed (renderable) messages and
+// version-neutral payload objects it yields. A block with payloads but no
+// messages carries only protocol traffic (callFunction/actionResponse);
+// one with neither was dropped entirely.
+func classifyA2UIBlock(body string) (messages, payloads int) {
+	parts, err := a2uistream.ParseAndValidate(a2uiOpenTag+body+a2uiCloseTag, nil)
+	if err != nil {
+		return 0, 0
+	}
+	for _, p := range parts {
+		messages += len(p.Messages)
+		payloads += len(p.Payload)
+	}
+	return messages, payloads
+}
+
+// The helpers below mirror a2uistream's unexported bare-JSON scanning rules
+// so scanA2UIBlocks segments content exactly as the parser does.
+
+// a2uiBareKeys are the JSON keys whose presence as a first key makes an
+// object a bare A2UI message candidate for the parser.
+var a2uiBareKeys = []string{
+	"version",
+	"functionCallId",
+	"actionId",
+	"wantResponse",
+	"createSurface",
+	"updateComponents",
+	"updateDataModel",
+	"deleteSurface",
+	"callFunction",
+	"actionResponse",
+}
+
+// a2uiPayloadKeys are the message-type keys that make the parser actually
+// consume a candidate object (the version-neutral payload check).
+var a2uiPayloadKeys = []string{
+	"createSurface",
+	"updateComponents",
+	"updateDataModel",
+	"deleteSurface",
+	"callFunction",
+	"actionResponse",
+}
+
+// atBareJSONBoundary reports whether an object starting at s[idx] sits at a
+// position the parser treats as a bare-JSON boundary: the start of its
+// buffer, or after whitespace.
+func atBareJSONBoundary(s string, idx int) bool {
+	if idx == 0 {
+		return true
+	}
+	switch s[idx-1] {
+	case ' ', '\t', '\n', '\r':
+		return true
+	default:
+		return false
+	}
+}
+
+// possibleBareA2UIPrefix reports whether s (starting at '{') could open a
+// bare A2UI message: its first key must be one of the keys the parser
+// recognizes.
+func possibleBareA2UIPrefix(s string) bool {
+	if s == "" || s[0] != '{' {
+		return false
+	}
+	i := 1
+	for i < len(s) && isJSONSpace(s[i]) {
+		i++
+	}
+	if i == len(s) {
+		return true
+	}
+	if s[i] != '"' {
+		return false
+	}
+	i++
+	start := i
+	for i < len(s) && isJSONKeyChar(s[i]) {
+		i++
+	}
+	fragment := s[start:i]
+	if i == len(s) || s[i] != '"' {
+		return hasBareA2UIKeyPrefix(fragment)
+	}
+	if !isBareA2UIKey(fragment) {
+		return false
+	}
+	i++
+	for i < len(s) && isJSONSpace(s[i]) {
+		i++
+	}
+	return i == len(s) || s[i] == ':'
+}
+
+func hasBareA2UIKeyPrefix(fragment string) bool {
+	if fragment == "" {
+		return true
+	}
+	for _, key := range a2uiBareKeys {
+		if strings.HasPrefix(key, fragment) {
+			return true
 		}
 	}
-	return dropped
+	return false
+}
+
+func isBareA2UIKey(fragment string) bool {
+	for _, key := range a2uiBareKeys {
+		if key == fragment {
+			return true
+		}
+	}
+	return false
+}
+
+func isJSONKeyChar(b byte) bool {
+	return (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z')
+}
+
+func isJSONSpace(b byte) bool {
+	switch b {
+	case ' ', '\t', '\n', '\r':
+		return true
+	default:
+		return false
+	}
+}
+
+// scanJSONObject reports the end of the JSON object starting at s[0] ('{'),
+// tracking strings and escapes so braces (and tag literals) inside string
+// values don't fool the scan. complete is false when the object runs past the
+// end of s.
+func scanJSONObject(s string) (end int, complete bool) {
+	if s == "" || s[0] != '{' {
+		return 0, false
+	}
+	depth := 0
+	inString := false
+	escaped := false
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if inString {
+			if escaped {
+				escaped = false
+				continue
+			}
+			switch c {
+			case '\\':
+				escaped = true
+			case '"':
+				inString = false
+			}
+			continue
+		}
+		switch c {
+		case '"':
+			inString = true
+		case '{':
+			depth++
+		case '}':
+			depth--
+			if depth == 0 {
+				return i + 1, true
+			}
+		}
+	}
+	return 0, false
+}
+
+// acceptedBareA2UIObject reports whether the parser would consume obj as a
+// bare A2UI message: valid JSON carrying at least one message-type key.
+func acceptedBareA2UIObject(obj string) bool {
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(obj), &m); err != nil {
+		return false
+	}
+	for _, key := range a2uiPayloadKeys {
+		if _, ok := m[key]; ok {
+			return true
+		}
+	}
+	return false
 }
 
 // repairA2UIButtons rewrites the raw JSON inside <a2ui-json> blocks to fix a
@@ -399,14 +634,21 @@ func (a *AssistantMessageItem) renderContentWithA2UI(content string, width int, 
 		writeChunk(surface.Width(max(width-surface.GetHorizontalBorderSize(), 1)).Render(rendered))
 	}
 
-	// Alert when a complete tag pair was dropped by the parser (#7) —
-	// checked directly so bare-JSON parts cannot mask the count — or when
-	// generation was truncated mid-block (#5). Only for finished messages:
-	// while streaming, an "unclosed" tag usually just means the close tag
-	// hasn't arrived yet, and flashing a red alert between flushes that then
-	// vanishes reads as a glitch.
-	if finished && (countDroppedTaggedBlocks(masked) > 0 || hasUnclosedA2UITag(masked)) {
-		writeChunk(a.renderA2UIAlert(width))
+	// Alert when the parser dropped a complete tagged block (#7) — checked
+	// directly so bare-JSON parts cannot mask the count — or when generation
+	// was truncated mid-block (#5). Blocks carrying only protocol messages
+	// were understood, just not drawable, so they get a quiet notice instead
+	// (#168). Only for finished messages: while streaming, an "unclosed" tag
+	// usually just means the close tag hasn't arrived yet, and flashing a red
+	// alert between flushes that then vanishes reads as a glitch.
+	if finished {
+		stats := scanA2UIBlocks(masked)
+		switch {
+		case stats.dropped > 0 || stats.unclosed:
+			writeChunk(a.renderA2UIAlert(width))
+		case stats.protocolOnly > 0:
+			writeChunk(a.renderA2UIProtocolNotice(width))
+		}
 	}
 
 	return b.String()
@@ -449,4 +691,14 @@ func (a *AssistantMessageItem) renderA2UIAlert(width int) string {
 	reason := a.sty.Messages.ErrorDetails.Width(inner).Render(
 		"The A2UI content was malformed or used unsupported components.")
 	return tag + " " + title + "\n\n" + reason
+}
+
+// renderA2UIProtocolNotice is the quiet counterpart to renderA2UIAlert for
+// tagged blocks holding only protocol messages (callFunction/actionResponse):
+// the content was understood, there is simply nothing to draw, so a muted
+// one-liner replaces the misleading malformed-content alert (#168).
+func (a *AssistantMessageItem) renderA2UIProtocolNotice(width int) string {
+	inner := max(width-2, 1)
+	return a.sty.Messages.ErrorDetails.Width(inner).Render(
+		"This message includes A2UI protocol data with nothing to display.")
 }

--- a/internal/ui/chat/a2ui.go
+++ b/internal/ui/chat/a2ui.go
@@ -5,13 +5,18 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"regexp"
+	"slices"
 	"strings"
+	"unicode"
 
 	tea "charm.land/bubbletea/v2"
 	"github.com/charmbracelet/crush/internal/ui/common"
 	"github.com/joestump-agent/a2tea"
+	"github.com/joestump-agent/a2tea/event"
 	"github.com/joestump-agent/a2tea/render"
+	a2ui "github.com/tmc/a2ui"
 	"github.com/tmc/a2ui/a2uistream"
 )
 
@@ -567,6 +572,7 @@ func (a *AssistantMessageItem) syncA2UISurfaces(src string, parts []a2tea.Part) 
 		return
 	}
 	surfaces := make([]render.Model, len(parts))
+	ids := make([]string, len(parts))
 	for i, p := range parts {
 		if len(p.Messages) == 0 {
 			continue
@@ -580,9 +586,11 @@ func (a *AssistantMessageItem) syncA2UISurfaces(src string, parts []a2tea.Part) 
 		}
 		if rm, ok := model.(render.Model); ok {
 			surfaces[i] = rm
+			ids[i] = a2uiPartSurfaceID(p.Messages)
 		}
 	}
 	a.a2uiSurfaces = surfaces
+	a.a2uiSurfaceIDs = ids
 	a.a2uiSrcHash = h
 	a.a2uiScanned = true
 	// A rebuild replaces focused models with fresh blurred ones; re-grant
@@ -593,11 +601,162 @@ func (a *AssistantMessageItem) syncA2UISurfaces(src string, parts []a2tea.Part) 
 }
 
 // dropA2UISurfaces discards the live surface models, e.g. when the content
-// no longer scans as A2UI.
+// no longer scans as A2UI. Retirement marks are kept: they are keyed by
+// surface ID, and a surface that reappears after a rescan was still already
+// submitted (#45).
 func (a *AssistantMessageItem) dropA2UISurfaces() {
 	a.a2uiSurfaces = nil
+	a.a2uiSurfaceIDs = nil
 	a.a2uiSrcHash = 0
 	a.a2uiScanned = false
+}
+
+// a2uiPartSurfaceID extracts the surface ID a scan-part's messages establish:
+// the first updateComponents' surfaceId — the same rule a2tea.Render uses to
+// pick the surface it draws, so the ID here always names the rendered model.
+func a2uiPartSurfaceID(msgs []a2ui.ServerMessage) string {
+	for _, m := range msgs {
+		if m.UpdateComponents != nil {
+			return m.UpdateComponents.SurfaceID
+		}
+	}
+	return ""
+}
+
+// a2uiSurfaceRetired reports whether the surface at part-index i has been
+// retired after a submission (#45). Retired surfaces still render (showing
+// their final state) but no longer receive focus or keys.
+func (a *AssistantMessageItem) a2uiSurfaceRetired(i int) bool {
+	if i < 0 || i >= len(a.a2uiSurfaceIDs) {
+		return false
+	}
+	return a.a2uiRetired[a.a2uiSurfaceIDs[i]]
+}
+
+// RetireA2UISurface retires the live surface with the given A2UI surface ID
+// after a button press (#45): it reads the surface's current field values,
+// revokes its focus, and marks it retired so the form cannot be re-submitted
+// — the mark is keyed by surface ID, so it survives streaming rebuilds of
+// the model. It returns the gathered values and whether the surface was
+// found on this item.
+func (a *AssistantMessageItem) RetireA2UISurface(surfaceID string) (map[string]any, bool) {
+	if surfaceID == "" {
+		return nil, false
+	}
+	for i, s := range a.a2uiSurfaces {
+		if s == nil || i >= len(a.a2uiSurfaceIDs) || a.a2uiSurfaceIDs[i] != surfaceID {
+			continue
+		}
+		if a.a2uiRetired[surfaceID] {
+			// Already submitted or dismissed: report not-found so a
+			// duplicate event cannot re-read values from a dead form.
+			return nil, false
+		}
+		var values map[string]any
+		if fv, ok := s.(interface{ FieldValues() map[string]any }); ok {
+			values = fv.FieldValues()
+		}
+		if a.a2uiRetired == nil {
+			a.a2uiRetired = make(map[string]bool)
+		}
+		a.a2uiRetired[surfaceID] = true
+		s.Blur()
+		a.Bump()
+		return values, true
+	}
+	return nil, false
+}
+
+// a2uiCancelWords are the button-name tokens read as "dismiss this form":
+// pressing such a button retires the surface without starting an agent turn
+// (#45). Matched against whole tokens of the button's component ID and its
+// action name, never as substrings, so ids like "notify" or "disclose" do
+// not false-positive.
+var a2uiCancelWords = map[string]bool{
+	"cancel":  true,
+	"dismiss": true,
+	"close":   true,
+	"no":      true,
+}
+
+// A2UIButtonIsCancel reports whether an activated button reads as a cancel /
+// dismiss control. A2UI has no cancel semantics of its own — model-authored
+// buttons typically carry no action at all — so the judgment is by naming
+// convention on the component ID (e.g. "btn-cancel", "dismissBtn") and, when
+// present, the server action's name.
+func A2UIButtonIsCancel(clicked event.ButtonClicked) bool {
+	if a2uiHasCancelToken(clicked.ID) {
+		return true
+	}
+	return clicked.Action != nil && a2uiHasCancelToken(clicked.Action.Name)
+}
+
+// a2uiHasCancelToken tokenizes s on non-alphanumeric and camelCase
+// boundaries and reports whether any token is a cancel word.
+func a2uiHasCancelToken(s string) bool {
+	for _, tok := range a2uiNameTokens(s) {
+		if a2uiCancelWords[tok] {
+			return true
+		}
+	}
+	return false
+}
+
+// a2uiNameTokens splits an identifier-ish name ("btn-cancel", "dismissBtn",
+// "close_form") into lowercase word tokens.
+func a2uiNameTokens(s string) []string {
+	var tokens []string
+	var b strings.Builder
+	flush := func() {
+		if b.Len() > 0 {
+			tokens = append(tokens, strings.ToLower(b.String()))
+			b.Reset()
+		}
+	}
+	var prev rune
+	for _, r := range s {
+		switch {
+		case !unicode.IsLetter(r) && !unicode.IsDigit(r):
+			flush()
+		case unicode.IsUpper(r) && unicode.IsLower(prev):
+			flush()
+			b.WriteRune(r)
+		default:
+			b.WriteRune(r)
+		}
+		prev = r
+	}
+	flush()
+	return tokens
+}
+
+// A2UISubmissionPrompt builds the agent-facing message for an A2UI form
+// submission (#45): which button was pressed on which surface, plus the
+// surface's field values at the moment of submission. Values are keyed by
+// component ID, sorted for determinism, and JSON-encoded so their types
+// (string, bool, number, string list) survive the trip through prose.
+func A2UISubmissionPrompt(clicked event.ButtonClicked, values map[string]any) string {
+	var b strings.Builder
+	b.WriteString("[A2UI form submission] The user pressed the ")
+	fmt.Fprintf(&b, "%q button", clicked.ID)
+	if clicked.Action != nil && clicked.Action.Name != "" {
+		fmt.Fprintf(&b, " (action %q)", clicked.Action.Name)
+	}
+	if clicked.SurfaceID != "" {
+		fmt.Fprintf(&b, " on surface %q", clicked.SurfaceID)
+	}
+	b.WriteString(".")
+	if len(values) > 0 {
+		b.WriteString("\nField values:")
+		for _, k := range slices.Sorted(maps.Keys(values)) {
+			enc, err := json.Marshal(values[k])
+			if err != nil {
+				enc = fmt.Appendf(nil, "%q", fmt.Sprintf("%v", values[k]))
+			}
+			fmt.Fprintf(&b, "\n- %s: %s", k, enc)
+		}
+	}
+	return b.String()
 }
 
 // a2uiSurfaceAt returns the live surface for scan-part i, or nil when the
@@ -621,17 +780,18 @@ func (a *AssistantMessageItem) hasLiveA2UISurfaces() bool {
 	return false
 }
 
-// focusA2UISurfaces grants keyboard focus to the first live surface and
-// blurs the rest, honoring the a2tea composition contract of at most one
-// focused child at a time. render.Surface's Focus returns a nil cmd, so
-// dropping it here loses nothing.
+// focusA2UISurfaces grants keyboard focus to the first live, non-retired
+// surface and blurs the rest, honoring the a2tea composition contract of at
+// most one focused child at a time. Retired surfaces (#45) never regain
+// focus — a submitted form must not be re-submittable. render.Surface's
+// Focus returns a nil cmd, so dropping it here loses nothing.
 func (a *AssistantMessageItem) focusA2UISurfaces() {
 	granted := false
-	for _, s := range a.a2uiSurfaces {
+	for i, s := range a.a2uiSurfaces {
 		if s == nil {
 			continue
 		}
-		if !granted {
+		if !granted && !a.a2uiSurfaceRetired(i) {
 			_ = s.Focus()
 			granted = true
 			continue

--- a/internal/ui/chat/a2ui_test.go
+++ b/internal/ui/chat/a2ui_test.go
@@ -1,6 +1,7 @@
 package chat
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 
@@ -135,6 +136,140 @@ func TestRenderContentWithA2UIMalformedNotMaskedByBareJSON(t *testing.T) {
 	plain := ansi.Strip(out)
 
 	require.Contains(t, plain, "couldn't render") // the malformed tagged block alerted
+}
+
+// --- Issue #47: childless-but-labeled buttons are repaired on the raw JSON ---
+
+// TestRenderContentWithA2UIRepairsTextOnButton pins the DoD for #47: a model
+// reply carrying the {"component":"Button","text":"Send"} anti-pattern (label
+// in a text field, no child) renders the intended labels — not IDs, not
+// "missing component" placeholders.
+func TestRenderContentWithA2UIRepairsTextOnButton(t *testing.T) {
+	t.Parallel()
+
+	sty := styles.CharmtonePantera()
+	item := &AssistantMessageItem{sty: &sty}
+
+	content := `Form: <a2ui-json>{"version":"v0.9","updateComponents":{"surfaceId":"s","components":[` +
+		`{"component":"Column","id":"root","children":["btn1","btn2"]},` +
+		`{"component":"Button","id":"btn1","text":"Send"},` +
+		`{"component":"Button","id":"btn2","text":"Cancel"}` +
+		`]}}</a2ui-json>`
+	out := item.renderContentWithA2UI(content, 80, true)
+	plain := ansi.Strip(out)
+
+	require.Contains(t, plain, "Send", "the button's intended label must render")
+	require.Contains(t, plain, "Cancel", "the second button's label must render")
+	require.NotContains(t, plain, "btn1", "the button must not fall back to its ID")
+	require.NotContains(t, plain, "missing component")
+	require.NotContains(t, plain, "couldn't render")
+}
+
+func TestRepairA2UIButtonsSynthesizesChildText(t *testing.T) {
+	t.Parallel()
+
+	content := `<a2ui-json>{"version":"v0.9","updateComponents":{"surfaceId":"s","components":[` +
+		`{"component":"Button","id":"btn1","text":"Send"}]}}</a2ui-json>`
+	repaired := repairA2UIButtons(content)
+
+	body := strings.TrimSuffix(strings.TrimPrefix(repaired, "<a2ui-json>"), "</a2ui-json>")
+	var msg struct {
+		UpdateComponents struct {
+			Components []map[string]any `json:"components"`
+		} `json:"updateComponents"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(body), &msg))
+
+	comps := msg.UpdateComponents.Components
+	require.Len(t, comps, 2, "a Text component must be added for the label")
+
+	btn := comps[0]
+	require.Equal(t, "Button", btn["component"])
+	require.Equal(t, "btn1-label", btn["child"], "the button must point at the synthesized Text")
+	require.NotContains(t, btn, "text", "the stray text field must be removed")
+
+	label := comps[1]
+	require.Equal(t, "Text", label["component"])
+	require.Equal(t, "btn1-label", label["id"])
+	require.Equal(t, "Send", label["text"])
+}
+
+func TestRepairA2UIButtonsLabelFieldAndIDCollision(t *testing.T) {
+	t.Parallel()
+
+	// The same anti-pattern with a `label` field instead of `text`, plus an
+	// existing component already occupying the derived label id.
+	content := `<a2ui-json>{"version":"v0.9","updateComponents":{"surfaceId":"s","components":[` +
+		`{"component":"Text","id":"btn1-label","text":"taken"},` +
+		`{"component":"Button","id":"btn1","label":"Send"}]}}</a2ui-json>`
+	repaired := repairA2UIButtons(content)
+
+	require.Contains(t, repaired, `"child":"btn1-label-2"`, "the synthesized id must not collide")
+	require.Contains(t, repaired, `"id":"btn1-label-2"`)
+	require.NotContains(t, repaired, `"label":"Send"`, "the stray label field must be removed")
+}
+
+// TestRepairA2UIButtonsLeavesValidUntouched pins the surgical guarantee:
+// content whose buttons already use a child Text id passes through repair
+// byte-for-byte unchanged, as does anything else the repair has no business
+// rewriting.
+func TestRepairA2UIButtonsLeavesValidUntouched(t *testing.T) {
+	t.Parallel()
+
+	valid := `<a2ui-json>{"version":"v0.9","updateComponents":{"surfaceId":"s","components":[` +
+		`{"component":"Button","id":"btn","child":"lbl"},` +
+		`{"component":"Text","id":"lbl","text":"OK"}]}}</a2ui-json>`
+	require.Equal(t, valid, repairA2UIButtons(valid))
+
+	// A button with BOTH child and text keeps its child (text is the parser's
+	// problem to drop, not ours to rewire).
+	both := `<a2ui-json>{"version":"v0.9","updateComponents":{"surfaceId":"s","components":[` +
+		`{"component":"Button","id":"btn","child":"lbl","text":"stray"},` +
+		`{"component":"Text","id":"lbl","text":"OK"}]}}</a2ui-json>`
+	require.Equal(t, both, repairA2UIButtons(both))
+
+	// Inline-nested child (an object, another anti-pattern) is not rewritten;
+	// it stays on the existing error path.
+	nested := `<a2ui-json>{"version":"v0.9","updateComponents":{"surfaceId":"s","components":[` +
+		`{"component":"Button","id":"btn","child":{"component":"Text","text":"X"}}]}}</a2ui-json>`
+	require.Equal(t, nested, repairA2UIButtons(nested))
+
+	// The canonical card surface is untouched too.
+	require.Equal(t, "prose "+a2uiSurface, repairA2UIButtons("prose "+a2uiSurface))
+
+	// Plain prose without any block is returned as-is.
+	require.Equal(t, "no blocks here", repairA2UIButtons("no blocks here"))
+}
+
+// TestRepairA2UIButtonsMalformedUnchanged: undecodable JSON passes through
+// verbatim so the existing malformed-block alert still fires downstream.
+func TestRepairA2UIButtonsMalformedUnchanged(t *testing.T) {
+	t.Parallel()
+
+	malformed := `before <a2ui-json>{"component":"Button","text":"Send"</a2ui-json> after`
+	require.Equal(t, malformed, repairA2UIButtons(malformed))
+
+	sty := styles.CharmtonePantera()
+	item := &AssistantMessageItem{sty: &sty}
+	plain := ansi.Strip(item.renderContentWithA2UI(malformed, 80, true))
+	require.Contains(t, plain, "couldn't render", "malformed A2UI must still alert")
+}
+
+// TestRenderContentWithA2UIValidButtonStillRenders: a correctly authored
+// child-based button renders its label with the repair in the path.
+func TestRenderContentWithA2UIValidButtonStillRenders(t *testing.T) {
+	t.Parallel()
+
+	sty := styles.CharmtonePantera()
+	item := &AssistantMessageItem{sty: &sty}
+
+	content := `<a2ui-json>{"version":"v0.9","updateComponents":{"surfaceId":"s","components":[` +
+		`{"component":"Button","id":"btn","child":"lbl"},` +
+		`{"component":"Text","id":"lbl","text":"Acknowledge"}]}}</a2ui-json>`
+	plain := ansi.Strip(item.renderContentWithA2UI(content, 80, true))
+
+	require.Contains(t, plain, "Acknowledge")
+	require.NotContains(t, plain, "couldn't render")
 }
 
 // --- Existing tests ---

--- a/internal/ui/chat/a2ui_test.go
+++ b/internal/ui/chat/a2ui_test.go
@@ -5,10 +5,12 @@ import (
 	"strings"
 	"testing"
 
+	tea "charm.land/bubbletea/v2"
 	"github.com/charmbracelet/crush/internal/message"
 
 	"github.com/charmbracelet/crush/internal/ui/styles"
 	"github.com/charmbracelet/x/ansi"
+	"github.com/joestump-agent/a2tea/render"
 	"github.com/stretchr/testify/require"
 )
 
@@ -634,4 +636,162 @@ And a second one: <a2ui-json>{"version":"v0.9","updateComp`
 	finished := ansi.Strip(item.cachedContent(80))
 	require.Contains(t, finished, "couldn't render",
 		"finished message with a dangling block must alert even when its text matches the cached streaming render")
+}
+
+// --- Issue #44: keep the surface model live; route focus + keys to it ---
+
+// a2uiTwoButtonForm is a surface with two focusable buttons so Tab moves
+// focus between distinct elements.
+const a2uiTwoButtonForm = `<a2ui-json>{"version":"v0.9","updateComponents":{"surfaceId":"form","components":[` +
+	`{"component":"Card","id":"root","child":"col"},` +
+	`{"component":"Column","id":"col","children":["b1","b2"]},` +
+	`{"component":"Button","id":"b1","child":"b1t"},` +
+	`{"component":"Text","id":"b1t","text":"Send"},` +
+	`{"component":"Button","id":"b2","child":"b2t"},` +
+	`{"component":"Text","id":"b2t","text":"Cancel"}` +
+	`]}}</a2ui-json>`
+
+// newA2UIFormItem builds a fully-constructed assistant item (version rail,
+// focus rail) whose message carries a two-button A2UI form.
+func newA2UIFormItem(t *testing.T) *AssistantMessageItem {
+	t.Helper()
+	sty := styles.CharmtonePantera()
+	msg := &message.Message{
+		ID:   "a2ui-form",
+		Role: message.Assistant,
+		Parts: []message.ContentPart{
+			message.TextContent{Text: "Here is a form:\n\n" + a2uiTwoButtonForm},
+		},
+	}
+	item, ok := NewAssistantMessageItem(&sty, msg).(*AssistantMessageItem)
+	require.True(t, ok)
+	return item
+}
+
+// firstLiveA2UISurface returns the item's first non-nil surface model.
+func firstLiveA2UISurface(t *testing.T, item *AssistantMessageItem) render.Model {
+	t.Helper()
+	for _, s := range item.a2uiSurfaces {
+		if s != nil {
+			return s
+		}
+	}
+	t.Fatal("item holds no live A2UI surface")
+	return nil
+}
+
+func TestA2UIItemHoldsLiveSurfaceModel(t *testing.T) {
+	t.Parallel()
+
+	item := newA2UIFormItem(t)
+	_ = item.RawRender(80)
+
+	require.True(t, item.hasLiveA2UISurfaces(), "rendering must keep the a2tea model, not just its string")
+	surf := firstLiveA2UISurface(t, item)
+	require.False(t, surf.Focused(), "surface starts blurred until the item is selected")
+}
+
+func TestA2UISetFocusedRoutesFocusToSurface(t *testing.T) {
+	t.Parallel()
+
+	item := newA2UIFormItem(t)
+	_ = item.RawRender(80)
+
+	require.Equal(t, -1, item.focusedA2UISurfaceIndex())
+	item.SetFocused(true)
+	require.GreaterOrEqual(t, item.focusedA2UISurfaceIndex(), 0, "selecting the item must focus its surface")
+	item.SetFocused(false)
+	require.Equal(t, -1, item.focusedA2UISurfaceIndex(), "deselecting the item must blur its surface")
+}
+
+func TestA2UIHandleKeyEventTabMovesFocus(t *testing.T) {
+	t.Parallel()
+
+	item := newA2UIFormItem(t)
+	_ = item.RawRender(80)
+	item.SetFocused(true)
+
+	before := item.RawRender(80)
+	v := item.Version()
+
+	handled, _ := item.HandleKeyEvent(tea.KeyPressMsg{Code: tea.KeyTab})
+	require.True(t, handled, "a focused surface must consume tab")
+	require.Greater(t, item.Version(), v, "key handling must bump the item version so the list re-renders")
+
+	after := item.RawRender(80)
+	require.NotEqual(t, before, after, "tab must visibly move the focus indicator")
+
+	// Two buttons: a second tab wraps the ring back to the first.
+	handled, _ = item.HandleKeyEvent(tea.KeyPressMsg{Code: tea.KeyTab})
+	require.True(t, handled)
+	require.Equal(t, before, item.RawRender(80), "tab must cycle back around the two-element ring")
+}
+
+func TestA2UIHandleKeyEventEnterActivatesButton(t *testing.T) {
+	t.Parallel()
+
+	item := newA2UIFormItem(t)
+	_ = item.RawRender(80)
+	item.SetFocused(true)
+
+	handled, cmd := item.HandleKeyEvent(tea.KeyPressMsg{Code: tea.KeyEnter})
+	require.True(t, handled, "enter must reach the surface")
+	require.NotNil(t, cmd, "button activation must emit the ButtonClicked cmd")
+}
+
+func TestA2UIHandleKeyEventIgnoresKeysWhileBlurred(t *testing.T) {
+	t.Parallel()
+
+	item := newA2UIFormItem(t)
+	_ = item.RawRender(80)
+
+	handled, _ := item.HandleKeyEvent(tea.KeyPressMsg{Code: tea.KeyTab})
+	require.False(t, handled, "a blurred surface must not consume tab")
+
+	// The copy shortcut still works when the surface is not focused.
+	handled, cmd := item.HandleKeyEvent(tea.KeyPressMsg{Code: 'c', Text: "c"})
+	require.True(t, handled)
+	require.NotNil(t, cmd)
+}
+
+func TestA2UISurfaceModelStableAcrossRenders(t *testing.T) {
+	t.Parallel()
+
+	item := newA2UIFormItem(t)
+	_ = item.RawRender(80)
+	first := firstLiveA2UISurface(t, item)
+
+	_ = item.RawRender(80) // same width
+	_ = item.RawRender(60) // width change
+	require.Same(t, first, firstLiveA2UISurface(t, item),
+		"re-renders must reuse the live model — rebuilding would drop interaction state")
+}
+
+func TestA2UIContentCacheBypassedForLiveSurfaces(t *testing.T) {
+	t.Parallel()
+
+	item := newA2UIFormItem(t)
+	_ = item.RawRender(80)
+	_ = item.RawRender(80)
+
+	require.True(t, item.hasLiveA2UISurfaces())
+	require.False(t, item.contentSec.valid,
+		"the content-hash cache must not freeze a live surface")
+}
+
+func TestPureTextContentStillCaches(t *testing.T) {
+	t.Parallel()
+
+	sty := styles.CharmtonePantera()
+	msg := &message.Message{
+		ID:    "plain",
+		Role:  message.Assistant,
+		Parts: []message.ContentPart{message.TextContent{Text: "just prose, no UI"}},
+	}
+	item, ok := NewAssistantMessageItem(&sty, msg).(*AssistantMessageItem)
+	require.True(t, ok)
+
+	_ = item.RawRender(80)
+	require.False(t, item.hasLiveA2UISurfaces())
+	require.True(t, item.contentSec.valid, "pure-text messages must keep the content cache")
 }

--- a/internal/ui/chat/a2ui_test.go
+++ b/internal/ui/chat/a2ui_test.go
@@ -69,6 +69,72 @@ func TestRenderContentWithA2UIRealSurfaceNextToFencedExample(t *testing.T) {
 	require.Contains(t, plain, "Hello from A2UI") // real surface rendered
 }
 
+// --- Issue #96: tag mentions in inline code must not be scanned ---
+
+func TestContentHasA2UIIgnoresInlineCode(t *testing.T) {
+	t.Parallel()
+	// A complete-looking tag pair in inline code is documentation, not live UI.
+	require.False(t, contentHasA2UI("Wrap the payload in `<a2ui-json>` and `</a2ui-json>` tags."))
+	// Double-backtick spans too.
+	require.False(t, contentHasA2UI("Wrap it in ``<a2ui-json>`` and ``</a2ui-json>``."))
+	// A whole example block quoted in one inline span.
+	require.False(t, contentHasA2UI("Like this: `"+a2uiSurface+"`"))
+}
+
+func TestContentHasUnclosedA2UIIgnoresInlineCode(t *testing.T) {
+	t.Parallel()
+	// A lone open tag in inline code is not a truncated block — without this,
+	// renderTruncatedA2UI chops the message at the mention.
+	require.False(t, contentHasUnclosedA2UI("Use the `<a2ui-json>` tag to open a block. More prose."))
+}
+
+func TestRenderContentWithA2UIInlineCodeMentionPreserved(t *testing.T) {
+	t.Parallel()
+
+	sty := styles.CharmtonePantera()
+	item := &AssistantMessageItem{sty: &sty}
+
+	// The exact repro from #96: prose explaining the format, with the tag pair
+	// in inline code. The scanner used to consume the pair, swallowing the
+	// prose between the mentions and raising a false alert.
+	content := "Wrap the payload in `<a2ui-json>` and `</a2ui-json>` tags, then send it."
+	plain := ansi.Strip(item.renderContentWithA2UI(content, 80, true))
+
+	require.Contains(t, plain, "<a2ui-json>", "the mention must render verbatim")
+	require.Contains(t, plain, "</a2ui-json>")
+	require.Contains(t, plain, "then send it", "prose after the mention must survive")
+	require.NotContains(t, plain, "couldn't render", "a documentation mention is not a dropped block")
+	require.NotContains(t, plain, "\x00", "mask placeholders must not leak")
+}
+
+func TestRenderContentWithA2UIRealSurfaceNextToInlineMention(t *testing.T) {
+	t.Parallel()
+
+	sty := styles.CharmtonePantera()
+	item := &AssistantMessageItem{sty: &sty}
+
+	// A live surface and an inline-code mention side by side: the surface
+	// renders, the mention stays prose, and no alert fires.
+	content := "I used the `<a2ui-json>` tag:\n\n" + a2uiSurface + "\n\nDone."
+	plain := ansi.Strip(item.renderContentWithA2UI(content, 80, true))
+
+	require.Contains(t, plain, "Hello from A2UI", "the real surface must render")
+	require.Contains(t, plain, "<a2ui-json>", "the inline mention must stay visible prose")
+	require.Contains(t, plain, "Done")
+	require.NotContains(t, plain, "couldn't render")
+}
+
+func TestMaskMarkdownCodeLeavesPlainInlineCodeAlone(t *testing.T) {
+	t.Parallel()
+
+	// Inline code without A2UI markers is not masked — a live surface whose
+	// JSON strings contain backticks must reach the parser byte-for-byte.
+	content := "Run `go test` first. " + a2uiSurface
+	masked, reps := maskMarkdownCode(content)
+	require.Equal(t, content, masked)
+	require.Empty(t, reps)
+}
+
 // --- Issue #5: truncated mid-block should show alert ---
 
 func TestContentHasUnclosedA2UI(t *testing.T) {

--- a/internal/ui/chat/a2ui_test.go
+++ b/internal/ui/chat/a2ui_test.go
@@ -338,6 +338,102 @@ func TestRenderContentWithA2UIValidButtonStillRenders(t *testing.T) {
 	require.NotContains(t, plain, "couldn't render")
 }
 
+// --- Issue #168: parser-derived segmentation; protocol-only blocks ---
+
+// a2uiDocSurface is a bare A2UI message whose *string content* mentions the
+// wire tags — documentation text inside a live surface. The parser consumes
+// the whole object as one message; the tag literals are content, not
+// delimiters.
+const a2uiDocSurface = `{"version":"v0.9","updateComponents":{"surfaceId":"s","components":[` +
+	`{"component":"Text","id":"t","text":"Wrap payloads in <a2ui-json> and </a2ui-json> tags"}]}}`
+
+func TestScanA2UIBlocks(t *testing.T) {
+	t.Parallel()
+
+	// A tag pair inside a bare message's JSON string is not a block.
+	require.Equal(t, a2uiBlockStats{}, scanA2UIBlocks(a2uiDocSurface))
+
+	// A lone open-tag literal inside a string is not a truncated block either.
+	lone := `{"version":"v0.9","updateComponents":{"surfaceId":"s","components":[` +
+		`{"component":"Text","id":"t","text":"start blocks with <a2ui-json>"}]}}`
+	require.Equal(t, a2uiBlockStats{}, scanA2UIBlocks(lone))
+
+	// Real blocks are still found and judged: rendered, malformed, unclosed.
+	require.Equal(t, a2uiBlockStats{}, scanA2UIBlocks("hi "+a2uiSurface))
+	require.Equal(t, a2uiBlockStats{dropped: 1}, scanA2UIBlocks(`<a2ui-json>{nope}</a2ui-json>`))
+	require.Equal(t, a2uiBlockStats{dropped: 1}, scanA2UIBlocks(`<a2ui-json>{"foo":1}</a2ui-json>`))
+	require.Equal(t, a2uiBlockStats{unclosed: true}, scanA2UIBlocks(`text <a2ui-json>{"version":"v0`))
+
+	// A consumed bare message followed by a real malformed block: the bare
+	// message must not hide the drop.
+	require.Equal(t, a2uiBlockStats{dropped: 1},
+		scanA2UIBlocks(a2uiDocSurface+"\n<a2ui-json>{nope}</a2ui-json>"))
+
+	// Protocol-only block: recognized but not drawable.
+	require.Equal(t, a2uiBlockStats{protocolOnly: 1},
+		scanA2UIBlocks(`<a2ui-json>{"version":"v0.9","callFunction":{"name":"getWeather"}}</a2ui-json>`))
+
+	// An incomplete bare candidate buffers the rest as text — the parser
+	// never honors the tag, so neither do we.
+	require.Equal(t, a2uiBlockStats{},
+		scanA2UIBlocks(`{"updateComponents": "unterminated <a2ui-json>{nope}</a2ui-json>`))
+}
+
+// TestNoAlertForTagLiteralInsideBareJSONString pins the #168 segmentation
+// fix end to end: a working bare surface whose text mentions the tag pair
+// must render without the false "couldn't render" alert the blind tag-pair
+// scan used to raise.
+func TestNoAlertForTagLiteralInsideBareJSONString(t *testing.T) {
+	t.Parallel()
+
+	sty := styles.CharmtonePantera()
+	item := &AssistantMessageItem{sty: &sty}
+
+	require.True(t, contentHasA2UI(a2uiDocSurface))
+	plain := ansi.Strip(item.renderContentWithA2UI(a2uiDocSurface, 80, true))
+
+	require.Contains(t, plain, "Wrap payloads in", "the surface must render its text")
+	require.NotContains(t, plain, "couldn't render",
+		"tag literals inside a consumed message's strings must not alert")
+}
+
+// TestProtocolOnlyBlockGetsNoticeNotAlert pins the #168 copy fix: a block
+// carrying only protocol messages was understood — it must show the quiet
+// notice, not the malformed-content alert.
+func TestProtocolOnlyBlockGetsNoticeNotAlert(t *testing.T) {
+	t.Parallel()
+
+	sty := styles.CharmtonePantera()
+	item := &AssistantMessageItem{sty: &sty}
+
+	content := `One sec: <a2ui-json>{"version":"v0.9","callFunction":{"name":"getWeather","args":{}}}</a2ui-json>`
+	plain := ansi.Strip(item.renderContentWithA2UI(content, 80, true))
+
+	require.Contains(t, plain, "nothing to display", "the protocol notice must show")
+	require.NotContains(t, plain, "couldn't render",
+		"a recognized protocol-only block is not a malformed block")
+	require.Contains(t, plain, "One sec", "surrounding prose is preserved")
+
+	// While streaming, notices stay quiet like the alert does.
+	streaming := ansi.Strip(item.renderContentWithA2UI(content, 80, false))
+	require.NotContains(t, streaming, "nothing to display")
+}
+
+// TestProtocolOnlyDoesNotMaskMalformedAlert: when both a protocol-only block
+// and a genuinely dropped block are present, the alert wins.
+func TestProtocolOnlyDoesNotMaskMalformedAlert(t *testing.T) {
+	t.Parallel()
+
+	sty := styles.CharmtonePantera()
+	item := &AssistantMessageItem{sty: &sty}
+
+	content := `<a2ui-json>{"version":"v0.9","callFunction":{"name":"f"}}</a2ui-json>` +
+		"\n\n<a2ui-json>{nope}</a2ui-json>"
+	plain := ansi.Strip(item.renderContentWithA2UI(content, 80, true))
+
+	require.Contains(t, plain, "couldn't render")
+}
+
 // --- Existing tests ---
 
 func TestRenderContentWithA2UI(t *testing.T) {
@@ -450,7 +546,7 @@ func TestNoDroppedBlockAlert_MultiMessageBody(t *testing.T) {
 	content := "Here: <a2ui-json>" + body + "</a2ui-json>"
 
 	// Sanity: the parser really does yield messages for this body.
-	require.Zero(t, countDroppedTaggedBlocks(content),
+	require.Zero(t, scanA2UIBlocks(content).dropped,
 		"multi-message body must not count as dropped")
 
 	out := item.renderContentWithA2UI(content, 80, true)

--- a/internal/ui/chat/a2ui_test.go
+++ b/internal/ui/chat/a2ui_test.go
@@ -1,6 +1,7 @@
 package chat
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/charmbracelet/crush/internal/message"
@@ -158,6 +159,44 @@ func TestRenderContentWithA2UI(t *testing.T) {
 	require.NotContains(t, plain, "updateComponents")
 	// No alert when the surface rendered fine.
 	require.NotContains(t, plain, "couldn't render")
+}
+
+// TestRenderContentWithA2UIThemedContainer asserts the rendered surface is
+// wrapped in the themed A2UISurface container (#46): the surface line sits
+// between the container's vertical border runes, under a top border and above
+// a bottom border. Prose outside the surface stays unboxed.
+func TestRenderContentWithA2UIThemedContainer(t *testing.T) {
+	t.Parallel()
+
+	sty := styles.CharmtonePantera()
+	item := &AssistantMessageItem{sty: &sty}
+
+	content := "Here is a card:\n\n" + a2uiSurface + "\n\nAnything else?"
+	out := item.renderContentWithA2UI(content, 80, true)
+	plain := ansi.Strip(out)
+
+	// Container corners from the rounded border are present.
+	require.Contains(t, plain, "╭")
+	require.Contains(t, plain, "╰")
+
+	// The surface content line is enclosed by the container's side borders.
+	var surfaceLine string
+	for _, line := range strings.Split(plain, "\n") {
+		if strings.Contains(line, "Hello from A2UI") {
+			surfaceLine = strings.TrimRight(line, " ")
+			break
+		}
+	}
+	require.NotEmpty(t, surfaceLine, "surface content line not found")
+	require.True(t, strings.HasPrefix(surfaceLine, "│"), "surface line should start with container border: %q", surfaceLine)
+	require.True(t, strings.HasSuffix(surfaceLine, "│"), "surface line should end with container border: %q", surfaceLine)
+
+	// Prose outside the surface is not boxed.
+	for _, line := range strings.Split(plain, "\n") {
+		if strings.Contains(line, "Here is a card") || strings.Contains(line, "Anything else") {
+			require.False(t, strings.Contains(line, "│"), "prose should not be inside the container: %q", line)
+		}
+	}
 }
 
 func TestRenderContentWithA2UIMixedGoodAndBadAlerts(t *testing.T) {

--- a/internal/ui/chat/a2ui_test.go
+++ b/internal/ui/chat/a2ui_test.go
@@ -10,8 +10,10 @@ import (
 
 	"github.com/charmbracelet/crush/internal/ui/styles"
 	"github.com/charmbracelet/x/ansi"
+	"github.com/joestump-agent/a2tea/event"
 	"github.com/joestump-agent/a2tea/render"
 	"github.com/stretchr/testify/require"
+	a2ui "github.com/tmc/a2ui"
 )
 
 // a2uiSurface is an <a2ui-json> block: a card wrapping a single text component.
@@ -794,4 +796,147 @@ func TestPureTextContentStillCaches(t *testing.T) {
 	_ = item.RawRender(80)
 	require.False(t, item.hasLiveA2UISurfaces())
 	require.True(t, item.contentSec.valid, "pure-text messages must keep the content cache")
+}
+
+// --- Issue #45: turn form submission into an agent turn ---
+
+// a2uiFieldForm is a surface with input components carrying literal values,
+// plus a submit and a cancel button.
+const a2uiFieldForm = `<a2ui-json>{"version":"v0.9","updateComponents":{"surfaceId":"contact","components":[` +
+	`{"component":"Card","id":"root","child":"col"},` +
+	`{"component":"Column","id":"col","children":["name","subscribe","btn-send","btn-cancel"]},` +
+	`{"component":"TextField","id":"name","label":"Name","value":"Joe"},` +
+	`{"component":"CheckBox","id":"subscribe","value":true},` +
+	`{"component":"Button","id":"btn-send","child":"btn-send-t"},` +
+	`{"component":"Text","id":"btn-send-t","text":"Send"},` +
+	`{"component":"Button","id":"btn-cancel","child":"btn-cancel-t"},` +
+	`{"component":"Text","id":"btn-cancel-t","text":"Cancel"}` +
+	`]}}</a2ui-json>`
+
+// newA2UIFieldFormItem builds an assistant item whose message carries the
+// input-bearing form surface.
+func newA2UIFieldFormItem(t *testing.T) *AssistantMessageItem {
+	t.Helper()
+	sty := styles.CharmtonePantera()
+	msg := &message.Message{
+		ID:   "a2ui-field-form",
+		Role: message.Assistant,
+		Parts: []message.ContentPart{
+			message.TextContent{Text: "Fill this in:\n\n" + a2uiFieldForm},
+		},
+	}
+	item, ok := NewAssistantMessageItem(&sty, msg).(*AssistantMessageItem)
+	require.True(t, ok)
+	return item
+}
+
+func TestA2UISubmissionPrompt(t *testing.T) {
+	t.Parallel()
+
+	clicked := event.ButtonClicked{
+		Source: event.Source{ComponentID: "btn-send", SurfaceID: "contact"},
+		ID:     "btn-send",
+	}
+
+	// Button only, no field values.
+	require.Equal(t,
+		`[A2UI form submission] The user pressed the "btn-send" button on surface "contact".`,
+		A2UISubmissionPrompt(clicked, nil))
+
+	// Field values are sorted by key and JSON-encoded so their types survive.
+	got := A2UISubmissionPrompt(clicked, map[string]any{
+		"name":      "Joe",
+		"subscribe": true,
+		"count":     float64(3),
+		"tags":      []string{"a", "b"},
+	})
+	require.Equal(t,
+		`[A2UI form submission] The user pressed the "btn-send" button on surface "contact".`+
+			"\nField values:"+
+			"\n- count: 3"+
+			"\n- name: \"Joe\""+
+			"\n- subscribe: true"+
+			"\n- tags: [\"a\",\"b\"]",
+		got)
+
+	// A server-side action's name is included when present.
+	withAction := clicked
+	withAction.Action = &a2ui.EventAction{Name: "submitContact"}
+	require.Equal(t,
+		`[A2UI form submission] The user pressed the "btn-send" button (action "submitContact") on surface "contact".`,
+		A2UISubmissionPrompt(withAction, nil))
+}
+
+func TestA2UIButtonIsCancel(t *testing.T) {
+	t.Parallel()
+
+	cancelIDs := []string{"btn-cancel", "cancel", "dismissBtn", "close_form", "btn-no", "Cancel"}
+	for _, id := range cancelIDs {
+		require.True(t, A2UIButtonIsCancel(event.ButtonClicked{ID: id}), "id %q must read as cancel", id)
+	}
+
+	submitIDs := []string{"btn-send", "submit", "ok", "notify", "disclose", "closest-match"}
+	for _, id := range submitIDs {
+		require.False(t, A2UIButtonIsCancel(event.ButtonClicked{ID: id}), "id %q must not read as cancel", id)
+	}
+
+	// The action name counts too.
+	require.True(t, A2UIButtonIsCancel(event.ButtonClicked{
+		ID:     "btn-2",
+		Action: &a2ui.EventAction{Name: "cancelOrder"},
+	}))
+	require.False(t, A2UIButtonIsCancel(event.ButtonClicked{
+		ID:     "btn-2",
+		Action: &a2ui.EventAction{Name: "placeOrder"},
+	}))
+}
+
+func TestRetireA2UISurfaceCollectsFieldValues(t *testing.T) {
+	t.Parallel()
+
+	item := newA2UIFieldFormItem(t)
+	_ = item.RawRender(80)
+
+	values, ok := item.RetireA2UISurface("contact")
+	require.True(t, ok, "the surface must be found by its A2UI surface ID")
+	require.Equal(t, "Joe", values["name"], "the TextField literal must be collected")
+	require.Equal(t, true, values["subscribe"], "the CheckBox literal must be collected")
+}
+
+func TestRetireA2UISurfaceBlocksRefocusAndKeys(t *testing.T) {
+	t.Parallel()
+
+	item := newA2UIFormItem(t)
+	_ = item.RawRender(80)
+	item.SetFocused(true)
+	require.GreaterOrEqual(t, item.focusedA2UISurfaceIndex(), 0)
+
+	_, ok := item.RetireA2UISurface("form")
+	require.True(t, ok)
+	require.Equal(t, -1, item.focusedA2UISurfaceIndex(), "retiring must blur the surface")
+
+	// Keys no longer reach the retired surface (enter cannot re-submit).
+	handled, _ := item.HandleKeyEvent(tea.KeyPressMsg{Code: tea.KeyEnter})
+	require.False(t, handled, "a retired surface must not consume enter")
+
+	// Re-selecting the item must not re-focus the retired surface.
+	item.SetFocused(false)
+	item.SetFocused(true)
+	require.Equal(t, -1, item.focusedA2UISurfaceIndex(), "a retired surface must never regain focus")
+}
+
+func TestRetireA2UISurfaceUnknownID(t *testing.T) {
+	t.Parallel()
+
+	item := newA2UIFormItem(t)
+	_ = item.RawRender(80)
+
+	_, ok := item.RetireA2UISurface("nope")
+	require.False(t, ok)
+	_, ok = item.RetireA2UISurface("")
+	require.False(t, ok)
+
+	// The live surface is untouched: it can still be focused.
+	item.SetFocused(true)
+	require.GreaterOrEqual(t, item.focusedA2UISurfaceIndex(), 0)
 }

--- a/internal/ui/chat/assistant.go
+++ b/internal/ui/chat/assistant.go
@@ -159,6 +159,17 @@ type AssistantMessageItem struct {
 	// scan-part: parts without a renderable surface hold nil. See
 	// syncA2UISurfaces in a2ui.go.
 	a2uiSurfaces []render.Model
+	// a2uiSurfaceIDs holds the A2UI surface ID for each entry of
+	// a2uiSurfaces (empty where the part has no renderable surface), so a
+	// ButtonClicked event's SurfaceID can be routed back to the model
+	// that emitted it (#45).
+	a2uiSurfaceIDs []string
+	// a2uiRetired marks surfaces (by A2UI surface ID) that were
+	// submitted or dismissed: they still render, but no longer receive
+	// focus or keys, so a form cannot be re-submitted (#45). Keyed by ID
+	// rather than index so the mark survives streaming rebuilds of the
+	// models.
+	a2uiRetired map[string]bool
 	// a2uiSrcHash fingerprints the scanned source the surfaces were
 	// built from, so streaming deltas rebuild them while pure re-renders
 	// (width changes, key events) reuse the same models and keep their

--- a/internal/ui/chat/assistant.go
+++ b/internal/ui/chat/assistant.go
@@ -14,6 +14,7 @@ import (
 	"github.com/charmbracelet/crush/internal/ui/list"
 	"github.com/charmbracelet/crush/internal/ui/styles"
 	"github.com/charmbracelet/x/ansi"
+	"github.com/joestump-agent/a2tea/render"
 )
 
 // assistantMessageTruncateFormat is the text shown when an assistant message is
@@ -151,6 +152,21 @@ type AssistantMessageItem struct {
 	// thinking text, which burns CPU and starves the terminal emulator
 	// during long reasoning traces.
 	streamingThinking streamingMarkdown
+
+	// a2uiSurfaces holds the live a2tea models for the A2UI surfaces in
+	// this message so they can receive focus and key input instead of
+	// being frozen to a rendered string (#44). The slice is indexed by
+	// scan-part: parts without a renderable surface hold nil. See
+	// syncA2UISurfaces in a2ui.go.
+	a2uiSurfaces []render.Model
+	// a2uiSrcHash fingerprints the scanned source the surfaces were
+	// built from, so streaming deltas rebuild them while pure re-renders
+	// (width changes, key events) reuse the same models and keep their
+	// interaction state.
+	a2uiSrcHash uint64
+	// a2uiScanned disambiguates "never scanned" from a source that
+	// hashes to zero.
+	a2uiScanned bool
 }
 
 var _ Expandable = (*AssistantMessageItem)(nil)
@@ -241,9 +257,11 @@ func (a *AssistantMessageItem) Render(width int) string {
 	// per-section srcHash/extra so that any sub-cache change
 	// invalidates this prefix cache without requiring an explicit
 	// drop. Bypass the cache while spinning (RawRender's spinner
-	// suffix changes every animation frame) or while a highlight
-	// range is active (selection drag).
-	useCache := !a.isSpinning() && !a.isHighlighted()
+	// suffix changes every animation frame), while a highlight
+	// range is active (selection drag), or while a live A2UI surface
+	// is present (its focus ring and edits mutate the render without
+	// touching any hashed source text).
+	useCache := !a.isSpinning() && !a.isHighlighted() && !a.hasLiveA2UISurfaces()
 	cappedWidth := cappedMessageWidth(width)
 	key := a.prefixCacheKey(cappedWidth)
 	if useCache {
@@ -434,7 +452,11 @@ func (a *AssistantMessageItem) cachedThinking(width int) string {
 // cachedContent returns the rendered content section.
 func (a *AssistantMessageItem) cachedContent(width int) string {
 	srcHash, extra := a.contentKey()
-	if a.contentSec.hit(width, srcHash, extra) {
+	// A live A2UI surface renders from mutable model state (focus ring,
+	// edited values) that the content hash cannot see — bypass the cache
+	// while one is present so interaction is never served a frozen frame.
+	// Pure-text messages keep the cache (#44).
+	if !a.hasLiveA2UISurfaces() && a.contentSec.hit(width, srcHash, extra) {
 		return a.contentSec.out
 	}
 	text := a.message.Content().Text
@@ -446,9 +468,14 @@ func (a *AssistantMessageItem) cachedContent(width int) string {
 	} else if a.message.IsFinished() && contentHasUnclosedA2UI(text) {
 		// Generation was truncated mid-block: an <a2ui-json> tag never got
 		// its closing partner. Show the alert instead of raw partial JSON.
+		a.dropA2UISurfaces()
 		out = a.renderTruncatedA2UI(text, width)
 	} else {
+		a.dropA2UISurfaces()
 		out = a.renderMarkdown(text, width)
+	}
+	if a.hasLiveA2UISurfaces() {
+		return out
 	}
 	a.contentSec.store(width, srcHash, extra, out, 0)
 	return out
@@ -686,8 +713,28 @@ func (a *AssistantMessageItem) HandleMouseClick(btn ansi.MouseButton, x, y int) 
 	return a.thinkingBoxHeight > 0 && y < a.thinkingBoxHeight
 }
 
-// HandleKeyEvent implements KeyEventHandler.
+// SetFocused implements list.Focusable. Besides the base focus bookkeeping
+// it routes focus into any live A2UI surface — a2tea's focus ring (Tab
+// cycling, Enter activation) only engages while the surface model holds
+// focus, so surface focus follows item selection (#44).
+func (a *AssistantMessageItem) SetFocused(focused bool) {
+	a.focusableMessageItem.SetFocused(focused)
+	if focused {
+		a.focusA2UISurfaces()
+	} else {
+		a.blurA2UISurfaces()
+	}
+}
+
+// HandleKeyEvent implements KeyEventHandler. A focused live A2UI surface
+// gets first claim on the keys it understands (Tab/Shift+Tab cycle its
+// focus ring, Enter activates — see a2uiSurfaceWantsKey); every other key
+// falls through, so the copy shortcut keeps working whenever no surface
+// consumes the key.
 func (a *AssistantMessageItem) HandleKeyEvent(key tea.KeyMsg) (bool, tea.Cmd) {
+	if idx := a.focusedA2UISurfaceIndex(); idx >= 0 && a2uiSurfaceWantsKey(a.a2uiSurfaces[idx], key) {
+		return true, a.updateA2UISurface(idx, key)
+	}
 	if k := key.String(); k == "c" || k == "y" {
 		text := a.message.Content().Text
 		return true, common.CopyToClipboard(text, "Message copied to clipboard")

--- a/internal/ui/chat/messages.go
+++ b/internal/ui/chat/messages.go
@@ -249,6 +249,13 @@ func newFocusableMessageItem(v *list.Versioned) *focusableMessageItem {
 	return &focusableMessageItem{version: v}
 }
 
+// isFocused reports the current focus state. It tolerates a nil receiver
+// so helpers can query partially-constructed items (tests build them
+// without the focus rail).
+func (f *focusableMessageItem) isFocused() bool {
+	return f != nil && f.focused
+}
+
 // SetFocused implements MessageItem.
 func (f *focusableMessageItem) SetFocused(focused bool) {
 	if f.focused == focused {

--- a/internal/ui/model/a2ui_submit_test.go
+++ b/internal/ui/model/a2ui_submit_test.go
@@ -1,0 +1,139 @@
+package model
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"charm.land/bubbles/v2/textarea"
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/charmbracelet/crush/internal/config"
+	"github.com/charmbracelet/crush/internal/message"
+	"github.com/charmbracelet/crush/internal/session"
+	"github.com/charmbracelet/crush/internal/ui/chat"
+	"github.com/charmbracelet/crush/internal/ui/common"
+	"github.com/charmbracelet/crush/internal/workspace"
+	"github.com/joestump-agent/a2tea/event"
+	"github.com/stretchr/testify/require"
+)
+
+// a2uiWorkspace stubs the workspace calls the A2UI submission path touches.
+// The embedded interface panics on anything else, keeping the stub honest.
+type a2uiWorkspace struct {
+	workspace.Workspace
+	prompts []string
+}
+
+func (w *a2uiWorkspace) AgentIsReady() bool     { return true }
+func (w *a2uiWorkspace) Config() *config.Config { return nil }
+
+func (w *a2uiWorkspace) AgentRun(_ context.Context, _, prompt string, _ ...message.Attachment) error {
+	w.prompts = append(w.prompts, prompt)
+	return nil
+}
+
+// a2uiSubmitForm carries a submit and a cancel button plus a pre-filled
+// TextField, mirroring the form shape the a2ui skill teaches the model.
+const a2uiSubmitForm = `<a2ui-json>{"version":"v0.9","updateComponents":{"surfaceId":"form","components":[` +
+	`{"component":"Card","id":"root","child":"col"},` +
+	`{"component":"Column","id":"col","children":["name","btn-send","btn-cancel"]},` +
+	`{"component":"TextField","id":"name","label":"Name","value":"Joe"},` +
+	`{"component":"Button","id":"btn-send","child":"btn-send-t"},` +
+	`{"component":"Text","id":"btn-send-t","text":"Send"},` +
+	`{"component":"Button","id":"btn-cancel","child":"btn-cancel-t"},` +
+	`{"component":"Text","id":"btn-cancel-t","text":"Cancel"}` +
+	`]}}</a2ui-json>`
+
+// newA2UISubmitUI builds a UI with an active session and a chat list holding
+// one assistant message with a live A2UI form surface.
+func newA2UISubmitUI(t *testing.T, ws *a2uiWorkspace) *UI {
+	t.Helper()
+	com := common.DefaultCommon(ws)
+	m := &UI{
+		com:      com,
+		status:   NewStatus(com, nil),
+		chat:     NewChat(com, config.ScrollbarDefault),
+		textarea: textarea.New(),
+		state:    uiChat,
+		focus:    uiFocusMain,
+		width:    140,
+		height:   45,
+		session:  &session.Session{ID: "sess-1"},
+	}
+	msg := &message.Message{
+		ID:   "a2ui-msg",
+		Role: message.Assistant,
+		Parts: []message.ContentPart{
+			message.TextContent{Text: "Fill this in:\n\n" + a2uiSubmitForm},
+		},
+	}
+	item, ok := chat.NewAssistantMessageItem(com.Styles, msg).(*chat.AssistantMessageItem)
+	require.True(t, ok)
+	m.chat.AppendMessages(item)
+	// Render once so the item builds its live surface models.
+	_ = item.RawRender(80)
+	return m
+}
+
+// runCmdTree executes a cmd (and any tea.BatchMsg it fans out into),
+// collecting the produced messages.
+func runCmdTree(cmd tea.Cmd) []tea.Msg {
+	if cmd == nil {
+		return nil
+	}
+	msg := cmd()
+	if batch, ok := msg.(tea.BatchMsg); ok {
+		var msgs []tea.Msg
+		for _, c := range batch {
+			msgs = append(msgs, runCmdTree(c)...)
+		}
+		return msgs
+	}
+	return []tea.Msg{msg}
+}
+
+func TestHandleA2UIButtonClickedStartsAgentTurn(t *testing.T) {
+	t.Parallel()
+
+	ws := &a2uiWorkspace{}
+	m := newA2UISubmitUI(t, ws)
+
+	cmd := m.handleA2UIButtonClicked(event.ButtonClicked{
+		Source: event.Source{ComponentID: "btn-send", SurfaceID: "form"},
+		ID:     "btn-send",
+	})
+	require.NotNil(t, cmd, "a submit button must start a turn")
+	runCmdTree(cmd)
+
+	require.Len(t, ws.prompts, 1, "exactly one agent turn must start")
+	prompt := ws.prompts[0]
+	require.Contains(t, prompt, `"btn-send"`, "the prompt must name the pressed button")
+	require.Contains(t, prompt, `"form"`, "the prompt must name the surface")
+	require.True(t, strings.Contains(prompt, `name: "Joe"`),
+		"the prompt must carry the collected field values, got: %q", prompt)
+
+	// The surface is retired: a second click of the same surface finds no
+	// live surface, and the submission goes out with the button identity
+	// only (never blocked, never re-reading stale values).
+	_, ok := m.chat.RetireA2UISurface("form")
+	require.False(t, ok, "the surface must be retired after submission")
+}
+
+func TestHandleA2UIButtonClickedCancelDismissesWithoutTurn(t *testing.T) {
+	t.Parallel()
+
+	ws := &a2uiWorkspace{}
+	m := newA2UISubmitUI(t, ws)
+
+	cmd := m.handleA2UIButtonClicked(event.ButtonClicked{
+		Source: event.Source{ComponentID: "btn-cancel", SurfaceID: "form"},
+		ID:     "btn-cancel",
+	})
+	require.Nil(t, cmd, "a cancel button must not start a turn")
+	require.Empty(t, ws.prompts)
+
+	// Cancel still retires the surface so it cannot be re-submitted.
+	_, ok := m.chat.RetireA2UISurface("form")
+	require.False(t, ok, "cancel must retire the surface")
+}

--- a/internal/ui/model/chat.go
+++ b/internal/ui/model/chat.go
@@ -703,6 +703,23 @@ func (m *Chat) MessageItem(id string) chat.MessageItem {
 	return item
 }
 
+// RetireA2UISurface finds the assistant message holding the live A2UI
+// surface with the given ID, reads its current field values, and retires the
+// surface so the form cannot be re-submitted (#45). It reports the gathered
+// values and whether a matching surface was found.
+func (m *Chat) RetireA2UISurface(surfaceID string) (map[string]any, bool) {
+	for i := range m.list.Len() {
+		item, ok := m.list.ItemAt(i).(*chat.AssistantMessageItem)
+		if !ok {
+			continue
+		}
+		if values, ok := item.RetireA2UISurface(surfaceID); ok {
+			return values, true
+		}
+	}
+	return nil, false
+}
+
 // ToggleExpandedSelectedItem expands the selected message item if it is expandable.
 func (m *Chat) ToggleExpandedSelectedItem() {
 	if expandable, ok := m.list.SelectedItem().(chat.Expandable); ok {

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -2515,6 +2515,13 @@ func (m *UI) handleKeyPressMsg(msg tea.KeyPressMsg) tea.Cmd {
 		case uiFocusMain:
 			switch {
 			case key.Matches(msg, m.keyMap.Tab):
+				// A selected live A2UI surface consumes Tab for its own
+				// focus ring (#44); pane switching applies only when no
+				// item claims the key.
+				if ok, cmd := m.chat.HandleKeyMsg(msg); ok {
+					cmds = append(cmds, cmd)
+					break
+				}
 				if m.isCompact {
 					m.focus = uiFocusEditor
 					cmds = append(cmds, m.textarea.Focus())

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -62,6 +62,7 @@ import (
 	"github.com/charmbracelet/ultraviolet/screen"
 	"github.com/charmbracelet/x/editor"
 	xstrings "github.com/charmbracelet/x/exp/strings"
+	a2uievent "github.com/joestump-agent/a2tea/event"
 )
 
 // Compact mode breakpoints.
@@ -736,6 +737,14 @@ func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case sendMessageMsg:
 		cmds = append(cmds, m.sendMessage(msg.Content, msg.Attachments...))
+
+	case a2uievent.ButtonClicked:
+		// A button on a live A2UI surface was activated (#45): retire the
+		// surface and, unless the button reads as a cancel, turn the
+		// submission into a new agent turn.
+		if cmd := m.handleA2UIButtonClicked(msg); cmd != nil {
+			cmds = append(cmds, cmd)
+		}
 
 	case userCommandsLoadedMsg:
 		m.customCommands = msg.Commands
@@ -3873,6 +3882,26 @@ func (m *UI) sendMessage(content string, attachments ...message.Attachment) tea.
 		return agentRunSubmittedMsg{}
 	})
 	return tea.Batch(cmds...)
+}
+
+// handleA2UIButtonClicked turns an activated A2UI button into an agent turn
+// (#45). The surface that emitted the event is retired first — its field
+// values are read and it stops accepting focus and keys, so the form cannot
+// be re-submitted. A button that reads as a cancel (see
+// chat.A2UIButtonIsCancel) only dismisses; any other button starts a new
+// turn carrying the button and the gathered field values, through the same
+// prompt path a typed message uses (sendMessage → AgentRun, which enqueues
+// behind a running turn).
+//
+// The retire lookup may miss — e.g. the message content was rescanned and
+// the surface rebuilt without an ID — in which case the submission still
+// goes out with just the button identity rather than being dropped.
+func (m *UI) handleA2UIButtonClicked(clicked a2uievent.ButtonClicked) tea.Cmd {
+	values, _ := m.chat.RetireA2UISurface(clicked.SurfaceID)
+	if chat.A2UIButtonIsCancel(clicked) {
+		return nil
+	}
+	return m.sendMessage(chat.A2UISubmissionPrompt(clicked, values))
 }
 
 // handleChannelMessage injects a channel event pushed by an MCP server into a

--- a/internal/ui/styles/quickstyle.go
+++ b/internal/ui/styles/quickstyle.go
@@ -872,6 +872,14 @@ func quickStyle(o quickStyleOpts) Styles {
 	s.Messages.ThinkingFooterTitle = muted
 	s.Messages.ThinkingFooterDuration = subtle
 
+	// A2UI surface container. a2tea renders its chrome with terminal
+	// defaults, so a subtle themed frame makes surfaces read as part of
+	// the chat (like the thinking box) rather than plain output.
+	s.Messages.A2UISurface = base.
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(o.bgMostVisible).
+		Padding(0, 1)
+
 	// Text selection.
 	s.TextSelection = lipgloss.NewStyle().Foreground(o.onPrimary).Background(o.primary)
 

--- a/internal/ui/styles/styles.go
+++ b/internal/ui/styles/styles.go
@@ -288,6 +288,9 @@ type Styles struct {
 		ChannelInfoSender    lipgloss.Style // Sender name in channel metadata line
 		ChannelInfoProvider  lipgloss.Style // "via <channel>" text
 		ChannelInfoTimestamp lipgloss.Style // "at <timestamp>" text
+
+		// A2UISurface - themed container around rendered A2UI surfaces
+		A2UISurface lipgloss.Style
 	}
 
 	// Tool - styles for tool call rendering


### PR DESCRIPTION
Foundational A2UI support for the chat UI: themed surface containers, host-side repair of malformed buttons, robust scanning that ignores tag mentions in code, live interactive surfaces with focus/key routing, and form submission that starts an agent turn.

Part of #43

## Per-issue outcomes

### Closes #46 — themed container for rendered surfaces
A2UI surfaces now render inside a themed lipgloss container. Added a `Messages.A2UISurface` style (rounded border + padding, colors derived from the theme palette — works in light and dark themes) and wrapped each rendered surface in `renderContentWithA2UI`, sizing the a2tea model to the container's inner width. Render assertion test added. (`ef5f8009`)

### Closes #47 — repair childless-but-labeled buttons + SKILL.md hardening
`renderContentWithA2UI` now runs `repairA2UIButtons` on masked content before scanning: any `<a2ui-json>` block whose `updateComponents` contains a Button with non-empty `text`/`label` and no `child` gets a synthesized Text component (unique id) wired in as the child. Valid buttons, inline-nested children, and undecodable JSON pass through byte-identical, preserving the malformed-block alert path. SKILL.md gains the explicit anti-pattern wording and a render-verified two-input/two-button form template. Seven new tests. (`45889a59`)

### Closes #96 — inline-code tag mentions no longer swallowed
Prose that mentions `a2ui-json` tags in inline code was being consumed as a live surface (or truncated the message on a lone open tag). `maskFencedCode` was generalized to `maskMarkdownCode`: fences always masked, inline code spans masked only when they contain an A2UI marker, so placeholders can't leak into legitimate surface JSON containing backticks. All scan/render paths share the masking; six repro-pinning tests added. (`ea31b8a2`)

### Closes #45 — form submission starts an agent turn
`event.ButtonClicked` from a focused surface now retires the surface (blur + re-submit block keyed by surface ID, surviving streaming rebuilds), collects field values via a2tea's `Surface.FieldValues`, and starts a new agent turn through the existing sendMessage path — unless the button reads as cancel (whole-token match on cancel/dismiss/close/no over button id and action name). Payload built by `chat.A2UISubmissionPrompt`: button id, action name, surface id, sorted JSON-encoded field values. UI-level submit/cancel flow tests included. (`0ad83ab8`)

### Already fixed on this branch (no new commits, verified green)

- **#168 — parser-derived block segmentation + quiet protocol-only notice**: already landed in `e728dd62` ("Implements #168"). `scanA2UIBlocks` mirrors the a2uistream parser so segmentation agrees with rendering by construction; protocol-only blocks (`callFunction`/`actionResponse`) get a muted "nothing to display" notice instead of the misleading could-not-render alert.
- **#44 — live surfaces with focus + key routing**: already landed in `00ed566c`. Live `a2tea render.Model` surfaces stored on `AssistantMessageItem`, string caches bypassed while a live surface is present, `SetFocused` routed to Focus/Blur, keys forwarded via `HandleKeyEvent`, Tab claim in the UI model. Tests cover live-model presence, tab focus movement, and blur on deselect.

## Verification

- `go build ./...` clean
- `go vet ./internal/...` — one pre-existing warning in `internal/csync/maps.go` (`JSONSchemaAlias` passes lock by value); identical on `main`, intentional per the `//nolint` comment (value receiver required by invopop/jsonschema). Not touched by this branch.
- `go test ./internal/ui/...` — all pass
- `go test ./internal/agent/...` — `tools` and `tools/mcp` pass; `TestCoordinator*`/`TestUpdateParentSessionCost` fail identically at the base commit (`agent/main`) with "failed to configure providers: default providers are disabled" — environmental (no provider config in the sandbox), not caused by this branch, which does not touch `internal/agent`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
