### PR TITLE
fix(chat): pin click-to-copy icon to the item's right edge

### DIFF
--- a/internal/ui/chat/assistant.go
+++ b/internal/ui/chat/assistant.go
@@ -424,15 +424,15 @@ func (a *AssistantMessageItem) renderMessageContent(width int) (string, int) {
 			head = out[:idx+1]
 			lastLine = out[idx+1:]
 		}
-		// Glamour pads the last line to the full render width with styled
-		// spaces, so appending the icon after it would push the line one
-		// cell past the item width, where the compositor clips it (and a
-		// chat-relative mouse x can never reach). Overwrite the trailing
-		// padding instead so the line stays within width.
-		iconCol := lipgloss.Width(lastLine)
-		if maxCol := width - iconWidth; iconCol > maxCol {
-			iconCol = max(maxCol, 0)
+		// The icon hugs the right edge of the item: pad (or truncate)
+		// the last line so the icon's rightmost cell lands on the item
+		// width, keeping the line within width so the compositor does
+		// not clip it and a chat-relative mouse x can reach it.
+		iconCol := max(width-iconWidth, 0)
+		if w := lipgloss.Width(lastLine); w > iconCol {
 			lastLine = ansi.Truncate(lastLine, iconCol, "")
+		} else {
+			lastLine += strings.Repeat(" ", iconCol-w)
 		}
 		a.copyIconColStart = iconCol
 		a.copyIconColEnd = iconCol + iconWidth

--- a/internal/ui/chat/user.go
+++ b/internal/ui/chat/user.go
@@ -134,15 +134,15 @@ func (m *UserMessageItem) RawRender(width int) string {
 			head = content[:idx+1]
 			lastLine = content[idx+1:]
 		}
-		// Glamour pads the last line to the full render width with styled
-		// spaces, so appending the icon after it would push the line one
-		// cell past the item width, where the compositor clips it (and a
-		// chat-relative mouse x can never reach). Overwrite the trailing
-		// padding instead so the line stays within width.
-		iconCol := lipgloss.Width(lastLine)
-		if maxCol := cappedWidth - iconWidth; iconCol > maxCol {
-			iconCol = max(maxCol, 0)
+		// The icon hugs the right edge of the item: pad (or truncate)
+		// the last line so the icon's rightmost cell lands on the item
+		// width, keeping the line within width so the compositor does
+		// not clip it and a chat-relative mouse x can reach it.
+		iconCol := max(cappedWidth-iconWidth, 0)
+		if w := lipgloss.Width(lastLine); w > iconCol {
 			lastLine = ansi.Truncate(lastLine, iconCol, "")
+		} else {
+			lastLine += strings.Repeat(" ", iconCol-w)
 		}
 		m.copyIconColStart = iconCol
 		m.copyIconColEnd = iconCol + iconWidth


### PR DESCRIPTION
The click-to-copy ⎘ was appended at the end of the last line's text, so on short final lines it floated mid-line instead of hugging the right edge of the message item, where the eye looks for it.

- Pad (or truncate) the last line so the icon's rightmost cell always lands on the item width, in both assistant and user messages.
- Click hitbox geometry (`copyIconColStart/End`) follows the same fixed column, so mouse hit-testing is unchanged in shape.

Verified: `go test ./internal/ui/chat/` passes; existing geometry assertions derive expectations from the recorded columns rather than hardcoded positions.

🤖 Posted on behalf of `@joestump` by [`kimi-k3`](https://openrouter.ai/moonshotai/kimi-k3) using [Crush](https://github.com/charmbracelet/crush).