### PR TITLE
feat(ui): add scheduled-task pill to the pills panel

### DIFF
--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -106,6 +106,7 @@ type Coordinator interface {
 	QueuedPrompts(sessionID string) int
 	QueuedPromptsList(sessionID string) []string
 	ClearQueue(sessionID string)
+	ListCronTasks(sessionID string) []scheduler.Task
 	Summarize(context.Context, string) error
 	Model() Model
 	UpdateModels(ctx context.Context) error
@@ -1258,6 +1259,11 @@ func (c *coordinator) CancelAll() {
 
 func (c *coordinator) ClearQueue(sessionID string) {
 	c.currentAgent.ClearQueue(sessionID)
+}
+
+// ListCronTasks returns the scheduled tasks belonging to sessionID.
+func (c *coordinator) ListCronTasks(sessionID string) []scheduler.Task {
+	return c.cronStore.List(sessionID)
 }
 
 func (c *coordinator) IsBusy() bool {

--- a/internal/backend/agent_runcomplete_test.go
+++ b/internal/backend/agent_runcomplete_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/charmbracelet/crush/internal/app"
 	"github.com/charmbracelet/crush/internal/message"
 	"github.com/charmbracelet/crush/internal/proto"
+	"github.com/charmbracelet/crush/internal/scheduler"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 )
@@ -44,6 +45,7 @@ func (c *errorCoordinator) IsSessionBusy(string) bool                         { 
 func (c *errorCoordinator) QueuedPrompts(string) int                          { return 0 }
 func (c *errorCoordinator) QueuedPromptsList(string) []string                 { return nil }
 func (c *errorCoordinator) ClearQueue(string)                                 {}
+func (c *errorCoordinator) ListCronTasks(string) []scheduler.Task             { return nil }
 func (c *errorCoordinator) Summarize(context.Context, string) error           { return nil }
 func (c *errorCoordinator) Model() agent.Model                                { return agent.Model{} }
 func (c *errorCoordinator) UpdateModels(context.Context) error                { return nil }

--- a/internal/backend/agent_test.go
+++ b/internal/backend/agent_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/charmbracelet/crush/internal/app"
 	"github.com/charmbracelet/crush/internal/message"
 	"github.com/charmbracelet/crush/internal/proto"
+	"github.com/charmbracelet/crush/internal/scheduler"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 )
@@ -54,6 +55,7 @@ func (c *blockingCoordinator) IsSessionBusy(string) bool                        
 func (c *blockingCoordinator) QueuedPrompts(string) int                          { return 0 }
 func (c *blockingCoordinator) QueuedPromptsList(string) []string                 { return nil }
 func (c *blockingCoordinator) ClearQueue(string)                                 {}
+func (c *blockingCoordinator) ListCronTasks(string) []scheduler.Task             { return nil }
 func (c *blockingCoordinator) Summarize(context.Context, string) error           { return nil }
 func (c *blockingCoordinator) Model() agent.Model                                { return agent.Model{} }
 func (c *blockingCoordinator) UpdateModels(context.Context) error                { return nil }

--- a/internal/backend/channels_test.go
+++ b/internal/backend/channels_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/charmbracelet/crush/internal/app"
 	"github.com/charmbracelet/crush/internal/config"
 	"github.com/charmbracelet/crush/internal/message"
+	"github.com/charmbracelet/crush/internal/scheduler"
 	"github.com/charmbracelet/crush/internal/session"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
@@ -154,6 +155,7 @@ func (c *recordingCoordinator) IsSessionBusy(string) bool                     { 
 func (c *recordingCoordinator) QueuedPrompts(string) int                      { return 0 }
 func (c *recordingCoordinator) QueuedPromptsList(string) []string             { return nil }
 func (c *recordingCoordinator) ClearQueue(string)                             {}
+func (c *recordingCoordinator) ListCronTasks(string) []scheduler.Task         { return nil }
 func (c *recordingCoordinator) Summarize(context.Context, string) error       { return nil }
 func (c *recordingCoordinator) Model() agent.Model                            { return agent.Model{} }
 func (c *recordingCoordinator) UpdateModels(context.Context) error            { return nil }

--- a/internal/config/atomicwrite_windows_test.go
+++ b/internal/config/atomicwrite_windows_test.go
@@ -22,7 +22,7 @@ func TestAtomicWriteFile_RetriesWhileDestinationHandleOpen(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
 	path := filepath.Join(dir, "test.json")
-	require.NoError(t, atomicWriteFile(path, []byte(`{"v":1}`), 0o600))
+	require.NoError(t, AtomicWriteFile(path, []byte(`{"v":1}`), 0o600))
 
 	// Hold the destination open with no sharing flags so the rename
 	// fails with ERROR_ACCESS_DENIED/ERROR_SHARING_VIOLATION until the
@@ -37,7 +37,7 @@ func TestAtomicWriteFile_RetriesWhileDestinationHandleOpen(t *testing.T) {
 		windows.CloseHandle(h)
 	}()
 
-	require.NoError(t, atomicWriteFile(path, []byte(`{"v":2}`), 0o600))
+	require.NoError(t, AtomicWriteFile(path, []byte(`{"v":2}`), 0o600))
 
 	data, err := os.ReadFile(path)
 	require.NoError(t, err)

--- a/internal/server/agent_cancel_test.go
+++ b/internal/server/agent_cancel_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/charmbracelet/crush/internal/backend"
 	"github.com/charmbracelet/crush/internal/message"
 	"github.com/charmbracelet/crush/internal/proto"
+	"github.com/charmbracelet/crush/internal/scheduler"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 )
@@ -73,9 +74,10 @@ func (s *runCoordinator) IsBusy() bool  { return false }
 func (s *runCoordinator) IsSessionBusy(string) bool {
 	return false
 }
-func (s *runCoordinator) QueuedPrompts(string) int          { return 0 }
-func (s *runCoordinator) QueuedPromptsList(string) []string { return nil }
-func (s *runCoordinator) ClearQueue(string)                 {}
+func (s *runCoordinator) QueuedPrompts(string) int              { return 0 }
+func (s *runCoordinator) QueuedPromptsList(string) []string     { return nil }
+func (s *runCoordinator) ClearQueue(string)                     {}
+func (s *runCoordinator) ListCronTasks(string) []scheduler.Task { return nil }
 func (s *runCoordinator) Summarize(context.Context, string) error {
 	return nil
 }

--- a/internal/server/e2e_agent_test.go
+++ b/internal/server/e2e_agent_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/charmbracelet/crush/internal/message"
 	"github.com/charmbracelet/crush/internal/proto"
 	"github.com/charmbracelet/crush/internal/pubsub"
+	"github.com/charmbracelet/crush/internal/scheduler"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 )
@@ -217,6 +218,7 @@ func (c *scriptedCoordinator) IsSessionBusy(string) bool                     { r
 func (c *scriptedCoordinator) QueuedPrompts(string) int                      { return 0 }
 func (c *scriptedCoordinator) QueuedPromptsList(string) []string             { return nil }
 func (c *scriptedCoordinator) ClearQueue(string)                             {}
+func (c *scriptedCoordinator) ListCronTasks(string) []scheduler.Task         { return nil }
 func (c *scriptedCoordinator) Summarize(context.Context, string) error       { return nil }
 func (c *scriptedCoordinator) Model() agent.Model                            { return agent.Model{} }
 func (c *scriptedCoordinator) UpdateModels(context.Context) error            { return nil }

--- a/internal/server/sessions_isbusy_test.go
+++ b/internal/server/sessions_isbusy_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/charmbracelet/crush/internal/backend"
 	"github.com/charmbracelet/crush/internal/message"
 	"github.com/charmbracelet/crush/internal/proto"
+	"github.com/charmbracelet/crush/internal/scheduler"
 	"github.com/charmbracelet/crush/internal/session"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
@@ -44,9 +45,10 @@ func (s *stubCoordinator) IsBusy() bool  { return false }
 func (s *stubCoordinator) IsSessionBusy(id string) bool {
 	return s.busy[id]
 }
-func (s *stubCoordinator) QueuedPrompts(string) int          { return 0 }
-func (s *stubCoordinator) QueuedPromptsList(string) []string { return nil }
-func (s *stubCoordinator) ClearQueue(string)                 {}
+func (s *stubCoordinator) QueuedPrompts(string) int              { return 0 }
+func (s *stubCoordinator) QueuedPromptsList(string) []string     { return nil }
+func (s *stubCoordinator) ClearQueue(string)                     {}
+func (s *stubCoordinator) ListCronTasks(string) []scheduler.Task { return nil }
 func (s *stubCoordinator) Summarize(context.Context, string) error {
 	return nil
 }

--- a/internal/ui/model/pills.go
+++ b/internal/ui/model/pills.go
@@ -3,9 +3,11 @@ package model
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/crush/internal/scheduler"
 	"github.com/charmbracelet/crush/internal/session"
 	"github.com/charmbracelet/crush/internal/ui/chat"
 	"github.com/charmbracelet/crush/internal/ui/styles"
@@ -27,6 +29,7 @@ type pillSection int
 const (
 	pillSectionTodos pillSection = iota
 	pillSectionQueue
+	pillSectionCron
 )
 
 // hasIncompleteTodos returns true if there are any non-completed todos.
@@ -129,6 +132,45 @@ func queueList(queueItems []string, t *styles.Styles) string {
 	return strings.Join(lines, "\n")
 }
 
+// cronPill renders the scheduled-task count pill.
+func cronPill(tasks []scheduler.Task, t *styles.Styles) string {
+	if len(tasks) == 0 {
+		return ""
+	}
+	icon := t.Pills.QueueLabel.Render("⏰")
+	label := t.Pills.QueueLabel.Render(fmt.Sprintf("%d Scheduled", len(tasks)))
+	content := fmt.Sprintf("%s %s", icon, label)
+	return t.Pills.Focused.Render(content)
+}
+
+// cronList renders the expanded scheduled-task list.
+func cronList(tasks []scheduler.Task, t *styles.Styles) string {
+	if len(tasks) == 0 {
+		return ""
+	}
+
+	var lines []string
+	for _, task := range tasks {
+		nextRun := task.NextRunAt.Local().Format("15:04")
+		if task.NextRunAt.Local().Day() != time.Now().Local().Day() {
+			nextRun = task.NextRunAt.Local().Format("Jan 2 15:04")
+		}
+		prompt := task.Prompt
+		if ansi.StringWidth(prompt) > maxQueueDisplayLength {
+			prompt = ansi.Truncate(prompt, maxQueueDisplayLength-1, "…")
+		}
+		recurring := ""
+		if task.Recurring {
+			recurring = " ↻"
+		}
+		text := fmt.Sprintf("%s %s%s — %s", task.ID, nextRun, recurring, prompt)
+		prefix := t.Pills.QueueItemPrefix.Render() + " "
+		lines = append(lines, prefix+t.Pills.QueueItemText.Render(text))
+	}
+
+	return strings.Join(lines, "\n")
+}
+
 // pillsHeightReasonableTerminalHeight is the minimum terminal height at which
 // we auto-expand pills when there are incomplete todos.
 const pillsHeightReasonableTerminalHeight = 40
@@ -145,7 +187,7 @@ func (m *UI) autoExpandPillsIfReasonable() tea.Cmd {
 	if m.height < pillsHeightReasonableTerminalHeight {
 		return nil
 	}
-	hasPills := hasIncompleteTodos(m.session.Todos) || m.promptQueue > 0
+	hasPills := hasIncompleteTodos(m.session.Todos) || m.promptQueue > 0 || len(m.cronTasks) > 0
 	if !hasPills {
 		return nil
 	}
@@ -159,8 +201,10 @@ func (m *UI) autoExpandPillsIfReasonable() tea.Cmd {
 	m.pillsAutoExpanded = true
 	if hasIncompleteTodos(m.session.Todos) {
 		m.focusedPillSection = pillSectionTodos
-	} else {
+	} else if m.promptQueue > 0 {
 		m.focusedPillSection = pillSectionQueue
+	} else {
+		m.focusedPillSection = pillSectionCron
 	}
 	m.updateLayoutAndSize()
 	if m.chat.Follow() {
@@ -174,7 +218,7 @@ func (m *UI) togglePillsExpanded() tea.Cmd {
 	if !m.hasSession() {
 		return nil
 	}
-	hasPills := hasIncompleteTodos(m.session.Todos) || m.promptQueue > 0
+	hasPills := hasIncompleteTodos(m.session.Todos) || m.promptQueue > 0 || len(m.cronTasks) > 0
 	if !hasPills {
 		return nil
 	}
@@ -182,8 +226,10 @@ func (m *UI) togglePillsExpanded() tea.Cmd {
 	if m.pillsExpanded {
 		if hasIncompleteTodos(m.session.Todos) {
 			m.focusedPillSection = pillSectionTodos
-		} else {
+		} else if m.promptQueue > 0 {
 			m.focusedPillSection = pillSectionQueue
+		} else {
+			m.focusedPillSection = pillSectionCron
 		}
 	}
 	m.updateLayoutAndSize()
@@ -198,23 +244,39 @@ func (m *UI) togglePillsExpanded() tea.Cmd {
 	return nil
 }
 
-// switchPillSection changes focus between todo and queue sections.
+// switchPillSection changes focus between todo, queue, and cron sections.
 func (m *UI) switchPillSection(dir int) tea.Cmd {
 	if !m.pillsExpanded || !m.hasSession() {
 		return nil
 	}
 	hasIncompleteTodos := hasIncompleteTodos(m.session.Todos)
 	hasQueue := m.promptQueue > 0
+	hasCron := len(m.cronTasks) > 0
 
-	if dir < 0 && m.focusedPillSection == pillSectionQueue && hasIncompleteTodos {
-		m.focusedPillSection = pillSectionTodos
-		m.updateLayoutAndSize()
+	// Build the ordered list of sections that have content.
+	var sections []pillSection
+	if hasIncompleteTodos {
+		sections = append(sections, pillSectionTodos)
+	}
+	if hasQueue {
+		sections = append(sections, pillSectionQueue)
+	}
+	if hasCron {
+		sections = append(sections, pillSectionCron)
+	}
+	if len(sections) < 2 {
 		return nil
 	}
-	if dir > 0 && m.focusedPillSection == pillSectionTodos && hasQueue {
-		m.focusedPillSection = pillSectionQueue
-		m.updateLayoutAndSize()
-		return nil
+
+	// Find the current section in the list and move by dir.
+	current := m.effectiveFocusedSection()
+	for i, s := range sections {
+		if s == current {
+			next := (i + dir + len(sections)) % len(sections)
+			m.focusedPillSection = sections[next]
+			m.updateLayoutAndSize()
+			return nil
+		}
 	}
 	return nil
 }
@@ -227,7 +289,19 @@ func (m *UI) switchPillSection(dir int) tea.Cmd {
 func (m *UI) effectiveFocusedSection() pillSection {
 	hasIncomplete := hasIncompleteTodos(m.session.Todos)
 	hasQueue := m.promptQueue > 0
+	hasCron := len(m.cronTasks) > 0
+
 	switch m.focusedPillSection {
+	case pillSectionCron:
+		if hasCron {
+			return pillSectionCron
+		}
+		if hasIncomplete {
+			return pillSectionTodos
+		}
+		if hasQueue {
+			return pillSectionQueue
+		}
 	case pillSectionQueue:
 		if hasQueue {
 			return pillSectionQueue
@@ -235,12 +309,18 @@ func (m *UI) effectiveFocusedSection() pillSection {
 		if hasIncomplete {
 			return pillSectionTodos
 		}
+		if hasCron {
+			return pillSectionCron
+		}
 	default: // pillSectionTodos
 		if hasIncomplete {
 			return pillSectionTodos
 		}
 		if hasQueue {
 			return pillSectionQueue
+		}
+		if hasCron {
+			return pillSectionCron
 		}
 	}
 	return m.focusedPillSection
@@ -258,7 +338,8 @@ func (m *UI) pillsAreaHeight() int {
 	}
 	hasIncomplete := hasIncompleteTodos(m.session.Todos)
 	hasQueue := m.promptQueue > 0
-	hasPills := hasIncomplete || hasQueue
+	hasCron := len(m.cronTasks) > 0
+	hasPills := hasIncomplete || hasQueue || hasCron
 	if !hasPills {
 		return 0
 	}
@@ -273,6 +354,10 @@ func (m *UI) pillsAreaHeight() int {
 		case pillSectionQueue:
 			if hasQueue {
 				pillsAreaHeight += m.promptQueue
+			}
+		case pillSectionCron:
+			if hasCron {
+				pillsAreaHeight += len(m.cronTasks)
 			}
 		}
 	}
@@ -300,8 +385,9 @@ func (m *UI) renderPills() {
 
 	hasIncomplete := hasIncompleteTodos(m.session.Todos)
 	hasQueue := m.promptQueue > 0
+	hasCron := len(m.cronTasks) > 0
 
-	if !hasIncomplete && !hasQueue {
+	if !hasIncomplete && !hasQueue && !hasCron {
 		return
 	}
 
@@ -309,6 +395,7 @@ func (m *UI) renderPills() {
 	effective := m.effectiveFocusedSection()
 	todosFocused := m.pillsExpanded && effective == pillSectionTodos
 	queueFocused := m.pillsExpanded && effective == pillSectionQueue
+	cronFocused := m.pillsExpanded && effective == pillSectionCron
 
 	inProgressIcon := t.Tool.TodoInProgressIcon.Render(styles.SpinnerIcon)
 	if m.todoIsSpinning {
@@ -324,6 +411,9 @@ func (m *UI) renderPills() {
 	if hasQueue {
 		pills = append(pills, queuePill(m.promptQueue, t))
 	}
+	if hasCron {
+		pills = append(pills, cronPill(m.cronTasks, t))
+	}
 
 	var expandedList string
 	if m.pillsExpanded {
@@ -336,6 +426,8 @@ func (m *UI) renderPills() {
 			if len(m.promptQueueItems) > 0 {
 				expandedList = queueList(m.promptQueueItems, t)
 			}
+		} else if cronFocused && hasCron {
+			expandedList = cronList(m.cronTasks, t)
 		}
 	}
 

--- a/internal/ui/model/session_busy_test.go
+++ b/internal/ui/model/session_busy_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/charmbracelet/crush/internal/config"
 	"github.com/charmbracelet/crush/internal/message"
 	"github.com/charmbracelet/crush/internal/pubsub"
+	"github.com/charmbracelet/crush/internal/scheduler"
 	"github.com/charmbracelet/crush/internal/session"
 	"github.com/charmbracelet/crush/internal/ui/attachments"
 	"github.com/charmbracelet/crush/internal/ui/common"
@@ -87,6 +88,8 @@ func (w *countingWorkspace) PermissionSetSkipRequests(skip bool) {
 
 func (w *countingWorkspace) AgentClearQueue(string) { w.clearQueueCalls++; w.queued = nil }
 func (w *countingWorkspace) AgentCancel(string)     { w.cancelCalls++ }
+
+func (w *countingWorkspace) AgentListCronTasks(string) []scheduler.Task { return nil }
 
 func (w *countingWorkspace) ListMessages(context.Context, string) ([]message.Message, error) {
 	return nil, nil

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -43,6 +43,7 @@ import (
 	"github.com/charmbracelet/crush/internal/permission"
 	"github.com/charmbracelet/crush/internal/pubsub"
 	"github.com/charmbracelet/crush/internal/question"
+	"github.com/charmbracelet/crush/internal/scheduler"
 	"github.com/charmbracelet/crush/internal/session"
 	"github.com/charmbracelet/crush/internal/skills"
 	"github.com/charmbracelet/crush/internal/stringext"
@@ -349,6 +350,10 @@ type UI struct {
 	promptQueueGen uint64
 	sidebarScroll  int
 	pillsView      string
+
+	// cronTasks holds the scheduled tasks for the current session,
+	// refreshed on session load and after cron tool results.
+	cronTasks []scheduler.Task
 
 	// Todo spinner
 	todoSpinner    spinner.Model
@@ -721,6 +726,7 @@ func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.promptQueue = 0
 		m.promptQueueItems = nil
 		m.promptQueueCheckedAt = time.Time{}
+		m.cronTasks = nil
 		if cmd := m.dispatchBusyRefresh(); cmd != nil {
 			cmds = append(cmds, cmd)
 		}
@@ -756,6 +762,7 @@ func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Reload prompt history for the new session.
 		m.historyReset()
 		cmds = append(cmds, m.loadPromptHistory())
+		m.refreshCronTasks()
 		m.updateLayoutAndSize()
 
 	case sessionFilesUpdatesMsg:
@@ -1575,6 +1582,12 @@ func (m *UI) appendSessionMessage(msg message.Message) tea.Cmd {
 					if cmd := m.chat.ScrollToBottomAndAnimate(); cmd != nil {
 						cmds = append(cmds, cmd)
 					}
+				}
+				// Refresh cron tasks after a cron tool result so the
+				// pill stays current.
+				toolName := toolMsgItem.ToolCall().Name
+				if toolName == "CronCreate" || toolName == "CronList" || toolName == "CronDelete" {
+					m.refreshCronTasks()
 				}
 			}
 		}
@@ -3926,6 +3939,17 @@ func (m *UI) isCurrentSessionBusy() bool {
 // hasSession returns true if there is an active session with a valid ID.
 func (m *UI) hasSession() bool {
 	return m.session != nil && m.session.ID != ""
+}
+
+// refreshCronTasks fetches the current session's scheduled tasks from
+// the workspace and re-renders the pills panel if the set changed.
+func (m *UI) refreshCronTasks() {
+	if !m.hasSession() {
+		m.cronTasks = nil
+		return
+	}
+	m.cronTasks = m.com.Workspace.AgentListCronTasks(m.session.ID)
+	m.renderPills()
 }
 
 // focusSidebar moves focus to the sidebar panel, blurring the editor and chat.

--- a/internal/workspace/app_workspace.go
+++ b/internal/workspace/app_workspace.go
@@ -20,6 +20,7 @@ import (
 	"github.com/charmbracelet/crush/internal/permission"
 	"github.com/charmbracelet/crush/internal/proto"
 	"github.com/charmbracelet/crush/internal/question"
+	"github.com/charmbracelet/crush/internal/scheduler"
 	"github.com/charmbracelet/crush/internal/session"
 	"github.com/charmbracelet/crush/internal/shell"
 	"github.com/charmbracelet/crush/internal/skills"
@@ -233,6 +234,13 @@ func (w *AppWorkspace) AgentClearQueue(sessionID string) {
 	if w.app.AgentCoordinator != nil {
 		w.app.AgentCoordinator.ClearQueue(sessionID)
 	}
+}
+
+func (w *AppWorkspace) AgentListCronTasks(sessionID string) []scheduler.Task {
+	if w.app.AgentCoordinator == nil {
+		return nil
+	}
+	return w.app.AgentCoordinator.ListCronTasks(sessionID)
 }
 
 func (w *AppWorkspace) AgentSummarize(ctx context.Context, sessionID string) error {

--- a/internal/workspace/client_workspace.go
+++ b/internal/workspace/client_workspace.go
@@ -26,6 +26,7 @@ import (
 	"github.com/charmbracelet/crush/internal/proto"
 	"github.com/charmbracelet/crush/internal/pubsub"
 	"github.com/charmbracelet/crush/internal/question"
+	"github.com/charmbracelet/crush/internal/scheduler"
 	"github.com/charmbracelet/crush/internal/session"
 	"github.com/charmbracelet/crush/internal/skills"
 	"github.com/charmbracelet/x/powernap/pkg/lsp/protocol"
@@ -313,6 +314,12 @@ func (w *ClientWorkspace) AgentQueuedPromptsList(sessionID string) []string {
 
 func (w *ClientWorkspace) AgentClearQueue(sessionID string) {
 	_ = w.client.ClearAgentSessionQueuedPrompts(context.Background(), w.workspaceID(), sessionID)
+}
+
+// AgentListCronTasks returns nil in client/server mode: the cron store
+// lives server-side and there is no client API for it yet.
+func (w *ClientWorkspace) AgentListCronTasks(sessionID string) []scheduler.Task {
+	return nil
 }
 
 func (w *ClientWorkspace) AgentSummarize(ctx context.Context, sessionID string) error {

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -21,6 +21,7 @@ import (
 	"github.com/charmbracelet/crush/internal/permission"
 	"github.com/charmbracelet/crush/internal/proto"
 	"github.com/charmbracelet/crush/internal/question"
+	"github.com/charmbracelet/crush/internal/scheduler"
 	"github.com/charmbracelet/crush/internal/session"
 	"github.com/charmbracelet/crush/internal/skills"
 )
@@ -126,6 +127,7 @@ type Workspace interface {
 	AgentQueuedPrompts(sessionID string) int
 	AgentQueuedPromptsList(sessionID string) []string
 	AgentClearQueue(sessionID string)
+	AgentListCronTasks(sessionID string) []scheduler.Task
 	AgentSummarize(ctx context.Context, sessionID string) error
 	UpdateAgentModel(ctx context.Context) error
 	InitCoderAgent(ctx context.Context) error


### PR DESCRIPTION
## Problem

When a scheduled task is created via `CronCreate`, the only visual feedback is an inline tool-result message in the chat scrollback. There is no persistent indicator that a scheduled task is active and waiting to fire.

## Solution

Add a **scheduled-task pill** to the pills panel, modeled on the existing `todoPill()` and `queuePill()`:

- **Collapsed state**: `⏰ N Scheduled` showing the count of active tasks
- **Expanded state**: lists each task with its ID, next-fire time, recurrence indicator (`↻`), and prompt text
- **Tab navigation**: cycles between To-Do, Queue, and Scheduled sections (whichever have content)

## Data flow

- New `AgentListCronTasks(sessionID)` method on the `Coordinator` interface exposes the cron store
- New `AgentListCronTasks(sessionID)` method on the `Workspace` interface delegates to it
- In `AppWorkspace` (in-process), delegates directly to `coordinator.ListCronTasks()`
- In `ClientWorkspace` (client/server), returns nil — no cron API exposed over the wire yet
- UI refreshes the task list on session load and after every `CronCreate`/`CronList`/`CronDelete` tool result

## Testing

- All `internal/ui/model` tests pass (including `countingWorkspace` stub updated)
- All `internal/workspace` tests pass
- All `internal/agent` cron tests pass
- `go build ./...` clean

Closes #201

🤖 Posted on behalf of `@joestump` by [`claude-opus-5`](https://openrouter.ai/anthropic/claude-opus-5) using [Crush](https://github.com/charmbracelet/crush).