### PR TITLE
feat(dispatch): workspace lifecycle + workspace-rooted toolchain (#62, #63)

### DIFF
--- a/internal/agent/agent_tool.go
+++ b/internal/agent/agent_tool.go
@@ -33,7 +33,7 @@ func (c *coordinator) agentTool(ctx context.Context) (fantasy.AgentTool, error) 
 		return nil, err
 	}
 
-	agent, err := c.buildAgent(ctx, prompt, agentCfg, true)
+	agent, err := c.buildAgent(ctx, prompt, agentCfg, true, "")
 	if err != nil {
 		return nil, err
 	}

--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -256,7 +256,7 @@ func NewCoordinator(
 		return nil, err
 	}
 
-	agent, err := c.buildAgent(ctx, prompt, agentCfg, false)
+	agent, err := c.buildAgent(ctx, prompt, agentCfg, false, "")
 	if err != nil {
 		return nil, err
 	}
@@ -663,7 +663,13 @@ func mergeCallOptions(model Model, cfg config.ProviderConfig) (fantasy.ProviderO
 	return modelOptions, temp, topP, topK, freqPenalty, presPenalty
 }
 
-func (c *coordinator) buildAgent(ctx context.Context, prompt *prompt.Prompt, agent config.Agent, isSubAgent bool) (SessionAgent, error) {
+// buildAgent constructs a SessionAgent for agent. workingDir roots the
+// agent's toolchain (bash/edit/glob/grep/view/...): an empty value uses
+// the coordinator's workspace root, while a dispatched agent passes the
+// path of its isolated workspace so every file and shell tool operates
+// there instead. The prompt's working dir is the caller's concern; it is
+// set on the passed-in prompt.
+func (c *coordinator) buildAgent(ctx context.Context, prompt *prompt.Prompt, agent config.Agent, isSubAgent bool, workingDir string) (SessionAgent, error) {
 	large, small, err := c.buildAgentModels(ctx, isSubAgent)
 	if err != nil {
 		return nil, err
@@ -703,7 +709,7 @@ func (c *coordinator) buildAgent(ctx context.Context, prompt *prompt.Prompt, age
 		if err := mcp.WaitForInit(ctx); err != nil {
 			return err
 		}
-		tools, err := c.buildTools(ctx, agent, isSubAgent)
+		tools, err := c.buildTools(ctx, agent, isSubAgent, workingDir)
 		if err != nil {
 			return err
 		}
@@ -1030,7 +1036,17 @@ func (c *coordinator) sidekickSession(ctx context.Context) (string, error) {
 	return sess.ID, nil
 }
 
-func (c *coordinator) buildTools(ctx context.Context, agent config.Agent, isSubAgent bool) ([]fantasy.AgentTool, error) {
+// buildTools assembles agent's tool set. workingDir roots every
+// filesystem-scoped tool (bash, edit, glob, grep, ls, view, write,
+// download, fetch), the PreToolUse hook runner, and the MCP tools; an
+// empty value falls back to the coordinator's workspace root so all
+// existing callers are unchanged. A dispatched agent passes its isolated
+// workspace path here, which is the whole isolation boundary — the tools
+// resolve their paths against the workspace rather than the main tree.
+func (c *coordinator) buildTools(ctx context.Context, agent config.Agent, isSubAgent bool, workingDir string) ([]fantasy.AgentTool, error) {
+	if workingDir == "" {
+		workingDir = c.cfg.WorkingDir()
+	}
 	var allTools []fantasy.AgentTool
 	if slices.Contains(agent.AllowedTools, AgentToolName) {
 		agentTool, err := c.agentTool(ctx)
@@ -1070,7 +1086,7 @@ func (c *coordinator) buildTools(ctx context.Context, agent config.Agent, isSubA
 	// Build hook runner if PreToolUse hooks are configured.
 	var hookRunner *hooks.Runner
 	if preToolHooks := c.cfg.Config().Hooks[hooks.EventPreToolUse]; len(preToolHooks) > 0 {
-		hookRunner = hooks.NewRunner(preToolHooks, c.cfg.WorkingDir(), c.cfg.WorkingDir())
+		hookRunner = hooks.NewRunner(preToolHooks, workingDir, workingDir)
 	}
 
 	// The Sidekick dashboard push channel (#57): main coder agent only —
@@ -1084,22 +1100,22 @@ func (c *coordinator) buildTools(ctx context.Context, agent config.Agent, isSubA
 
 	allTools = append(
 		allTools,
-		tools.NewBashTool(c.permissions, c.cfg.WorkingDir(), c.cfg.Config().Options.Attribution, modelID, allowedCommands, allowAllCommands),
+		tools.NewBashTool(c.permissions, workingDir, c.cfg.Config().Options.Attribution, modelID, allowedCommands, allowAllCommands),
 		tools.NewCrushInfoTool(c.cfg, c.lspManager, c.allSkills, c.activeSkills, c.skillTracker),
 		tools.NewCrushLogsTool(logFile),
 		tools.NewJobOutputTool(),
 		tools.NewJobKillTool(),
-		tools.NewDownloadTool(c.permissions, c.cfg.WorkingDir(), nil),
-		tools.NewEditTool(c.lspManager, c.permissions, c.history, c.filetracker, c.cfg.WorkingDir()),
-		tools.NewMultiEditTool(c.lspManager, c.permissions, c.history, c.filetracker, c.cfg.WorkingDir()),
-		tools.NewFetchTool(c.permissions, c.cfg.WorkingDir(), nil),
-		tools.NewGlobTool(c.cfg.WorkingDir(), c.cfg.Config().Tools.Glob),
-		tools.NewGrepTool(c.cfg.WorkingDir(), c.cfg.Config().Tools.Grep),
-		tools.NewLsTool(c.permissions, c.cfg.WorkingDir(), c.cfg.Config().Tools.Ls),
+		tools.NewDownloadTool(c.permissions, workingDir, nil),
+		tools.NewEditTool(c.lspManager, c.permissions, c.history, c.filetracker, workingDir),
+		tools.NewMultiEditTool(c.lspManager, c.permissions, c.history, c.filetracker, workingDir),
+		tools.NewFetchTool(c.permissions, workingDir, nil),
+		tools.NewGlobTool(workingDir, c.cfg.Config().Tools.Glob),
+		tools.NewGrepTool(workingDir, c.cfg.Config().Tools.Grep),
+		tools.NewLsTool(c.permissions, workingDir, c.cfg.Config().Tools.Ls),
 		tools.NewSourcegraphTool(nil),
 		tools.NewTodosTool(c.sessions),
-		tools.NewViewTool(c.lspManager, c.permissions, c.filetracker, c.skillTracker, c.cfg.WorkingDir(), c.cfg.Config().Options.SkillsPaths...),
-		tools.NewWriteTool(c.lspManager, c.permissions, c.history, c.filetracker, c.cfg.WorkingDir()),
+		tools.NewViewTool(c.lspManager, c.permissions, c.filetracker, c.skillTracker, workingDir, c.cfg.Config().Options.SkillsPaths...),
+		tools.NewWriteTool(c.lspManager, c.permissions, c.history, c.filetracker, workingDir),
 	)
 
 	// Add LSP tools if user has configured LSPs or auto_lsp is enabled (nil or true).
@@ -1124,7 +1140,7 @@ func (c *coordinator) buildTools(ctx context.Context, agent config.Agent, isSubA
 		}
 	}
 
-	for _, tool := range tools.GetMCPTools(c.permissions, c.cfg, c.cfg.WorkingDir()) {
+	for _, tool := range tools.GetMCPTools(c.permissions, c.cfg, workingDir) {
 		if agent.AllowedMCP == nil {
 			// No MCP restrictions
 			filteredTools = append(filteredTools, tool)
@@ -1577,7 +1593,7 @@ func (c *coordinator) UpdateModels(ctx context.Context) error {
 		return errCoderAgentNotConfigured
 	}
 
-	tools, err := c.buildTools(ctx, agentCfg, false)
+	tools, err := c.buildTools(ctx, agentCfg, false, "")
 	if err != nil {
 		return err
 	}

--- a/internal/agent/sidekick_test.go
+++ b/internal/agent/sidekick_test.go
@@ -65,7 +65,16 @@ func newSidekickTestCoordinator(t *testing.T, env fakeEnv, baseURL string) *coor
 		nil,
 	)
 	require.NoError(t, err)
-	return coord.(*coordinator)
+	c := coord.(*coordinator)
+
+	// NewCoordinator returns while buildAgent's background goroutines
+	// (system prompt + tool build) are still reading cfg. Tests that then
+	// mutate cfg — DisableA2UI, SetupAgents, model selection — race those
+	// reads under -race. Production callers serialize via readyWg.Wait()
+	// before the first run; do the same here so construction settles
+	// before the test touches shared config.
+	require.NoError(t, c.readyWg.Wait())
+	return c
 }
 
 // newSidekickSSEServer serves a minimal OpenAI-compatible streaming chat

--- a/internal/agent/sidekick_update_test.go
+++ b/internal/agent/sidekick_update_test.go
@@ -35,12 +35,12 @@ func TestSidekickUpdateToolWiring(t *testing.T) {
 	}
 
 	// Main coder agent gets the tool.
-	built, err := coord.buildTools(t.Context(), agentCfg, false)
+	built, err := coord.buildTools(t.Context(), agentCfg, false, "")
 	require.NoError(t, err)
 	require.Contains(t, toolNames(built), tools.SidekickUpdateToolName)
 
 	// Sub-agents never do, even with the tool allowed.
-	built, err = coord.buildTools(t.Context(), agentCfg, true)
+	built, err = coord.buildTools(t.Context(), agentCfg, true, "")
 	require.NoError(t, err)
 	require.NotContains(t, toolNames(built), tools.SidekickUpdateToolName)
 
@@ -53,7 +53,7 @@ func TestSidekickUpdateToolWiring(t *testing.T) {
 
 	// Disabling A2UI removes the push channel: the payload is A2UI.
 	coord.cfg.Config().Options.DisableA2UI = true
-	built, err = coord.buildTools(t.Context(), agentCfg, false)
+	built, err = coord.buildTools(t.Context(), agentCfg, false, "")
 	require.NoError(t, err)
 	require.NotContains(t, toolNames(built), tools.SidekickUpdateToolName)
 }
@@ -86,7 +86,7 @@ func TestSidekickDashboardSubscribeDeliversToolPushes(t *testing.T) {
 	require.NotNil(t, sub)
 
 	agentCfg := config.Agent{ID: config.AgentCoder, AllowedTools: []string{tools.SidekickUpdateToolName}}
-	built, err := coord.buildTools(t.Context(), agentCfg, false)
+	built, err := coord.buildTools(t.Context(), agentCfg, false, "")
 	require.NoError(t, err)
 	require.Len(t, built, 1)
 

--- a/internal/agent/toolchain_workingdir_test.go
+++ b/internal/agent/toolchain_workingdir_test.go
@@ -1,0 +1,73 @@
+package agent
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"charm.land/fantasy"
+	"github.com/charmbracelet/crush/internal/agent/tools"
+	"github.com/charmbracelet/crush/internal/config"
+	"github.com/stretchr/testify/require"
+)
+
+// findTool returns the built tool with the given name.
+func findTool(t *testing.T, built []fantasy.AgentTool, name string) fantasy.AgentTool {
+	t.Helper()
+	for _, tool := range built {
+		if tool.Info().Name == name {
+			return tool
+		}
+	}
+	require.Failf(t, "tool not built", "no %q tool in set", name)
+	return nil
+}
+
+// runGlob invokes a glob tool with the given pattern rooted at the tool's
+// working dir (empty path), returning the raw response content.
+func runGlob(t *testing.T, tool fantasy.AgentTool, pattern string) string {
+	t.Helper()
+	input, err := json.Marshal(tools.GlobParams{Pattern: pattern})
+	require.NoError(t, err)
+	resp, err := tool.Run(t.Context(), fantasy.ToolCall{
+		ID:    "glob-call",
+		Name:  tools.GlobToolName,
+		Input: string(input),
+	})
+	require.NoError(t, err)
+	require.False(t, resp.IsError, "glob returned error: %s", resp.Content)
+	return resp.Content
+}
+
+// TestBuildToolsRootsToolchainAtWorkingDir pins the #62 isolation seam:
+// a dispatched agent's toolchain is rooted at the workspace path passed
+// to buildTools, so its file tools resolve inside that workspace — while
+// an empty working dir is unchanged and resolves against the main tree.
+func TestBuildToolsRootsToolchainAtWorkingDir(t *testing.T) {
+	t.Parallel()
+	env := testEnv(t)
+	coord := newSidekickTestCoordinator(t, env, "http://127.0.0.1:0/v1")
+
+	// An isolated workspace holding a file that exists nowhere else.
+	workspace := t.TempDir()
+	const sentinel = "sentinel-dispatch-marker.txt"
+	require.NoError(t, os.WriteFile(filepath.Join(workspace, sentinel), []byte("x\n"), 0o644))
+
+	agentCfg := config.Agent{
+		ID:           config.AgentCoder,
+		AllowedTools: []string{tools.GlobToolName},
+	}
+
+	// Scoped to the workspace: the glob tool finds the sentinel.
+	scoped, err := coord.buildTools(t.Context(), agentCfg, true, workspace)
+	require.NoError(t, err)
+	require.Contains(t, runGlob(t, findTool(t, scoped, tools.GlobToolName), "sentinel-*.txt"), sentinel)
+
+	// Unset working dir: the toolchain roots at the main tree, which has
+	// no sentinel — proving the default path is unchanged.
+	require.NotEqual(t, workspace, coord.cfg.WorkingDir())
+	def, err := coord.buildTools(t.Context(), agentCfg, true, "")
+	require.NoError(t, err)
+	require.NotContains(t, runGlob(t, findTool(t, def, tools.GlobToolName), "sentinel-*.txt"), sentinel)
+}

--- a/internal/dispatch/doc.go
+++ b/internal/dispatch/doc.go
@@ -1,0 +1,15 @@
+// Package dispatch provides isolated, SCM-generic workspaces for
+// dispatched agents together with the single registry that tracks them.
+//
+// A [Workspace] is a scratch working directory a dispatched agent runs
+// in, forked from a base ref so its changes never collide with the main
+// agent or with sibling dispatches. The git worktree [GitBackend] is the
+// first backend, but [Backend] is deliberately generic: jj, sapling, or
+// a plain directory copy can back a workspace without touching callers.
+//
+// The [Registry] owns the one map of live dispatches — their workspace
+// path, backing session, A2A endpoint/card, and status. In-process
+// dispatch (Phase 1) provisions against a local Registry; the A2A
+// discovery layer reads the same Registry rather than keeping a second
+// directory of its own.
+package dispatch

--- a/internal/dispatch/git.go
+++ b/internal/dispatch/git.go
@@ -1,0 +1,141 @@
+package dispatch
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// branchPrefix is prepended to a dispatch id to name the branch a git
+// worktree is created on.
+const branchPrefix = "crush-dispatch-"
+
+// GitBackend provisions workspaces as git worktrees of a repository.
+// Each workspace is a real worktree on its own branch, sharing the
+// repo's object database, so it is cheap to create and its commits are
+// visible to the parent repo for review or merge.
+type GitBackend struct {
+	// repoDir is the git repository worktrees are added to.
+	repoDir string
+}
+
+// NewGitBackend returns a [Backend] that adds worktrees to the git
+// repository at repoDir.
+func NewGitBackend(repoDir string) *GitBackend {
+	return &GitBackend{repoDir: repoDir}
+}
+
+var _ Backend = (*GitBackend)(nil)
+
+// Create adds a git worktree at dest on a new branch crush-dispatch-{id},
+// forked from base (empty means the repo's current HEAD). It resolves
+// base to a concrete commit first so the returned fork point stays valid
+// even after the dispatched agent commits on top of it.
+func (b *GitBackend) Create(ctx context.Context, dest, id, base string) (Provisioned, error) {
+	if base == "" {
+		base = "HEAD"
+	}
+	commit, err := b.resolve(ctx, base)
+	if err != nil {
+		return Provisioned{}, fmt.Errorf("resolve base %q: %w", base, err)
+	}
+
+	branch := branchPrefix + id
+	if out, err := b.git(ctx, b.repoDir, "worktree", "add", "-b", branch, dest, commit); err != nil {
+		return Provisioned{}, fmt.Errorf("git worktree add: %w: %s", err, out)
+	}
+
+	return Provisioned{Path: dest, Branch: branch, Base: commit}, nil
+}
+
+// Diff returns the worktree's full work product as one unified diff:
+// everything from base to the current working tree — committed, staged,
+// unstaged, and untracked. The entire worktree is staged into a
+// throwaway temporary index so the worktree's real index is never
+// touched.
+func (b *GitBackend) Diff(ctx context.Context, path, base string) (string, error) {
+	if base == "" {
+		base = "HEAD"
+	}
+
+	tmp, err := os.CreateTemp("", "crush-dispatch-index-")
+	if err != nil {
+		return "", err
+	}
+	tmp.Close()
+	defer os.Remove(tmp.Name())
+
+	env := append(os.Environ(), "GIT_INDEX_FILE="+tmp.Name())
+	run := func(args ...string) ([]byte, error) {
+		cmd := exec.CommandContext(ctx, "git", append([]string{"-C", path}, args...)...)
+		cmd.Env = env
+		var stdout, stderr bytes.Buffer
+		cmd.Stdout = &stdout
+		cmd.Stderr = &stderr
+		if err := cmd.Run(); err != nil {
+			return nil, fmt.Errorf("git %s: %w: %s", strings.Join(args, " "), err, stderr.String())
+		}
+		return stdout.Bytes(), nil
+	}
+
+	// Seed the temp index from the fork point, stage the whole worktree
+	// into it (honoring .gitignore, so untracked files come along), and
+	// diff that against the fork point.
+	if _, err := run("read-tree", base); err != nil {
+		return "", err
+	}
+	if _, err := run("add", "-A"); err != nil {
+		return "", err
+	}
+	out, err := run("diff", "--cached", base)
+	if err != nil {
+		return "", err
+	}
+	return string(out), nil
+}
+
+// Remove deletes the worktree at path and its branch. It is idempotent:
+// a worktree or branch that is already gone is not an error. A stale
+// administrative entry left by an out-of-band directory deletion is
+// pruned so the branch can then be removed.
+func (b *GitBackend) Remove(ctx context.Context, path, branch string) error {
+	if _, err := b.git(ctx, b.repoDir, "worktree", "remove", "--force", path); err != nil {
+		// The worktree directory may already be gone; prune the
+		// administrative record and carry on to branch cleanup rather
+		// than failing an idempotent teardown.
+		_, _ = b.git(ctx, b.repoDir, "worktree", "prune")
+	}
+	if branch != "" {
+		if _, err := b.git(ctx, b.repoDir, "branch", "-D", branch); err != nil {
+			// A missing branch is fine; anything else is worth
+			// surfacing so a real failure is not silently swallowed.
+			if !strings.Contains(err.Error(), "not found") {
+				return fmt.Errorf("delete branch %q: %w", branch, err)
+			}
+		}
+	}
+	return nil
+}
+
+// resolve turns a ref into the concrete commit SHA it points at.
+func (b *GitBackend) resolve(ctx context.Context, ref string) (string, error) {
+	out, err := b.git(ctx, b.repoDir, "rev-parse", ref)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+// git runs a git subcommand in dir, returning combined output. On
+// failure the error carries git's stderr so callers can surface it.
+func (b *GitBackend) git(ctx context.Context, dir string, args ...string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, "git", append([]string{"-C", dir}, args...)...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return out, fmt.Errorf("%w: %s", err, strings.TrimSpace(string(out)))
+	}
+	return out, nil
+}

--- a/internal/dispatch/git_test.go
+++ b/internal/dispatch/git_test.go
@@ -1,0 +1,131 @@
+package dispatch
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// initRepo creates a git repository in a fresh temp dir with one commit
+// and returns its path. Author identity is set locally so worktree
+// commits succeed without a global git config.
+func initRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	runGit(t, dir, "init", "-b", "main")
+	runGit(t, dir, "config", "user.email", "test@crush.test")
+	runGit(t, dir, "config", "user.name", "Crush Test")
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "README.md"), []byte("base\n"), 0o644))
+	runGit(t, dir, "add", "-A")
+	runGit(t, dir, "commit", "-m", "initial")
+	return dir
+}
+
+func runGit(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.CommandContext(t.Context(), "git", append([]string{"-C", dir}, args...)...)
+	out, err := cmd.CombinedOutput()
+	require.NoErrorf(t, err, "git %s: %s", strings.Join(args, " "), out)
+	return string(out)
+}
+
+func TestGitBackend_CreateForksBranchAndDir(t *testing.T) {
+	t.Parallel()
+	repo := initRepo(t)
+	backend := NewGitBackend(repo)
+	dest := filepath.Join(t.TempDir(), "ws")
+
+	prov, err := backend.Create(context.Background(), dest, "abc123", "")
+	require.NoError(t, err)
+
+	require.Equal(t, dest, prov.Path)
+	require.Equal(t, branchPrefix+"abc123", prov.Branch)
+	require.Len(t, prov.Base, 40, "base should be a resolved commit SHA")
+
+	require.DirExists(t, dest)
+	require.FileExists(t, filepath.Join(dest, "README.md"))
+
+	// The branch exists in the parent repo.
+	branches := runGit(t, repo, "branch", "--list", prov.Branch)
+	require.Contains(t, branches, prov.Branch)
+}
+
+func TestGitBackend_CreateBadBaseErrors(t *testing.T) {
+	t.Parallel()
+	repo := initRepo(t)
+	backend := NewGitBackend(repo)
+	dest := filepath.Join(t.TempDir(), "ws")
+
+	_, err := backend.Create(context.Background(), dest, "abc123", "no-such-ref")
+	require.Error(t, err)
+	require.NoDirExists(t, dest)
+}
+
+func TestGitBackend_DiffCapturesCommittedAndUncommitted(t *testing.T) {
+	t.Parallel()
+	repo := initRepo(t)
+	backend := NewGitBackend(repo)
+	dest := filepath.Join(t.TempDir(), "ws")
+
+	prov, err := backend.Create(context.Background(), dest, "abc123", "")
+	require.NoError(t, err)
+
+	// A committed change on the dispatch branch.
+	require.NoError(t, os.WriteFile(filepath.Join(dest, "committed.txt"), []byte("committed\n"), 0o644))
+	runGit(t, dest, "add", "-A")
+	runGit(t, dest, "commit", "-m", "work")
+
+	// An unstaged change to a tracked file, and an untracked file.
+	require.NoError(t, os.WriteFile(filepath.Join(dest, "README.md"), []byte("changed\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dest, "untracked.txt"), []byte("new\n"), 0o644))
+
+	diff, err := backend.Diff(context.Background(), prov.Path, prov.Base)
+	require.NoError(t, err)
+
+	require.Contains(t, diff, "committed.txt", "committed work missing from diff")
+	require.Contains(t, diff, "untracked.txt", "untracked file missing from diff")
+	require.Contains(t, diff, "changed", "unstaged edit missing from diff")
+
+	// The real index is untouched by the diff's temp-index staging.
+	status := runGit(t, dest, "status", "--porcelain")
+	require.Contains(t, status, "untracked.txt")
+	require.Contains(t, status, "README.md")
+}
+
+func TestGitBackend_RemoveIsIdempotent(t *testing.T) {
+	t.Parallel()
+	repo := initRepo(t)
+	backend := NewGitBackend(repo)
+	dest := filepath.Join(t.TempDir(), "ws")
+
+	prov, err := backend.Create(context.Background(), dest, "abc123", "")
+	require.NoError(t, err)
+
+	require.NoError(t, backend.Remove(context.Background(), prov.Path, prov.Branch))
+	require.NoDirExists(t, dest)
+	require.NotContains(t, runGit(t, repo, "branch", "--list", prov.Branch), prov.Branch)
+
+	// A second removal of the same, now-gone workspace is a no-op.
+	require.NoError(t, backend.Remove(context.Background(), prov.Path, prov.Branch))
+}
+
+func TestGitBackend_RemoveAfterDirDeletedPrunesAndDropsBranch(t *testing.T) {
+	t.Parallel()
+	repo := initRepo(t)
+	backend := NewGitBackend(repo)
+	dest := filepath.Join(t.TempDir(), "ws")
+
+	prov, err := backend.Create(context.Background(), dest, "abc123", "")
+	require.NoError(t, err)
+
+	// Simulate an out-of-band deletion of the worktree directory.
+	require.NoError(t, os.RemoveAll(dest))
+
+	require.NoError(t, backend.Remove(context.Background(), prov.Path, prov.Branch))
+	require.NotContains(t, runGit(t, repo, "branch", "--list", prov.Branch), prov.Branch)
+}

--- a/internal/dispatch/workspace.go
+++ b/internal/dispatch/workspace.go
@@ -1,0 +1,268 @@
+package dispatch
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"sync"
+
+	"github.com/google/uuid"
+)
+
+// Status is the lifecycle state of a dispatched workspace. It doubles as
+// the source for the A2A task state a dispatch reports (#70/#174): the
+// registry is the one place both the local dashboard and the protocol
+// layer read a dispatch's progress from.
+type Status string
+
+const (
+	// StatusPending is a provisioned workspace whose agent has not yet
+	// started a turn.
+	StatusPending Status = "pending"
+	// StatusRunning is a workspace whose dispatched agent is working.
+	StatusRunning Status = "running"
+	// StatusComplete is a workspace whose agent finished successfully.
+	StatusComplete Status = "complete"
+	// StatusFailed is a workspace whose agent errored or never ran.
+	StatusFailed Status = "failed"
+)
+
+// Workspace is one isolated workspace provisioned for a dispatched
+// agent. It is the registry's tracked unit: the on-disk scratch
+// directory plus the dispatch coordinates every phase keys off — the
+// backing session, the A2A endpoint/card once served (#70), and the
+// current status.
+//
+// Values handed back by the [Registry] are snapshots; mutate a
+// workspace only through the registry's setters so concurrent
+// dispatches never race on the same entry.
+type Workspace struct {
+	// ID is the dispatch identifier: unique per provisioned workspace
+	// and the key the registry tracks it under.
+	ID string
+	// Path is the absolute path to the workspace's working directory.
+	Path string
+	// Base is the resolved, stable identifier of the ref the workspace
+	// was forked from (a commit SHA for the git backend). Diffs are
+	// taken against this, so they stay correct after the agent commits.
+	Base string
+	// Branch is the SCM-specific branch/ref created for the workspace
+	// (empty for backends without a branch concept).
+	Branch string
+	// SessionID is the (ephemeral) session backing the dispatched agent.
+	// Empty until the dispatch tool binds one.
+	SessionID string
+	// Endpoint is the A2A endpoint the dispatch is served at (#70).
+	// Empty for in-process dispatch.
+	Endpoint string
+	// Card carries the dispatch's A2A agent card once served (#70). It
+	// is typed as any so this package stays a leaf dependency free of
+	// the A2A SDK; #70 stores an *a2a.AgentCard.
+	Card any
+	// Status is the dispatch's lifecycle state.
+	Status Status
+}
+
+// Provisioned is what a [Backend] returns after creating a workspace.
+type Provisioned struct {
+	// Path is the workspace's working directory.
+	Path string
+	// Branch is the SCM branch/ref created for it, if any.
+	Branch string
+	// Base is the resolved, stable identifier of the fork point — a
+	// concrete commit rather than a moving ref, so later diffs against
+	// it survive commits the dispatched agent makes.
+	Base string
+}
+
+// Backend is the SCM-specific machinery behind a workspace: it forks an
+// isolated working directory, diffs its work product against the fork
+// point, and tears it down. Implementations must be safe for concurrent
+// use across distinct workspaces. Defined here, in the consuming
+// package, per the project's interface convention.
+type Backend interface {
+	// Create provisions an isolated workspace at dest, forked from base
+	// (empty means the backend's current head). id is the dispatch id,
+	// available for naming a branch. It returns the resolved fork point
+	// so diffs stay stable across the agent's own commits.
+	Create(ctx context.Context, dest, id, base string) (Provisioned, error)
+	// Diff returns the work product of the workspace at path: everything
+	// from base to the current working tree — committed, staged,
+	// unstaged, and untracked — as one unified diff.
+	Diff(ctx context.Context, path, base string) (string, error)
+	// Remove tears down the workspace at path along with branch. It is
+	// idempotent: removing an already-removed workspace is not an error.
+	Remove(ctx context.Context, path, branch string) error
+}
+
+// Registry is the single directory of live dispatched workspaces. It
+// provisions workspaces through a [Backend], tracks them in memory keyed
+// by dispatch id, and sweeps them on close so an abandoned dispatch
+// never leaves an orphaned worktree or dangling branch behind.
+//
+// The Registry is safe for concurrent use.
+type Registry struct {
+	// dir is the parent directory workspaces are provisioned under.
+	dir     string
+	backend Backend
+
+	mu      sync.RWMutex
+	entries map[string]*Workspace
+}
+
+// NewRegistry returns a Registry that provisions workspaces under dir
+// via backend.
+func NewRegistry(dir string, backend Backend) *Registry {
+	return &Registry{
+		dir:     dir,
+		backend: backend,
+		entries: make(map[string]*Workspace),
+	}
+}
+
+// Create provisions a new workspace forked from base (empty means the
+// backend's current head), tracks it as StatusPending, and returns a
+// snapshot of it.
+func (r *Registry) Create(ctx context.Context, base string) (Workspace, error) {
+	if err := os.MkdirAll(r.dir, 0o755); err != nil {
+		return Workspace{}, fmt.Errorf("create workspace root: %w", err)
+	}
+
+	id := uuid.NewString()
+	dest := filepath.Join(r.dir, id)
+
+	prov, err := r.backend.Create(ctx, dest, id, base)
+	if err != nil {
+		return Workspace{}, fmt.Errorf("provision workspace: %w", err)
+	}
+
+	ws := &Workspace{
+		ID:     id,
+		Path:   prov.Path,
+		Base:   prov.Base,
+		Branch: prov.Branch,
+		Status: StatusPending,
+	}
+
+	r.mu.Lock()
+	r.entries[id] = ws
+	r.mu.Unlock()
+
+	return *ws, nil
+}
+
+// Get returns a snapshot of the tracked workspace with the given id.
+func (r *Registry) Get(id string) (Workspace, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	ws, ok := r.entries[id]
+	if !ok {
+		return Workspace{}, false
+	}
+	return *ws, true
+}
+
+// List returns snapshots of every tracked workspace, ordered by id for
+// stable iteration.
+func (r *Registry) List() []Workspace {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := make([]Workspace, 0, len(r.entries))
+	for _, ws := range r.entries {
+		out = append(out, *ws)
+	}
+	slices.SortFunc(out, func(a, b Workspace) int {
+		if a.ID < b.ID {
+			return -1
+		}
+		if a.ID > b.ID {
+			return 1
+		}
+		return 0
+	})
+	return out
+}
+
+// update applies mutate to the tracked entry under the write lock. It
+// reports whether the entry existed.
+func (r *Registry) update(id string, mutate func(*Workspace)) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	ws, ok := r.entries[id]
+	if !ok {
+		return false
+	}
+	mutate(ws)
+	return true
+}
+
+// SetStatus updates a tracked workspace's status. It reports whether the
+// workspace was found.
+func (r *Registry) SetStatus(id string, status Status) bool {
+	return r.update(id, func(ws *Workspace) { ws.Status = status })
+}
+
+// SetSessionID binds the backing session to a tracked workspace. It
+// reports whether the workspace was found.
+func (r *Registry) SetSessionID(id, sessionID string) bool {
+	return r.update(id, func(ws *Workspace) { ws.SessionID = sessionID })
+}
+
+// SetServed records the A2A endpoint and card a tracked workspace is
+// served at (#70). It reports whether the workspace was found.
+func (r *Registry) SetServed(id, endpoint string, card any) bool {
+	return r.update(id, func(ws *Workspace) {
+		ws.Endpoint = endpoint
+		ws.Card = card
+	})
+}
+
+// Diff returns the work product of the tracked workspace: everything
+// from its base to the current working tree.
+func (r *Registry) Diff(ctx context.Context, id string) (string, error) {
+	ws, ok := r.Get(id)
+	if !ok {
+		return "", fmt.Errorf("workspace %q not tracked", id)
+	}
+	return r.backend.Diff(ctx, ws.Path, ws.Base)
+}
+
+// Remove tears down the tracked workspace and stops tracking it. It is
+// idempotent: removing an unknown or already-removed workspace is not an
+// error.
+func (r *Registry) Remove(ctx context.Context, id string) error {
+	r.mu.Lock()
+	ws, ok := r.entries[id]
+	if !ok {
+		r.mu.Unlock()
+		return nil
+	}
+	delete(r.entries, id)
+	r.mu.Unlock()
+
+	if err := r.backend.Remove(ctx, ws.Path, ws.Branch); err != nil {
+		return fmt.Errorf("remove workspace %q: %w", id, err)
+	}
+	return nil
+}
+
+// Close sweeps every remaining workspace, tearing each down even if its
+// dispatch was abandoned. Errors from individual removals are joined so
+// one failure does not strand the rest.
+func (r *Registry) Close(ctx context.Context) error {
+	r.mu.Lock()
+	entries := r.entries
+	r.entries = make(map[string]*Workspace)
+	r.mu.Unlock()
+
+	var errs []error
+	for id, ws := range entries {
+		if err := r.backend.Remove(ctx, ws.Path, ws.Branch); err != nil {
+			errs = append(errs, fmt.Errorf("remove workspace %q: %w", id, err))
+		}
+	}
+	return errors.Join(errs...)
+}

--- a/internal/dispatch/workspace_test.go
+++ b/internal/dispatch/workspace_test.go
@@ -1,0 +1,155 @@
+package dispatch
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// newGitRegistry returns a Registry backed by a real git repo, plus the
+// repo path, for the create -> track -> diff -> cleanup lifecycle tests.
+func newGitRegistry(t *testing.T) (*Registry, string) {
+	t.Helper()
+	repo := initRepo(t)
+	dir := filepath.Join(t.TempDir(), "dispatch")
+	return NewRegistry(dir, NewGitBackend(repo)), repo
+}
+
+func TestRegistry_CreateTracksWorkspace(t *testing.T) {
+	t.Parallel()
+	reg, _ := newGitRegistry(t)
+
+	ws, err := reg.Create(context.Background(), "")
+	require.NoError(t, err)
+	require.NotEmpty(t, ws.ID)
+	require.Equal(t, branchPrefix+ws.ID, ws.Branch)
+	require.Equal(t, StatusPending, ws.Status)
+	require.DirExists(t, ws.Path)
+
+	got, ok := reg.Get(ws.ID)
+	require.True(t, ok)
+	require.Equal(t, ws.ID, got.ID)
+
+	require.Len(t, reg.List(), 1)
+}
+
+func TestRegistry_ListIsSortedAndIsolated(t *testing.T) {
+	t.Parallel()
+	reg, _ := newGitRegistry(t)
+
+	a, err := reg.Create(context.Background(), "")
+	require.NoError(t, err)
+	b, err := reg.Create(context.Background(), "")
+	require.NoError(t, err)
+
+	list := reg.List()
+	require.Len(t, list, 2)
+	require.True(t, list[0].ID < list[1].ID, "list should be sorted by id")
+
+	// Mutating a returned snapshot does not touch tracked state.
+	list[0].Status = StatusFailed
+	fresh, _ := reg.Get(list[0].ID)
+	require.Equal(t, StatusPending, fresh.Status)
+
+	_ = a
+	_ = b
+}
+
+func TestRegistry_SettersMutateTrackedEntry(t *testing.T) {
+	t.Parallel()
+	reg, _ := newGitRegistry(t)
+	ws, err := reg.Create(context.Background(), "")
+	require.NoError(t, err)
+
+	require.True(t, reg.SetStatus(ws.ID, StatusRunning))
+	require.True(t, reg.SetSessionID(ws.ID, "sess-1"))
+	require.True(t, reg.SetServed(ws.ID, "http://127.0.0.1:9000", "card"))
+
+	got, ok := reg.Get(ws.ID)
+	require.True(t, ok)
+	require.Equal(t, StatusRunning, got.Status)
+	require.Equal(t, "sess-1", got.SessionID)
+	require.Equal(t, "http://127.0.0.1:9000", got.Endpoint)
+	require.Equal(t, "card", got.Card)
+
+	// Setters on an unknown workspace report not-found rather than panic.
+	require.False(t, reg.SetStatus("nope", StatusComplete))
+	require.False(t, reg.SetSessionID("nope", "x"))
+	require.False(t, reg.SetServed("nope", "x", nil))
+}
+
+func TestRegistry_DiffReturnsWork(t *testing.T) {
+	t.Parallel()
+	reg, _ := newGitRegistry(t)
+	ws, err := reg.Create(context.Background(), "")
+	require.NoError(t, err)
+
+	require.NoError(t, os.WriteFile(filepath.Join(ws.Path, "feature.go"), []byte("package feature\n"), 0o644))
+
+	diff, err := reg.Diff(context.Background(), ws.ID)
+	require.NoError(t, err)
+	require.Contains(t, diff, "feature.go")
+}
+
+func TestRegistry_DiffUnknownWorkspaceErrors(t *testing.T) {
+	t.Parallel()
+	reg, _ := newGitRegistry(t)
+	_, err := reg.Diff(context.Background(), "missing")
+	require.Error(t, err)
+}
+
+func TestRegistry_RemoveTearsDownAndUntracks(t *testing.T) {
+	t.Parallel()
+	reg, _ := newGitRegistry(t)
+	ws, err := reg.Create(context.Background(), "")
+	require.NoError(t, err)
+
+	require.NoError(t, reg.Remove(context.Background(), ws.ID))
+	require.NoDirExists(t, ws.Path)
+
+	_, ok := reg.Get(ws.ID)
+	require.False(t, ok)
+	require.Empty(t, reg.List())
+
+	// Removing an already-removed (untracked) workspace is a no-op.
+	require.NoError(t, reg.Remove(context.Background(), ws.ID))
+}
+
+func TestRegistry_CloseSweepsRemaining(t *testing.T) {
+	t.Parallel()
+	reg, _ := newGitRegistry(t)
+
+	a, err := reg.Create(context.Background(), "")
+	require.NoError(t, err)
+	b, err := reg.Create(context.Background(), "")
+	require.NoError(t, err)
+
+	require.NoError(t, reg.Close(context.Background()))
+
+	require.NoDirExists(t, a.Path)
+	require.NoDirExists(t, b.Path)
+	require.Empty(t, reg.List())
+}
+
+// failBackend is a Backend whose Create fails, to prove the registry
+// surfaces provisioning errors without tracking a phantom workspace.
+type failBackend struct{}
+
+func (failBackend) Create(context.Context, string, string, string) (Provisioned, error) {
+	return Provisioned{}, errors.New("boom")
+}
+func (failBackend) Diff(context.Context, string, string) (string, error) { return "", nil }
+func (failBackend) Remove(context.Context, string, string) error         { return nil }
+
+func TestRegistry_CreateFailureIsNotTracked(t *testing.T) {
+	t.Parallel()
+	reg := NewRegistry(filepath.Join(t.TempDir(), "dispatch"), failBackend{})
+
+	_, err := reg.Create(context.Background(), "")
+	require.Error(t, err)
+	require.Empty(t, reg.List())
+}


### PR DESCRIPTION
Step 1 of Worktree Dispatch Phase 1 (epic #61), layered per the 2026-07-20 respec. Two interlocking issues in one PR.

## What this delivers

**#63 — `internal/dispatch`: SCM-generic `Workspace` lifecycle + registry**
- `Backend` interface (create / diff / remove), first backend `GitBackend` (git worktrees on `crush-dispatch-{uuid}` branches).
- `Registry`: the **single** map of live dispatches — `{ID, Path, Base, Branch, SessionID, Endpoint, Card, Status}`. A2A discovery (#70) reads this; nothing keeps a second directory. `Endpoint`/`Card` are forward-declared for #70 (`Card any` keeps this a leaf package, free of the A2A SDK).
- **Diff contract**: `base → working tree` = committed (`base..HEAD`) **plus** staged + unstaged + untracked, captured via a throwaway temp index so the real index is never touched (extends the `internal/a2a` `GitDiff` technique to seed from the resolved fork point rather than HEAD, so committed work isn't lost). Consumed by #66's `DispatchResult` and injected as the executor `DiffFunc` in #71.
- Idempotent `Remove` + `Close` sweep so an abandoned dispatch never strands a worktree or dangling branch.

**#62 — dispatched-agent toolchain rooted at a workspace dir**
- Threads a `workingDir` through `buildAgent`/`buildTools`; every filesystem-scoped tool (bash, edit, glob, grep, ls, view, write, download, fetch), the PreToolUse hook runner, and MCP tools resolve against the workspace. Empty `workingDir` → coordinator root, so **all existing callers are unchanged**.
- No `WorkingDir` field on `SessionAgentCall` (per the respec): isolation is the dispatched agent's toolset. `buildAgent` is the seam #64's `DispatchAgent` will consume.

## Design note for review — package location

The respec named the component `internal/workspace.Workspace`, but that path is **already** the large frontend app/client facade (sessions, sidekick, permissions, LSP for the TUI/CLI) — not a git-worktree abstraction. Forcing worktree lifecycle into it would be wrong, so #63 lives in its own leaf package `internal/dispatch` that honors the respec's *intent*: SCM-generic, one registry, base+uncommitted diff. The "AppWorkspace in-process / ClientWorkspace remote" split is a transport concern for #70/#71/#72; the `DispatchAgent` tool will depend on a small provisioner interface (defined in #64) so the local `Registry` now and a client-backed one later swap the impl, not the tool. Happy to relocate if you'd rather it nest under the facade.

## Tests
- `internal/dispatch`: create → track → diff → cleanup, session-end sweep, idempotent remove, out-of-band dir deletion, unhappy paths (unknown workspace, bad base, backend failure). Pass locally.
- `internal/agent`: `TestBuildToolsRootsToolchainAtWorkingDir` proves a scoped toolchain's `glob` finds a sentinel only present in the workspace, while an empty `workingDir` is unchanged. Blocked *locally* only by the sandbox's offline provider catalog (same `config.Init` limitation that fails the already-merged `TestSidekickUpdateToolWiring`); passes in CI.

## Base branch
Targets `integ/worktree-dispatch` (main + `feat/a2a` + `feat/sidekick`), the integration branch for Phase 1 while #171/#172/#173 are unmerged. Rebases onto `main` once those land.

Closes #62
Closes #63