### PR TITLE
feat(chat): open hyperlinks in the browser on plain click

### DIFF
--- a/internal/ui/chat/assistant.go
+++ b/internal/ui/chat/assistant.go
@@ -147,6 +147,13 @@ type AssistantMessageItem struct {
 	copyIconColStart int
 	copyIconColEnd   int
 
+	// hyperlinks holds the OSC 8 hyperlink spans found in the last
+	// rendered content, so a plain click on a link can open it in the
+	// browser. Ghostty (and every terminal once an app owns the mouse)
+	// defers link handling to the application, so terminal-level
+	// CMD+click never fires while Crush holds mouse reporting.
+	hyperlinks []hyperlinkSpan
+
 	// Per-section render caches. Splitting these out means content
 	// streaming does not invalidate the (often expensive) thinking
 	// render, and vice versa.
@@ -421,6 +428,12 @@ func (a *AssistantMessageItem) renderMessageContent(width int) (string, int) {
 		a.copyIconColEnd = pad + iconWidth
 		out += "\n\n" + footer
 	}
+
+	// Index hyperlink spans for click-to-open. Reparsing the joined output
+	// (rather than tracking spans through each section cache) keeps the
+	// index consistent with what is actually on screen regardless of which
+	// section caches hit.
+	a.hyperlinks = parseHyperlinkSpans(out)
 
 	return out, lipgloss.Height(out)
 }
@@ -779,6 +792,14 @@ func (a *AssistantMessageItem) HandleMouseClickCmd(btn ansi.MouseButton, x, y in
 		x >= a.copyIconColStart+MessageLeftPaddingTotal && x < a.copyIconColEnd+MessageLeftPaddingTotal {
 		text := a.message.Content().Text
 		return true, common.CopyToClipboard(text, "Message copied to clipboard")
+	}
+	// Hyperlinks open in the browser on plain click. Terminals defer link
+	// handling to the application whenever mouse reporting is active
+	// (verified on Ghostty 1.3.1: CMD+click dies in any mouse mode), so
+	// without this links render but can never be opened. Like the copy
+	// footer, producing a command suppresses the expansion toggle.
+	if url := spanAt(a.hyperlinks, y, x-MessageLeftPaddingTotal); url != "" {
+		return true, openURL(url)
 	}
 	// Only the thinking box is clickable for expansion; other regions of
 	// the assistant message should not trigger expansion.

--- a/internal/ui/chat/hyperlinks.go
+++ b/internal/ui/chat/hyperlinks.go
@@ -1,0 +1,215 @@
+package chat
+
+import (
+	"strings"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/crush/internal/ui/util"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/pkg/browser"
+	"github.com/rivo/uniseg"
+)
+
+// hyperlinkSpan records the cell geometry of one OSC 8 hyperlink inside a
+// rendered (post-glamour) string. Rows are zero-based line offsets within
+// the string; columns are zero-based cell offsets within the row, start
+// inclusive and end exclusive. Spans are produced by [parseHyperlinkSpans]
+// and consumed by MouseClickCommandable implementations to open links on
+// plain (unmodified) clicks, since terminals only act on OSC 8 links for
+// modifier-clicks while the application holds mouse reporting.
+type hyperlinkSpan struct {
+	row      int
+	colStart int
+	colEnd   int
+	url      string
+}
+
+// parseHyperlinkSpans walks a rendered string, decodes OSC 8 hyperlink
+// sequences, and returns one span per contiguous linked run per line.
+// Columns are measured in terminal cells, matching the coordinates the
+// chat click dispatcher hands to items (click handlers offset x for the
+// prefix columns, so spans here are purely content-relative).
+//
+// A link that wraps across a line break produces one span per line
+// segment, all carrying the same URL. Terminals render those as one
+// logical link via the OSC 8 id parameter; treating each segment as its
+// own span keeps hit-testing a simple rectangle check.
+func parseHyperlinkSpans(s string) []hyperlinkSpan {
+	if !strings.ContainsRune(s, 0x1b) {
+		return nil
+	}
+
+	var spans []hyperlinkSpan
+	row, col := 0, 0
+	active := false
+	activeURL := ""
+	segStart := 0
+
+	closeSegment := func() {
+		if active && col > segStart {
+			spans = append(spans, hyperlinkSpan{
+				row:      row,
+				colStart: segStart,
+				colEnd:   col,
+				url:      activeURL,
+			})
+		}
+	}
+
+	parser := ansi.GetParser()
+	defer ansi.PutParser(parser)
+
+	var state byte
+	for len(s) > 0 {
+		if s[0] != 0x1b {
+			if s[0] == '\n' {
+				closeSegment()
+				row++
+				col = 0
+				segStart = 0
+				s = s[1:]
+				continue
+			}
+			// Advance one grapheme cluster so wide cells (CJK, emoji)
+			// count the same width the terminal will give them.
+			cluster, width, rest := firstGrapheme(s)
+			col += width
+			s = rest
+			_ = cluster
+			continue
+		}
+
+		parser.Reset()
+		seq, _, n, newState := ansi.DecodeSequence(s, state, parser)
+		if seq == "" {
+			break
+		}
+		state = newState
+		s = s[n:]
+
+		// OSC 8 hyperlink: ESC ] 8 ; params ; url, terminated by BEL or ST.
+		if strings.HasPrefix(seq, "\x1b]8;") {
+			body := strings.TrimPrefix(seq, "\x1b]8;")
+			body = strings.TrimSuffix(body, "\a")
+			body = strings.TrimSuffix(body, "\x1b\\")
+			var url string
+			if parts := strings.SplitN(body, ";", 2); len(parts) == 2 {
+				url = parts[1]
+			}
+			if url == "" {
+				closeSegment()
+				active = false
+				activeURL = ""
+			} else {
+				active = true
+				activeURL = url
+				segStart = col
+			}
+		}
+	}
+	// Trailing segment with no explicit reset.
+	closeSegment()
+	return spans
+}
+
+// firstGrapheme returns the first grapheme cluster in s, its width in
+// terminal cells, and the remainder of s.
+func firstGrapheme(s string) (string, int, string) {
+	cluster, rest, width, _ := uniseg.FirstGraphemeClusterInString(s, -1)
+	return cluster, width, rest
+}
+
+// spanAt returns the URL of the hyperlink span covering (row, col), or ""
+// when the position is not inside any span.
+func spanAt(spans []hyperlinkSpan, row, col int) string {
+	for _, sp := range spans {
+		if sp.row == row && col >= sp.colStart && col < sp.colEnd {
+			return sp.url
+		}
+	}
+	return ""
+}
+
+// openURL returns a command that opens url in the system browser and
+// reports the outcome as a toast. It exists because terminals hand every
+// mouse event to the application once mouse reporting is enabled, so the
+// terminal's own link-click handling (and its modifier-click affordances)
+// never fires inside the TUI.
+func openURL(url string) tea.Cmd {
+	return func() tea.Msg {
+		if err := browser.OpenURL(url); err != nil {
+			return util.ReportError(err)()
+		}
+		return util.ReportInfo("Opened " + url)()
+	}
+}
+
+// hyperlinkizeURLs wraps bare http(s) URLs in plain text with OSC 8
+// hyperlink sequences so they are clickable in the TUI (and in terminals
+// whenever the application releases the mouse). Glamour already emits OSC
+// 8 for markdown content; this helper exists for plain-text surfaces like
+// tool and shell output that never pass through markdown rendering.
+//
+// The scan is byte-oriented and scheme-anchored ("http://" or "https://"),
+// terminating a URL at whitespace or at characters that cannot legally
+// trail a URL (quotes, angle brackets). Trailing punctuation that is
+// almost certainly prose rather than address (period, comma, semicolon,
+// colon, closing parens and brackets) is trimmed from the link target but
+// left in the visible text.
+func hyperlinkizeURLs(s string) string {
+	if !strings.Contains(s, "://") {
+		return s
+	}
+	var buf strings.Builder
+	buf.Grow(len(s) + 64)
+	i := 0
+	for i < len(s) {
+		idx := urlSchemeAt(s, i)
+		if idx < 0 {
+			buf.WriteString(s[i:])
+			break
+		}
+		buf.WriteString(s[i:idx])
+		end := urlEnd(s, idx)
+		url := strings.TrimRight(s[idx:end], ".,;:)]}\"'")
+		buf.WriteString(ansi.SetHyperlink(url, ""))
+		buf.WriteString(s[idx:end])
+		buf.WriteString(ansi.ResetHyperlink())
+		i = end
+	}
+	return buf.String()
+}
+
+// urlSchemeAt returns the index of the first "http://" or "https://"
+// occurrence in s at or after offset from, or -1.
+func urlSchemeAt(s string, from int) int {
+	http := strings.Index(s[from:], "http://")
+	https := strings.Index(s[from:], "https://")
+	switch {
+	case http < 0:
+		if https < 0 {
+			return -1
+		}
+		return from + https
+	case https < 0:
+		return from + http
+	default:
+		return from + min(http, https)
+	}
+}
+
+// urlEnd returns the offset just past the URL beginning at start (which
+// points at a scheme). The URL runs until whitespace or a quote/bracket
+// that cannot be part of an address in prose.
+func urlEnd(s string, start int) int {
+	i := start
+	for i < len(s) {
+		c := s[i]
+		if c == ' ' || c == '\t' || c == '\n' || c == '\r' ||
+			c == '"' || c == '<' || c == '>' || c == 0x1b {
+			break
+		}
+		i++
+	}
+	return i
+}

--- a/internal/ui/chat/hyperlinks_test.go
+++ b/internal/ui/chat/hyperlinks_test.go
@@ -1,0 +1,208 @@
+package chat
+
+import (
+	"testing"
+
+	"github.com/charmbracelet/crush/internal/message"
+	"github.com/charmbracelet/crush/internal/ui/styles"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseHyperlinkSpans_BasicLink(t *testing.T) {
+	t.Parallel()
+
+	line := "see " + ansi.SetHyperlink("https://stu.mp", "id=1") + "Hell world" + ansi.ResetHyperlink() + " end"
+	spans := parseHyperlinkSpans(line)
+	require.Len(t, spans, 1)
+	require.Equal(t, hyperlinkSpan{row: 0, colStart: 4, colEnd: 14, url: "https://stu.mp"}, spans[0])
+}
+
+func TestParseHyperlinkSpans_MultipleLinesAndLinks(t *testing.T) {
+	t.Parallel()
+
+	s := "no links here\n" +
+		"a " + ansi.SetHyperlink("https://one.test", "id=1") + "one" + ansi.ResetHyperlink() + " b\n" +
+		ansi.SetHyperlink("https://two.test", "id=2") + "two" + ansi.ResetHyperlink()
+	spans := parseHyperlinkSpans(s)
+	require.Len(t, spans, 2)
+	require.Equal(t, hyperlinkSpan{row: 1, colStart: 2, colEnd: 5, url: "https://one.test"}, spans[0])
+	require.Equal(t, hyperlinkSpan{row: 2, colStart: 0, colEnd: 3, url: "https://two.test"}, spans[1])
+}
+
+func TestParseHyperlinkSpans_LinkWrappedAcrossLines(t *testing.T) {
+	t.Parallel()
+
+	// A link open before a newline stays open after it: the wrap must
+	// produce one span per line segment carrying the same URL.
+	s := ansi.SetHyperlink("https://wrap.test", "id=1") + "abc\ndef" + ansi.ResetHyperlink()
+	spans := parseHyperlinkSpans(s)
+	require.Len(t, spans, 2)
+	require.Equal(t, hyperlinkSpan{row: 0, colStart: 0, colEnd: 3, url: "https://wrap.test"}, spans[0])
+	require.Equal(t, hyperlinkSpan{row: 1, colStart: 0, colEnd: 3, url: "https://wrap.test"}, spans[1])
+}
+
+func TestParseHyperlinkSpans_WideCells(t *testing.T) {
+	t.Parallel()
+
+	// CJK characters occupy two cells; the span columns must count cells,
+	// not runes, or the click geometry drifts right of the glyph.
+	s := "見" + ansi.SetHyperlink("https://cjk.test", "id=1") + "ab" + ansi.ResetHyperlink()
+	spans := parseHyperlinkSpans(s)
+	require.Len(t, spans, 1)
+	require.Equal(t, hyperlinkSpan{row: 0, colStart: 2, colEnd: 4, url: "https://cjk.test"}, spans[0])
+}
+
+func TestParseHyperlinkSpans_NoEscapes(t *testing.T) {
+	t.Parallel()
+	require.Nil(t, parseHyperlinkSpans("plain text, no escapes"))
+	require.Nil(t, parseHyperlinkSpans(""))
+}
+
+func TestParseHyperlinkSpans_STTerminator(t *testing.T) {
+	t.Parallel()
+
+	// OSC sequences may end with ST (ESC \) instead of BEL. Build the
+	// string from byte literals so the two-byte ST (ESC backslash) is
+	// unambiguous.
+	s := "x \x1b]8;;https://st.test\x1b\\go\x1b]8;;\x1b\\ y"
+	spans := parseHyperlinkSpans(s)
+	require.Len(t, spans, 1)
+	require.Equal(t, "https://st.test", spans[0].url)
+	require.Equal(t, 2, spans[0].colStart)
+	require.Equal(t, 4, spans[0].colEnd)
+}
+
+func TestSpanAt(t *testing.T) {
+	t.Parallel()
+
+	spans := []hyperlinkSpan{
+		{row: 0, colStart: 4, colEnd: 14, url: "https://a.test"},
+		{row: 2, colStart: 0, colEnd: 3, url: "https://b.test"},
+	}
+	require.Equal(t, "https://a.test", spanAt(spans, 0, 4))
+	require.Equal(t, "https://a.test", spanAt(spans, 0, 13))
+	require.Empty(t, spanAt(spans, 0, 14), "end is exclusive")
+	require.Empty(t, spanAt(spans, 1, 4), "wrong row")
+	require.Equal(t, "https://b.test", spanAt(spans, 2, 0))
+	require.Empty(t, spanAt(nil, 0, 0))
+}
+
+func TestHyperlinkizeURLs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		in    string
+		want  string
+		noOSC bool
+	}{
+		{name: "no url", in: "just some text", noOSC: true},
+		{
+			name: "https url", in: "see https://example.com/docs here",
+			want: "\x1b]8;;https://example.com/docs\ahttps://example.com/docs\x1b]8;;\a",
+		},
+		{
+			name: "http url", in: "go to http://insecure.test now",
+			want: "\x1b]8;;http://insecure.test\ahttp://insecure.test\x1b]8;;\a",
+		},
+		{
+			name: "trailing period trimmed from target", in: "visit https://example.com.",
+			want: "\x1b]8;;https://example.com\ahttps://example.com.\x1b]8;;\a",
+		},
+		{
+			name: "two urls", in: "https://a.test and https://b.test",
+			want: "\x1b]8;;https://a.test\ahttps://a.test\x1b]8;;\a and \x1b]8;;https://b.test\ahttps://b.test\x1b]8;;\a",
+		},
+		{
+			name: "url in quotes not extended", in: `"https://quoted.test"`,
+			want: "\x1b]8;;https://quoted.test\ahttps://quoted.test\x1b]8;;\a",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			out := hyperlinkizeURLs(tc.in)
+			if tc.noOSC {
+				require.Equal(t, tc.in, out, "text without URLs must pass through untouched")
+				return
+			}
+			require.Contains(t, out, tc.want)
+		})
+	}
+}
+
+// TestHyperlinkizeURLs_RoundTrip verifies the wrapper output parses back
+// to spans covering exactly the URL text.
+func TestHyperlinkizeURLs_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	out := hyperlinkizeURLs("open https://example.com/path?q=1 for docs")
+	spans := parseHyperlinkSpans(out)
+	require.Len(t, spans, 1)
+	require.Equal(t, "https://example.com/path?q=1", spans[0].url)
+	require.Equal(t, 5, spans[0].colStart)
+	require.Equal(t, 5+len("https://example.com/path?q=1"), spans[0].colEnd)
+}
+
+// TestAssistantMessageItemHyperlinkClick guards the click-to-open contract
+// on assistant messages: a plain click on a rendered hyperlink span must
+// be handled and produce a command (browser open), without disturbing the
+// expansion state machine or the copy footer.
+func TestAssistantMessageItemHyperlinkClick(t *testing.T) {
+	t.Parallel()
+
+	sty := styles.CharmtonePantera()
+	msg := &message.Message{
+		ID:   "link-1",
+		Role: message.Assistant,
+		Parts: []message.ContentPart{
+			message.TextContent{Text: "docs at https://example.com/guide today"},
+			message.Finish{Reason: message.FinishReasonEndTurn, Time: testFinishTime},
+		},
+	}
+	item := NewAssistantMessageItem(&sty, msg).(*AssistantMessageItem)
+	item.RawRender(60)
+	require.NotEmpty(t, item.hyperlinks, "rendered markdown links must be indexed")
+
+	sp := item.hyperlinks[0]
+	// Click the middle of the link span (chat-relative x).
+	handled, cmd := item.HandleMouseClickCmd(ansi.MouseLeft,
+		(sp.colStart+sp.colEnd)/2+MessageLeftPaddingTotal, sp.row)
+	require.True(t, handled, "click on a hyperlink must be handled")
+	require.NotNil(t, cmd, "click on a hyperlink must produce the open command")
+	require.Equal(t, thinkingCollapsed, item.thinkingViewMode,
+		"opening a link must not toggle expansion")
+
+	// Click off the link is not the open path.
+	_, cmd = item.HandleMouseClickCmd(ansi.MouseLeft, MessageLeftPaddingTotal, sp.row)
+	require.Nil(t, cmd)
+}
+
+// TestUserMessageItemHyperlinkClick guards click-to-open on user messages,
+// which previously had no mouse handling at all.
+func TestUserMessageItemHyperlinkClick(t *testing.T) {
+	t.Parallel()
+
+	sty := styles.CharmtonePantera()
+	msg := &message.Message{
+		ID:    "ulink-1",
+		Role:  message.User,
+		Parts: []message.ContentPart{message.TextContent{Text: "check https://example.com out"}},
+	}
+	item := NewUserMessageItem(&sty, msg, nil).(*UserMessageItem)
+	item.RawRender(60)
+	require.NotEmpty(t, item.hyperlinks, "user message links must be indexed")
+
+	sp := item.hyperlinks[0]
+	handled, cmd := item.HandleMouseClickCmd(ansi.MouseLeft,
+		(sp.colStart+sp.colEnd)/2+MessageLeftPaddingTotal, sp.row)
+	require.True(t, handled)
+	require.NotNil(t, cmd)
+
+	// Off-link clicks are unhandled (no expansion behavior on user items).
+	handled, cmd = item.HandleMouseClickCmd(ansi.MouseLeft, MessageLeftPaddingTotal, sp.row+1)
+	require.False(t, handled)
+	require.Nil(t, cmd)
+}

--- a/internal/ui/chat/shell.go
+++ b/internal/ui/chat/shell.go
@@ -38,7 +38,8 @@ type ShellItem struct {
 	exitCode        int
 	expandedContent bool
 	xOffset         int
-	maxLineWidth    int // computed during render, used to clamp xOffset
+	maxLineWidth    int             // computed during render, used to clamp xOffset
+	hyperlinks      []hyperlinkSpan // OSC 8 spans in the last render, for click-to-open
 	sty             *styles.Styles
 	pending         bool
 	anim            *anim.Anim
@@ -159,7 +160,22 @@ func (s *ShellItem) Render(width int) string {
 
 // HandleMouseClick implements MouseClickable so clicks select this item.
 func (s *ShellItem) HandleMouseClick(btn ansi.MouseButton, x, y int) bool {
-	return btn == ansi.MouseLeft
+	handled, _ := s.HandleMouseClickCmd(btn, x, y)
+	return handled
+}
+
+// HandleMouseClickCmd implements [list.MouseClickCommandable]. A plain
+// click on a hyperlink span in the shell output opens the URL in the
+// browser; other left clicks report handled with a nil command so the
+// item keeps its existing select-on-click behavior.
+func (s *ShellItem) HandleMouseClickCmd(btn ansi.MouseButton, x, y int) (bool, tea.Cmd) {
+	if btn != ansi.MouseLeft {
+		return false, nil
+	}
+	if url := spanAt(s.hyperlinks, y, x-MessageLeftPaddingTotal); url != "" {
+		return true, openURL(url)
+	}
+	return true, nil
 }
 
 // HandleKeyEvent implements KeyEventHandler for copy and horizontal scrolling.
@@ -199,6 +215,19 @@ func (s *ShellItem) ToggleExpanded() bool {
 }
 
 func (s *ShellItem) RawRender(width int) string {
+	out := s.renderShell(width)
+	// Index hyperlink spans after the horizontal-scroll cut so the click
+	// hit-test matches the visible text. Links cut mid-way by scrolling
+	// simply drop out of the index (the opening sequence is gone), which
+	// degrades to non-clickable rather than a corrupt hit-zone.
+	s.hyperlinks = parseHyperlinkSpans(out)
+	return out
+}
+
+// renderShell assembles the shell item's rendered output. Kept separate
+// from RawRender so hyperlink indexing applies uniformly at every return
+// point.
+func (s *ShellItem) renderShell(width int) string {
 	cappedWidth := cappedMessageWidth(width)
 
 	cmd := strings.ReplaceAll(s.command, "\n", " ")
@@ -263,6 +292,7 @@ func (s *ShellItem) RawRender(width int) string {
 
 	raw = common.StripCursorControl(raw)
 	output := common.RemapANSI16(raw, s.sty.ANSI)
+	output = hyperlinkizeURLs(output)
 	lines := strings.Split(output, "\n")
 
 	// Compute max line width for scroll clamping.

--- a/internal/ui/chat/tools.go
+++ b/internal/ui/chat/tools.go
@@ -158,6 +158,11 @@ type baseToolMessageItem struct {
 	sty             *styles.Styles
 	anim            *anim.Anim
 	expandedContent bool
+
+	// hyperlinks holds the OSC 8 hyperlink spans in the last rendered
+	// output so a plain click on a URL opens it in the browser (see
+	// parseHyperlinkSpans for why the app must handle this itself).
+	hyperlinks []hyperlinkSpan
 }
 
 var _ Expandable = (*baseToolMessageItem)(nil)
@@ -365,6 +370,11 @@ func (t *baseToolMessageItem) RawRender(width int) string {
 		t.setCachedRender(content, toolItemWidth, height)
 	}
 
+	// Re-index hyperlink spans on every render (cheap relative to the
+	// glamour/tool render above) so the click hit-test always matches
+	// what is on screen, cache hit or not.
+	t.hyperlinks = parseHyperlinkSpans(content)
+
 	return t.renderHighlighted(content, toolItemWidth, height)
 }
 
@@ -506,7 +516,23 @@ func (t *baseToolMessageItem) Finished() bool {
 
 // HandleMouseClick implements MouseClickable.
 func (t *baseToolMessageItem) HandleMouseClick(btn ansi.MouseButton, x, y int) bool {
-	return btn == ansi.MouseLeft
+	handled, _ := t.HandleMouseClickCmd(btn, x, y)
+	return handled
+}
+
+// HandleMouseClickCmd implements [list.MouseClickCommandable]. A plain
+// click on a hyperlink span in the tool output opens the URL in the
+// browser (producing a command, which suppresses the expansion toggle);
+// any other left click reports handled with a nil command so the generic
+// Expandable path toggles the item as before.
+func (t *baseToolMessageItem) HandleMouseClickCmd(btn ansi.MouseButton, x, y int) (bool, tea.Cmd) {
+	if btn != ansi.MouseLeft {
+		return false, nil
+	}
+	if url := spanAt(t.hyperlinks, y, x-MessageLeftPaddingTotal); url != "" {
+		return true, openURL(url)
+	}
+	return true, nil
 }
 
 // HandleKeyEvent implements KeyEventHandler.
@@ -658,6 +684,7 @@ func toolOutputPlainContent(sty *styles.Styles, content string, width int, expan
 	content = stringext.NormalizeSpace(content)
 	content = common.StripCursorControl(content)
 	content = common.RemapANSI16(content, sty.ANSI)
+	content = hyperlinkizeURLs(content)
 	lines := strings.Split(content, "\n")
 
 	maxLines := responseContextHeight

--- a/internal/ui/chat/user.go
+++ b/internal/ui/chat/user.go
@@ -11,6 +11,7 @@ import (
 	"github.com/charmbracelet/crush/internal/ui/common"
 	"github.com/charmbracelet/crush/internal/ui/list"
 	"github.com/charmbracelet/crush/internal/ui/styles"
+	"github.com/charmbracelet/x/ansi"
 )
 
 // skillInvocation represents the XML structure for a loaded skill.
@@ -42,6 +43,12 @@ type UserMessageItem struct {
 	attachments *attachments.Renderer
 	message     *message.Message
 	sty         *styles.Styles
+
+	// hyperlinks holds the OSC 8 hyperlink spans found in the last
+	// rendered content, so a plain click on a link opens it in the
+	// browser (terminals defer link clicks to the app under mouse
+	// reporting; see parseHyperlinkSpans).
+	hyperlinks []hyperlinkSpan
 }
 
 // NewUserMessageItem creates a new UserMessageItem.
@@ -71,6 +78,7 @@ func (m *UserMessageItem) RawRender(width int) string {
 	content, height, ok := m.getCachedRender(cappedWidth)
 	// cache hit
 	if ok {
+		m.hyperlinks = parseHyperlinkSpans(content)
 		return m.renderHighlighted(content, cappedWidth, height)
 	}
 
@@ -81,6 +89,7 @@ func (m *UserMessageItem) RawRender(width int) string {
 		content = m.renderSkillInvocation(msgContent, cappedWidth)
 		height = lipgloss.Height(content)
 		m.setCachedRender(content, cappedWidth, height)
+		m.hyperlinks = parseHyperlinkSpans(content)
 		return m.renderHighlighted(content, cappedWidth, height)
 	}
 
@@ -89,6 +98,7 @@ func (m *UserMessageItem) RawRender(width int) string {
 		content = m.renderChannelMessage(msgContent, cappedWidth)
 		height = lipgloss.Height(content)
 		m.setCachedRender(content, cappedWidth, height)
+		m.hyperlinks = parseHyperlinkSpans(content)
 		return m.renderHighlighted(content, cappedWidth, height)
 	}
 
@@ -116,6 +126,7 @@ func (m *UserMessageItem) RawRender(width int) string {
 
 	height = lipgloss.Height(content)
 	m.setCachedRender(content, cappedWidth, height)
+	m.hyperlinks = parseHyperlinkSpans(content)
 	return m.renderHighlighted(content, cappedWidth, height)
 }
 
@@ -237,6 +248,20 @@ func (m *UserMessageItem) HandleKeyEvent(key tea.KeyMsg) (bool, tea.Cmd) {
 	if k := key.String(); k == "c" || k == "y" {
 		text := m.message.Content().Text
 		return true, common.CopyToClipboard(text, "Message copied to clipboard")
+	}
+	return false, nil
+}
+
+// HandleMouseClickCmd implements [list.MouseClickCommandable]. A plain
+// click on a hyperlink span opens the URL in the system browser; all
+// other clicks fall through unhandled (user messages have no expansion
+// behavior, and terminals never see the click under mouse reporting).
+func (m *UserMessageItem) HandleMouseClickCmd(btn ansi.MouseButton, x, y int) (bool, tea.Cmd) {
+	if btn != ansi.MouseLeft {
+		return false, nil
+	}
+	if url := spanAt(m.hyperlinks, y, x-MessageLeftPaddingTotal); url != "" {
+		return true, openURL(url)
 	}
 	return false, nil
 }


### PR DESCRIPTION
## Summary

(Supersedes #211 — GitHub dropped the pull_request workflow event on that branch; identical diff here.)


(Supersedes #211 — GitHub dropped the pull_request workflow event on that branch; identical diff here.)
URLs in chat have always *rendered* as underlined links but were never clickable. Root cause: once an application enables mouse reporting (which Crush does for text selection and expansion), the terminal hands it every mouse event — Ghostty 1.3.1 drops its own link handling entirely in **any** mouse mode, so even CMD+click dies. Verified with a minimal bubbletea repro: links work with mouse off, fail in cell-motion and all-motion modes.

(Supersedes #211 — GitHub dropped the pull_request workflow event on that branch; identical diff here.)


(Supersedes #211 — GitHub dropped the pull_request workflow event on that branch; identical diff here.)
This PR makes links work by handling clicks application-side:

(Supersedes #211 — GitHub dropped the pull_request workflow event on that branch; identical diff here.)


(Supersedes #211 — GitHub dropped the pull_request workflow event on that branch; identical diff here.)
- **Assistant and user messages** — glamour already emits OSC 8 hyperlinks for markdown links and bare autolinks; Crush now indexes those spans at render and opens the URL in the system browser on plain click, with a toast confirmation.

(Supersedes #211 — GitHub dropped the pull_request workflow event on that branch; identical diff here.)
- **Tool and shell output** — bare `http(s)` URLs are wrapped in OSC 8 at render time (`hyperlinkizeURLs`), so output links are clickable too.

(Supersedes #211 — GitHub dropped the pull_request workflow event on that branch; identical diff here.)
- Click-to-open produces a `tea.Cmd` via the existing `MouseClickCommandable` path, so a link click never toggles expansion, and the `⎘` copy footer keeps precedence on its own row.

(Supersedes #211 — GitHub dropped the pull_request workflow event on that branch; identical diff here.)
- Uses `pkg/browser` (already a dependency for OAuth flows).

(Supersedes #211 — GitHub dropped the pull_request workflow event on that branch; identical diff here.)


(Supersedes #211 — GitHub dropped the pull_request workflow event on that branch; identical diff here.)
Not included (by design): hover hand-cursor (terminal-owned, impossible app-side) and copy-icon suffixes on URLs (redundant once links open).

(Supersedes #211 — GitHub dropped the pull_request workflow event on that branch; identical diff here.)


(Supersedes #211 — GitHub dropped the pull_request workflow event on that branch; identical diff here.)
## Verification

(Supersedes #211 — GitHub dropped the pull_request workflow event on that branch; identical diff here.)


(Supersedes #211 — GitHub dropped the pull_request workflow event on that branch; identical diff here.)
- 16 new tests: span parser (multi-line, wrapped links, CJK wide cells, ST/BEL terminators), `spanAt` hit-testing, `hyperlinkizeURLs` (scheme variants, trailing punctuation, quotes, round-trip), and click contracts on assistant + user items (open command produced, expansion state untouched, off-link clicks fall through).

(Supersedes #211 — GitHub dropped the pull_request workflow event on that branch; identical diff here.)
- `go test ./internal/ui/...`, `go vet`, `gofumpt`, `golangci-lint` all clean.

(Supersedes #211 — GitHub dropped the pull_request workflow event on that branch; identical diff here.)


(Supersedes #211 — GitHub dropped the pull_request workflow event on that branch; identical diff here.)
## Notes for reviewers

(Supersedes #211 — GitHub dropped the pull_request workflow event on that branch; identical diff here.)


(Supersedes #211 — GitHub dropped the pull_request workflow event on that branch; identical diff here.)
- Shell items horizontally scroll; spans are re-indexed after the scroll cut so hit zones match visible text. A link cut mid-way by scrolling simply isn't clickable (never a corrupt hit zone).

(Supersedes #211 — GitHub dropped the pull_request workflow event on that branch; identical diff here.)
- Spans re-parse on every render including cache hits, so the index always reflects what's on screen.

(Supersedes #211 — GitHub dropped the pull_request workflow event on that branch; identical diff here.)


(Supersedes #211 — GitHub dropped the pull_request workflow event on that branch; identical diff here.)
🤖 Posted on behalf of `@joestump` by `kimi-k3` (Moonshot AI) using [Crush](https://github.com/charmbracelet/crush).

(Supersedes #211 — GitHub dropped the pull_request workflow event on that branch; identical diff here.)