### PR TITLE
fix(dialog): match commands by shortcut in the / menu filter

### DIFF
--- a/internal/ui/dialog/commands_item.go
+++ b/internal/ui/dialog/commands_item.go
@@ -71,16 +71,22 @@ func (c *CommandItem) HasChildren() bool {
 	return len(c.children) > 0
 }
 
-// Filter implements ListItem.
+// Filter implements ListItem. The shortcut is folded in so slash-command
+// shortcuts like "/clear" or "/compact" are findable by typing the command
+// name; without it the shortcut is display-only and the command appears to
+// vanish from the list as the user types.
 func (c *CommandItem) Filter() string {
-	base := c.title
+	parts := []string{c.title}
 	if len(c.aliases) > 0 {
-		base = c.title + " " + strings.Join(c.aliases, " ")
+		parts = append(parts, strings.Join(c.aliases, " "))
+	}
+	if c.shortcut != "" {
+		parts = append(parts, c.shortcut)
 	}
 	if c.description != "" {
-		base = base + " " + c.description
+		parts = append(parts, c.description)
 	}
-	return base
+	return strings.Join(parts, " ")
 }
 
 // ID implements ListItem.

--- a/internal/ui/dialog/commands_test.go
+++ b/internal/ui/dialog/commands_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/charmbracelet/crush/internal/ui/styles"
 	"github.com/charmbracelet/crush/internal/workspace"
 	uv "github.com/charmbracelet/ultraviolet"
+	"github.com/sahilm/fuzzy"
 	"github.com/stretchr/testify/require"
 )
 
@@ -139,6 +140,26 @@ func TestCommands_FilterScopedToCurrentLevel(t *testing.T) {
 			require.NotEqual(t, ci.id, "parent", "filter should not show parent items")
 		}
 	}
+}
+
+// TestCommandItem_FilterIncludesShortcut is a regression guard for the
+// commands dialog swallowing slash-command names. Typing "/clear" (or
+// "clear") after opening the dialog must keep "New Session" visible; the
+// filter previously matched only title+aliases+description, so a query for
+// the shortcut text left the list empty.
+func TestCommandItem_FilterIncludesShortcut(t *testing.T) {
+	t.Parallel()
+
+	s := styles.CharmtonePantera()
+	item := NewCommandItem(&s, "new_session", "New Session", "ctrl+n / /clear", ActionNewSession{})
+
+	filter := item.Filter()
+	require.Contains(t, filter, "/clear", "shortcut must be part of the filter string")
+	require.Contains(t, filter, "New Session", "title must remain in the filter string")
+
+	// The fuzzy matcher must find the item by its slash-command name.
+	matches := fuzzy.FindFrom("clear", list.FilterableItemsSource{item})
+	require.Len(t, matches, 1, "typing 'clear' should match the New Session command")
 }
 
 func TestCommands_TabDisabledInSubMenu(t *testing.T) {


### PR DESCRIPTION
## Summary

Typing `/clear` in the editor opens the commands dialog and then filters on `clear` — which left the list empty, hiding **New Session** (and **Summarize Session** at `/compact`). `CommandItem.Filter()` only matched `title + aliases + description`; the shortcut string was display-only.

## Fix

Fold `c.shortcut` into the filter string in `internal/ui/dialog/commands_item.go`, so slash commands are findable by their `/name` as well as their title.

## Verification

- New regression test `TestCommandItem_FilterIncludesShortcut` asserts the shortcut is in the filter string and that the fuzzy matcher finds "New Session" by querying `clear`.
- Confirmed the test **fails** with the fix reverted and passes with it.
- `go test ./internal/ui/dialog/`, `go vet`, and `gofumpt` all clean.

🤖 Posted on behalf of `@joestump` by `kimi-k3` (Moonshot AI) using [Crush](https://github.com/charmbracelet/crush).