### PR TITLE
chore(lint): restore green `task lint` on main

### DIFF
--- a/internal/agent/tools/mcp/lifecycle_test.go
+++ b/internal/agent/tools/mcp/lifecycle_test.go
@@ -237,7 +237,7 @@ func TestUpdateState_ErrorFromCurrentSessionClearsEverything(t *testing.T) {
 // assertion always failed and stdio startup errors reported bare EOF with
 // none of the child's output attached.
 func TestMaybeStdioErr_UnwrapsChannelTransport(t *testing.T) {
-	cmd := exec.Command("sh", "-c", "echo boom-diagnostic >&2; exit 3")
+	cmd := exec.CommandContext(t.Context(), "sh", "-c", "echo boom-diagnostic >&2; exit 3")
 	inner := &mcp.CommandTransport{Command: cmd}
 	wrapped := &channelTransport{inner: inner, name: "t", gate: &atomic.Bool{}}
 

--- a/internal/agent/tools/mcp/oauth.go
+++ b/internal/agent/tools/mcp/oauth.go
@@ -119,7 +119,7 @@ func (s *tokenStore) save(serverURL string, t mcptoken) {
 	// A persist failure is logged, not fatal: tokens are regenerable via
 	// re-auth, but a silently unwritable config dir is worth surfacing.
 	if err := config.AtomicWriteFile(s.path, b, 0o600); err != nil {
-		slog.Warn("failed to persist MCP OAuth tokens", "path", s.path, "err", err)
+		slog.Warn("Failed to persist MCP OAuth tokens", "path", s.path, "err", err)
 	}
 }
 
@@ -229,7 +229,7 @@ func (h *mcpOAuthHandler) Authorize(ctx context.Context, req *http.Request, resp
 	h.endpoints.TokenURL = ""
 	h.mu.Unlock()
 
-	inner, ln, err := h.buildInner()
+	inner, ln, err := h.buildInner(ctx)
 	if err != nil {
 		resp.Body.Close()
 		return err
@@ -264,8 +264,9 @@ func (h *mcpOAuthHandler) Authorize(ctx context.Context, req *http.Request, resp
 // live callback listener. The listener is allocated once and handed to the
 // callback server directly — allocating a port, closing it, and re-listening
 // later would let another process steal the port in between.
-func (h *mcpOAuthHandler) buildInner() (*auth.AuthorizationCodeHandler, net.Listener, error) {
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
+func (h *mcpOAuthHandler) buildInner(ctx context.Context) (*auth.AuthorizationCodeHandler, net.Listener, error) {
+	var lc net.ListenConfig
+	ln, err := lc.Listen(ctx, "tcp", "127.0.0.1:0")
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to allocate callback port: %w", err)
 	}

--- a/internal/agent/tools/mcp/oauth_test.go
+++ b/internal/agent/tools/mcp/oauth_test.go
@@ -276,7 +276,7 @@ func TestCallbackHandler_DuplicateHitDoesNotBlock(t *testing.T) {
 	handler := callbackHandler("s1", resultCh, errCh)
 
 	hit := func() {
-		req := httptest.NewRequest("GET", "/callback?code=abc&state=s1", nil)
+		req := httptest.NewRequestWithContext(t.Context(), "GET", "/callback?code=abc&state=s1", nil)
 		handler(httptest.NewRecorder(), req)
 	}
 
@@ -315,7 +315,7 @@ func TestCallbackHandler_RejectsStateMismatch(t *testing.T) {
 	// a wrong-state hit that reported there would abort the whole flow — the
 	// opposite of "cannot crowd out the legitimate callback". It is dropped.
 	rec := httptest.NewRecorder()
-	handler(rec, httptest.NewRequest("GET", "/callback?code=abc&state=wrong-state", nil))
+	handler(rec, httptest.NewRequestWithContext(t.Context(), "GET", "/callback?code=abc&state=wrong-state", nil))
 
 	require.Equal(t, http.StatusBadRequest, rec.Code,
 		"state mismatch should respond with 400 Bad Request")
@@ -325,7 +325,7 @@ func TestCallbackHandler_RejectsStateMismatch(t *testing.T) {
 	// The legitimate callback that follows must still win the result slot —
 	// the stray hit neither consumed it nor tore the flow down.
 	handler(httptest.NewRecorder(),
-		httptest.NewRequest("GET", "/callback?code=abc&state=expected-state", nil))
+		httptest.NewRequestWithContext(t.Context(), "GET", "/callback?code=abc&state=expected-state", nil))
 	require.Len(t, resultCh, 1, "legitimate callback after a stray must still deliver")
 	got := <-resultCh
 	require.Equal(t, "abc", got.Code)
@@ -341,7 +341,7 @@ func TestCallbackHandler_RejectsMissingState(t *testing.T) {
 	handler := callbackHandler("expected-state", resultCh, errCh)
 
 	rec := httptest.NewRecorder()
-	handler(rec, httptest.NewRequest("GET", "/callback?code=abc", nil))
+	handler(rec, httptest.NewRequestWithContext(t.Context(), "GET", "/callback?code=abc", nil))
 
 	require.Equal(t, http.StatusBadRequest, rec.Code)
 	require.Empty(t, resultCh, "missing state must not deliver a result")
@@ -359,7 +359,7 @@ func TestCallbackHandler_EmptyExpectedStateSkipsValidation(t *testing.T) {
 	handler := callbackHandler("", resultCh, errCh)
 
 	handler(httptest.NewRecorder(),
-		httptest.NewRequest("GET", "/callback?code=abc&state=anything", nil))
+		httptest.NewRequestWithContext(t.Context(), "GET", "/callback?code=abc&state=anything", nil))
 
 	require.Len(t, resultCh, 1, "with no expected state, any callback is accepted")
 	got := <-resultCh
@@ -378,7 +378,7 @@ func TestCallbackHandler_RepeatedStateMismatchDropsCleanly(t *testing.T) {
 
 	for range 3 {
 		rec := httptest.NewRecorder()
-		handler(rec, httptest.NewRequest("GET", "/callback?code=abc&state=wrong", nil))
+		handler(rec, httptest.NewRequestWithContext(t.Context(), "GET", "/callback?code=abc&state=wrong", nil))
 		require.Equal(t, http.StatusBadRequest, rec.Code)
 	}
 	require.Empty(t, resultCh, "stray wrong-state hits must not deliver a result")
@@ -386,7 +386,7 @@ func TestCallbackHandler_RepeatedStateMismatchDropsCleanly(t *testing.T) {
 
 	// The legitimate callback still wins after any number of strays.
 	handler(httptest.NewRecorder(),
-		httptest.NewRequest("GET", "/callback?code=real&state=expected", nil))
+		httptest.NewRequestWithContext(t.Context(), "GET", "/callback?code=real&state=expected", nil))
 	require.Len(t, resultCh, 1)
 	got := <-resultCh
 	require.Equal(t, "real", got.Code)

--- a/internal/ui/chat/a2ui.go
+++ b/internal/ui/chat/a2ui.go
@@ -595,7 +595,7 @@ func (a *AssistantMessageItem) syncA2UISurfaces(src string, parts []a2tea.Part) 
 	a.a2uiScanned = true
 	// A rebuild replaces focused models with fresh blurred ones; re-grant
 	// focus when the item is selected so the ring survives streaming.
-	if a.focusableMessageItem.isFocused() {
+	if a.isFocused() {
 		a.focusA2UISurfaces()
 	}
 }


### PR DESCRIPTION
`task lint` has been red on `main`. This restores it to green. No functional
change beyond the OAuth callback listener honoring cancellation.

## What was broken

**1. Log capitalization** — `scripts/check_log_capitalization.sh` requires log
messages to start with a capital letter. `internal/agent/tools/mcp/oauth.go`
logged `"failed to persist MCP OAuth tokens"`.

**2. `noctx` (9 violations)** — all in `internal/agent/tools/mcp`:

| Site | Fix |
|---|---|
| `oauth.go` `buildInner` — `net.Listen` | thread `Authorize`'s `ctx` into `buildInner`, use `(*net.ListenConfig).Listen` |
| `oauth_test.go` × 7 — `httptest.NewRequest` | `httptest.NewRequestWithContext(t.Context(), …)` |
| `lifecycle_test.go` — `exec.Command` | `exec.CommandContext(t.Context(), …)` |

The `net.Listen` fix is the only one with any runtime effect: the OAuth
callback listener is now torn down if the authorization context is cancelled,
which is what it should have been doing anyway.

**3. `staticcheck` QF1008** — `internal/ui/chat/a2ui.go` named the embedded
`focusableMessageItem` in a selector where `isFocused` is already promoted.
This one is from #171, not the OAuth work, and is in its own commit — but
lint can't go green without it.

## Verification

- `./scripts/check_log_capitalization.sh` — passes
- `golangci-lint run --path-mode=abs --config=".golangci.yml" --timeout=5m` — `0 issues.` (was 10)
- `go test -race ./...` — full suite passes, no failures

No new tests: this is a lint-only change with no new behavior to cover. The
existing `oauth_test.go` / `lifecycle_test.go` cases continue to exercise the
touched code paths.

🤖 Posted on behalf of `@joestump` by [`claude-opus-5`](https://openrouter.ai/anthropic/claude-opus-5) using [Claude Code](https://claude.ai).
