### PR TITLE
Allow enabling MCP channels via crush.json config

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,14 +435,32 @@ build failed on main: https://ci.example.com/run/1234
 ```
 
 Listing a channel server in `mcp` is **not** enough to enable it — pushing is
-gated behind an explicit per-session opt-in, so a server present in config
-stays silent until you ask for it:
+gated behind an explicit opt-in, so a server present in config stays silent
+until you ask for it. Opt in per launch with the `--channels` flag:
 
 ```bash
 # Enable one or more configured MCP servers as channels for this session.
 crush --channels server:webhook
 crush --channels server:webhook --channels server:signal
 ```
+
+Or persistently, with `channel_enabled` on the server's `mcp` entry — no CLI
+flag needed on each launch:
+
+```json
+{
+  "mcp": {
+    "webhook": {
+      "type": "http",
+      "url": "https://example.com/mcp",
+      "channel_enabled": true
+    }
+  }
+}
+```
+
+Either source enables the channel; the server must still declare the
+`claude/channel` capability.
 
 #### Signal Setup
 

--- a/internal/agent/tools/mcp/channel.go
+++ b/internal/agent/tools/mcp/channel.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"sync/atomic"
 
+	"github.com/charmbracelet/crush/internal/config"
 	"github.com/charmbracelet/crush/internal/pubsub"
 	"github.com/modelcontextprotocol/go-sdk/jsonrpc"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -170,6 +171,18 @@ func ChannelEnabled(enabled []string, name string) bool {
 		}
 	}
 	return false
+}
+
+// ChannelOptIn reports whether server `name` should be treated as a channel,
+// considering both enablement sources: persistently via crush.json
+// (m.ChannelEnabled) or per-launch via the --channels overrides list. Every
+// site that gates channel behaviour — session creation, session renewal, and
+// backend routing — must use this so the two sources are always ORed together
+// and no site drifts out of sync (a config-enabled channel that keeps its gate
+// on session creation but loses it on renewal is exactly the kind of bug this
+// prevents).
+func ChannelOptIn(m config.MCPConfig, enabled []string, name string) bool {
+	return m.ChannelEnabled || ChannelEnabled(enabled, name)
 }
 
 // publishChannelMessage validates and renders a payload, then publishes it as

--- a/internal/agent/tools/mcp/channel_test.go
+++ b/internal/agent/tools/mcp/channel_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/charmbracelet/crush/internal/config"
 	"github.com/charmbracelet/crush/internal/pubsub"
 	"github.com/modelcontextprotocol/go-sdk/jsonrpc"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -308,6 +309,33 @@ func TestChannelEnabled(t *testing.T) {
 		if got := ChannelEnabled(tt.enabled, tt.name); got != tt.want {
 			t.Errorf("ChannelEnabled(%v, %q) = %v, want %v", tt.enabled, tt.name, got, tt.want)
 		}
+	}
+}
+
+func TestChannelOptIn(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name       string
+		cfgEnabled bool
+		overrides  []string
+		server     string
+		want       bool
+	}{
+		{"neither source", false, nil, "webhook", false},
+		{"config only (channel_enabled: true)", true, nil, "webhook", true},
+		{"override only (--channels)", false, []string{"webhook"}, "webhook", true},
+		{"both sources", true, []string{"webhook"}, "webhook", true},
+		{"override for a different server", false, []string{"other"}, "webhook", false},
+		{"config-enabled via server: form override", true, []string{"server:other"}, "webhook", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			m := config.MCPConfig{ChannelEnabled: tt.cfgEnabled}
+			if got := ChannelOptIn(m, tt.overrides, tt.server); got != tt.want {
+				t.Errorf("ChannelOptIn(%+v, %v, %q) = %v, want %v", m, tt.overrides, tt.server, got, tt.want)
+			}
+		})
 	}
 }
 

--- a/internal/agent/tools/mcp/init.go
+++ b/internal/agent/tools/mcp/init.go
@@ -535,8 +535,9 @@ func createSession(ctx context.Context, name string, m config.MCPConfig, resolve
 	slog.Debug("MCP client initialized", "name", name)
 
 	// Open the channel gate only for a server that both declares the
-	// claude/channel capability and was opted in via --channels. Listed in MCP
-	// config is not enough; this enforces the "listed is not enabled" model.
+	// claude/channel capability and was opted in — via --channels or
+	// channel_enabled in config. Merely listing a server under mcp is not
+	// enough; this enforces the "listed is not enabled" model.
 	isChannel := channelOptIn && hasChannelCapability(session.InitializeResult())
 	if isChannel {
 		channelGate.Store(true)

--- a/internal/agent/tools/mcp/init.go
+++ b/internal/agent/tools/mcp/init.go
@@ -282,7 +282,7 @@ func initClient(ctx context.Context, cfg *config.ConfigStore, name string, m con
 	updateState(name, StateStarting, nil, nil, Counts{})
 
 	// createSession handles its own timeout internally.
-	session, err := createSession(ctx, name, m, resolver, ChannelEnabled(cfg.Overrides().EnabledChannels, name))
+	session, err := createSession(ctx, name, m, resolver, m.ChannelEnabled || ChannelEnabled(cfg.Overrides().EnabledChannels, name))
 	if err != nil {
 		return err
 	}

--- a/internal/agent/tools/mcp/init.go
+++ b/internal/agent/tools/mcp/init.go
@@ -282,7 +282,7 @@ func initClient(ctx context.Context, cfg *config.ConfigStore, name string, m con
 	updateState(name, StateStarting, nil, nil, Counts{})
 
 	// createSession handles its own timeout internally.
-	session, err := createSession(ctx, name, m, resolver, m.ChannelEnabled || ChannelEnabled(cfg.Overrides().EnabledChannels, name))
+	session, err := createSession(ctx, name, m, resolver, ChannelOptIn(m, cfg.Overrides().EnabledChannels, name))
 	if err != nil {
 		return err
 	}
@@ -367,7 +367,7 @@ func getOrRenewClient(ctx context.Context, cfg *config.ConfigStore, name string)
 	// only that session is closed and deregistered.
 	updateState(name, StateError, maybeTimeoutErr(err, timeout), sess, state.Counts)
 
-	fresh, err := createSession(ctx, name, m, cfg.Resolver(), ChannelEnabled(cfg.Overrides().EnabledChannels, name))
+	fresh, err := createSession(ctx, name, m, cfg.Resolver(), ChannelOptIn(m, cfg.Overrides().EnabledChannels, name))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/backend/channels.go
+++ b/internal/backend/channels.go
@@ -49,11 +49,11 @@ func (b *Backend) startChannelRouter() {
 // enabled the channel.
 func (b *Backend) routeChannelMessage(ev mcptools.Event) {
 	for _, ws := range b.workspaces.Seq2() {
-		cfg := ws.Cfg.Config()
-		if _, declared := cfg.MCP[ev.Name]; !declared {
+		mcpCfg, declared := ws.Cfg.Config().MCP[ev.Name]
+		if !declared {
 			continue
 		}
-		if !mcptools.ChannelOptIn(cfg.MCP[ev.Name], ws.Cfg.Overrides().EnabledChannels, ev.Name) {
+		if !mcptools.ChannelOptIn(mcpCfg, ws.Cfg.Overrides().EnabledChannels, ev.Name) {
 			continue
 		}
 		b.injectChannelMessage(ws, ev.Name, ev.ChannelMessage)

--- a/internal/backend/channels.go
+++ b/internal/backend/channels.go
@@ -53,7 +53,7 @@ func (b *Backend) routeChannelMessage(ev mcptools.Event) {
 		if _, declared := cfg.MCP[ev.Name]; !declared {
 			continue
 		}
-		if !mcptools.ChannelEnabled(ws.Cfg.Overrides().EnabledChannels, ev.Name) && !cfg.MCP[ev.Name].ChannelEnabled {
+		if !mcptools.ChannelOptIn(cfg.MCP[ev.Name], ws.Cfg.Overrides().EnabledChannels, ev.Name) {
 			continue
 		}
 		b.injectChannelMessage(ws, ev.Name, ev.ChannelMessage)

--- a/internal/backend/channels.go
+++ b/internal/backend/channels.go
@@ -53,7 +53,7 @@ func (b *Backend) routeChannelMessage(ev mcptools.Event) {
 		if _, declared := cfg.MCP[ev.Name]; !declared {
 			continue
 		}
-		if !mcptools.ChannelEnabled(ws.Cfg.Overrides().EnabledChannels, ev.Name) {
+		if !mcptools.ChannelEnabled(ws.Cfg.Overrides().EnabledChannels, ev.Name) && !cfg.MCP[ev.Name].ChannelEnabled {
 			continue
 		}
 		b.injectChannelMessage(ws, ev.Name, ev.ChannelMessage)

--- a/internal/backend/channels_test.go
+++ b/internal/backend/channels_test.go
@@ -287,3 +287,66 @@ func TestRouteChannelMessage_PrefersViewedSession(t *testing.T) {
 	}
 	ws.runWG.Wait()
 }
+
+// TestRouteChannelMessage_ConfigEnabled verifies that a server with
+// channel_enabled: true in crush.json receives channel pushes without
+// needing --channels on the CLI.
+func TestRouteChannelMessage_ConfigEnabled(t *testing.T) {
+	xdgIsolated(t)
+	b, _ := newTestBackend(t)
+
+	coord := newRecordingCoordinator()
+
+	// Build a workspace whose MCP config sets channel_enabled: true on
+	// the server, but does NOT set any override (no --channels).
+	wd := t.TempDir()
+	cfgJSON, err := json.Marshal(map[string]any{
+		"mcp": map[string]any{
+			"webhook": map[string]any{
+				"type":            "http",
+				"url":             "http://127.0.0.1:0/mcp",
+				"channel_enabled": true,
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(wd, "crush.json"), cfgJSON, 0o644))
+
+	cfg, err := config.Init(wd, "", false)
+	require.NoError(t, err)
+	// Deliberately do NOT set cfg.Overrides().EnabledChannels.
+
+	ws := &Workspace{
+		ID:           uuid.New().String(),
+		Path:         wd,
+		Cfg:          cfg,
+		resolvedPath: wd,
+		clients:      make(map[string]*clientState),
+		shutdownFn:   func() {},
+	}
+	ws.App = &app.App{
+		AgentCoordinator: coord,
+		Sessions:         &fullFakeSessions{fakeChannelSessions: &fakeChannelSessions{listed: []session.Session{{ID: "recent"}}}},
+	}
+	ws.ctx, ws.cancel = context.WithCancel(b.ctx)
+	b.mu.Lock()
+	b.workspaces.Set(ws.ID, ws)
+	b.pathIndex[ws.resolvedPath] = ws.ID
+	b.mu.Unlock()
+
+	const content = `<channel source="webhook">config-enabled push</channel>`
+	b.routeChannelMessage(mcptools.Event{
+		Type:           mcptools.EventChannelMessage,
+		Name:           "webhook",
+		ChannelMessage: content,
+	})
+
+	select {
+	case run := <-coord.runs:
+		require.Equal(t, "recent", run[0])
+		require.Equal(t, content, run[1])
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected the config-enabled workspace to receive the channel push")
+	}
+	ws.runWG.Wait()
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -205,6 +205,12 @@ type MCPConfig struct {
 	// "Header:".
 	Headers map[string]string `json:"headers,omitempty" jsonschema:"description=HTTP headers for HTTP/SSE MCP servers"`
 
+	// ChannelEnabled enables an MCP server as a channel directly from config,
+	// equivalent to passing its name via --channels on the CLI. This lets
+	// channels be declared persistently in crush.json without needing a CLI
+	// flag on every launch.
+	ChannelEnabled bool `json:"channel_enabled,omitempty" jsonschema:"description=Enable this MCP server as a channel (equivalent to --channels),default=false"`
+
 	// ChannelReply, when set on a server enabled as a channel, makes Crush
 	// route the final assistant response of every turn that originated from
 	// this channel back through one of the server's own tools, so a message

--- a/schema.json
+++ b/schema.json
@@ -352,6 +352,11 @@
           "type": "object",
           "description": "HTTP headers for HTTP/SSE MCP servers"
         },
+        "channel_enabled": {
+          "type": "boolean",
+          "description": "Enable this MCP server as a channel (equivalent to --channels)",
+          "default": false
+        },
         "channel_reply": {
           "$ref": "#/$defs/MCPChannelReply",
           "description": "Automatically route replies for turns originating from this channel back through one of the server's tools"
@@ -596,6 +601,23 @@
         "disable_a2ui": {
           "type": "boolean",
           "description": "Disable the A2UI prompt section that invites the model to emit renderable \u003ca2ui-json\u003e UI surfaces in chat",
+          "default": false
+        },
+        "allowed_commands": {
+          "items": {
+            "type": "string",
+            "examples": [
+              "ssh",
+              "curl",
+              "scp"
+            ]
+          },
+          "type": "array",
+          "description": "List of commands to allow that are normally banned. Only affects the exact-command block list; package-manager argument blocks (e.g. 'apt install') are unaffected. Allowed commands still require permission approval."
+        },
+        "allow_all_commands": {
+          "type": "boolean",
+          "description": "Remove all command restrictions from the bash tool",
           "default": false
         }
       },


### PR DESCRIPTION
## Summary

Adds a `channel_enabled` boolean field to the per-server MCP config so channels can be declared persistently in crush.json instead of requiring `--channels <name>` on every CLI launch.

## Problem

Currently the only way to opt an MCP server into the channel system is the `--channels` CLI flag, which is runtime-only and never persisted. This means every Crush launch (interactive, server mode, etc.) must remember to pass `--channels switchboard --channels signal`, and there's no way to declare in config that a server should always be a channel.

## Changes

- **`internal/config/config.go`**: Add `ChannelEnabled bool` (`json:"channel_enabled"`) to `MCPConfig`
- **`internal/agent/tools/mcp/init.go`**: OR the config flag with the existing `--channels` override check at session init
- **`internal/backend/channels.go`**: OR the config flag with the existing `--channels` override check at message routing
- **`internal/backend/channels_test.go`**: Add `TestRouteChannelMessage_ConfigEnabled` verifying a server with `channel_enabled: true` in config receives pushes without any CLI flag

The two enablement paths (config flag vs `--channels` override) are OR'd, so either method works and they compose. The server must still declare the `claude/channel` experimental capability — config just replaces the CLI opt-in, it doesn't bypass the capability gate.

## Usage

```json
{
  "mcp": {
    "switchboard": {
      "type": "http",
      "url": "...",
      "channel_enabled": true
    }
  }
}
```

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./internal/...` passes
- [x] `go test ./internal/agent/tools/mcp/... -run TestChannel` passes
- [x] `go test ./internal/backend/... -run TestRouteChannel` passes (including new config-enabled test)
- [x] `gofumpt -w .` clean


💘 Generated with Crush