### PR TITLE
feat(agent): stream dispatched-agent todo progress to Sidekick (#65)

### DIFF
--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -199,6 +199,10 @@ type coordinator struct {
 	// has no workspace root (e.g. some test harnesses), in which case the
 	// tool reports dispatch unavailable rather than panicking.
 	dispatchRegistry *dispatch.Registry
+	// dispatchProgress streams dispatched agents' todo progress to the
+	// Sidekick dashboard (#65). Each dispatch registers its ephemeral
+	// session with it for the duration of the run.
+	dispatchProgress *dispatchProgress
 
 	readyWg errgroup.Group
 }
@@ -249,6 +253,9 @@ func NewCoordinator(
 			dispatch.NewGitBackend(cfg.WorkingDir()),
 		),
 	}
+	// Dispatched agents stream their todo progress to the Sidekick
+	// dashboard via the same broker the sidekick_update tool feeds (#65).
+	c.dispatchProgress = newDispatchProgress(dashboardSink{dashboard: c.sidekickDashboard})
 
 	agentCfg, ok := cfg.Config().Agents[config.AgentCoder]
 	if !ok {
@@ -725,7 +732,7 @@ func (c *coordinator) buildAgent(ctx context.Context, prompt *prompt.Prompt, age
 		if err := mcp.WaitForInit(ctx); err != nil {
 			return err
 		}
-		tools, err := c.buildTools(ctx, agent, isSubAgent, workingDir)
+		tools, err := c.buildTools(ctx, agent, isSubAgent, workingDir, nil)
 		if err != nil {
 			return err
 		}
@@ -1059,9 +1066,17 @@ func (c *coordinator) sidekickSession(ctx context.Context) (string, error) {
 // existing callers are unchanged. A dispatched agent passes its isolated
 // workspace path here, which is the whole isolation boundary — the tools
 // resolve their paths against the workspace rather than the main tree.
-func (c *coordinator) buildTools(ctx context.Context, agent config.Agent, isSubAgent bool, workingDir string) ([]fantasy.AgentTool, error) {
+func (c *coordinator) buildTools(ctx context.Context, agent config.Agent, isSubAgent bool, workingDir string, sessions session.Service) ([]fantasy.AgentTool, error) {
 	if workingDir == "" {
 		workingDir = c.cfg.WorkingDir()
+	}
+	// sessions roots the todos tool's store. A dispatched agent passes its
+	// own ephemeral store so its todos persist there (and stream from
+	// there, #65) instead of vanishing against the main store, which has
+	// no record of the dispatch's session. Empty falls back to the main
+	// store, unchanged for every existing caller.
+	if sessions == nil {
+		sessions = c.sessions
 	}
 	var allTools []fantasy.AgentTool
 	if slices.Contains(agent.AllowedTools, AgentToolName) {
@@ -1133,7 +1148,7 @@ func (c *coordinator) buildTools(ctx context.Context, agent config.Agent, isSubA
 		tools.NewGrepTool(workingDir, c.cfg.Config().Tools.Grep),
 		tools.NewLsTool(c.permissions, workingDir, c.cfg.Config().Tools.Ls),
 		tools.NewSourcegraphTool(nil),
-		tools.NewTodosTool(c.sessions),
+		tools.NewTodosTool(sessions),
 		tools.NewViewTool(c.lspManager, c.permissions, c.filetracker, c.skillTracker, workingDir, c.cfg.Config().Options.SkillsPaths...),
 		tools.NewWriteTool(c.lspManager, c.permissions, c.history, c.filetracker, workingDir),
 	)
@@ -1613,7 +1628,7 @@ func (c *coordinator) UpdateModels(ctx context.Context) error {
 		return errCoderAgentNotConfigured
 	}
 
-	tools, err := c.buildTools(ctx, agentCfg, false, "")
+	tools, err := c.buildTools(ctx, agentCfg, false, "", nil)
 	if err != nil {
 		return err
 	}

--- a/internal/agent/dispatch_progress.go
+++ b/internal/agent/dispatch_progress.go
@@ -1,0 +1,225 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+
+	a2ui "github.com/tmc/a2ui"
+
+	"github.com/charmbracelet/crush/internal/agent/tools"
+	"github.com/charmbracelet/crush/internal/pubsub"
+	"github.com/charmbracelet/crush/internal/session"
+)
+
+// dispatchSnapshot is the reduced progress of one active dispatch: the
+// todos its agent has recorded so far, plus the coordinates that let a
+// sink render or route it.
+type dispatchSnapshot struct {
+	DispatchID string
+	Workspace  string
+	Status     string
+	Todos      []session.Todo
+}
+
+// progressSink receives the full, ordered set of active dispatch
+// snapshots on every change. Sinks must return promptly (they run on the
+// collector's emit path) and must not mutate the slice. The dashboard
+// sink composes an A2UI surface (#65); #174 attaches a second sink that
+// re-emits the same snapshots as A2A TaskStatusUpdateEvents — the
+// subscription and reduction below are written once and sunk twice.
+type progressSink interface {
+	emit(snapshots []dispatchSnapshot)
+}
+
+// dispatchProgress collects todo progress from dispatched sessions and
+// fans reduced snapshots to sinks. There is one collector per
+// coordinator; each dispatch registers with track and deregisters with
+// untrack. It is safe for concurrent use.
+type dispatchProgress struct {
+	sinks []progressSink
+
+	mu      sync.Mutex
+	active  map[string]*dispatchSnapshot
+	order   []string
+	cancels map[string]context.CancelFunc
+}
+
+func newDispatchProgress(sinks ...progressSink) *dispatchProgress {
+	return &dispatchProgress{
+		sinks:   sinks,
+		active:  make(map[string]*dispatchSnapshot),
+		cancels: make(map[string]context.CancelFunc),
+	}
+}
+
+// track begins collecting todos for a dispatch. It subscribes to the
+// dispatch's (ephemeral) session store and, on every update to that
+// session, refreshes the snapshot's todos and re-emits to all sinks. The
+// subscription runs until untrack is called or ctx is canceled. Passing
+// a nil collector is a no-op so dispatch works when progress is disabled.
+func (p *dispatchProgress) track(ctx context.Context, dispatchID, workspace, sessionID string, sessions session.Service) {
+	if p == nil || sessions == nil {
+		return
+	}
+
+	subCtx, cancel := context.WithCancel(ctx)
+	p.mu.Lock()
+	p.active[dispatchID] = &dispatchSnapshot{
+		DispatchID: dispatchID,
+		Workspace:  workspace,
+		Status:     dispatchStatusRunning,
+	}
+	p.order = append(p.order, dispatchID)
+	p.cancels[dispatchID] = cancel
+	p.mu.Unlock()
+
+	events := sessions.Subscribe(subCtx)
+	p.emit()
+
+	go func() {
+		for ev := range events {
+			if ev.Payload.ID != sessionID {
+				continue
+			}
+			p.mu.Lock()
+			if snap, ok := p.active[dispatchID]; ok {
+				snap.Todos = ev.Payload.Todos
+			}
+			p.mu.Unlock()
+			p.emit()
+		}
+	}()
+}
+
+// untrack stops collecting for a dispatch and drops it from the active
+// set, re-emitting so the surface reflects its completion (collapsing to
+// empty when it was the last one).
+func (p *dispatchProgress) untrack(dispatchID string) {
+	if p == nil {
+		return
+	}
+	p.mu.Lock()
+	if cancel, ok := p.cancels[dispatchID]; ok {
+		cancel()
+		delete(p.cancels, dispatchID)
+	}
+	delete(p.active, dispatchID)
+	for i, id := range p.order {
+		if id == dispatchID {
+			p.order = append(p.order[:i], p.order[i+1:]...)
+			break
+		}
+	}
+	p.mu.Unlock()
+	p.emit()
+}
+
+// emit snapshots the active set under the lock and fans it to every sink
+// outside the lock, so a slow sink never blocks a tracked session's event
+// loop.
+func (p *dispatchProgress) emit() {
+	p.mu.Lock()
+	snaps := make([]dispatchSnapshot, 0, len(p.order))
+	for _, id := range p.order {
+		if snap, ok := p.active[id]; ok {
+			snaps = append(snaps, *snap)
+		}
+	}
+	sinks := p.sinks
+	p.mu.Unlock()
+
+	for _, sink := range sinks {
+		sink.emit(snaps)
+	}
+}
+
+// dispatchStatusRunning is the snapshot status while a dispatch's agent
+// is working. (Terminal states drop out of the active set on untrack.)
+const dispatchStatusRunning = "running"
+
+const (
+	// dispatchSurfaceID is the A2UI surface the composite dashboard card
+	// is published under, stable across updates so the client composites
+	// in place.
+	dispatchSurfaceID = "dispatch-progress"
+	dispatchRootID    = "dispatch-progress-root"
+)
+
+// dashboardSink is the #65 sink: it composes the active dispatches into a
+// single A2UI surface and publishes it to the Sidekick dashboard broker,
+// the same pinned slot the sidekick_update tool feeds (#56/#57).
+type dashboardSink struct {
+	dashboard pubsub.Publisher[tools.SidekickSurface]
+}
+
+func (s dashboardSink) emit(snapshots []dispatchSnapshot) {
+	if s.dashboard == nil {
+		return
+	}
+	s.dashboard.Publish(pubsub.UpdatedEvent, composeDispatchSurface(snapshots))
+}
+
+// composeDispatchSurface renders the active dispatches into one A2UI
+// surface: a column of one text line per dispatch (workspace, status,
+// todo progress). With nothing active it emits a DeleteSurface so the
+// dashboard slot collapses.
+func composeDispatchSurface(snapshots []dispatchSnapshot) tools.SidekickSurface {
+	msg := a2ui.ServerMessage{Version: a2ui.Version}
+
+	if len(snapshots) == 0 {
+		msg.DeleteSurface = &a2ui.DeleteSurface{SurfaceID: dispatchSurfaceID}
+	} else {
+		childIDs := make([]string, 0, len(snapshots))
+		components := make([]a2ui.Component, 0, len(snapshots)+1)
+		for i, snap := range snapshots {
+			id := fmt.Sprintf("dispatch-%d", i)
+			childIDs = append(childIDs, id)
+			components = append(components, a2ui.Component{
+				ID:   id,
+				Text: &a2ui.TextComponent{Text: a2ui.StringLiteral(formatDispatchLine(snap))},
+			})
+		}
+		// The root column must precede its children in the component list.
+		components = append([]a2ui.Component{{
+			ID:     dispatchRootID,
+			Column: &a2ui.ColumnComponent{Children: a2ui.ChildList{IDs: childIDs}},
+		}}, components...)
+
+		msg.UpdateComponents = &a2ui.UpdateComponents{
+			SurfaceID:  dispatchSurfaceID,
+			Components: components,
+		}
+	}
+
+	payload, err := json.Marshal(msg)
+	if err != nil {
+		// The message is built from fixed shapes and plain strings, so a
+		// marshal error is not reachable in practice; degrade to an empty
+		// surface rather than panic on the collector's hot path.
+		return tools.SidekickSurface{}
+	}
+	return tools.SidekickSurface{Content: "<a2ui-json>" + string(payload) + "</a2ui-json>"}
+}
+
+// formatDispatchLine summarizes one dispatch: its workspace, status, todo
+// completion count, and the currently in-progress todo when there is one.
+func formatDispatchLine(snap dispatchSnapshot) string {
+	done := 0
+	active := ""
+	for _, todo := range snap.Todos {
+		if todo.Status == session.TodoStatusCompleted {
+			done++
+		}
+		if todo.Status == session.TodoStatusInProgress && active == "" {
+			active = todo.Content
+		}
+	}
+
+	line := fmt.Sprintf("%s · %s · %d/%d", snap.Workspace, snap.Status, done, len(snap.Todos))
+	if active != "" {
+		line += " · " + active
+	}
+	return line
+}

--- a/internal/agent/dispatch_progress_test.go
+++ b/internal/agent/dispatch_progress_test.go
@@ -1,0 +1,166 @@
+package agent
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/joestump-agent/a2tea"
+	"github.com/stretchr/testify/require"
+
+	"github.com/charmbracelet/crush/internal/session"
+)
+
+// captureSink records the latest snapshot set the collector emitted.
+type captureSink struct {
+	mu   sync.Mutex
+	last []dispatchSnapshot
+	got  int
+}
+
+func (s *captureSink) emit(snaps []dispatchSnapshot) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.last = snaps
+	s.got++
+}
+
+func (s *captureSink) latest() []dispatchSnapshot {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.last
+}
+
+func TestFormatDispatchLine(t *testing.T) {
+	t.Parallel()
+	line := formatDispatchLine(dispatchSnapshot{
+		Workspace: "/ws/a",
+		Status:    "running",
+		Todos: []session.Todo{
+			{Content: "step one", Status: session.TodoStatusCompleted},
+			{Content: "step two", Status: session.TodoStatusInProgress},
+			{Content: "step three", Status: session.TodoStatusPending},
+		},
+	})
+	require.Contains(t, line, "/ws/a")
+	require.Contains(t, line, "running")
+	require.Contains(t, line, "1/3")
+	require.Contains(t, line, "step two", "the in-progress todo should be surfaced")
+}
+
+func TestComposeDispatchSurface_Empty(t *testing.T) {
+	t.Parallel()
+	surface := composeDispatchSurface(nil)
+	require.Contains(t, surface.Content, "deleteSurface")
+	require.Contains(t, surface.Content, dispatchSurfaceID)
+	// The clear payload must still be valid A2UI the renderer can scan.
+	_, err := a2tea.Scan(surface.Content)
+	require.NoError(t, err)
+}
+
+func TestComposeDispatchSurface_WithDispatches(t *testing.T) {
+	t.Parallel()
+	surface := composeDispatchSurface([]dispatchSnapshot{
+		{DispatchID: "d1", Workspace: "/ws/one", Status: "running", Todos: []session.Todo{
+			{Content: "a", Status: session.TodoStatusCompleted},
+			{Content: "b", Status: session.TodoStatusInProgress},
+		}},
+		{DispatchID: "d2", Workspace: "/ws/two", Status: "running"},
+	})
+
+	require.Contains(t, surface.Content, "updateComponents")
+	require.Contains(t, surface.Content, dispatchSurfaceID)
+	require.Contains(t, surface.Content, "/ws/one")
+	require.Contains(t, surface.Content, "/ws/two")
+	require.Contains(t, surface.Content, "1/2")
+
+	// It must render as a valid A2UI surface.
+	parts, err := a2tea.Scan(surface.Content)
+	require.NoError(t, err)
+	require.NotEmpty(t, parts)
+}
+
+func TestDispatchProgress_TracksReducesAndUntracks(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	sessions := session.NewInMemoryService()
+	sink := &captureSink{}
+	p := newDispatchProgress(sink)
+
+	sess, err := sessions.Create(ctx, "dispatch")
+	require.NoError(t, err)
+
+	p.track(ctx, "d1", "/ws/one", sess.ID, sessions)
+
+	// Initial emit: one active dispatch, no todos yet.
+	require.Eventually(t, func() bool {
+		snaps := sink.latest()
+		return len(snaps) == 1 && snaps[0].DispatchID == "d1" && len(snaps[0].Todos) == 0
+	}, time.Second, 5*time.Millisecond)
+
+	// The dispatched agent records todos: a save publishes an update the
+	// collector reduces into the snapshot.
+	sess.Todos = []session.Todo{
+		{Content: "a", Status: session.TodoStatusCompleted},
+		{Content: "b", Status: session.TodoStatusInProgress},
+	}
+	_, err = sessions.Save(ctx, sess)
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		snaps := sink.latest()
+		return len(snaps) == 1 && len(snaps[0].Todos) == 2
+	}, time.Second, 5*time.Millisecond)
+
+	// Untrack drops it and re-emits an empty set.
+	p.untrack("d1")
+	require.Eventually(t, func() bool {
+		return len(sink.latest()) == 0
+	}, time.Second, 5*time.Millisecond)
+}
+
+func TestDispatchProgress_IgnoresOtherSessions(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	sessions := session.NewInMemoryService()
+	sink := &captureSink{}
+	p := newDispatchProgress(sink)
+
+	tracked, err := sessions.Create(ctx, "tracked")
+	require.NoError(t, err)
+	other, err := sessions.Create(ctx, "other")
+	require.NoError(t, err)
+
+	p.track(ctx, "d1", "/ws", tracked.ID, sessions)
+	defer p.untrack("d1")
+
+	// An update to a different session in the same store must not alter
+	// the tracked dispatch's todos.
+	other.Todos = []session.Todo{{Content: "x", Status: session.TodoStatusInProgress}}
+	_, err = sessions.Save(ctx, other)
+	require.NoError(t, err)
+
+	require.Never(t, func() bool {
+		snaps := sink.latest()
+		return len(snaps) == 1 && len(snaps[0].Todos) > 0
+	}, 100*time.Millisecond, 10*time.Millisecond)
+}
+
+// nonBlockingSink asserts the collector composes text the surface builder
+// accepts even for many concurrent dispatches (defensive smoke over the
+// reduce/compose path).
+func TestComposeSurface_ScansForManyDispatches(t *testing.T) {
+	t.Parallel()
+	var snaps []dispatchSnapshot
+	for i := 0; i < 5; i++ {
+		snaps = append(snaps, dispatchSnapshot{
+			DispatchID: "d" + strings.Repeat("x", i+1),
+			Workspace:  "/ws/" + strings.Repeat("y", i+1),
+			Status:     "running",
+		})
+	}
+	_, err := a2tea.Scan(composeDispatchSurface(snaps).Content)
+	require.NoError(t, err)
+}

--- a/internal/agent/dispatch_tool.go
+++ b/internal/agent/dispatch_tool.go
@@ -14,6 +14,8 @@ import (
 	"github.com/charmbracelet/crush/internal/agent/tools"
 	"github.com/charmbracelet/crush/internal/config"
 	"github.com/charmbracelet/crush/internal/dispatch"
+	"github.com/charmbracelet/crush/internal/message"
+	"github.com/charmbracelet/crush/internal/session"
 )
 
 //go:embed templates/dispatch_agent.md
@@ -122,6 +124,12 @@ func (c *coordinator) runDispatch(ctx context.Context, params DispatchAgentParam
 	c.dispatchRegistry.SetSessionID(ws.ID, sess.ID)
 	c.dispatchRegistry.SetStatus(ws.ID, dispatch.StatusRunning)
 
+	// Stream the dispatched agent's todo progress to the Sidekick
+	// dashboard for the duration of the run (#65); untrack collapses its
+	// card when the run finishes.
+	c.dispatchProgress.track(ctx, ws.ID, ws.Path, sess.ID, agent.Sessions)
+	defer c.dispatchProgress.untrack(ws.ID)
+
 	maxTokens := model.CatwalkCfg.DefaultMaxTokens
 	if model.ModelCfg.MaxTokens != 0 {
 		maxTokens = model.ModelCfg.MaxTokens
@@ -226,7 +234,14 @@ func (c *coordinator) buildDispatchAgent(ctx context.Context, workspacePath, mod
 		model = large
 	}
 
-	agentTools, err := c.buildTools(ctx, dispatchCfg, true, workspacePath)
+	// Private in-memory stores for this dispatch. The toolchain's todos
+	// tool writes into this session store, and the progress collector
+	// (#65) subscribes to the same store — so todo updates stream to the
+	// dashboard instead of vanishing against the main store.
+	sessions := session.NewInMemoryService()
+	messages := message.NewInMemoryService()
+
+	agentTools, err := c.buildTools(ctx, dispatchCfg, true, workspacePath, sessions)
 	if err != nil {
 		return nil, Model{}, err
 	}
@@ -250,6 +265,8 @@ func (c *coordinator) buildDispatchAgent(ctx context.Context, workspacePath, mod
 		IsYolo:             c.permissions.SkipRequests(),
 		Cfg:                c.cfg,
 		Tools:              agentTools,
+		Sessions:           sessions,
+		Messages:           messages,
 	})
 	return agent, model, nil
 }

--- a/internal/agent/ephemeral.go
+++ b/internal/agent/ephemeral.go
@@ -34,19 +34,23 @@ type EphemeralAgent struct {
 	Messages message.Service
 }
 
-// NewEphemeralAgent builds an [EphemeralAgent] from opts. The Sessions,
-// Messages, Ephemeral, DisableAutoSummarize, and Notify fields of opts
-// are overridden to enforce the ephemeral contract; everything else
-// (models, prompt, tools, config) is used as provided.
+// NewEphemeralAgent builds an [EphemeralAgent] from opts. Ephemeral is
+// forced on to enforce the fire-and-forget contract. Sessions and
+// Messages default to fresh private in-memory stores, but a caller may
+// supply its own in-memory stores (both must be in-memory to preserve
+// the no-persistence contract) — a dispatched agent does this so it can
+// subscribe to the same store its todos tool writes to (#65).
 func NewEphemeralAgent(opts SessionAgentOptions) *EphemeralAgent {
-	sessions := session.NewInMemoryService()
-	messages := message.NewInMemoryService()
-	opts.Sessions = sessions
-	opts.Messages = messages
+	if opts.Sessions == nil {
+		opts.Sessions = session.NewInMemoryService()
+	}
+	if opts.Messages == nil {
+		opts.Messages = message.NewInMemoryService()
+	}
 	opts.Ephemeral = true
 	return &EphemeralAgent{
 		SessionAgent: NewSessionAgent(opts),
-		Sessions:     sessions,
-		Messages:     messages,
+		Sessions:     opts.Sessions,
+		Messages:     opts.Messages,
 	}
 }

--- a/internal/agent/sidekick_update_test.go
+++ b/internal/agent/sidekick_update_test.go
@@ -35,12 +35,12 @@ func TestSidekickUpdateToolWiring(t *testing.T) {
 	}
 
 	// Main coder agent gets the tool.
-	built, err := coord.buildTools(t.Context(), agentCfg, false, "")
+	built, err := coord.buildTools(t.Context(), agentCfg, false, "", nil)
 	require.NoError(t, err)
 	require.Contains(t, toolNames(built), tools.SidekickUpdateToolName)
 
 	// Sub-agents never do, even with the tool allowed.
-	built, err = coord.buildTools(t.Context(), agentCfg, true, "")
+	built, err = coord.buildTools(t.Context(), agentCfg, true, "", nil)
 	require.NoError(t, err)
 	require.NotContains(t, toolNames(built), tools.SidekickUpdateToolName)
 
@@ -53,7 +53,7 @@ func TestSidekickUpdateToolWiring(t *testing.T) {
 
 	// Disabling A2UI removes the push channel: the payload is A2UI.
 	coord.cfg.Config().Options.DisableA2UI = true
-	built, err = coord.buildTools(t.Context(), agentCfg, false, "")
+	built, err = coord.buildTools(t.Context(), agentCfg, false, "", nil)
 	require.NoError(t, err)
 	require.NotContains(t, toolNames(built), tools.SidekickUpdateToolName)
 }
@@ -86,7 +86,7 @@ func TestSidekickDashboardSubscribeDeliversToolPushes(t *testing.T) {
 	require.NotNil(t, sub)
 
 	agentCfg := config.Agent{ID: config.AgentCoder, AllowedTools: []string{tools.SidekickUpdateToolName}}
-	built, err := coord.buildTools(t.Context(), agentCfg, false, "")
+	built, err := coord.buildTools(t.Context(), agentCfg, false, "", nil)
 	require.NoError(t, err)
 	require.Len(t, built, 1)
 

--- a/internal/agent/toolchain_workingdir_test.go
+++ b/internal/agent/toolchain_workingdir_test.go
@@ -60,14 +60,14 @@ func TestBuildToolsRootsToolchainAtWorkingDir(t *testing.T) {
 	}
 
 	// Scoped to the workspace: the glob tool finds the sentinel.
-	scoped, err := coord.buildTools(t.Context(), agentCfg, true, workspace)
+	scoped, err := coord.buildTools(t.Context(), agentCfg, true, workspace, nil)
 	require.NoError(t, err)
 	require.Contains(t, runGlob(t, findTool(t, scoped, tools.GlobToolName), "sentinel-*.txt"), sentinel)
 
 	// Unset working dir: the toolchain roots at the main tree, which has
 	// no sentinel — proving the default path is unchanged.
 	require.NotEqual(t, workspace, coord.cfg.WorkingDir())
-	def, err := coord.buildTools(t.Context(), agentCfg, true, "")
+	def, err := coord.buildTools(t.Context(), agentCfg, true, "", nil)
 	require.NoError(t, err)
 	require.NotContains(t, runGlob(t, findTool(t, def, tools.GlobToolName), "sentinel-*.txt"), sentinel)
 }


### PR DESCRIPTION
Step 3 of Worktree Dispatch Phase 1 (epic #61), on the integration branch. Builds on #176/#177 (merged).

Dispatched agents (#64) now surface their **todo progress** on the Sidekick dashboard, **streaming via session pubsub — no polling** (the respec dropped the poll model).

## What this delivers

**Session-store fix (prerequisite, flagged in the plan).** #64's dispatched agent is an ephemeral agent with a private in-memory session store, but `buildTools` hardcoded the *main* store for the `todos` tool — so a dispatch's todos wrote against a session the main store has no record of and silently vanished. Fixed by:
- `buildTools` takes a `session.Service` override (nil → main store, **unchanged for every existing caller**).
- A dispatch builds its toolchain against its own ephemeral store; `NewEphemeralAgent` now respects caller-supplied in-memory stores so the collector can subscribe to the same store the agent writes to.

**Reusable todo collector** (`dispatch_progress.go`): subscribes to each dispatched session's pubsub, reduces to per-dispatch snapshots, fans them to sinks. **Written once, sunk twice by design** — #174 attaches a second sink re-emitting the same snapshots as A2A `TaskStatusUpdateEvent`s.

**Dashboard sink**: composes a composite A2UI surface (one line per active dispatch — workspace, status, todo counts, current in-progress todo) via the `a2ui` types, publishes it to the Sidekick dashboard broker (#56/#57). An empty active set emits a `DeleteSurface`, so the slot **collapses when dispatches finish**.

`runDispatch` `track`s a dispatch on start and `untrack`s on completion (deferred).

## Tests (all offline-verified)
- `composeDispatchSurface`: populated → valid, `a2tea.Scan`-able surface containing each workspace + todo counts; empty → `DeleteSurface`; many-dispatch scan smoke.
- `formatDispatchLine`: completion counts + surfaces the in-progress todo.
- Collector against a real in-memory `session.Service`: `track` → save-with-todos reduces into the snapshot → `untrack` collapses to empty; and updates to a *different* session in the same store are ignored.

## Base
Targets `integ/worktree-dispatch`. Rebases onto `main` once the prereq stack lands.

Closes #65