### PR TITLE
feat(chat): click-to-copy icon on finished assistant messages

### DIFF
--- a/internal/ui/chat/assistant.go
+++ b/internal/ui/chat/assistant.go
@@ -21,6 +21,11 @@ import (
 // truncated in the collapsed state.
 const assistantMessageTruncateFormat = "… (%d lines hidden) [click or space to expand]"
 
+// assistantCopyIcon is the click-to-copy glyph rendered as a right-aligned
+// footer on finished assistant messages. Clicking it copies the message's
+// raw Markdown source (not the glamour-rendered text) to the clipboard.
+const assistantCopyIcon = "⎘"
+
 // assistantMessageTailWindowFormat is shown above a tail-windowed thinking
 // block to advertise that earlier lines exist and that the user can
 // promote the view to a full expansion. The promotion is wired through
@@ -131,6 +136,16 @@ type AssistantMessageItem struct {
 	anim              *anim.Anim
 	thinkingViewMode  thinkingViewMode
 	thinkingBoxHeight int // Tracks the rendered thinking box height for click detection.
+
+	// Click-to-copy footer geometry, recorded during renderMessageContent
+	// so HandleMouseClickCmd can hit-test without re-deriving the layout.
+	// copyIconRow is the item-relative row of the footer line, or -1 when
+	// the footer is not rendered (streaming, empty, or non-copyable end
+	// states). copyIconColStart/End bound the icon's cell span within the
+	// line (start inclusive, end exclusive).
+	copyIconRow      int
+	copyIconColStart int
+	copyIconColEnd   int
 
 	// Per-section render caches. Splitting these out means content
 	// streaming does not invalidate the (often expensive) thinking
@@ -386,6 +401,27 @@ func (a *AssistantMessageItem) renderMessageContent(width int) (string, int) {
 	}
 
 	out := strings.Join(messageParts, "\n")
+
+	// Click-to-copy footer: a right-aligned ⎘ on its own line below the
+	// message, shown once the message is finished and has copyable content.
+	// The icon copies the raw Markdown source via HandleMouseClickCmd.
+	a.copyIconRow = -1
+	if a.message.IsFinished() && content != "" {
+		icon := a.sty.Messages.AssistantCopyIcon.Render(assistantCopyIcon)
+		iconWidth := lipgloss.Width(icon)
+		pad := width - iconWidth
+		if pad < 0 {
+			pad = 0
+		}
+		footer := strings.Repeat(" ", pad) + icon
+		// The footer line index is the current height plus one for the blank
+		// separator line inserted between the body and the footer.
+		a.copyIconRow = lipgloss.Height(out) + 1
+		a.copyIconColStart = pad
+		a.copyIconColEnd = pad + iconWidth
+		out += "\n\n" + footer
+	}
+
 	return out, lipgloss.Height(out)
 }
 
@@ -720,12 +756,33 @@ func (a *AssistantMessageItem) tailWindowWouldTruncate() bool {
 // path. Toggling here directly would double-toggle because the caller always
 // runs the generic path after a handled click.
 func (a *AssistantMessageItem) HandleMouseClick(btn ansi.MouseButton, x, y int) bool {
+	handled, _ := a.HandleMouseClickCmd(btn, x, y)
+	return handled
+}
+
+// HandleMouseClickCmd implements [list.MouseClickCommandable]. A click on
+// the click-to-copy footer returns the copy command, which suppresses the
+// generic expansion toggle in the chat click dispatcher; a click on the
+// thinking box reports handled with a nil command so expansion proceeds
+// through the generic [Expandable] path (see HandleMouseClick for why the
+// toggle itself must not run here).
+func (a *AssistantMessageItem) HandleMouseClickCmd(btn ansi.MouseButton, x, y int) (bool, tea.Cmd) {
 	if btn != ansi.MouseLeft {
-		return false
+		return false, nil
 	}
-	// Only the thinking box is clickable; other regions of the assistant
-	// message should not trigger expansion.
-	return a.thinkingBoxHeight > 0 && y < a.thinkingBoxHeight
+	// The click-to-copy footer wins over every other region: it is a
+	// discrete action, not an expansion target. The copy takes the raw
+	// Markdown source (the same text the c/y keybinding copies), not the
+	// glamour-rendered output. Click coordinates are chat-relative, so the
+	// content column is offset by MessageLeftPaddingTotal (the prefix bar).
+	if a.copyIconRow >= 0 && y == a.copyIconRow &&
+		x >= a.copyIconColStart+MessageLeftPaddingTotal && x < a.copyIconColEnd+MessageLeftPaddingTotal {
+		text := a.message.Content().Text
+		return true, common.CopyToClipboard(text, "Message copied to clipboard")
+	}
+	// Only the thinking box is clickable for expansion; other regions of
+	// the assistant message should not trigger expansion.
+	return a.thinkingBoxHeight > 0 && y < a.thinkingBoxHeight, nil
 }
 
 // SetFocused implements list.Focusable. Besides the base focus bookkeeping

--- a/internal/ui/chat/assistant_test.go
+++ b/internal/ui/chat/assistant_test.go
@@ -1,6 +1,7 @@
 package chat
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/charmbracelet/crush/internal/message"
@@ -139,4 +140,134 @@ func TestAssistantMessageItemHandleMouseClick(t *testing.T) {
 	// Non-left button is ignored.
 	require.False(t, item.HandleMouseClick(ansi.MouseRight, 0, 2))
 	require.Equal(t, thinkingCollapsed, item.thinkingViewMode)
+}
+
+// finishedTextMessage builds an assistant message with the given Markdown
+// text and an end_turn finish part, so the click-to-copy footer renders.
+func finishedTextMessage(id, text string) *message.Message {
+	return &message.Message{
+		ID:   id,
+		Role: message.Assistant,
+		Parts: []message.ContentPart{
+			message.TextContent{Text: text},
+			message.Finish{Reason: message.FinishReasonEndTurn, Time: testFinishTime},
+		},
+	}
+}
+
+// TestAssistantMessageItemCopyFooterRendered guards the render side of the
+// click-to-copy footer: a finished message with content must render the ⎘
+// footer on its own row at the right edge, and the recorded click geometry
+// must agree with the rendered output.
+func TestAssistantMessageItemCopyFooterRendered(t *testing.T) {
+	t.Parallel()
+
+	sty := styles.CharmtonePantera()
+	msg := finishedTextMessage("copy-1", "hello **world**")
+	item := NewAssistantMessageItem(&sty, msg).(*AssistantMessageItem)
+
+	const width = 40
+	rendered := item.RawRender(width)
+	lines := strings.Split(rendered, "\n")
+
+	require.GreaterOrEqual(t, item.copyIconRow, 0, "finished message with content must render the copy footer")
+	require.Less(t, item.copyIconRow, len(lines), "recorded footer row must be within the rendered output")
+	// The blank separator line precedes the footer row.
+	require.Empty(t, strings.TrimSpace(lines[item.copyIconRow-1]),
+		"the line above the footer must be the blank separator")
+
+	footerLine := lines[item.copyIconRow]
+	require.Contains(t, footerLine, "⎘", "footer line must contain the copy glyph")
+	// The glyph must be right-aligned inside the capped content width:
+	// strip ANSI styling before measuring its cell offset within the line.
+	plain := ansi.Strip(footerLine)
+	require.Equal(t, item.copyIconColStart, len([]rune(strings.Split(plain, "⎘")[0])),
+		"icon must sit at the recorded start column")
+	require.Equal(t, item.copyIconColStart+1, item.copyIconColEnd,
+		"the single-cell glyph must span exactly one column")
+}
+
+// TestAssistantMessageItemCopyFooterSuppressed guards the states where the
+// footer must not render: a still-streaming message and an empty finished
+// message.
+func TestAssistantMessageItemCopyFooterSuppressed(t *testing.T) {
+	t.Parallel()
+
+	sty := styles.CharmtonePantera()
+
+	// Streaming: no Finish part yet, so IsFinished is false.
+	streaming := NewAssistantMessageItem(&sty, thinkingMessage("copy-2", "", "partial")).(*AssistantMessageItem)
+	streaming.RawRender(40)
+	require.Equal(t, -1, streaming.copyIconRow,
+		"streaming message must not render the copy footer")
+
+	// Finished but empty content: nothing worth copying.
+	empty := NewAssistantMessageItem(&sty, &message.Message{
+		ID:   "copy-3",
+		Role: message.Assistant,
+		Parts: []message.ContentPart{
+			message.Finish{Reason: message.FinishReasonEndTurn, Time: testFinishTime},
+		},
+	}).(*AssistantMessageItem)
+	empty.RawRender(40)
+	require.Equal(t, -1, empty.copyIconRow,
+		"empty finished message must not render the copy footer")
+}
+
+// TestAssistantMessageItemCopyIconClick guards the click contract: a click
+// on the footer glyph must be handled, return a non-nil command (the
+// clipboard copy), and leave the view-mode untouched so the generic
+// expansion path cannot fire. Clicks elsewhere on the footer row or with
+// the wrong button must not copy.
+func TestAssistantMessageItemCopyIconClick(t *testing.T) {
+	t.Parallel()
+
+	sty := styles.CharmtonePantera()
+	msg := finishedTextMessage("copy-4", "raw **markdown** body")
+	item := NewAssistantMessageItem(&sty, msg).(*AssistantMessageItem)
+	item.RawRender(40)
+	require.GreaterOrEqual(t, item.copyIconRow, 0)
+
+	// Click on the glyph: x is chat-relative, so the content column is
+	// offset by MessageLeftPaddingTotal.
+	handled, cmd := item.HandleMouseClickCmd(ansi.MouseLeft,
+		item.copyIconColStart+MessageLeftPaddingTotal, item.copyIconRow)
+	require.True(t, handled, "click on the copy glyph must be handled")
+	require.NotNil(t, cmd, "click on the copy glyph must produce the copy command")
+	require.Equal(t, thinkingCollapsed, item.thinkingViewMode,
+		"a copy click must not disturb the expansion state machine")
+
+	// Click to the left of the glyph on the same row is not a copy.
+	handled, cmd = item.HandleMouseClickCmd(ansi.MouseLeft, 0, item.copyIconRow)
+	require.False(t, handled, "click outside the glyph span must not copy")
+	require.Nil(t, cmd)
+
+	// Right button on the glyph is ignored.
+	handled, cmd = item.HandleMouseClickCmd(ansi.MouseRight,
+		item.copyIconColStart+MessageLeftPaddingTotal, item.copyIconRow)
+	require.False(t, handled)
+	require.Nil(t, cmd)
+
+	// The plain MouseClickable path (defensive: chat falls back to it)
+	// must agree the glyph click is handled without producing a toggle.
+	require.True(t, item.HandleMouseClick(ansi.MouseLeft,
+		item.copyIconColStart+MessageLeftPaddingTotal, item.copyIconRow))
+	require.Equal(t, thinkingCollapsed, item.thinkingViewMode)
+}
+
+// TestAssistantMessageItemThinkingClickStillExpands guards against the new
+// commandable path breaking the old expansion contract: a click on the
+// thinking box reports handled with a nil command so the generic
+// Expandable toggle in model/chat.go still fires.
+func TestAssistantMessageItemThinkingClickStillExpands(t *testing.T) {
+	t.Parallel()
+
+	sty := styles.CharmtonePantera()
+	msg := &message.Message{ID: "copy-5", Role: message.Assistant}
+	item := NewAssistantMessageItem(&sty, msg).(*AssistantMessageItem)
+	item.thinkingBoxHeight = 5
+
+	handled, cmd := item.HandleMouseClickCmd(ansi.MouseLeft, 0, 2)
+	require.True(t, handled, "thinking-box click must still be handled")
+	require.Nil(t, cmd, "thinking-box click must not produce a command (expansion proceeds)")
 }

--- a/internal/ui/list/item.go
+++ b/internal/ui/list/item.go
@@ -3,6 +3,7 @@ package list
 import (
 	"strings"
 
+	tea "charm.land/bubbletea/v2"
 	"github.com/charmbracelet/x/ansi"
 )
 
@@ -97,6 +98,20 @@ type MouseClickable interface {
 	// HandleMouseClick processes a mouse click event at the given coordinates.
 	// It returns true if the event was handled, false otherwise.
 	HandleMouseClick(btn ansi.MouseButton, x, y int) bool
+}
+
+// MouseClickCommandable is an optional extension of [MouseClickable] for
+// items whose click regions can produce a command (e.g. copying text to the
+// clipboard) rather than only signalling hit detection. The chat click
+// dispatcher prefers this interface over [MouseClickable] when an item
+// implements both: a non-nil returned command suppresses the generic
+// expansion toggle that a plain handled click would otherwise trigger.
+type MouseClickCommandable interface {
+	// HandleMouseClickCmd processes a mouse click event at the given
+	// coordinates. It returns whether the event was handled and an optional
+	// command to run. A handled click with a nil command keeps the generic
+	// post-click behavior (expansion); a non-nil command replaces it.
+	HandleMouseClickCmd(btn ansi.MouseButton, x, y int) (bool, tea.Cmd)
 }
 
 // SpacerItem is a spacer item that adds vertical space in the list.

--- a/internal/ui/model/chat.go
+++ b/internal/ui/model/chat.go
@@ -914,41 +914,52 @@ func (m *Chat) HandleMouseDown(x, y int) (bool, tea.Cmd) {
 
 // HandleDelayedClick handles a delayed single-click action (like expansion).
 // It only executes if the click ID matches (i.e., no double-click occurred)
-// and no text selection was made (drag to select).
-func (m *Chat) HandleDelayedClick(msg DelayedClickMsg) bool {
+// and no text selection was made (drag to select). It returns whether the
+// click was handled and an optional command produced by the clicked item
+// (e.g. a clipboard copy from a click-to-copy affordance).
+func (m *Chat) HandleDelayedClick(msg DelayedClickMsg) (bool, tea.Cmd) {
 	// Ignore if this click was superseded by a newer click (double/triple).
 	if msg.ClickID != m.pendingClickID {
-		return false
+		return false, nil
 	}
 
 	// Don't expand if user dragged to select text.
 	if m.HasHighlight() {
-		return false
+		return false, nil
 	}
 
 	// Execute the click action (e.g., expansion).
 	selectedItem := m.list.SelectedItem()
-	if clickable, ok := selectedItem.(list.MouseClickable); ok {
-		handled := clickable.HandleMouseClick(ansi.MouseButton1, msg.X, msg.Y)
-		// Toggle expansion only when the item signalled it handled the
-		// click. Items like AssistantMessageItem only report handled when
-		// the click is on their expandable region, so this avoids
-		// toggling expansion for clicks outside the clickable area.
-		if handled {
-			if expandable, ok := selectedItem.(chat.Expandable); ok {
-				wasFollowing := m.follow
-				if !expandable.ToggleExpanded() {
-					m.ScrollToIndex(m.list.Selected())
-				}
-				if wasFollowing {
-					m.ScrollToBottom()
-				}
-			}
-		}
-		return handled
+	var handled bool
+	var cmd tea.Cmd
+	if commandable, ok := selectedItem.(list.MouseClickCommandable); ok {
+		// Items that can produce click commands get first refusal. A
+		// non-nil command (e.g. copy-to-clipboard) replaces the generic
+		// expansion toggle below.
+		handled, cmd = commandable.HandleMouseClickCmd(ansi.MouseButton1, msg.X, msg.Y)
+	} else if clickable, ok := selectedItem.(list.MouseClickable); ok {
+		handled = clickable.HandleMouseClick(ansi.MouseButton1, msg.X, msg.Y)
+	} else {
+		return false, nil
 	}
 
-	return false
+	// Toggle expansion only when the item signalled it handled the
+	// click without producing a command of its own. Items like
+	// AssistantMessageItem only report handled when the click is on
+	// their expandable region, so this avoids toggling expansion for
+	// clicks outside the clickable area.
+	if handled && cmd == nil {
+		if expandable, ok := selectedItem.(chat.Expandable); ok {
+			wasFollowing := m.follow
+			if !expandable.ToggleExpanded() {
+				m.ScrollToIndex(m.list.Selected())
+			}
+			if wasFollowing {
+				m.ScrollToBottom()
+			}
+		}
+	}
+	return handled, cmd
 }
 
 // HandleMouseUp handles mouse up events for the chat component.

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -991,8 +991,10 @@ func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case copyChatHighlightMsg:
 		cmds = append(cmds, m.copyChatHighlight())
 	case DelayedClickMsg:
-		// Handle delayed single-click action (e.g., expansion).
-		m.chat.HandleDelayedClick(msg)
+		// Handle delayed single-click action (e.g., expansion, copy).
+		if _, cmd := m.chat.HandleDelayedClick(msg); cmd != nil {
+			cmds = append(cmds, cmd)
+		}
 	case tea.MouseClickMsg:
 		// Pass mouse events to dialogs first if any are open.
 		if m.dialog.HasDialogs() {

--- a/internal/ui/styles/quickstyle.go
+++ b/internal/ui/styles/quickstyle.go
@@ -917,6 +917,7 @@ func quickStyle(o quickStyleOpts) Styles {
 	s.Messages.AssistantInfoProvider = subtle
 	s.Messages.AssistantInfoDuration = subtle
 	s.Messages.AssistantCanceled = lipgloss.NewStyle().Foreground(o.fgSubtle).Italic(true)
+	s.Messages.AssistantCopyIcon = muted
 
 	// Channel message metadata styles.
 	s.Messages.ChannelInfoIcon = subtle

--- a/internal/ui/styles/styles.go
+++ b/internal/ui/styles/styles.go
@@ -318,6 +318,7 @@ type Styles struct {
 		AssistantInfoProvider  lipgloss.Style
 		AssistantInfoDuration  lipgloss.Style
 		AssistantCanceled      lipgloss.Style // Italic "Canceled" footer
+		AssistantCopyIcon      lipgloss.Style // Muted click-to-copy footer glyph
 
 		// A2UISurface is the themed container wrapped around rendered A2UI
 		// surfaces so they read as part of the chat (fork: A2UI).


### PR DESCRIPTION
## Summary

Finished assistant messages render a right-aligned **⎘** glyph in the lower-right of the message. Clicking it copies the message's **raw Markdown source** (not the glamour-rendered text) to the clipboard — OSC 52 plus native clipboard, with the standard "Message copied to clipboard" toast, matching the existing `c`/`y` keybinding behavior.

The footer only appears once a message is finished and has content: never while streaming, and never on empty messages.

## How it works

- `internal/ui/chat/assistant.go` — renders the footer row in `renderMessageContent`, records the icon's row/column span, and hit-tests clicks in the new `HandleMouseClickCmd`. The copy reuses the exact keybinding path (`common.CopyToClipboard` on `message.Content().Text`).
- `internal/ui/list/item.go` — new optional `MouseClickCommandable` interface: a click handler that can return a `tea.Cmd`. The old click contract coupled every handled click to the thinking-box expansion toggle; a non-nil command now **replaces** expansion for that click, so copying never toggles the thinking block.
- `internal/ui/model/chat.go` — `HandleDelayedClick` prefers `MouseClickCommandable` and returns the produced command; `MouseClickable` items (shell, tools) are untouched.
- `internal/ui/styles` — `AssistantCopyIcon` style (muted), so the glyph recolors with themes.

## Verification

Five new tests in `assistant_test.go`: footer renders with correct geometry for a finished message, footer suppressed while streaming and on empty messages, icon click produces a copy command without disturbing expansion state, off-glyph/right-button clicks don't copy, and thinking-box clicks still route to expansion with a nil command.

`go test ./internal/ui/...`, `go vet`, `gofumpt`, and `golangci-lint` all clean.

🤖 Posted on behalf of `@joestump` by `kimi-k3` (Moonshot AI) using [Crush](https://github.com/charmbracelet/crush).