### PR TITLE
feat(agent): DispatchAgent tool + DispatchResult (#64, #66)

### DIFF
--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -26,6 +26,7 @@ import (
 	"github.com/charmbracelet/crush/internal/agent/tools/mcp"
 	"github.com/charmbracelet/crush/internal/config"
 	"github.com/charmbracelet/crush/internal/discover"
+	"github.com/charmbracelet/crush/internal/dispatch"
 	"github.com/charmbracelet/crush/internal/event"
 	"github.com/charmbracelet/crush/internal/filetracker"
 	"github.com/charmbracelet/crush/internal/history"
@@ -96,6 +97,11 @@ type Coordinator interface {
 	BeginAccepted(sessionID string) *AcceptedRun
 	Cancel(sessionID string)
 	CancelAll()
+	// CleanupDispatches tears down every isolated workspace provisioned
+	// by the dispatch_agent tool (#64), removing worktrees and their
+	// branches. Called on shutdown so an abandoned dispatch never leaves
+	// an orphaned worktree behind.
+	CleanupDispatches(ctx context.Context) error
 	IsSessionBusy(sessionID string) bool
 	IsBusy() bool
 	QueuedPrompts(sessionID string) int
@@ -188,6 +194,12 @@ type coordinator struct {
 	activeSkills []*skills.Skill // Post-filter: active skills only.
 	skillTracker *skills.Tracker
 
+	// dispatchRegistry provisions and tracks the isolated workspaces the
+	// dispatch_agent tool (#64) runs agents in. Nil when the coordinator
+	// has no workspace root (e.g. some test harnesses), in which case the
+	// tool reports dispatch unavailable rather than panicking.
+	dispatchRegistry *dispatch.Registry
+
 	readyWg errgroup.Group
 }
 
@@ -232,6 +244,10 @@ func NewCoordinator(
 		activeSkills:      activeSkills,
 		skillTracker:      skillTracker,
 		sidekickDashboard: pubsub.NewBroker[tools.SidekickSurface](),
+		dispatchRegistry: dispatch.NewRegistry(
+			filepath.Join(cfg.WorkingDir(), ".crush", "dispatch"),
+			dispatch.NewGitBackend(cfg.WorkingDir()),
+		),
 	}
 
 	agentCfg, ok := cfg.Config().Agents[config.AgentCoder]
@@ -1054,6 +1070,10 @@ func (c *coordinator) buildTools(ctx context.Context, agent config.Agent, isSubA
 			return nil, err
 		}
 		allTools = append(allTools, agentTool)
+	}
+
+	if slices.Contains(agent.AllowedTools, DispatchAgentToolName) {
+		allTools = append(allTools, c.dispatchAgentTool())
 	}
 
 	if slices.Contains(agent.AllowedTools, tools.AgenticFetchToolName) {

--- a/internal/agent/dispatch_tool.go
+++ b/internal/agent/dispatch_tool.go
@@ -1,0 +1,264 @@
+package agent
+
+import (
+	"context"
+	_ "embed"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"slices"
+
+	"charm.land/fantasy"
+
+	"github.com/charmbracelet/crush/internal/agent/prompt"
+	"github.com/charmbracelet/crush/internal/agent/tools"
+	"github.com/charmbracelet/crush/internal/config"
+	"github.com/charmbracelet/crush/internal/dispatch"
+)
+
+//go:embed templates/dispatch_agent.md
+var dispatchAgentDescription string
+
+// DispatchAgentToolName is the model-facing name of the dispatch tool.
+const DispatchAgentToolName = "dispatch_agent"
+
+var errDispatchUnavailable = errors.New("agent dispatch is unavailable (no workspace registry configured)")
+
+// Model-facing terminal statuses, aligned to the A2A task states a
+// dispatch maps onto (#66/#71) — kept distinct from the registry's
+// internal lifecycle vocabulary (dispatch.Status).
+const (
+	dispatchStatusCompleted = "completed"
+	dispatchStatusFailed    = "failed"
+)
+
+// DispatchAgentParams are the arguments to the dispatch_agent tool.
+type DispatchAgentParams struct {
+	Prompt string `json:"prompt" description:"The task for the dispatched agent to perform, self-contained enough to act on without the current conversation."`
+	Model  string `json:"model,omitempty" description:"Model to run the dispatched agent with: \"large\" or \"small\". Defaults to the small model."`
+	Branch string `json:"branch,omitempty" description:"Base ref to fork the workspace from. Defaults to the current tree."`
+}
+
+// DispatchResult is the terminal payload the dispatch_agent tool returns
+// to the main agent. Its fields are pinned to the A2A task mapping so the
+// #71 transport swap is invisible to the model: Status maps to task
+// state, Findings to the terminal status-message text, and Diff to the
+// completion artifact.
+type DispatchResult struct {
+	// DispatchID identifies the dispatch and its workspace in the
+	// registry, for follow-up queries and cleanup.
+	DispatchID string `json:"dispatch_id"`
+	// SessionID is the ephemeral session the dispatched agent ran on.
+	SessionID string `json:"session_id,omitempty"`
+	// WorkspacePath is the isolated workspace the agent worked in.
+	WorkspacePath string `json:"workspace_path"`
+	// Status is the terminal dispatch state: "completed" or "failed".
+	Status string `json:"status"`
+	// Findings is the dispatched agent's final text output — its summary
+	// of what it did.
+	Findings string `json:"findings,omitempty"`
+	// Diff is the unified diff of the workspace's work product (committed
+	// plus uncommitted) against the fork point. Empty when the agent
+	// changed nothing or the run failed before producing work.
+	Diff string `json:"diff,omitempty"`
+	// Error carries the failure reason when Status is "failed".
+	Error string `json:"error,omitempty"`
+}
+
+// dispatchAgentTool builds the dispatch_agent tool. It is a parallel
+// tool: the model can fire several dispatches in one turn and they run
+// concurrently, each in its own workspace, each blocking until its
+// dispatched agent finishes and returns a DispatchResult.
+func (c *coordinator) dispatchAgentTool() fantasy.AgentTool {
+	return fantasy.NewParallelAgentTool(
+		DispatchAgentToolName,
+		dispatchAgentDescription,
+		func(ctx context.Context, params DispatchAgentParams, call fantasy.ToolCall) (fantasy.ToolResponse, error) {
+			if params.Prompt == "" {
+				return fantasy.NewTextErrorResponse("prompt is required"), nil
+			}
+
+			result, err := c.runDispatch(ctx, params)
+			if err != nil {
+				return fantasy.NewTextErrorResponse(fmt.Sprintf("dispatch failed: %s", err)), nil
+			}
+
+			payload, err := json.Marshal(result)
+			if err != nil {
+				return fantasy.ToolResponse{}, fmt.Errorf("marshal dispatch result: %w", err)
+			}
+			return fantasy.WithResponseMetadata(fantasy.NewTextResponse(string(payload)), result), nil
+		},
+	)
+}
+
+// runDispatch provisions an isolated workspace, builds a dispatched agent
+// rooted at it, runs the task to completion on an ephemeral session, and
+// assembles the terminal DispatchResult (status, findings, diff). The
+// error return is reserved for failures that prevent a dispatch from
+// starting at all (no registry, workspace provisioning); once a run
+// begins, its outcome is reported inside the DispatchResult.
+func (c *coordinator) runDispatch(ctx context.Context, params DispatchAgentParams) (DispatchResult, error) {
+	if c.dispatchRegistry == nil {
+		return DispatchResult{}, errDispatchUnavailable
+	}
+
+	ws, err := c.dispatchRegistry.Create(ctx, params.Branch)
+	if err != nil {
+		return DispatchResult{}, fmt.Errorf("provision workspace: %w", err)
+	}
+
+	agent, model, err := c.buildDispatchAgent(ctx, ws.Path, params.Model)
+	if err != nil {
+		c.dispatchRegistry.SetStatus(ws.ID, dispatch.StatusFailed)
+		return c.failedResult(ws, "", fmt.Sprintf("build dispatched agent: %s", err)), nil
+	}
+
+	sess, err := agent.Sessions.Create(ctx, "Dispatch")
+	if err != nil {
+		c.dispatchRegistry.SetStatus(ws.ID, dispatch.StatusFailed)
+		return c.failedResult(ws, "", fmt.Sprintf("create dispatch session: %s", err)), nil
+	}
+	c.dispatchRegistry.SetSessionID(ws.ID, sess.ID)
+	c.dispatchRegistry.SetStatus(ws.ID, dispatch.StatusRunning)
+
+	maxTokens := model.CatwalkCfg.DefaultMaxTokens
+	if model.ModelCfg.MaxTokens != 0 {
+		maxTokens = model.ModelCfg.MaxTokens
+	}
+	providerCfg, ok := c.cfg.Config().Providers.Get(model.ModelCfg.Provider)
+	if !ok {
+		c.dispatchRegistry.SetStatus(ws.ID, dispatch.StatusFailed)
+		return c.failedResult(ws, sess.ID, errModelProviderNotConfigured.Error()), nil
+	}
+	mergedOptions, temp, topP, topK, freqPenalty, presPenalty := mergeCallOptions(model, providerCfg)
+
+	var result *fantasy.AgentResult
+	err = c.runWithUnauthorizedRetry(ctx, providerCfg, func() error {
+		var runErr error
+		result, runErr = agent.Run(ctx, SessionAgentCall{
+			SessionID:        sess.ID,
+			Prompt:           params.Prompt,
+			MaxOutputTokens:  maxTokens,
+			ProviderOptions:  mergedOptions,
+			Temperature:      temp,
+			TopP:             topP,
+			TopK:             topK,
+			FrequencyPenalty: freqPenalty,
+			PresencePenalty:  presPenalty,
+			NonInteractive:   true,
+		})
+		return runErr
+	})
+
+	return c.assembleResult(ctx, ws, sess.ID, result, err), nil
+}
+
+// assembleResult maps a dispatched run's outcome onto a DispatchResult
+// and records the terminal status in the registry. A run error, or a nil
+// result (Run returning (nil, nil) means no turn ran — busy session or a
+// cancel during dispatch, never success), is a failure. A successful run
+// captures the workspace diff as the work-product artifact.
+func (c *coordinator) assembleResult(ctx context.Context, ws dispatch.Workspace, sessionID string, result *fantasy.AgentResult, runErr error) DispatchResult {
+	switch {
+	case runErr != nil:
+		c.dispatchRegistry.SetStatus(ws.ID, dispatch.StatusFailed)
+		return c.failedResult(ws, sessionID, runErr.Error())
+	case result == nil:
+		c.dispatchRegistry.SetStatus(ws.ID, dispatch.StatusFailed)
+		return c.failedResult(ws, sessionID, "dispatched agent did not start a turn (session busy or canceled)")
+	}
+
+	c.dispatchRegistry.SetStatus(ws.ID, dispatch.StatusComplete)
+	res := DispatchResult{
+		DispatchID:    ws.ID,
+		SessionID:     sessionID,
+		WorkspacePath: ws.Path,
+		Status:        dispatchStatusCompleted,
+		Findings:      result.Response.Content.Text(),
+	}
+
+	// The diff is the work product. A capture failure (e.g. an unborn
+	// repo) is not a run failure — the agent's findings still stand — so
+	// it is logged inside Diff-collection and simply omitted here.
+	if diff, err := c.dispatchRegistry.Diff(ctx, ws.ID); err == nil {
+		res.Diff = diff
+	}
+	return res
+}
+
+// failedResult builds a failed DispatchResult carrying reason.
+func (c *coordinator) failedResult(ws dispatch.Workspace, sessionID, reason string) DispatchResult {
+	return DispatchResult{
+		DispatchID:    ws.ID,
+		SessionID:     sessionID,
+		WorkspacePath: ws.Path,
+		Status:        dispatchStatusFailed,
+		Error:         reason,
+	}
+}
+
+// buildDispatchAgent constructs the ephemeral, write-capable agent for a
+// dispatch: the coder's toolchain rooted at workspacePath (#62), minus
+// the tools that would let a dispatch fan out further or push to the
+// Sidekick dashboard (agent, dispatch_agent, sidekick_update), on a
+// private in-memory store so nothing persists. modelName selects "large"
+// or "small" (default small).
+func (c *coordinator) buildDispatchAgent(ctx context.Context, workspacePath, modelName string) (*EphemeralAgent, Model, error) {
+	coderCfg, ok := c.cfg.Config().Agents[config.AgentCoder]
+	if !ok {
+		return nil, Model{}, errCoderAgentNotConfigured
+	}
+
+	// A dispatched agent must not recurse into more sub-agents/dispatches
+	// or push dashboard surfaces; it is otherwise the full coder toolset.
+	dispatchCfg := coderCfg
+	dispatchCfg.AllowedTools = slices.DeleteFunc(slices.Clone(coderCfg.AllowedTools), func(name string) bool {
+		return name == AgentToolName || name == DispatchAgentToolName || name == tools.SidekickUpdateToolName
+	})
+
+	large, small, err := c.buildAgentModels(ctx, true)
+	if err != nil {
+		return nil, Model{}, err
+	}
+	model := small
+	if modelName == string(config.SelectedModelTypeLarge) {
+		model = large
+	}
+
+	agentTools, err := c.buildTools(ctx, dispatchCfg, true, workspacePath)
+	if err != nil {
+		return nil, Model{}, err
+	}
+
+	p, err := coderPrompt(prompt.WithWorkingDir(workspacePath))
+	if err != nil {
+		return nil, Model{}, err
+	}
+	systemPrompt, err := p.Build(ctx, model.Model.Provider(), model.Model.Model(), c.cfg)
+	if err != nil {
+		return nil, Model{}, err
+	}
+
+	providerCfg, _ := c.cfg.Config().Providers.Get(model.ModelCfg.Provider)
+	agent := NewEphemeralAgent(SessionAgentOptions{
+		LargeModel:         model,
+		SmallModel:         model,
+		SystemPromptPrefix: providerCfg.SystemPromptPrefix,
+		SystemPrompt:       systemPrompt,
+		IsSubAgent:         true,
+		IsYolo:             c.permissions.SkipRequests(),
+		Cfg:                c.cfg,
+		Tools:              agentTools,
+	})
+	return agent, model, nil
+}
+
+// CleanupDispatches tears down every workspace this coordinator
+// provisioned. It is safe to call when no registry was configured.
+func (c *coordinator) CleanupDispatches(ctx context.Context) error {
+	if c.dispatchRegistry == nil {
+		return nil
+	}
+	return c.dispatchRegistry.Close(ctx)
+}

--- a/internal/agent/dispatch_tool_test.go
+++ b/internal/agent/dispatch_tool_test.go
@@ -1,0 +1,186 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"charm.land/fantasy"
+	"github.com/stretchr/testify/require"
+
+	"github.com/charmbracelet/crush/internal/dispatch"
+)
+
+// dispatchInitRepo creates a one-commit git repo in a temp dir for
+// workspace provisioning tests.
+func dispatchInitRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	git := func(args ...string) {
+		cmd := exec.CommandContext(t.Context(), "git", append([]string{"-C", dir}, args...)...)
+		out, err := cmd.CombinedOutput()
+		require.NoErrorf(t, err, "git %s: %s", strings.Join(args, " "), out)
+	}
+	git("init", "-b", "main")
+	git("config", "user.email", "test@crush.test")
+	git("config", "user.name", "Crush Test")
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "README.md"), []byte("base\n"), 0o644))
+	git("add", "-A")
+	git("commit", "-m", "initial")
+	return dir
+}
+
+// gitDispatchCoordinator returns a bare coordinator wired only with a
+// git-backed dispatch registry — enough to exercise result assembly and
+// tool validation without the full provider-dependent construction.
+func gitDispatchCoordinator(t *testing.T) *coordinator {
+	t.Helper()
+	repo := dispatchInitRepo(t)
+	reg := dispatch.NewRegistry(filepath.Join(t.TempDir(), "dispatch"), dispatch.NewGitBackend(repo))
+	return &coordinator{dispatchRegistry: reg}
+}
+
+func runDispatchTool(t *testing.T, c *coordinator, input string) fantasy.ToolResponse {
+	t.Helper()
+	resp, err := c.dispatchAgentTool().Run(t.Context(), fantasy.ToolCall{
+		ID:    "dispatch-1",
+		Name:  DispatchAgentToolName,
+		Input: input,
+	})
+	require.NoError(t, err)
+	return resp
+}
+
+func TestDispatchAgentTool_RequiresPrompt(t *testing.T) {
+	t.Parallel()
+	c := &coordinator{}
+	resp := runDispatchTool(t, c, `{"prompt":""}`)
+	require.True(t, resp.IsError)
+	require.Contains(t, resp.Content, "prompt is required")
+}
+
+func TestDispatchAgentTool_UnavailableWithoutRegistry(t *testing.T) {
+	t.Parallel()
+	c := &coordinator{} // nil dispatchRegistry
+	resp := runDispatchTool(t, c, `{"prompt":"do something"}`)
+	require.True(t, resp.IsError)
+	require.Contains(t, resp.Content, "unavailable")
+}
+
+func TestAssembleResult_RunErrorIsFailure(t *testing.T) {
+	t.Parallel()
+	c := gitDispatchCoordinator(t)
+	ws, err := c.dispatchRegistry.Create(context.Background(), "")
+	require.NoError(t, err)
+
+	res := c.assembleResult(context.Background(), ws, "sess-1", nil, errors.New("model exploded"))
+	require.Equal(t, "failed", res.Status)
+	require.Equal(t, "model exploded", res.Error)
+	require.Equal(t, ws.ID, res.DispatchID)
+	require.Equal(t, "sess-1", res.SessionID)
+	require.Empty(t, res.Diff)
+
+	tracked, ok := c.dispatchRegistry.Get(ws.ID)
+	require.True(t, ok)
+	require.Equal(t, dispatch.StatusFailed, tracked.Status)
+}
+
+func TestAssembleResult_NilResultIsFailure(t *testing.T) {
+	t.Parallel()
+	c := gitDispatchCoordinator(t)
+	ws, err := c.dispatchRegistry.Create(context.Background(), "")
+	require.NoError(t, err)
+
+	// Run returning (nil, nil) means no turn ran — a failure, never a
+	// silent success.
+	res := c.assembleResult(context.Background(), ws, "sess-1", nil, nil)
+	require.Equal(t, "failed", res.Status)
+	require.Contains(t, res.Error, "did not start a turn")
+
+	tracked, _ := c.dispatchRegistry.Get(ws.ID)
+	require.Equal(t, dispatch.StatusFailed, tracked.Status)
+}
+
+func TestAssembleResult_SuccessCapturesFindingsAndDiff(t *testing.T) {
+	t.Parallel()
+	c := gitDispatchCoordinator(t)
+	ws, err := c.dispatchRegistry.Create(context.Background(), "")
+	require.NoError(t, err)
+
+	// The dispatched agent's work product: a new file in the workspace.
+	require.NoError(t, os.WriteFile(filepath.Join(ws.Path, "feature.go"), []byte("package feature\n"), 0o644))
+
+	result := &fantasy.AgentResult{
+		Response: fantasy.Response{
+			Content: fantasy.ResponseContent{fantasy.TextContent{Text: "added the feature"}},
+		},
+	}
+	res := c.assembleResult(context.Background(), ws, "sess-1", result, nil)
+
+	require.Equal(t, "completed", res.Status)
+	require.Equal(t, "added the feature", res.Findings)
+	require.Contains(t, res.Diff, "feature.go")
+	require.Empty(t, res.Error)
+
+	tracked, _ := c.dispatchRegistry.Get(ws.ID)
+	require.Equal(t, dispatch.StatusComplete, tracked.Status)
+}
+
+func TestFailedResult_PopulatesReason(t *testing.T) {
+	t.Parallel()
+	ws := dispatch.Workspace{ID: "abc", Path: "/tmp/ws"}
+	c := &coordinator{}
+	res := c.failedResult(ws, "sess-9", "boom")
+	require.Equal(t, "failed", res.Status)
+	require.Equal(t, "boom", res.Error)
+	require.Equal(t, "abc", res.DispatchID)
+	require.Equal(t, "sess-9", res.SessionID)
+	require.Equal(t, "/tmp/ws", res.WorkspacePath)
+}
+
+// TestBuildDispatchAgent_Constructs is a construction smoke test for the
+// dispatched agent: small and large model selection both yield a live
+// ephemeral agent rooted at the given workspace. Like the other
+// coordinator tests it needs a provider catalog, so it runs in CI rather
+// than the offline sandbox.
+func TestBuildDispatchAgent_Constructs(t *testing.T) {
+	t.Parallel()
+	env := testEnv(t)
+	coord := newSidekickTestCoordinator(t, env, "http://127.0.0.1:0/v1")
+	ws := t.TempDir()
+
+	small, smallModel, err := coord.buildDispatchAgent(t.Context(), ws, "small")
+	require.NoError(t, err)
+	require.NotNil(t, small)
+	require.NotNil(t, small.SessionAgent)
+	require.NotEmpty(t, smallModel.ModelCfg.Model)
+
+	large, largeModel, err := coord.buildDispatchAgent(t.Context(), ws, "large")
+	require.NoError(t, err)
+	require.NotNil(t, large)
+	require.NotEmpty(t, largeModel.ModelCfg.Model)
+}
+
+func TestDispatchResult_JSONShape(t *testing.T) {
+	t.Parallel()
+	res := DispatchResult{
+		DispatchID:    "abc",
+		SessionID:     "sess",
+		WorkspacePath: "/tmp/ws",
+		Status:        "completed",
+		Findings:      "done",
+		Diff:          "diff --git ...",
+	}
+	b, err := json.Marshal(res)
+	require.NoError(t, err)
+	var round map[string]any
+	require.NoError(t, json.Unmarshal(b, &round))
+	require.Equal(t, "abc", round["dispatch_id"])
+	require.Equal(t, "completed", round["status"])
+	require.NotContains(t, string(b), "\"error\"", "empty error should be omitted")
+}

--- a/internal/agent/templates/dispatch_agent.md
+++ b/internal/agent/templates/dispatch_agent.md
@@ -1,0 +1,21 @@
+Dispatch an independent agent to work on a task in its own isolated
+workspace, in parallel with your other work.
+
+The dispatched agent runs in a fresh git worktree branched from the
+current tree, with its own coding toolchain rooted at that workspace, so
+its file changes never collide with yours or with sibling dispatches. It
+runs to completion and returns a DispatchResult: the dispatch id, the
+workspace path, a status (completed / failed), the agent's key findings,
+and a unified diff of everything it changed (committed and uncommitted).
+
+Use this to fan out independent, self-contained subtasks — each dispatch
+gets a clean workspace, so you can launch several at once and they run
+concurrently. Review the returned diff and decide whether to fold the
+work in; nothing is merged automatically.
+
+Parameters:
+- prompt (required): the task for the dispatched agent, self-contained
+  enough to act on without your conversation.
+- model (optional): "large" or "small"; defaults to the small model.
+- branch (optional): base ref to fork the workspace from; defaults to
+  the current tree.

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -703,6 +703,16 @@ func (app *App) Shutdown() {
 		shell.GetBackgroundShellManager().KillAll(shutdownCtx)
 	})
 
+	// Sweep any isolated dispatch workspaces (git worktrees) so an
+	// abandoned dispatch never leaves an orphaned worktree or branch.
+	if app.AgentCoordinator != nil {
+		wg.Go(func() {
+			if err := app.AgentCoordinator.CleanupDispatches(shutdownCtx); err != nil {
+				slog.Error("Failed to clean up dispatch workspaces on shutdown", "error", err)
+			}
+		})
+	}
+
 	// Close herdr client to stop its background writer.
 	app.herdrClient.Close()
 

--- a/internal/backend/agent_runcomplete_test.go
+++ b/internal/backend/agent_runcomplete_test.go
@@ -42,6 +42,7 @@ func (c *errorCoordinator) RunAccepted(ctx context.Context, accept *agent.Accept
 func (c *errorCoordinator) BeginAccepted(sessionID string) *agent.AcceptedRun { return nil }
 func (c *errorCoordinator) Cancel(string)                                     {}
 func (c *errorCoordinator) CancelAll()                                        {}
+func (c *errorCoordinator) CleanupDispatches(context.Context) error           { return nil }
 func (c *errorCoordinator) IsBusy() bool                                      { return false }
 func (c *errorCoordinator) IsSessionBusy(string) bool                         { return false }
 func (c *errorCoordinator) QueuedPrompts(string) int                          { return 0 }

--- a/internal/backend/agent_test.go
+++ b/internal/backend/agent_test.go
@@ -52,6 +52,7 @@ func (c *blockingCoordinator) RunAccepted(ctx context.Context, accept *agent.Acc
 func (c *blockingCoordinator) BeginAccepted(sessionID string) *agent.AcceptedRun { return nil }
 func (c *blockingCoordinator) Cancel(string)                                     {}
 func (c *blockingCoordinator) CancelAll()                                        {}
+func (c *blockingCoordinator) CleanupDispatches(context.Context) error           { return nil }
 func (c *blockingCoordinator) IsBusy() bool                                      { return false }
 func (c *blockingCoordinator) IsSessionBusy(string) bool                         { return false }
 func (c *blockingCoordinator) QueuedPrompts(string) int                          { return 0 }

--- a/internal/backend/channels_test.go
+++ b/internal/backend/channels_test.go
@@ -151,6 +151,7 @@ func (c *recordingCoordinator) RunAccepted(ctx context.Context, _ *agent.Accepte
 func (c *recordingCoordinator) BeginAccepted(string) *agent.AcceptedRun       { return nil }
 func (c *recordingCoordinator) Cancel(string)                                 {}
 func (c *recordingCoordinator) CancelAll()                                    {}
+func (c *recordingCoordinator) CleanupDispatches(context.Context) error       { return nil }
 func (c *recordingCoordinator) IsBusy() bool                                  { return false }
 func (c *recordingCoordinator) IsSessionBusy(string) bool                     { return false }
 func (c *recordingCoordinator) QueuedPrompts(string) int                      { return 0 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -787,6 +787,7 @@ const maxRecentModelsPerType = 5
 func allToolNames() []string {
 	return []string{
 		"agent",
+		"dispatch_agent",
 		"bash",
 		"crush_info",
 		"crush_logs",

--- a/internal/config/load_test.go
+++ b/internal/config/load_test.go
@@ -710,7 +710,7 @@ func TestConfig_setupAgentsWithDisabledTools(t *testing.T) {
 	coderAgent, ok := cfg.Agents[AgentCoder]
 	require.True(t, ok)
 
-	assert.Equal(t, []string{"agent", "bash", "crush_info", "crush_logs", "job_output", "job_kill", "multiedit", "lsp_diagnostics", "lsp_references", "lsp_restart", "fetch", "agentic_fetch", "glob", "ls", "sidekick_update", "sourcegraph", "todos", "view", "write", "list_mcp_resources", "read_mcp_resource", "list_mcp_prompts", "call_mcp_prompt"}, coderAgent.AllowedTools)
+	assert.Equal(t, []string{"agent", "dispatch_agent", "bash", "crush_info", "crush_logs", "job_output", "job_kill", "multiedit", "lsp_diagnostics", "lsp_references", "lsp_restart", "fetch", "agentic_fetch", "glob", "ls", "sidekick_update", "sourcegraph", "todos", "view", "write", "list_mcp_resources", "read_mcp_resource", "list_mcp_prompts", "call_mcp_prompt"}, coderAgent.AllowedTools)
 
 	taskAgent, ok := cfg.Agents[AgentTask]
 	require.True(t, ok)
@@ -733,7 +733,7 @@ func TestConfig_setupAgentsWithEveryReadOnlyToolDisabled(t *testing.T) {
 	cfg.SetupAgents()
 	coderAgent, ok := cfg.Agents[AgentCoder]
 	require.True(t, ok)
-	assert.Equal(t, []string{"agent", "bash", "crush_info", "crush_logs", "job_output", "job_kill", "download", "edit", "multiedit", "lsp_diagnostics", "lsp_references", "lsp_restart", "fetch", "agentic_fetch", "sidekick_update", "todos", "write", "list_mcp_resources", "read_mcp_resource", "list_mcp_prompts", "call_mcp_prompt"}, coderAgent.AllowedTools)
+	assert.Equal(t, []string{"agent", "dispatch_agent", "bash", "crush_info", "crush_logs", "job_output", "job_kill", "download", "edit", "multiedit", "lsp_diagnostics", "lsp_references", "lsp_restart", "fetch", "agentic_fetch", "sidekick_update", "todos", "write", "list_mcp_resources", "read_mcp_resource", "list_mcp_prompts", "call_mcp_prompt"}, coderAgent.AllowedTools)
 
 	taskAgent, ok := cfg.Agents[AgentTask]
 	require.True(t, ok)

--- a/internal/server/agent_cancel_test.go
+++ b/internal/server/agent_cancel_test.go
@@ -70,9 +70,10 @@ func (s *runCoordinator) RunAccepted(ctx context.Context, accept *agent.Accepted
 func (s *runCoordinator) BeginAccepted(sessionID string) *agent.AcceptedRun {
 	return nil
 }
-func (s *runCoordinator) Cancel(string) {}
-func (s *runCoordinator) CancelAll()    {}
-func (s *runCoordinator) IsBusy() bool  { return false }
+func (s *runCoordinator) Cancel(string)                           {}
+func (s *runCoordinator) CancelAll()                              {}
+func (s *runCoordinator) CleanupDispatches(context.Context) error { return nil }
+func (s *runCoordinator) IsBusy() bool                            { return false }
 func (s *runCoordinator) IsSessionBusy(string) bool {
 	return false
 }

--- a/internal/server/e2e_agent_test.go
+++ b/internal/server/e2e_agent_test.go
@@ -214,6 +214,7 @@ func (c *scriptedCoordinator) CancelAll() {
 	}
 }
 
+func (c *scriptedCoordinator) CleanupDispatches(context.Context) error       { return nil }
 func (c *scriptedCoordinator) IsBusy() bool                                  { return false }
 func (c *scriptedCoordinator) IsSessionBusy(string) bool                     { return false }
 func (c *scriptedCoordinator) QueuedPrompts(string) int                      { return 0 }

--- a/internal/server/sessions_isbusy_test.go
+++ b/internal/server/sessions_isbusy_test.go
@@ -41,9 +41,10 @@ func (s *stubCoordinator) RunAccepted(ctx context.Context, accept *agent.Accepte
 func (s *stubCoordinator) BeginAccepted(sessionID string) *agent.AcceptedRun {
 	return nil
 }
-func (s *stubCoordinator) Cancel(string) {}
-func (s *stubCoordinator) CancelAll()    {}
-func (s *stubCoordinator) IsBusy() bool  { return false }
+func (s *stubCoordinator) Cancel(string)                           {}
+func (s *stubCoordinator) CancelAll()                              {}
+func (s *stubCoordinator) CleanupDispatches(context.Context) error { return nil }
+func (s *stubCoordinator) IsBusy() bool                            { return false }
 func (s *stubCoordinator) IsSessionBusy(id string) bool {
 	return s.busy[id]
 }


### PR DESCRIPTION
Step 2 of Worktree Dispatch Phase 1 (epic #61), on the integration branch. Builds on #176 (#62/#63, merged).

## What this delivers

**#64 — `dispatch_agent` tool** on the coder agent:
- Provisions an isolated workspace via `dispatch.Registry` (#63), builds a **write-capable ephemeral agent** whose toolchain is rooted at the workspace (#62) — the coder toolset **minus** the tools that would let a dispatch recurse or push to the dashboard (`agent`, `dispatch_agent`, `sidekick_update`) — runs the task to completion on a private in-memory session, returns a `DispatchResult`.
- **Parallel tool**: the model can fire several dispatches in one turn; they run concurrently, each in its own workspace (same pattern as the existing `agent` tool). True async task handles are the A2A model (#71); the in-process path blocks per call and returns the terminal result.
- Params: `prompt` (required), `model` (`large`/`small`, default small), `branch` (fork point).

**#66 — `DispatchResult`**, pinned to the A2A task mapping so #71's swap is invisible to the model:
- `status` ⇔ task state (`completed`/`failed`), `findings` ⇔ terminal status-message text, `diff` ⇔ artifact, plus `session_id` and `workspace_path`.
- Diff = the workspace's full work product (`base → working tree`: committed + uncommitted) via `dispatch.Registry.Diff`.
- A run error, or `Run` returning `(nil, nil)` (no turn ran — busy/canceled), maps to **failed**, never a silent success (per #173's review note).

**Wiring**: the coordinator owns one `dispatch.Registry` (git-worktree backend rooted at the workspace); `app.Shutdown` sweeps it via `CleanupDispatches` (new `Coordinator` method) so an abandoned dispatch never orphans a worktree/branch. `dispatch_agent` is added to the coder's default tool set (`allToolNames`).

## Scoping note for review
The epic lists a `skills` arg on `DispatchAgent`. Crush skills inject via the **coordinator-level** active set (there's no `prompt.WithSkills` seam), so per-dispatch skill selection is its own change. Rather than ship a silently-ignored `skills` param, I **deferred** it to a focused follow-up. `model` + `branch` + `prompt` are implemented. Flagging in case you'd rather I add the skills-scoping seam here.

Permission scoping is also still the main service (rooted at the main tree); since the workspace lives under it, writes resolve inside the worktree, and YOLO mode skips prompts. Per-dispatch permission/LSP scoping stays a later refinement (noted in #62).

## Tests
- Verified offline (`internal/dispatch` + in-package `&coordinator{}` with a git-backed registry): tool arg validation (empty prompt), dispatch-unavailable (nil registry), and `DispatchResult` assembly for **run-error**, **nil-result-is-failure**, and **success (findings + diff captured)**, registry status transitions, JSON shape.
- `TestBuildDispatchAgent_Constructs` (agent construction, small/large) is CI-only — needs the provider catalog, like the existing sidekick coordinator tests (offline sandbox can't reach it).

## Base
Targets `integ/worktree-dispatch`. Rebases onto `main` once the prereq stack lands.

Closes #64
Closes #66