### PR TITLE
fix(config): retry transient Windows rename failures in atomicWriteFile

### DIFF
--- a/internal/config/atomicwrite.go
+++ b/internal/config/atomicwrite.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"time"
 )
 
 // atomicWriteFile writes data to a file atomically by writing to a unique
@@ -30,9 +31,33 @@ func atomicWriteFile(path string, data []byte, perm os.FileMode) error {
 		os.Remove(tmp)
 		return err
 	}
-	if err := os.Rename(tmp, path); err != nil {
+	if err := renameFile(tmp, path); err != nil {
 		os.Remove(tmp)
 		return err
 	}
 	return nil
+}
+
+// renameRetryBudget bounds how long renameFile keeps retrying transient
+// failures before giving up and returning the error.
+const renameRetryBudget = 2 * time.Second
+
+// renameFile renames tmp over path. On Windows the rename fails with
+// ERROR_ACCESS_DENIED or ERROR_SHARING_VIOLATION while another process
+// (antivirus, search indexer) or a concurrent reader briefly holds a
+// handle on the destination, so transient failures are retried with
+// backoff. On other platforms isTransientRenameError is always false
+// and this is a plain os.Rename.
+func renameFile(tmp, path string) error {
+	var slept time.Duration
+	delay := time.Millisecond
+	for {
+		err := os.Rename(tmp, path)
+		if err == nil || !isTransientRenameError(err) || slept >= renameRetryBudget {
+			return err
+		}
+		time.Sleep(delay)
+		slept += delay
+		delay = min(delay*2, 50*time.Millisecond)
+	}
 }

--- a/internal/config/atomicwrite_unix.go
+++ b/internal/config/atomicwrite_unix.go
@@ -1,0 +1,7 @@
+//go:build !windows
+
+package config
+
+// isTransientRenameError reports whether err is a rename failure that
+// can resolve on its own. Only Windows has such failures.
+func isTransientRenameError(error) bool { return false }

--- a/internal/config/atomicwrite_windows.go
+++ b/internal/config/atomicwrite_windows.go
@@ -1,0 +1,18 @@
+//go:build windows
+
+package config
+
+import (
+	"errors"
+
+	"golang.org/x/sys/windows"
+)
+
+// isTransientRenameError reports whether err is a Windows rename
+// failure that can resolve on its own: replacing the destination fails
+// while another handle (a concurrent reader, antivirus, or the search
+// indexer) is briefly open on it without FILE_SHARE_DELETE.
+func isTransientRenameError(err error) bool {
+	return errors.Is(err, windows.ERROR_ACCESS_DENIED) ||
+		errors.Is(err, windows.ERROR_SHARING_VIOLATION)
+}

--- a/internal/config/atomicwrite_windows_test.go
+++ b/internal/config/atomicwrite_windows_test.go
@@ -1,0 +1,45 @@
+//go:build windows
+
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/windows"
+)
+
+// Regression test for the windows-latest CI flake where
+// TestConfigStore_SetConfigFields_concurrentInProcess failed with
+// "rename ...crush.json.<rand>.tmp ...crush.json: Access is denied":
+// renaming over a destination while another handle is open on it
+// without sharing must be retried until the handle closes, not
+// surfaced as an error.
+func TestAtomicWriteFile_RetriesWhileDestinationHandleOpen(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.json")
+	require.NoError(t, atomicWriteFile(path, []byte(`{"v":1}`), 0o600))
+
+	// Hold the destination open with no sharing flags so the rename
+	// fails with ERROR_ACCESS_DENIED/ERROR_SHARING_VIOLATION until the
+	// handle closes, mimicking an antivirus scan or exclusive reader.
+	p, err := windows.UTF16PtrFromString(path)
+	require.NoError(t, err)
+	h, err := windows.CreateFile(p, windows.GENERIC_READ, 0, nil,
+		windows.OPEN_EXISTING, windows.FILE_ATTRIBUTE_NORMAL, 0)
+	require.NoError(t, err)
+	go func() {
+		time.Sleep(200 * time.Millisecond)
+		windows.CloseHandle(h)
+	}()
+
+	require.NoError(t, atomicWriteFile(path, []byte(`{"v":2}`), 0o600))
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	require.JSONEq(t, `{"v":2}`, string(data))
+}


### PR DESCRIPTION
## Problem

`TestConfigStore_SetConfigFields_concurrentInProcess` (internal/config/store_test.go) is flaky on windows-latest:

```
rename C:\...\crush.json.<rand>.tmp C:\...\crush.json: Access is denied.
```

Example failing run (same commit passed on retry): https://github.com/joestump-agent/crush/actions/runs/29724740625/job/88295137885

## Root cause

The store's write path is already fully serialized — in-process mutex plus cross-process flock in `ConfigStore.lockConfig` — so the failing rename is not a race between our own writers. On Windows, `os.Rename` over an existing file (`MoveFileEx` with `MOVEFILE_REPLACE_EXISTING`) fails with `ERROR_ACCESS_DENIED` or `ERROR_SHARING_VIOLATION` while **any** process holds a handle on the destination without `FILE_SHARE_DELETE` — on CI runners that's typically Windows Defender or the search indexer scanning the freshly written file. The concurrent test just writes often enough to hit the window.

## Fix

- `atomicWriteFile` now renames via a `renameFile` helper that retries transient failures with exponential backoff (1ms doubling to a 50ms cap, ~2s total budget) before surfacing the error.
- Transient detection is platform-split: `atomicwrite_windows.go` matches `ERROR_ACCESS_DENIED` / `ERROR_SHARING_VIOLATION` via `golang.org/x/sys/windows`; `atomicwrite_unix.go` always reports false, so non-Windows keeps plain `os.Rename` semantics with zero retries.
- The production helper is fixed rather than the test skipped/serialized — `load.go`'s config migrations use the same helper and get the same protection.

## Regression test

`TestAtomicWriteFile_RetriesWhileDestinationHandleOpen` (windows-only) reproduces the failure deterministically: it holds the destination open via `CreateFile` with share mode 0, closes the handle after 200ms from a goroutine, and asserts `atomicWriteFile` succeeds and lands the new contents. Without the retry this fails exactly like the CI flake.

## Testing

- `go test ./internal/config/` passes locally (darwin) except the pre-existing sandbox-environmental failures (provider catalog needs network; unrelated to this change).
- `GOOS=windows go build` / `go vet` pass; the new regression test runs in this PR's windows-latest CI leg.

🤖 Generated with [Claude Code](https://claude.com/claude-code)