### PR TITLE
fix(scheduler): truncate NextRunAt to minute boundary

### DIFF
--- a/internal/agent/tools/croncreate.md
+++ b/internal/agent/tools/croncreate.md
@@ -2,6 +2,8 @@ Schedule a new scheduled task that re-runs a prompt automatically on a cron sche
 
 Takes a 5-field cron expression (minute hour day-of-month month day-of-week) evaluated in the user's local timezone. Supports wildcards (* and ?), single values (5), steps (*/15), ranges (1-5), comma lists (1,15,30), and three-letter names (JAN, MON). There is no seconds field, descriptors like @daily are not accepted, and extended syntax (L, W) is not supported. Day-of-week: 0 or 7 = Sunday through 6 = Saturday; when both day-of-month and day-of-week are restricted, the task fires when either matches.
 
+Tasks fire at the top of the specified minute. If you pin the current minute (e.g. it is 06:22:50 and you schedule for minute 22), the task fires at 06:23:00, not 10 seconds later. Sub-minute precision is not supported.
+
 Expressions that are syntactically valid but can never match — "0 0 30 2 *", February 30th — are rejected rather than accepted as a task that silently never runs.
 
 Set recurring to false for a one-shot reminder that fires once and deletes itself (pin minute/hour/day-of-month/month to specific values). Set durable to true to persist the task to disk so it survives restarts; otherwise it lives only in this session. A session can hold up to 50 scheduled tasks. Returns a task ID you can pass to CronDelete.

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -115,7 +115,7 @@ func (s *Store) Load() error {
 			continue
 		}
 		if t.NextRunAt.Before(s.now().Add(-time.Minute)) {
-			t.NextRunAt = sched.Next(s.now())
+			t.NextRunAt = sched.Next(s.now()).Truncate(time.Minute)
 		}
 		// A zero next run is always "due", so a task carrying one would
 		// fire on every tick forever. Drop it instead.
@@ -167,6 +167,12 @@ func (s *Store) Create(sessionID, cronExpr, prompt string, recurring, durable bo
 	if nextRun.IsZero() {
 		return Task{}, fmt.Errorf("%w: %s", ErrNeverFires, cronExpr)
 	}
+	// Truncate to the start of the minute so a task created at HH:MM:50
+	// for minute HH:MM fires at the top of the next minute, not 10
+	// seconds later. The ticker polls every second, but cron expressions
+	// have minute-level granularity — the stored next-run must reflect
+	// that so users are not confused by sub-minute firing.
+	nextRun = nextRun.Truncate(time.Minute)
 
 	id, err := NewTaskID()
 	if err != nil {
@@ -313,7 +319,7 @@ func (s *Store) rescheduleLocked(t *Task, now time.Time) {
 		delete(s.tasks, t.ID)
 		return
 	}
-	t.NextRunAt = next
+	t.NextRunAt = next.Truncate(time.Minute)
 }
 
 // persistBestEffort writes durable tasks, logging rather than returning


### PR DESCRIPTION
## Problem

The cron parser uses strict 5-field expressions with minute-level granularity, but the ticker polls every 1 second. This creates a confusing mismatch:

1. User asks to "fire in 10 seconds"
2. Agent correctly says sub-minute cron is not possible
3. But the agent can pin the exact next minute (e.g. `23 6 30 7 *` when current time is 06:22:50)
4. The task fires 10 seconds later — because the ticker checks every second and `NextRunAt` is stored at second precision

The system achieves sub-minute firing in practice, contradicting the user's expectation.

## Fix

**`NextRunAt` is now truncated to the start of the minute** in all three places where it is computed:

- `Store.Create()` — when a task is first registered
- `Store.Load()` — when a durable task's next run is recomputed on restart
- `Store.rescheduleLocked()` — when a recurring task advances to its next fire time

The `CronCreate` tool description now explicitly states: "Tasks fire at the top of the specified minute. If you pin the current minute (e.g. it is 06:22:50 and you schedule for minute 22), the task fires at 06:23:00, not 10 seconds later. Sub-minute precision is not supported."

## Testing

- All `internal/scheduler` tests pass
- All `internal/agent` cron tests pass
- All `internal/ui/chat` cron tests pass
- `go build` clean

Closes #202

🤖 Posted on behalf of `@joestump` by [`claude-opus-5`](https://openrouter.ai/anthropic/claude-opus-5) using [Crush](https://github.com/charmbracelet/crush).