### PR TITLE
feat(a2a): Phase 1 foundation — a2a-go SDK, Agent Card, AgentExecutor (#68, #69)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/MakeNowJust/heredoc v1.0.0
 	github.com/Microsoft/go-winio v0.6.2
 	github.com/PuerkitoBio/goquery v1.12.0
+	github.com/a2aproject/a2a-go/v2 v2.3.1
 	github.com/alecthomas/chroma/v2 v2.27.0
 	github.com/aymanbagabas/go-udiff v0.4.1
 	github.com/bmatcuk/doublestar/v4 v4.10.0

--- a/go.sum
+++ b/go.sum
@@ -45,6 +45,8 @@ github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA
 github.com/PuerkitoBio/goquery v1.9.2/go.mod h1:GHPCaP0ODyyxqcNoFGYlAprUFH81NuRPd0GX3Zu2Mvk=
 github.com/PuerkitoBio/goquery v1.12.0 h1:pAcL4g3WRXekcB9AU/y1mbKez2dbY2AajVhtkO8RIBo=
 github.com/PuerkitoBio/goquery v1.12.0/go.mod h1:802ej+gV2y7bbIhOIoPY5sT183ZW0YFofScC4q/hIpQ=
+github.com/a2aproject/a2a-go/v2 v2.3.1 h1:QWMdOX2UsJ8BJmjs952eo1FRyGsOVl0gFCKeM76AgGE=
+github.com/a2aproject/a2a-go/v2 v2.3.1/go.mod h1:mkZr8y2bUgAVQsjs/5fHK7xrRlAHDybMEyxWh2tKRC8=
 github.com/alecthomas/assert/v2 v2.11.0 h1:2Q9r3ki8+JYXvGsDyBXwH3LcJ+WK5D0gc5E8vS6K3D0=
 github.com/alecthomas/assert/v2 v2.11.0/go.mod h1:Bze95FyfUr7x34QZrjL+XP+0qgp/zg8yS+TtBj1WA3k=
 github.com/alecthomas/chroma/v2 v2.27.0 h1:FodwmyOBgJULFYmDqibcp9pvfDLWdtPRh9v/r5BXYZs=

--- a/internal/a2a/agentcard.go
+++ b/internal/a2a/agentcard.go
@@ -1,0 +1,109 @@
+package a2a
+
+import (
+	a2aspec "github.com/a2aproject/a2a-go/v2/a2a"
+
+	"github.com/charmbracelet/crush/internal/config"
+	"github.com/charmbracelet/crush/internal/skills"
+)
+
+// A dispatched Crush agent is prompted with, and replies in, plain text; its
+// work product (a git diff) is also text. These are the card's default MIME
+// modes, overridable per-skill by the spec but unused as such in Phase 1.
+var (
+	defaultInputModes  = []string{"text/plain"}
+	defaultOutputModes = []string{"text/plain"}
+)
+
+// skillTag is the single tag applied to every derived A2A skill. AgentSkill.Tags
+// is a required (non-omitempty) field, and Crush skills have no native tag
+// concept, so a stable marker keeps the card spec-valid without inventing
+// per-skill taxonomy.
+const skillTag = "crush-skill"
+
+// CardParams are the inputs needed to describe a dispatched worktree agent as
+// an A2A [a2aspec.AgentCard]. It is populated from the same dispatch config the
+// DispatchAgent tool (#64) takes: the agent definition, the skills loaded for
+// it, and the endpoint it serves A2A on.
+type CardParams struct {
+	// Agent is the dispatched agent's configuration — name, description,
+	// model, tools. Required.
+	Agent config.Agent
+
+	// Skills are the Crush skills loaded for this agent. Each becomes one
+	// A2A skill entry on the card. Optional.
+	Skills []*skills.Skill
+
+	// Endpoint is the base URL the agent serves A2A on (loopback in
+	// Phase 1). Required for a resolvable card.
+	Endpoint string
+
+	// Transport is the protocol binding served at Endpoint. Defaults to
+	// JSON-RPC over HTTP — the Phase 1 transport — when empty.
+	Transport a2aspec.TransportProtocol
+
+	// Version is the agent/build version advertised on the card.
+	Version string
+}
+
+// BuildAgentCard derives a spec-valid A2A AgentCard from a dispatched agent's
+// config. The card advertises the agent's identity, its endpoint and
+// transport, streaming capability (dispatched runs stream progress via SSE),
+// and one A2A skill per loaded Crush skill.
+func BuildAgentCard(p CardParams) *a2aspec.AgentCard {
+	transport := p.Transport
+	if transport == "" {
+		transport = a2aspec.TransportProtocolJSONRPC
+	}
+
+	return &a2aspec.AgentCard{
+		Name:        cardName(p.Agent),
+		Description: p.Agent.Description,
+		Version:     p.Version,
+		SupportedInterfaces: []*a2aspec.AgentInterface{
+			// NewAgentInterface stamps the SDK's protocol version.
+			a2aspec.NewAgentInterface(p.Endpoint, transport),
+		},
+		Capabilities: a2aspec.AgentCapabilities{
+			// Dispatched agents stream todo/progress updates over SSE.
+			Streaming: true,
+		},
+		DefaultInputModes:  defaultInputModes,
+		DefaultOutputModes: defaultOutputModes,
+		Skills:             agentSkills(p.Skills),
+	}
+}
+
+// cardName resolves a human-readable card name from the agent config, falling
+// back through the agent ID to a generic label so the required Name field is
+// never empty.
+func cardName(a config.Agent) string {
+	switch {
+	case a.Name != "":
+		return a.Name
+	case a.ID != "":
+		return a.ID
+	default:
+		return "crush-agent"
+	}
+}
+
+// agentSkills maps each loaded Crush skill onto an A2A skill entry. A skill's
+// name doubles as its A2A id — skill names are unique after discovery dedupe.
+// It always returns a non-nil slice so the card's required "skills" field
+// marshals as [] rather than null when the agent has no skills.
+func agentSkills(sk []*skills.Skill) []a2aspec.AgentSkill {
+	out := make([]a2aspec.AgentSkill, 0, len(sk))
+	for _, s := range sk {
+		if s == nil {
+			continue
+		}
+		out = append(out, a2aspec.AgentSkill{
+			ID:          s.Name,
+			Name:        s.Name,
+			Description: s.Description,
+			Tags:        []string{skillTag},
+		})
+	}
+	return out
+}

--- a/internal/a2a/agentcard.go
+++ b/internal/a2a/agentcard.go
@@ -15,10 +15,10 @@ var (
 	defaultOutputModes = []string{"text/plain"}
 )
 
-// skillTag is the single tag applied to every derived A2A skill. AgentSkill.Tags
-// is a required (non-omitempty) field, and Crush skills have no native tag
-// concept, so a stable marker keeps the card spec-valid without inventing
-// per-skill taxonomy.
+// skillTag is the single tag applied to every derived A2A skill.
+// AgentSkill.Tags is a required (non-omitempty) field, and Crush skills have
+// no native tag concept, so a stable marker keeps the card spec-valid
+// without inventing per-skill taxonomy.
 const skillTag = "crush-skill"
 
 // CardParams are the inputs needed to describe a dispatched worktree agent as

--- a/internal/a2a/agentcard_test.go
+++ b/internal/a2a/agentcard_test.go
@@ -4,12 +4,15 @@ import (
 	"testing"
 
 	a2aspec "github.com/a2aproject/a2a-go/v2/a2a"
+	"github.com/stretchr/testify/require"
 
 	"github.com/charmbracelet/crush/internal/config"
 	"github.com/charmbracelet/crush/internal/skills"
 )
 
 func TestBuildAgentCard(t *testing.T) {
+	t.Parallel()
+
 	card := BuildAgentCard(CardParams{
 		Agent: config.Agent{
 			ID:          "reviewer",
@@ -25,105 +28,76 @@ func TestBuildAgentCard(t *testing.T) {
 		Version:  "1.2.3",
 	})
 
-	if card.Name != "Reviewer" {
-		t.Errorf("Name = %q, want %q", card.Name, "Reviewer")
-	}
-	if card.Description != "Reviews a worktree diff" {
-		t.Errorf("Description = %q, want %q", card.Description, "Reviews a worktree diff")
-	}
-	if card.Version != "1.2.3" {
-		t.Errorf("Version = %q, want %q", card.Version, "1.2.3")
-	}
-	if !card.Capabilities.Streaming {
-		t.Error("Capabilities.Streaming = false, want true")
-	}
+	require.Equal(t, "Reviewer", card.Name)
+	require.Equal(t, "Reviews a worktree diff", card.Description)
+	require.Equal(t, "1.2.3", card.Version)
+	require.True(t, card.Capabilities.Streaming)
 
-	if len(card.SupportedInterfaces) != 1 {
-		t.Fatalf("SupportedInterfaces = %d, want 1", len(card.SupportedInterfaces))
-	}
+	require.Len(t, card.SupportedInterfaces, 1)
 	iface := card.SupportedInterfaces[0]
-	if iface.URL != "http://127.0.0.1:8080" {
-		t.Errorf("interface URL = %q, want %q", iface.URL, "http://127.0.0.1:8080")
-	}
-	if iface.ProtocolBinding != a2aspec.TransportProtocolJSONRPC {
-		t.Errorf("interface transport = %q, want %q", iface.ProtocolBinding, a2aspec.TransportProtocolJSONRPC)
-	}
-	if iface.ProtocolVersion != a2aspec.Version {
-		t.Errorf("interface protocol version = %q, want %q", iface.ProtocolVersion, a2aspec.Version)
-	}
+	require.Equal(t, "http://127.0.0.1:8080", iface.URL)
+	require.Equal(t, a2aspec.TransportProtocolJSONRPC, iface.ProtocolBinding)
+	require.Equal(t, a2aspec.Version, iface.ProtocolVersion)
 
-	if want := []string{"text/plain"}; !equalStrings(card.DefaultInputModes, want) {
-		t.Errorf("DefaultInputModes = %v, want %v", card.DefaultInputModes, want)
-	}
-	if want := []string{"text/plain"}; !equalStrings(card.DefaultOutputModes, want) {
-		t.Errorf("DefaultOutputModes = %v, want %v", card.DefaultOutputModes, want)
-	}
+	require.Equal(t, []string{"text/plain"}, card.DefaultInputModes)
+	require.Equal(t, []string{"text/plain"}, card.DefaultOutputModes)
 
-	if len(card.Skills) != 2 {
-		t.Fatalf("Skills = %d, want 2", len(card.Skills))
-	}
+	require.Len(t, card.Skills, 2)
 	first := card.Skills[0]
-	if first.ID != "code-review" || first.Name != "code-review" {
-		t.Errorf("skill[0] id/name = %q/%q, want code-review/code-review", first.ID, first.Name)
-	}
-	if first.Description != "Review a diff for bugs" {
-		t.Errorf("skill[0] description = %q", first.Description)
-	}
-	if len(first.Tags) == 0 {
-		t.Error("skill[0] Tags is empty; A2A requires a non-empty tags list")
-	}
+	require.Equal(t, "code-review", first.ID)
+	require.Equal(t, "code-review", first.Name)
+	require.Equal(t, "Review a diff for bugs", first.Description)
+	require.NotEmpty(t, first.Tags, "A2A requires a non-empty tags list")
 }
 
 func TestBuildAgentCardDefaultTransport(t *testing.T) {
+	t.Parallel()
+
 	card := BuildAgentCard(CardParams{
 		Agent:    config.Agent{Name: "worker"},
 		Endpoint: "http://127.0.0.1:9000",
 	})
-	if got := card.SupportedInterfaces[0].ProtocolBinding; got != a2aspec.TransportProtocolJSONRPC {
-		t.Errorf("default transport = %q, want %q", got, a2aspec.TransportProtocolJSONRPC)
-	}
+	require.Equal(t, a2aspec.TransportProtocolJSONRPC, card.SupportedInterfaces[0].ProtocolBinding)
 }
 
 func TestBuildAgentCardExplicitTransport(t *testing.T) {
+	t.Parallel()
+
 	card := BuildAgentCard(CardParams{
 		Agent:     config.Agent{Name: "worker"},
 		Endpoint:  "http://127.0.0.1:9000",
 		Transport: a2aspec.TransportProtocolGRPC,
 	})
-	if got := card.SupportedInterfaces[0].ProtocolBinding; got != a2aspec.TransportProtocolGRPC {
-		t.Errorf("transport = %q, want %q", got, a2aspec.TransportProtocolGRPC)
-	}
+	require.Equal(t, a2aspec.TransportProtocolGRPC, card.SupportedInterfaces[0].ProtocolBinding)
 }
 
 func TestBuildAgentCardNoSkills(t *testing.T) {
+	t.Parallel()
+
 	card := BuildAgentCard(CardParams{
 		Agent:    config.Agent{Name: "worker"},
 		Endpoint: "http://127.0.0.1:9000",
 	})
 	// Required field: must be non-nil so it marshals as [] not null.
-	if card.Skills == nil {
-		t.Error("Skills is nil; want non-nil empty slice for a valid card")
-	}
-	if len(card.Skills) != 0 {
-		t.Errorf("Skills = %d, want 0", len(card.Skills))
-	}
+	require.NotNil(t, card.Skills)
+	require.Empty(t, card.Skills)
 }
 
 func TestBuildAgentCardSkipsNilSkills(t *testing.T) {
+	t.Parallel()
+
 	card := BuildAgentCard(CardParams{
 		Agent:    config.Agent{Name: "worker"},
 		Endpoint: "http://127.0.0.1:9000",
 		Skills:   []*skills.Skill{nil, {Name: "real"}, nil},
 	})
-	if len(card.Skills) != 1 {
-		t.Fatalf("Skills = %d, want 1 (nils skipped)", len(card.Skills))
-	}
-	if card.Skills[0].Name != "real" {
-		t.Errorf("skill name = %q, want real", card.Skills[0].Name)
-	}
+	require.Len(t, card.Skills, 1)
+	require.Equal(t, "real", card.Skills[0].Name)
 }
 
 func TestCardNameFallbacks(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name  string
 		agent config.Agent
@@ -135,21 +109,8 @@ func TestCardNameFallbacks(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := cardName(tc.agent); got != tc.want {
-				t.Errorf("cardName = %q, want %q", got, tc.want)
-			}
+			t.Parallel()
+			require.Equal(t, tc.want, cardName(tc.agent))
 		})
 	}
-}
-
-func equalStrings(a, b []string) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for i := range a {
-		if a[i] != b[i] {
-			return false
-		}
-	}
-	return true
 }

--- a/internal/a2a/agentcard_test.go
+++ b/internal/a2a/agentcard_test.go
@@ -1,0 +1,155 @@
+package a2a
+
+import (
+	"testing"
+
+	a2aspec "github.com/a2aproject/a2a-go/v2/a2a"
+
+	"github.com/charmbracelet/crush/internal/config"
+	"github.com/charmbracelet/crush/internal/skills"
+)
+
+func TestBuildAgentCard(t *testing.T) {
+	card := BuildAgentCard(CardParams{
+		Agent: config.Agent{
+			ID:          "reviewer",
+			Name:        "Reviewer",
+			Description: "Reviews a worktree diff",
+			Model:       config.SelectedModelTypeSmall,
+		},
+		Skills: []*skills.Skill{
+			{Name: "code-review", Description: "Review a diff for bugs"},
+			{Name: "run-tests", Description: "Run the test suite"},
+		},
+		Endpoint: "http://127.0.0.1:8080",
+		Version:  "1.2.3",
+	})
+
+	if card.Name != "Reviewer" {
+		t.Errorf("Name = %q, want %q", card.Name, "Reviewer")
+	}
+	if card.Description != "Reviews a worktree diff" {
+		t.Errorf("Description = %q, want %q", card.Description, "Reviews a worktree diff")
+	}
+	if card.Version != "1.2.3" {
+		t.Errorf("Version = %q, want %q", card.Version, "1.2.3")
+	}
+	if !card.Capabilities.Streaming {
+		t.Error("Capabilities.Streaming = false, want true")
+	}
+
+	if len(card.SupportedInterfaces) != 1 {
+		t.Fatalf("SupportedInterfaces = %d, want 1", len(card.SupportedInterfaces))
+	}
+	iface := card.SupportedInterfaces[0]
+	if iface.URL != "http://127.0.0.1:8080" {
+		t.Errorf("interface URL = %q, want %q", iface.URL, "http://127.0.0.1:8080")
+	}
+	if iface.ProtocolBinding != a2aspec.TransportProtocolJSONRPC {
+		t.Errorf("interface transport = %q, want %q", iface.ProtocolBinding, a2aspec.TransportProtocolJSONRPC)
+	}
+	if iface.ProtocolVersion != a2aspec.Version {
+		t.Errorf("interface protocol version = %q, want %q", iface.ProtocolVersion, a2aspec.Version)
+	}
+
+	if want := []string{"text/plain"}; !equalStrings(card.DefaultInputModes, want) {
+		t.Errorf("DefaultInputModes = %v, want %v", card.DefaultInputModes, want)
+	}
+	if want := []string{"text/plain"}; !equalStrings(card.DefaultOutputModes, want) {
+		t.Errorf("DefaultOutputModes = %v, want %v", card.DefaultOutputModes, want)
+	}
+
+	if len(card.Skills) != 2 {
+		t.Fatalf("Skills = %d, want 2", len(card.Skills))
+	}
+	first := card.Skills[0]
+	if first.ID != "code-review" || first.Name != "code-review" {
+		t.Errorf("skill[0] id/name = %q/%q, want code-review/code-review", first.ID, first.Name)
+	}
+	if first.Description != "Review a diff for bugs" {
+		t.Errorf("skill[0] description = %q", first.Description)
+	}
+	if len(first.Tags) == 0 {
+		t.Error("skill[0] Tags is empty; A2A requires a non-empty tags list")
+	}
+}
+
+func TestBuildAgentCardDefaultTransport(t *testing.T) {
+	card := BuildAgentCard(CardParams{
+		Agent:    config.Agent{Name: "worker"},
+		Endpoint: "http://127.0.0.1:9000",
+	})
+	if got := card.SupportedInterfaces[0].ProtocolBinding; got != a2aspec.TransportProtocolJSONRPC {
+		t.Errorf("default transport = %q, want %q", got, a2aspec.TransportProtocolJSONRPC)
+	}
+}
+
+func TestBuildAgentCardExplicitTransport(t *testing.T) {
+	card := BuildAgentCard(CardParams{
+		Agent:     config.Agent{Name: "worker"},
+		Endpoint:  "http://127.0.0.1:9000",
+		Transport: a2aspec.TransportProtocolGRPC,
+	})
+	if got := card.SupportedInterfaces[0].ProtocolBinding; got != a2aspec.TransportProtocolGRPC {
+		t.Errorf("transport = %q, want %q", got, a2aspec.TransportProtocolGRPC)
+	}
+}
+
+func TestBuildAgentCardNoSkills(t *testing.T) {
+	card := BuildAgentCard(CardParams{
+		Agent:    config.Agent{Name: "worker"},
+		Endpoint: "http://127.0.0.1:9000",
+	})
+	// Required field: must be non-nil so it marshals as [] not null.
+	if card.Skills == nil {
+		t.Error("Skills is nil; want non-nil empty slice for a valid card")
+	}
+	if len(card.Skills) != 0 {
+		t.Errorf("Skills = %d, want 0", len(card.Skills))
+	}
+}
+
+func TestBuildAgentCardSkipsNilSkills(t *testing.T) {
+	card := BuildAgentCard(CardParams{
+		Agent:    config.Agent{Name: "worker"},
+		Endpoint: "http://127.0.0.1:9000",
+		Skills:   []*skills.Skill{nil, {Name: "real"}, nil},
+	})
+	if len(card.Skills) != 1 {
+		t.Fatalf("Skills = %d, want 1 (nils skipped)", len(card.Skills))
+	}
+	if card.Skills[0].Name != "real" {
+		t.Errorf("skill name = %q, want real", card.Skills[0].Name)
+	}
+}
+
+func TestCardNameFallbacks(t *testing.T) {
+	tests := []struct {
+		name  string
+		agent config.Agent
+		want  string
+	}{
+		{"name wins", config.Agent{ID: "id", Name: "Name"}, "Name"},
+		{"id fallback", config.Agent{ID: "id"}, "id"},
+		{"generic fallback", config.Agent{}, "crush-agent"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := cardName(tc.agent); got != tc.want {
+				t.Errorf("cardName = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/a2a/doc.go
+++ b/internal/a2a/doc.go
@@ -1,0 +1,25 @@
+// Package a2a is Crush's coordination layer for dispatching agents over the
+// A2A (Agent-to-Agent) protocol, using the official Go SDK
+// (github.com/a2aproject/a2a-go/v2).
+//
+// It replaces the in-process Go call between the main agent and a dispatched
+// worktree agent with a protocol boundary: each dispatched agent is described
+// by an [AgentCard] and served as an A2A server; the coordinator is an A2A
+// client. This unlocks process isolation, remote workers, and third-party
+// agents without changing the model-facing DispatchAgent tool.
+//
+// This package currently implements Phase 1 foundations:
+//
+//   - BuildAgentCard derives a spec-valid A2A AgentCard from a dispatched
+//     agent's config (issue #68).
+//   - Executor adapts a Crush SessionAgent to the a2asrv.AgentExecutor
+//     interface, mapping the agent run lifecycle onto A2A task states
+//     (issue #69).
+//
+// The in-process A2A servers + discovery (#70) and the DispatchAgent A2A
+// client + SSE progress (#71) build on these. See the A2A Coordination epic
+// (#67) for the full plan.
+//
+// The SDK's core type package is imported as a2aspec throughout to avoid
+// colliding with this package's own name.
+package a2a

--- a/internal/a2a/executor.go
+++ b/internal/a2a/executor.go
@@ -2,7 +2,9 @@ package a2a
 
 import (
 	"context"
+	"errors"
 	"iter"
+	"os"
 	"os/exec"
 	"strings"
 
@@ -66,12 +68,12 @@ func NewExecutor(runner Runner, sessionID string, opts ...Option) *Executor {
 
 var _ a2asrv.AgentExecutor = (*Executor)(nil)
 
-// Execute runs one dispatched agent turn. It announces the task submitted (for
-// a new task), emits Working, invokes the SessionAgent, then emits the diff
-// artifact (if any) and a terminal Completed status carrying the agent's text
-// output. A run error maps to a Failed status with the error surfaced; per the
-// AgentExecutor contract, failures after work has begun are reported as events,
-// not as a returned error.
+// Execute runs one dispatched agent turn. It announces the task submitted
+// (for a new task), emits Working, invokes the SessionAgent, then emits the
+// diff artifact (if any) and a terminal Completed status carrying the agent's
+// text output. A run error maps to a Failed status with the error surfaced;
+// per the AgentExecutor contract, failures after work has begun are reported
+// as events, not as a returned error.
 func (e *Executor) Execute(ctx context.Context, execCtx *a2asrv.ExecutorContext) iter.Seq2[a2aspec.Event, error] {
 	return func(yield func(a2aspec.Event, error) bool) {
 		// A message that referenced no existing task starts a new one:
@@ -82,16 +84,43 @@ func (e *Executor) Execute(ctx context.Context, execCtx *a2asrv.ExecutorContext)
 			}
 		}
 
+		// A message with no text carries nothing to run — SessionAgent.Run
+		// would bounce it as an empty prompt — so reject the task without
+		// starting a turn. Rejected is the terminal state for "was not
+		// started"; Failed is reserved for work that began and broke.
+		prompt := messageText(execCtx.Message)
+		if prompt == "" {
+			yield(a2aspec.NewStatusUpdateEvent(execCtx, a2aspec.TaskStateRejected,
+				agentMessage(execCtx, "message has no text to run")), nil)
+			return
+		}
+
 		if !yield(a2aspec.NewStatusUpdateEvent(execCtx, a2aspec.TaskStateWorking, nil), nil) {
 			return
 		}
 
 		result, err := e.runner.Run(ctx, agent.SessionAgentCall{
 			SessionID: e.sessionID,
-			Prompt:    messageText(execCtx.Message),
+			Prompt:    prompt,
 		})
-		if err != nil {
-			yield(a2aspec.NewStatusUpdateEvent(execCtx, a2aspec.TaskStateFailed, errorMessage(err)), nil)
+		switch {
+		case errors.Is(err, context.Canceled):
+			// The run was canceled — by this executor's Cancel, which
+			// emits the terminal Canceled status itself. A Failed status
+			// here would race it.
+			return
+		case err != nil:
+			yield(a2aspec.NewStatusUpdateEvent(execCtx, a2aspec.TaskStateFailed,
+				agentMessage(execCtx, err.Error())), nil)
+			return
+		case result == nil:
+			// Run returns (nil, nil) without doing any work when the
+			// session is busy (the prompt was silently queued behind the
+			// active turn) or a cancel landed during dispatch. No turn ran
+			// on behalf of this task, so completing it would misreport;
+			// fail it and let the caller retry against an idle session.
+			yield(a2aspec.NewStatusUpdateEvent(execCtx, a2aspec.TaskStateFailed,
+				agentMessage(execCtx, "agent session did not start a turn (busy or canceled)")), nil)
 			return
 		}
 
@@ -103,7 +132,8 @@ func (e *Executor) Execute(ctx context.Context, execCtx *a2asrv.ExecutorContext)
 			}
 		}
 
-		yield(a2aspec.NewStatusUpdateEvent(execCtx, a2aspec.TaskStateCompleted, resultMessage(result)), nil)
+		yield(a2aspec.NewStatusUpdateEvent(execCtx, a2aspec.TaskStateCompleted,
+			agentMessage(execCtx, result.Response.Content.Text())), nil)
 	}
 }
 
@@ -116,13 +146,39 @@ func (e *Executor) Cancel(ctx context.Context, execCtx *a2asrv.ExecutorContext) 
 	}
 }
 
-// GitDiff returns a [DiffFunc] that captures the uncommitted diff of the git
-// worktree rooted at dir (`git -C dir diff`), the dispatched agent's work
-// product. A non-zero git exit or missing repo surfaces as an error, which the
+// GitDiff returns a [DiffFunc] that captures the full uncommitted state of
+// the git worktree rooted at dir — staged and unstaged changes to tracked
+// files plus untracked files — as one unified diff against HEAD, the
+// dispatched agent's work product. Everything is staged into a throwaway
+// temporary index so the worktree's real index is never touched. A git
+// failure, missing repo, or unborn HEAD surfaces as an error, which the
 // executor treats as "no artifact" rather than a run failure.
 func GitDiff(dir string) DiffFunc {
 	return func(ctx context.Context) (string, error) {
-		out, err := exec.CommandContext(ctx, "git", "-C", dir, "diff").Output()
+		tmp, err := os.CreateTemp("", "crush-a2a-index-")
+		if err != nil {
+			return "", err
+		}
+		tmp.Close()
+		defer os.Remove(tmp.Name())
+
+		env := append(os.Environ(), "GIT_INDEX_FILE="+tmp.Name())
+		git := func(args ...string) *exec.Cmd {
+			cmd := exec.CommandContext(ctx, "git", append([]string{"-C", dir}, args...)...)
+			cmd.Env = env
+			return cmd
+		}
+
+		// Seed the temp index from HEAD, stage the entire worktree into it
+		// (respecting .gitignore, so untracked files are included), and
+		// diff that against HEAD.
+		if err := git("read-tree", "HEAD").Run(); err != nil {
+			return "", err
+		}
+		if err := git("add", "-A").Run(); err != nil {
+			return "", err
+		}
+		out, err := git("diff", "--cached", "HEAD").Output()
 		if err != nil {
 			return "", err
 		}
@@ -151,18 +207,8 @@ func messageText(msg *a2aspec.Message) string {
 	return b.String()
 }
 
-// resultMessage wraps a run's text output as an agent-role A2A message for the
-// terminal status update. A nil result yields an empty message.
-func resultMessage(result *fantasy.AgentResult) *a2aspec.Message {
-	var text string
-	if result != nil {
-		text = result.Response.Content.Text()
-	}
-	return a2aspec.NewMessage(a2aspec.MessageRoleAgent, a2aspec.NewTextPart(text))
-}
-
-// errorMessage wraps a run error as an agent-role A2A message for the failed
-// status update.
-func errorMessage(err error) *a2aspec.Message {
-	return a2aspec.NewMessage(a2aspec.MessageRoleAgent, a2aspec.NewTextPart(err.Error()))
+// agentMessage wraps text as an agent-role A2A message stamped with the
+// task's IDs, for terminal status-update payloads.
+func agentMessage(info a2aspec.TaskInfoProvider, text string) *a2aspec.Message {
+	return a2aspec.NewMessageForTask(a2aspec.MessageRoleAgent, info, a2aspec.NewTextPart(text))
 }

--- a/internal/a2a/executor.go
+++ b/internal/a2a/executor.go
@@ -1,0 +1,168 @@
+package a2a
+
+import (
+	"context"
+	"iter"
+	"os/exec"
+	"strings"
+
+	"charm.land/fantasy"
+	a2aspec "github.com/a2aproject/a2a-go/v2/a2a"
+	"github.com/a2aproject/a2a-go/v2/a2asrv"
+
+	"github.com/charmbracelet/crush/internal/agent"
+)
+
+// Runner is the slice of [agent.SessionAgent] the [Executor] drives. The full
+// SessionAgent interface satisfies it; the narrow interface documents exactly
+// what A2A execution depends on and keeps the executor unit-testable with a
+// fake instead of the whole agent surface.
+type Runner interface {
+	Run(context.Context, agent.SessionAgentCall) (*fantasy.AgentResult, error)
+	Cancel(sessionID string)
+}
+
+// Compile-time proof that a real SessionAgent can be used as a Runner.
+var _ Runner = agent.SessionAgent(nil)
+
+// DiffFunc returns the git diff produced by a dispatched run, emitted as the
+// task's completion artifact. It is called after a successful run. An empty
+// string or an error yields no artifact (the run still completes).
+type DiffFunc func(ctx context.Context) (string, error)
+
+// Executor adapts a Crush [agent.SessionAgent] to the [a2asrv.AgentExecutor]
+// interface: it runs one dispatched agent turn, maps the run lifecycle onto
+// A2A task states (submitted -> working -> completed/failed), and emits the git
+// diff as the terminal artifact.
+//
+// Phase 1 emits a single Working status before the run and a terminal status
+// after it; richer per-todo progress streaming into the Sidekick dashboard is
+// wired in #71, where the SessionAgent's progress broker is bridged to SSE.
+type Executor struct {
+	runner    Runner
+	sessionID string
+	diff      DiffFunc
+}
+
+// Option configures an [Executor].
+type Option func(*Executor)
+
+// WithDiff sets the function used to collect the completion artifact — the git
+// diff of the dispatched worktree. Without it, runs complete with their text
+// output and no artifact. See [GitDiff] for the default production collector.
+func WithDiff(fn DiffFunc) Option {
+	return func(e *Executor) { e.diff = fn }
+}
+
+// NewExecutor builds an Executor that drives runner against sessionID — the
+// (ephemeral) session backing the dispatched agent.
+func NewExecutor(runner Runner, sessionID string, opts ...Option) *Executor {
+	e := &Executor{runner: runner, sessionID: sessionID}
+	for _, opt := range opts {
+		opt(e)
+	}
+	return e
+}
+
+var _ a2asrv.AgentExecutor = (*Executor)(nil)
+
+// Execute runs one dispatched agent turn. It announces the task submitted (for
+// a new task), emits Working, invokes the SessionAgent, then emits the diff
+// artifact (if any) and a terminal Completed status carrying the agent's text
+// output. A run error maps to a Failed status with the error surfaced; per the
+// AgentExecutor contract, failures after work has begun are reported as events,
+// not as a returned error.
+func (e *Executor) Execute(ctx context.Context, execCtx *a2asrv.ExecutorContext) iter.Seq2[a2aspec.Event, error] {
+	return func(yield func(a2aspec.Event, error) bool) {
+		// A message that referenced no existing task starts a new one:
+		// announce it submitted before transitioning to working.
+		if execCtx.StoredTask == nil {
+			if !yield(a2aspec.NewSubmittedTask(execCtx, execCtx.Message), nil) {
+				return
+			}
+		}
+
+		if !yield(a2aspec.NewStatusUpdateEvent(execCtx, a2aspec.TaskStateWorking, nil), nil) {
+			return
+		}
+
+		result, err := e.runner.Run(ctx, agent.SessionAgentCall{
+			SessionID: e.sessionID,
+			Prompt:    messageText(execCtx.Message),
+		})
+		if err != nil {
+			yield(a2aspec.NewStatusUpdateEvent(execCtx, a2aspec.TaskStateFailed, errorMessage(err)), nil)
+			return
+		}
+
+		if e.diff != nil {
+			if diff, derr := e.diff(ctx); derr == nil && diff != "" {
+				if !yield(a2aspec.NewArtifactEvent(execCtx, a2aspec.NewTextPart(diff)), nil) {
+					return
+				}
+			}
+		}
+
+		yield(a2aspec.NewStatusUpdateEvent(execCtx, a2aspec.TaskStateCompleted, resultMessage(result)), nil)
+	}
+}
+
+// Cancel stops the in-flight dispatched run for this executor's session and
+// reports the task canceled.
+func (e *Executor) Cancel(ctx context.Context, execCtx *a2asrv.ExecutorContext) iter.Seq2[a2aspec.Event, error] {
+	return func(yield func(a2aspec.Event, error) bool) {
+		e.runner.Cancel(e.sessionID)
+		yield(a2aspec.NewStatusUpdateEvent(execCtx, a2aspec.TaskStateCanceled, nil), nil)
+	}
+}
+
+// GitDiff returns a [DiffFunc] that captures the uncommitted diff of the git
+// worktree rooted at dir (`git -C dir diff`), the dispatched agent's work
+// product. A non-zero git exit or missing repo surfaces as an error, which the
+// executor treats as "no artifact" rather than a run failure.
+func GitDiff(dir string) DiffFunc {
+	return func(ctx context.Context) (string, error) {
+		out, err := exec.CommandContext(ctx, "git", "-C", dir, "diff").Output()
+		if err != nil {
+			return "", err
+		}
+		return string(out), nil
+	}
+}
+
+// messageText concatenates the text parts of an incoming A2A message into a
+// single prompt. Non-text parts are ignored in Phase 1.
+func messageText(msg *a2aspec.Message) string {
+	if msg == nil {
+		return ""
+	}
+	var b strings.Builder
+	for _, part := range msg.Parts {
+		if part == nil {
+			continue
+		}
+		if t := part.Text(); t != "" {
+			if b.Len() > 0 {
+				b.WriteByte('\n')
+			}
+			b.WriteString(t)
+		}
+	}
+	return b.String()
+}
+
+// resultMessage wraps a run's text output as an agent-role A2A message for the
+// terminal status update. A nil result yields an empty message.
+func resultMessage(result *fantasy.AgentResult) *a2aspec.Message {
+	var text string
+	if result != nil {
+		text = result.Response.Content.Text()
+	}
+	return a2aspec.NewMessage(a2aspec.MessageRoleAgent, a2aspec.NewTextPart(text))
+}
+
+// errorMessage wraps a run error as an agent-role A2A message for the failed
+// status update.
+func errorMessage(err error) *a2aspec.Message {
+	return a2aspec.NewMessage(a2aspec.MessageRoleAgent, a2aspec.NewTextPart(err.Error()))
+}

--- a/internal/a2a/executor_test.go
+++ b/internal/a2a/executor_test.go
@@ -1,0 +1,296 @@
+package a2a
+
+import (
+	"context"
+	"errors"
+	"iter"
+	"testing"
+
+	"charm.land/fantasy"
+	a2aspec "github.com/a2aproject/a2a-go/v2/a2a"
+	"github.com/a2aproject/a2a-go/v2/a2asrv"
+
+	"github.com/charmbracelet/crush/internal/agent"
+)
+
+// fakeRunner is a test double for the SessionAgent slice the Executor drives.
+type fakeRunner struct {
+	result *fantasy.AgentResult
+	err    error
+
+	gotCall     agent.SessionAgentCall
+	ran         bool
+	canceledFor string
+}
+
+func (f *fakeRunner) Run(_ context.Context, call agent.SessionAgentCall) (*fantasy.AgentResult, error) {
+	f.ran = true
+	f.gotCall = call
+	return f.result, f.err
+}
+
+func (f *fakeRunner) Cancel(sessionID string) { f.canceledFor = sessionID }
+
+func textResult(s string) *fantasy.AgentResult {
+	return &fantasy.AgentResult{
+		Response: fantasy.Response{
+			Content: fantasy.ResponseContent{fantasy.TextContent{Text: s}},
+		},
+	}
+}
+
+func newExecCtx(msg *a2aspec.Message) *a2asrv.ExecutorContext {
+	return &a2asrv.ExecutorContext{
+		Message:   msg,
+		TaskID:    "task-1",
+		ContextID: "ctx-1",
+	}
+}
+
+func collect(seq iter.Seq2[a2aspec.Event, error]) []a2aspec.Event {
+	var evs []a2aspec.Event
+	for ev, err := range seq {
+		if err != nil {
+			// The executor reports failures as events, never as the
+			// second value of the sequence.
+			panic("unexpected error from executor sequence: " + err.Error())
+		}
+		evs = append(evs, ev)
+	}
+	return evs
+}
+
+// states summarizes an event stream as a slice of task states, using a
+// sentinel for artifact events so ordering can be asserted in one shot.
+func states(t *testing.T, evs []a2aspec.Event) []a2aspec.TaskState {
+	t.Helper()
+	const artifactState a2aspec.TaskState = "<artifact>"
+	out := make([]a2aspec.TaskState, 0, len(evs))
+	for _, ev := range evs {
+		switch e := ev.(type) {
+		case *a2aspec.Task:
+			out = append(out, e.Status.State)
+		case *a2aspec.TaskStatusUpdateEvent:
+			out = append(out, e.Status.State)
+		case *a2aspec.TaskArtifactUpdateEvent:
+			out = append(out, artifactState)
+		default:
+			t.Fatalf("unexpected event type %T", ev)
+		}
+	}
+	return out
+}
+
+func statusMessageText(t *testing.T, ev a2aspec.Event) string {
+	t.Helper()
+	sue, ok := ev.(*a2aspec.TaskStatusUpdateEvent)
+	if !ok {
+		t.Fatalf("event is %T, want *TaskStatusUpdateEvent", ev)
+	}
+	if sue.Status.Message == nil {
+		return ""
+	}
+	return partsText(sue.Status.Message.Parts)
+}
+
+func partsText(parts a2aspec.ContentParts) string {
+	var s string
+	for _, p := range parts {
+		s += p.Text()
+	}
+	return s
+}
+
+func TestExecuteHappyPathWithDiff(t *testing.T) {
+	runner := &fakeRunner{result: textResult("all done")}
+	exec := NewExecutor(runner, "sess-1", WithDiff(func(context.Context) (string, error) {
+		return "the diff", nil
+	}))
+
+	msg := a2aspec.NewMessage(a2aspec.MessageRoleUser, a2aspec.NewTextPart("do the thing"))
+	evs := collect(exec.Execute(context.Background(), newExecCtx(msg)))
+
+	const artifactState a2aspec.TaskState = "<artifact>"
+	want := []a2aspec.TaskState{
+		a2aspec.TaskStateSubmitted,
+		a2aspec.TaskStateWorking,
+		artifactState,
+		a2aspec.TaskStateCompleted,
+	}
+	if got := states(t, evs); !equalStates(got, want) {
+		t.Fatalf("state sequence = %v, want %v", got, want)
+	}
+
+	if !runner.ran {
+		t.Error("runner.Run was not called")
+	}
+	if runner.gotCall.SessionID != "sess-1" {
+		t.Errorf("Run SessionID = %q, want sess-1", runner.gotCall.SessionID)
+	}
+	if runner.gotCall.Prompt != "do the thing" {
+		t.Errorf("Run Prompt = %q, want %q", runner.gotCall.Prompt, "do the thing")
+	}
+
+	// The artifact carries the diff.
+	art := evs[2].(*a2aspec.TaskArtifactUpdateEvent)
+	if got := partsText(art.Artifact.Parts); got != "the diff" {
+		t.Errorf("artifact text = %q, want %q", got, "the diff")
+	}
+
+	// The terminal status carries the agent's text output.
+	if got := statusMessageText(t, evs[3]); got != "all done" {
+		t.Errorf("completed message = %q, want %q", got, "all done")
+	}
+}
+
+func TestExecuteNoDiffFunc(t *testing.T) {
+	runner := &fakeRunner{result: textResult("done")}
+	exec := NewExecutor(runner, "sess-1")
+
+	msg := a2aspec.NewMessage(a2aspec.MessageRoleUser, a2aspec.NewTextPart("go"))
+	evs := collect(exec.Execute(context.Background(), newExecCtx(msg)))
+
+	want := []a2aspec.TaskState{
+		a2aspec.TaskStateSubmitted,
+		a2aspec.TaskStateWorking,
+		a2aspec.TaskStateCompleted,
+	}
+	if got := states(t, evs); !equalStates(got, want) {
+		t.Fatalf("state sequence = %v, want %v (no artifact expected)", got, want)
+	}
+}
+
+func TestExecuteEmptyDiffEmitsNoArtifact(t *testing.T) {
+	runner := &fakeRunner{result: textResult("done")}
+	exec := NewExecutor(runner, "sess-1", WithDiff(func(context.Context) (string, error) {
+		return "", nil // clean worktree
+	}))
+
+	msg := a2aspec.NewMessage(a2aspec.MessageRoleUser, a2aspec.NewTextPart("go"))
+	evs := collect(exec.Execute(context.Background(), newExecCtx(msg)))
+
+	for _, ev := range evs {
+		if _, ok := ev.(*a2aspec.TaskArtifactUpdateEvent); ok {
+			t.Fatal("emitted an artifact event for an empty diff")
+		}
+	}
+}
+
+func TestExecuteDiffErrorStillCompletes(t *testing.T) {
+	runner := &fakeRunner{result: textResult("done")}
+	exec := NewExecutor(runner, "sess-1", WithDiff(func(context.Context) (string, error) {
+		return "", errors.New("not a git repo")
+	}))
+
+	msg := a2aspec.NewMessage(a2aspec.MessageRoleUser, a2aspec.NewTextPart("go"))
+	evs := collect(exec.Execute(context.Background(), newExecCtx(msg)))
+
+	want := []a2aspec.TaskState{
+		a2aspec.TaskStateSubmitted,
+		a2aspec.TaskStateWorking,
+		a2aspec.TaskStateCompleted,
+	}
+	if got := states(t, evs); !equalStates(got, want) {
+		t.Fatalf("state sequence = %v, want %v (diff error must not fail the run)", got, want)
+	}
+}
+
+func TestExecuteRunFailure(t *testing.T) {
+	runner := &fakeRunner{err: errors.New("model exploded")}
+	exec := NewExecutor(runner, "sess-1", WithDiff(func(context.Context) (string, error) {
+		return "should not be called", nil
+	}))
+
+	msg := a2aspec.NewMessage(a2aspec.MessageRoleUser, a2aspec.NewTextPart("go"))
+	evs := collect(exec.Execute(context.Background(), newExecCtx(msg)))
+
+	want := []a2aspec.TaskState{
+		a2aspec.TaskStateSubmitted,
+		a2aspec.TaskStateWorking,
+		a2aspec.TaskStateFailed,
+	}
+	if got := states(t, evs); !equalStates(got, want) {
+		t.Fatalf("state sequence = %v, want %v", got, want)
+	}
+
+	// The error is surfaced in the failed status message.
+	if got := statusMessageText(t, evs[2]); got != "model exploded" {
+		t.Errorf("failed message = %q, want %q", got, "model exploded")
+	}
+}
+
+func TestExecuteExistingTaskSkipsSubmitted(t *testing.T) {
+	runner := &fakeRunner{result: textResult("done")}
+	exec := NewExecutor(runner, "sess-1")
+
+	msg := a2aspec.NewMessage(a2aspec.MessageRoleUser, a2aspec.NewTextPart("go"))
+	execCtx := newExecCtx(msg)
+	execCtx.StoredTask = &a2aspec.Task{ID: "task-1", ContextID: "ctx-1"}
+
+	evs := collect(exec.Execute(context.Background(), execCtx))
+
+	want := []a2aspec.TaskState{
+		a2aspec.TaskStateWorking,
+		a2aspec.TaskStateCompleted,
+	}
+	if got := states(t, evs); !equalStates(got, want) {
+		t.Fatalf("state sequence = %v, want %v (no submitted for an existing task)", got, want)
+	}
+}
+
+func TestCancel(t *testing.T) {
+	runner := &fakeRunner{}
+	exec := NewExecutor(runner, "sess-1")
+
+	evs := collect(exec.Cancel(context.Background(), newExecCtx(nil)))
+
+	if runner.canceledFor != "sess-1" {
+		t.Errorf("Cancel session = %q, want sess-1", runner.canceledFor)
+	}
+	want := []a2aspec.TaskState{a2aspec.TaskStateCanceled}
+	if got := states(t, evs); !equalStates(got, want) {
+		t.Fatalf("state sequence = %v, want %v", got, want)
+	}
+}
+
+func TestMessageText(t *testing.T) {
+	tests := []struct {
+		name string
+		msg  *a2aspec.Message
+		want string
+	}{
+		{"nil message", nil, ""},
+		{
+			"single part",
+			a2aspec.NewMessage(a2aspec.MessageRoleUser, a2aspec.NewTextPart("hello")),
+			"hello",
+		},
+		{
+			"multiple parts joined by newline",
+			a2aspec.NewMessage(a2aspec.MessageRoleUser,
+				a2aspec.NewTextPart("line one"),
+				a2aspec.NewTextPart("line two"),
+			),
+			"line one\nline two",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := messageText(tc.msg); got != tc.want {
+				t.Errorf("messageText = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func equalStates(a, b []a2aspec.TaskState) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/a2a/executor_test.go
+++ b/internal/a2a/executor_test.go
@@ -4,11 +4,15 @@ import (
 	"context"
 	"errors"
 	"iter"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"testing"
 
 	"charm.land/fantasy"
 	a2aspec "github.com/a2aproject/a2a-go/v2/a2a"
 	"github.com/a2aproject/a2a-go/v2/a2asrv"
+	"github.com/stretchr/testify/require"
 
 	"github.com/charmbracelet/crush/internal/agent"
 )
@@ -47,24 +51,25 @@ func newExecCtx(msg *a2aspec.Message) *a2asrv.ExecutorContext {
 	}
 }
 
-func collect(seq iter.Seq2[a2aspec.Event, error]) []a2aspec.Event {
+func collect(t *testing.T, seq iter.Seq2[a2aspec.Event, error]) []a2aspec.Event {
+	t.Helper()
 	var evs []a2aspec.Event
 	for ev, err := range seq {
-		if err != nil {
-			// The executor reports failures as events, never as the
-			// second value of the sequence.
-			panic("unexpected error from executor sequence: " + err.Error())
-		}
+		// The executor reports failures as events, never as the second
+		// value of the sequence.
+		require.NoError(t, err, "unexpected error from executor sequence")
 		evs = append(evs, ev)
 	}
 	return evs
 }
 
-// states summarizes an event stream as a slice of task states, using a
-// sentinel for artifact events so ordering can be asserted in one shot.
+// artifactState is the sentinel states uses for artifact events so ordering
+// can be asserted in one shot alongside status updates.
+const artifactState a2aspec.TaskState = "<artifact>"
+
+// states summarizes an event stream as a slice of task states.
 func states(t *testing.T, evs []a2aspec.Event) []a2aspec.TaskState {
 	t.Helper()
-	const artifactState a2aspec.TaskState = "<artifact>"
 	out := make([]a2aspec.TaskState, 0, len(evs))
 	for _, ev := range evs {
 		switch e := ev.(type) {
@@ -81,12 +86,16 @@ func states(t *testing.T, evs []a2aspec.Event) []a2aspec.TaskState {
 	return out
 }
 
-func statusMessageText(t *testing.T, ev a2aspec.Event) string {
+func statusUpdate(t *testing.T, ev a2aspec.Event) *a2aspec.TaskStatusUpdateEvent {
 	t.Helper()
 	sue, ok := ev.(*a2aspec.TaskStatusUpdateEvent)
-	if !ok {
-		t.Fatalf("event is %T, want *TaskStatusUpdateEvent", ev)
-	}
+	require.True(t, ok, "event is %T, want *TaskStatusUpdateEvent", ev)
+	return sue
+}
+
+func statusMessageText(t *testing.T, ev a2aspec.Event) string {
+	t.Helper()
+	sue := statusUpdate(t, ev)
 	if sue.Status.Message == nil {
 		return ""
 	}
@@ -102,124 +111,198 @@ func partsText(parts a2aspec.ContentParts) string {
 }
 
 func TestExecuteHappyPathWithDiff(t *testing.T) {
+	t.Parallel()
+
 	runner := &fakeRunner{result: textResult("all done")}
 	exec := NewExecutor(runner, "sess-1", WithDiff(func(context.Context) (string, error) {
 		return "the diff", nil
 	}))
 
 	msg := a2aspec.NewMessage(a2aspec.MessageRoleUser, a2aspec.NewTextPart("do the thing"))
-	evs := collect(exec.Execute(context.Background(), newExecCtx(msg)))
+	evs := collect(t, exec.Execute(context.Background(), newExecCtx(msg)))
 
-	const artifactState a2aspec.TaskState = "<artifact>"
 	want := []a2aspec.TaskState{
 		a2aspec.TaskStateSubmitted,
 		a2aspec.TaskStateWorking,
 		artifactState,
 		a2aspec.TaskStateCompleted,
 	}
-	if got := states(t, evs); !equalStates(got, want) {
-		t.Fatalf("state sequence = %v, want %v", got, want)
-	}
+	require.Equal(t, want, states(t, evs))
 
-	if !runner.ran {
-		t.Error("runner.Run was not called")
-	}
-	if runner.gotCall.SessionID != "sess-1" {
-		t.Errorf("Run SessionID = %q, want sess-1", runner.gotCall.SessionID)
-	}
-	if runner.gotCall.Prompt != "do the thing" {
-		t.Errorf("Run Prompt = %q, want %q", runner.gotCall.Prompt, "do the thing")
-	}
+	require.True(t, runner.ran, "runner.Run was not called")
+	require.Equal(t, "sess-1", runner.gotCall.SessionID)
+	require.Equal(t, "do the thing", runner.gotCall.Prompt)
 
-	// The artifact carries the diff.
-	art := evs[2].(*a2aspec.TaskArtifactUpdateEvent)
-	if got := partsText(art.Artifact.Parts); got != "the diff" {
-		t.Errorf("artifact text = %q, want %q", got, "the diff")
-	}
+	// The artifact carries the diff and the task's identifiers.
+	art, ok := evs[2].(*a2aspec.TaskArtifactUpdateEvent)
+	require.True(t, ok, "event is %T, want *TaskArtifactUpdateEvent", evs[2])
+	require.Equal(t, "the diff", partsText(art.Artifact.Parts))
+	require.Equal(t, a2aspec.TaskID("task-1"), art.TaskID)
+	require.Equal(t, "ctx-1", art.ContextID)
 
-	// The terminal status carries the agent's text output.
-	if got := statusMessageText(t, evs[3]); got != "all done" {
-		t.Errorf("completed message = %q, want %q", got, "all done")
-	}
+	// The terminal status carries the agent's text output, stamped with
+	// the task's identifiers.
+	terminal := statusUpdate(t, evs[3])
+	require.Equal(t, a2aspec.TaskID("task-1"), terminal.TaskID)
+	require.Equal(t, "ctx-1", terminal.ContextID)
+	require.Equal(t, "all done", statusMessageText(t, evs[3]))
+	require.NotNil(t, terminal.Status.Message)
+	require.Equal(t, a2aspec.TaskID("task-1"), terminal.Status.Message.TaskID)
 }
 
 func TestExecuteNoDiffFunc(t *testing.T) {
+	t.Parallel()
+
 	runner := &fakeRunner{result: textResult("done")}
 	exec := NewExecutor(runner, "sess-1")
 
 	msg := a2aspec.NewMessage(a2aspec.MessageRoleUser, a2aspec.NewTextPart("go"))
-	evs := collect(exec.Execute(context.Background(), newExecCtx(msg)))
+	evs := collect(t, exec.Execute(context.Background(), newExecCtx(msg)))
 
 	want := []a2aspec.TaskState{
 		a2aspec.TaskStateSubmitted,
 		a2aspec.TaskStateWorking,
 		a2aspec.TaskStateCompleted,
 	}
-	if got := states(t, evs); !equalStates(got, want) {
-		t.Fatalf("state sequence = %v, want %v (no artifact expected)", got, want)
-	}
+	require.Equal(t, want, states(t, evs), "no artifact expected")
 }
 
 func TestExecuteEmptyDiffEmitsNoArtifact(t *testing.T) {
+	t.Parallel()
+
 	runner := &fakeRunner{result: textResult("done")}
 	exec := NewExecutor(runner, "sess-1", WithDiff(func(context.Context) (string, error) {
 		return "", nil // clean worktree
 	}))
 
 	msg := a2aspec.NewMessage(a2aspec.MessageRoleUser, a2aspec.NewTextPart("go"))
-	evs := collect(exec.Execute(context.Background(), newExecCtx(msg)))
+	evs := collect(t, exec.Execute(context.Background(), newExecCtx(msg)))
 
 	for _, ev := range evs {
-		if _, ok := ev.(*a2aspec.TaskArtifactUpdateEvent); ok {
-			t.Fatal("emitted an artifact event for an empty diff")
-		}
+		_, isArtifact := ev.(*a2aspec.TaskArtifactUpdateEvent)
+		require.False(t, isArtifact, "emitted an artifact event for an empty diff")
 	}
 }
 
 func TestExecuteDiffErrorStillCompletes(t *testing.T) {
+	t.Parallel()
+
 	runner := &fakeRunner{result: textResult("done")}
 	exec := NewExecutor(runner, "sess-1", WithDiff(func(context.Context) (string, error) {
 		return "", errors.New("not a git repo")
 	}))
 
 	msg := a2aspec.NewMessage(a2aspec.MessageRoleUser, a2aspec.NewTextPart("go"))
-	evs := collect(exec.Execute(context.Background(), newExecCtx(msg)))
+	evs := collect(t, exec.Execute(context.Background(), newExecCtx(msg)))
 
 	want := []a2aspec.TaskState{
 		a2aspec.TaskStateSubmitted,
 		a2aspec.TaskStateWorking,
 		a2aspec.TaskStateCompleted,
 	}
-	if got := states(t, evs); !equalStates(got, want) {
-		t.Fatalf("state sequence = %v, want %v (diff error must not fail the run)", got, want)
-	}
+	require.Equal(t, want, states(t, evs), "diff error must not fail the run")
 }
 
 func TestExecuteRunFailure(t *testing.T) {
+	t.Parallel()
+
 	runner := &fakeRunner{err: errors.New("model exploded")}
 	exec := NewExecutor(runner, "sess-1", WithDiff(func(context.Context) (string, error) {
 		return "should not be called", nil
 	}))
 
 	msg := a2aspec.NewMessage(a2aspec.MessageRoleUser, a2aspec.NewTextPart("go"))
-	evs := collect(exec.Execute(context.Background(), newExecCtx(msg)))
+	evs := collect(t, exec.Execute(context.Background(), newExecCtx(msg)))
 
 	want := []a2aspec.TaskState{
 		a2aspec.TaskStateSubmitted,
 		a2aspec.TaskStateWorking,
 		a2aspec.TaskStateFailed,
 	}
-	if got := states(t, evs); !equalStates(got, want) {
-		t.Fatalf("state sequence = %v, want %v", got, want)
-	}
+	require.Equal(t, want, states(t, evs))
 
 	// The error is surfaced in the failed status message.
-	if got := statusMessageText(t, evs[2]); got != "model exploded" {
-		t.Errorf("failed message = %q, want %q", got, "model exploded")
+	require.Equal(t, "model exploded", statusMessageText(t, evs[2]))
+}
+
+func TestExecuteNilResultFails(t *testing.T) {
+	t.Parallel()
+
+	// SessionAgent.Run returns (nil, nil) without running anything when
+	// the session is busy (prompt silently queued) or a cancel landed
+	// during dispatch. The task must not report Completed.
+	runner := &fakeRunner{result: nil, err: nil}
+	exec := NewExecutor(runner, "sess-1", WithDiff(func(context.Context) (string, error) {
+		return "should not become an artifact", nil
+	}))
+
+	msg := a2aspec.NewMessage(a2aspec.MessageRoleUser, a2aspec.NewTextPart("go"))
+	evs := collect(t, exec.Execute(context.Background(), newExecCtx(msg)))
+
+	want := []a2aspec.TaskState{
+		a2aspec.TaskStateSubmitted,
+		a2aspec.TaskStateWorking,
+		a2aspec.TaskStateFailed,
 	}
+	require.Equal(t, want, states(t, evs), "a turn that never ran must not complete")
+	require.Contains(t, statusMessageText(t, evs[2]), "did not start a turn")
+}
+
+func TestExecuteCanceledRunEmitsNoTerminalStatus(t *testing.T) {
+	t.Parallel()
+
+	// A canceled run is reported by Cancel's own Canceled status; Execute
+	// must not race it with a Failed status.
+	runner := &fakeRunner{err: context.Canceled}
+	exec := NewExecutor(runner, "sess-1")
+
+	msg := a2aspec.NewMessage(a2aspec.MessageRoleUser, a2aspec.NewTextPart("go"))
+	evs := collect(t, exec.Execute(context.Background(), newExecCtx(msg)))
+
+	want := []a2aspec.TaskState{
+		a2aspec.TaskStateSubmitted,
+		a2aspec.TaskStateWorking,
+	}
+	require.Equal(t, want, states(t, evs), "no terminal status for a canceled run")
+}
+
+func TestExecuteEmptyPromptRejects(t *testing.T) {
+	t.Parallel()
+
+	runner := &fakeRunner{result: textResult("never")}
+	exec := NewExecutor(runner, "sess-1")
+
+	// A message with no text parts carries nothing to run.
+	msg := a2aspec.NewMessage(a2aspec.MessageRoleUser, a2aspec.NewDataPart(map[string]any{"k": "v"}))
+	evs := collect(t, exec.Execute(context.Background(), newExecCtx(msg)))
+
+	want := []a2aspec.TaskState{
+		a2aspec.TaskStateSubmitted,
+		a2aspec.TaskStateRejected,
+	}
+	require.Equal(t, want, states(t, evs))
+	require.False(t, runner.ran, "runner.Run must not be called for an empty prompt")
+}
+
+func TestExecuteConsumerStopsBeforeRun(t *testing.T) {
+	t.Parallel()
+
+	runner := &fakeRunner{result: textResult("never")}
+	exec := NewExecutor(runner, "sess-1")
+
+	msg := a2aspec.NewMessage(a2aspec.MessageRoleUser, a2aspec.NewTextPart("go"))
+	// Stop consuming after the first (Submitted) event, as a disconnecting
+	// consumer would.
+	for range exec.Execute(context.Background(), newExecCtx(msg)) {
+		break
+	}
+
+	require.False(t, runner.ran, "runner.Run must not be called after the consumer stops")
 }
 
 func TestExecuteExistingTaskSkipsSubmitted(t *testing.T) {
+	t.Parallel()
+
 	runner := &fakeRunner{result: textResult("done")}
 	exec := NewExecutor(runner, "sess-1")
 
@@ -227,33 +310,30 @@ func TestExecuteExistingTaskSkipsSubmitted(t *testing.T) {
 	execCtx := newExecCtx(msg)
 	execCtx.StoredTask = &a2aspec.Task{ID: "task-1", ContextID: "ctx-1"}
 
-	evs := collect(exec.Execute(context.Background(), execCtx))
+	evs := collect(t, exec.Execute(context.Background(), execCtx))
 
 	want := []a2aspec.TaskState{
 		a2aspec.TaskStateWorking,
 		a2aspec.TaskStateCompleted,
 	}
-	if got := states(t, evs); !equalStates(got, want) {
-		t.Fatalf("state sequence = %v, want %v (no submitted for an existing task)", got, want)
-	}
+	require.Equal(t, want, states(t, evs), "no submitted for an existing task")
 }
 
 func TestCancel(t *testing.T) {
+	t.Parallel()
+
 	runner := &fakeRunner{}
 	exec := NewExecutor(runner, "sess-1")
 
-	evs := collect(exec.Cancel(context.Background(), newExecCtx(nil)))
+	evs := collect(t, exec.Cancel(context.Background(), newExecCtx(nil)))
 
-	if runner.canceledFor != "sess-1" {
-		t.Errorf("Cancel session = %q, want sess-1", runner.canceledFor)
-	}
-	want := []a2aspec.TaskState{a2aspec.TaskStateCanceled}
-	if got := states(t, evs); !equalStates(got, want) {
-		t.Fatalf("state sequence = %v, want %v", got, want)
-	}
+	require.Equal(t, "sess-1", runner.canceledFor)
+	require.Equal(t, []a2aspec.TaskState{a2aspec.TaskStateCanceled}, states(t, evs))
 }
 
 func TestMessageText(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name string
 		msg  *a2aspec.Message
@@ -273,24 +353,103 @@ func TestMessageText(t *testing.T) {
 			),
 			"line one\nline two",
 		},
+		{
+			// A nil parts entry is constructible from a remote peer's
+			// JSON ([null, ...]) and must be skipped, not dereferenced.
+			"nil part entry skipped",
+			&a2aspec.Message{Parts: a2aspec.ContentParts{nil, a2aspec.NewTextPart("x")}},
+			"x",
+		},
+		{
+			// Non-text parts are ignored without leaving stray
+			// separators between the surviving text parts.
+			"non-text parts ignored",
+			a2aspec.NewMessage(a2aspec.MessageRoleUser,
+				a2aspec.NewTextPart("a"),
+				a2aspec.NewDataPart(map[string]any{"k": "v"}),
+				a2aspec.NewRawPart([]byte("zz")),
+				a2aspec.NewTextPart("b"),
+			),
+			"a\nb",
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := messageText(tc.msg); got != tc.want {
-				t.Errorf("messageText = %q, want %q", got, tc.want)
-			}
+			t.Parallel()
+			require.Equal(t, tc.want, messageText(tc.msg))
 		})
 	}
 }
 
-func equalStates(a, b []a2aspec.TaskState) bool {
-	if len(a) != len(b) {
-		return false
+// initTestRepo creates a git repo in a temp dir with one committed file and
+// returns the dir. Skips the test when git is unavailable.
+func initTestRepo(t *testing.T) string {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not found in PATH")
 	}
-	for i := range a {
-		if a[i] != b[i] {
-			return false
-		}
+	dir := t.TempDir()
+	run := func(args ...string) {
+		t.Helper()
+		cmd := exec.CommandContext(t.Context(), "git", append([]string{
+			"-C", dir,
+			"-c", "user.name=test",
+			"-c", "user.email=test@example.com",
+			"-c", "commit.gpgsign=false",
+		}, args...)...)
+		out, err := cmd.CombinedOutput()
+		require.NoError(t, err, "git %v: %s", args, out)
 	}
-	return true
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "tracked.txt"), []byte("original\n"), 0o644))
+	run("init", "-q")
+	run("add", "tracked.txt")
+	run("commit", "-q", "-m", "initial")
+	return dir
+}
+
+func TestGitDiff(t *testing.T) {
+	t.Parallel()
+
+	dir := initTestRepo(t)
+
+	// Unstaged change to a tracked file, plus a brand-new untracked file:
+	// both are the dispatched agent's work product and must appear.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "tracked.txt"), []byte("modified\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "created.txt"), []byte("new file\n"), 0o644))
+
+	diff, err := GitDiff(dir)(t.Context())
+	require.NoError(t, err)
+	require.Contains(t, diff, "tracked.txt")
+	require.Contains(t, diff, "modified")
+	require.Contains(t, diff, "created.txt")
+	require.Contains(t, diff, "new file")
+
+	// The real index must be untouched: the new file stays untracked and
+	// nothing is staged.
+	out, err := exec.CommandContext(t.Context(), "git", "-C", dir, "status", "--porcelain").Output()
+	require.NoError(t, err)
+	require.Contains(t, string(out), "?? created.txt")
+	staged, err := exec.CommandContext(t.Context(), "git", "-C", dir, "diff", "--cached", "--name-only").Output()
+	require.NoError(t, err)
+	require.Empty(t, string(staged), "GitDiff must not stage anything in the real index")
+}
+
+func TestGitDiffCleanWorktree(t *testing.T) {
+	t.Parallel()
+
+	dir := initTestRepo(t)
+	diff, err := GitDiff(dir)(t.Context())
+	require.NoError(t, err)
+	require.Empty(t, diff)
+}
+
+func TestGitDiffNotARepo(t *testing.T) {
+	t.Parallel()
+
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not found in PATH")
+	}
+	diff, err := GitDiff(t.TempDir())(t.Context())
+	require.Error(t, err)
+	require.Empty(t, diff)
 }


### PR DESCRIPTION
## What

First batch of the **A2A Coordination** epic ([#67](https://github.com/joestump-agent/crush/issues/67)) — the two Phase 1 child issues that are unblocked today. Additive scaffolding only: it introduces a new `internal/a2a` package and **does not touch the live dispatch path**. The existing `"agent"` tool still runs sub-agents in-process exactly as before.

Closes [#68](https://github.com/joestump-agent/crush/issues/68), closes [#69](https://github.com/joestump-agent/crush/issues/69).

## Commits

- **[#68](https://github.com/joestump-agent/crush/issues/68) — a2a-go SDK + Agent Card builder.** Adds `github.com/a2aproject/a2a-go/v2 v2.3.1` and `BuildAgentCard`, which derives a spec-valid `a2a.AgentCard` from a dispatched agent's config (`config.Agent` + loaded skills + serving endpoint). Advertises identity, endpoint/transport (JSON-RPC over HTTP by default), streaming capability, and one A2A skill per loaded Crush skill.
- **[#69](https://github.com/joestump-agent/crush/issues/69) — `AgentExecutor` wrapping `SessionAgent.Run`.** Adds `Executor`, an `a2asrv.AgentExecutor` that runs one dispatched turn and maps the run lifecycle onto A2A task states (`submitted → working → completed/failed`), emitting the worktree git diff as the terminal artifact.

## Design notes

- **New package `internal/a2a`** (SDK core imported as `a2aspec` to avoid a name clash). It imports `internal/agent`/`config`/`skills` one-directionally — no import cycle, nothing imports it back yet.
- **Narrow `Runner` interface** (satisfied by `agent.SessionAgent`) keeps the executor unit-testable with a fake instead of the full 16-method agent surface. Pluggable `DiffFunc` (`GitDiff` is the default) supplies the completion artifact.
- **Agent Card definitions on disk** will follow the skills-discovery pattern (`.crush/agents/` project + `~/.config/crush/agents/` global), authored as `config.Agent` JSON and *derived* into A2A cards at serve time — rationale pinned in [#68 comment](https://github.com/joestump-agent/crush/issues/68#issuecomment-5017642246). File discovery lands with #70.
- **Dependency footprint: one module.** Every transitive dep a2a-go needs (gRPC, protobuf, uuid, cobra, genproto) was already in the graph.

## Deliberately deferred

- Per-todo progress streaming to Sidekick (Phase 1 emits a single `Working` status around the run) → **#71**, alongside `SidekickUpdate`.
- Standing the executor up as an actual in-process A2A server + discovery → **#70**.
- Re-pointing `DispatchAgent` through an A2A client (the point where the main agent starts talking to sub-agents over the protocol) → **#71**.

Both `#70` and `#71` also depend on the Worktree Dispatch epic (#61) and Sidekick, which don't exist on `main` yet — hence this PR stops at the two foundation issues.

## Testing

- `go test ./internal/a2a/` — green. Covers Agent Card construction (fields, default/explicit transport, skill mapping, nil-skill skipping, name fallbacks, non-nil empty skills) and the full executor lifecycle (happy path + artifact, no-diff, empty-diff, diff-error-still-completes, run failure → failed state, existing-task skips submitted, cancel, prompt extraction).
- `go build ./...`, `go vet ./internal/a2a/`, `gofmt -l` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
