### PR TITLE
fix(scheduler): reject stale-clock one-shots; clear fired tasks from the pill

### DIFF
--- a/internal/agent/tools/croncreate.md
+++ b/internal/agent/tools/croncreate.md
@@ -4,7 +4,7 @@ Takes a 5-field cron expression (minute hour day-of-month month day-of-week) eva
 
 Tasks fire at the top of the specified minute. If you pin the current minute (e.g. it is 06:22:50 and you schedule for minute 22), the task fires at 06:23:00, not 10 seconds later. Sub-minute precision is not supported.
 
-**Scheduling relative to "now"**: The current date and time is available in the `<env>` block of your system prompt — use it directly to compute cron fields. Do NOT call `date`, `time`, or any shell command to look up the current time.
+**Scheduling relative to "now"**: The `<env>` block in your system prompt carries the session's START time, which goes stale the longer the session runs. Before computing cron fields, call `date` in the shell to get the actual current time — a schedule built from the stale env time lands in the past and is rejected.
 
 To schedule N minutes from now, add N to the current minute (handling hour/day rollover). For example, if the env says "7/30/2026, 7:29:00 PM PDT" and the user asks for "1 minute from now", use minute 30 (29+1). If they ask for "5 minutes from now", use minute 34 (29+5). If the sum exceeds 59, rollover to the next hour and adjust accordingly.
 
@@ -15,5 +15,7 @@ To schedule N minutes from now, add N to the current minute (handling hour/day r
 - "At 2:30pm today": "30 14 <today_dom> <today_month> *", recurring: false
 
 Expressions that are syntactically valid but can never match — "0 0 30 2 *", February 30th — are rejected rather than accepted as a task that silently never runs.
+
+A one-shot (recurring: false) whose pinned time has already passed today is also rejected: its next match would jump to tomorrow or next year, which is never what a one-shot means. Recompute the cron fields against the current time and try again. Recurring schedules are unaffected — a daily 9am task created at 10:30 legitimately fires tomorrow.
 
 Set recurring to false for a one-shot reminder that fires once and deletes itself (pin minute/hour/day-of-month/month to specific values). Set durable to true to persist the task to disk so it survives restarts; otherwise it lives only in this session. A session can hold up to 50 scheduled tasks. Returns a task ID you can pass to CronDelete.

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -62,6 +62,16 @@ var ErrTooManyTasks = errors.New("session already has the maximum of 50 schedule
 // match, such as "0 0 30 2 *" (February 30th).
 var ErrNeverFires = errors.New("cron expression is valid but will never fire")
 
+// ErrOneShotInPast is returned when a one-shot (non-recurring) task's
+// schedule already matched at an earlier minute today. The intended
+// fire time is then unrecoverable: the schedule's next match has jumped
+// to tomorrow, next month, or next year, which is never what a one-shot
+// means. The usual cause is an agent computing the cron fields against
+// a stale clock (e.g. the session-start time in its prompt rather than
+// the actual current time), so the error names the next match to make
+// the discrepancy visible.
+var ErrOneShotInPast = errors.New("one-shot schedule's fire time has already passed today")
+
 // Store keeps scheduled tasks for all sessions. Session tasks live only
 // in memory; durable tasks are additionally persisted to a JSON file so
 // they survive restarts.
@@ -174,6 +184,13 @@ func (s *Store) Create(sessionID, cronExpr, prompt string, recurring, durable bo
 	// that so users are not confused by sub-minute firing.
 	nextRun = nextRun.Truncate(time.Minute)
 
+	// A one-shot whose schedule already matched earlier today pinned a
+	// fire time that has passed; accepting it would store a task firing
+	// tomorrow or next year when the caller meant "in a few minutes".
+	if !recurring && matchedEarlierToday(sched, now) {
+		return Task{}, fmt.Errorf("%w: %q next matches %s", ErrOneShotInPast, cronExpr, nextRun.Format(time.RFC3339))
+	}
+
 	id, err := NewTaskID()
 	if err != nil {
 		return Task{}, err
@@ -194,6 +211,22 @@ func (s *Store) Create(sessionID, cronExpr, prompt string, recurring, durable bo
 		return Task{}, err
 	}
 	return *task, nil
+}
+
+// matchedEarlierToday reports whether the schedule's most recent match
+// is at or before the current minute today. A one-shot created after
+// such a match can only fire on a later day than its fields suggest —
+// the signature of cron fields computed against a stale clock. The
+// current minute counts as "already passed": robfig treats it as
+// consumed, so a schedule matching it next fires tomorrow or beyond.
+// Next returns the first match strictly after its argument, so the
+// cursor starts a second before midnight to include a "0 0 ..."
+// schedule firing exactly at midnight.
+func matchedEarlierToday(sched *Schedule, now time.Time) bool {
+	midnight := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
+	today := now.Truncate(time.Minute)
+	next := sched.Next(midnight.Add(-time.Second))
+	return !next.IsZero() && !next.After(today)
 }
 
 // List returns the tasks belonging to sessionID, ordered by next run.

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -348,6 +348,38 @@ func TestCreateRejectsScheduleThatNeverFires(t *testing.T) {
 	require.Empty(t, store.ListAll(), "a rejected task must not be stored")
 }
 
+// A one-shot pinned to a minute that already passed today must be
+// rejected: its next match has jumped to tomorrow or next year, which
+// is never what "remind me in 3 minutes" means. This is the signature
+// of cron fields computed against a stale clock. Recurring tasks are
+// exempt — "0 9 * * *" created at 10:30 legitimately fires tomorrow.
+func TestCreateRejectsOneShotInPast(t *testing.T) {
+	t.Parallel()
+
+	// testStore's clock is 2026-07-27 10:30 local.
+	store := testStore(t)
+
+	// 09:15 today already passed: the next match is tomorrow.
+	_, err := store.Create("s1", "15 9 27 7 *", "stale-clock one-shot", false, false)
+	require.ErrorIs(t, err, ErrOneShotInPast)
+	require.Empty(t, store.ListAll(), "a rejected task must not be stored")
+
+	// 10:45 today is still ahead: accepted, fires today.
+	task, err := store.Create("s1", "45 10 27 7 *", "future one-shot", false, false)
+	require.NoError(t, err)
+	require.Equal(t, time.Date(2026, 7, 27, 10, 45, 0, 0, time.Local), task.NextRunAt)
+
+	// The current minute counts as already passed: robfig treats it as
+	// consumed, so a fully-pinned one-shot for 10:30 created at 10:30
+	// would otherwise store a next run a year out.
+	_, err = store.Create("s1", "30 10 27 7 *", "this minute", false, false)
+	require.ErrorIs(t, err, ErrOneShotInPast)
+
+	// A daily recurring schedule whose time passed today is fine.
+	_, err = store.Create("s1", "0 9 * * *", "recurring 9am", true, false)
+	require.NoError(t, err)
+}
+
 // The same guard has to hold on the rescheduling path. A recurring task
 // whose next fire falls outside the lookahead window is deleted rather
 // than left with a zero NextRunAt, which would spin the scheduler.

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -1535,6 +1535,11 @@ func (m *UI) appendSessionMessage(msg message.Message) tea.Cmd {
 			return nil
 		}
 		m.lastUserMessageTime = msg.CreatedAt
+		// A scheduled task's prompt arrives as an ordinary user
+		// message; firing also deletes one-shots from the store, so
+		// re-list to keep the scheduled pill from showing a task that
+		// has already run.
+		m.refreshCronTasks()
 		items := chat.ExtractMessageItems(m.com.Styles, &msg, nil)
 		for _, item := range items {
 			if animatable, ok := item.(chat.Animatable); ok {


### PR DESCRIPTION
Two scheduling bugs surfaced by a single symptom: a "remind me in 3 minutes" one-shot got scheduled for **2027** and then kept showing in the pill even after it fired.

- **Reject one-shots whose fire time has passed today.** The CronCreate tool doc told agents to compute cron fields from the `<env>` block time — the session's *start* time, which goes stale the longer the session runs. A one-shot pinned to an already-passed minute silently scheduled its next match for tomorrow or next year. `Create` now rejects these with `ErrOneShotInPast` naming the actual next match, and the doc tells the agent to run `date` for the real current time. Recurring schedules are unaffected (a daily 9am task created at 10:30 legitimately fires tomorrow). Verified against robfig semantics: the current minute counts as consumed, so a fully-pinned one-shot for "this minute" would otherwise wait a year.
- **Clear fired tasks from the scheduled pill.** Firing a one-shot deletes it from the store, but the pill only re-listed on session load and after cron *tool* results — a fired task's prompt arrives as an ordinary user message, so the pill showed the stale entry until an unrelated refresh. Re-list on incoming user messages.

Verified: `go test -count=1 ./internal/scheduler/ ./internal/agent/tools/ ./internal/ui/model/` all pass, including new `TestCreateRejectsOneShotInPast` covering past-minute rejection, future-minute acceptance, current-minute rejection, and the recurring exemption.

🤖 Posted on behalf of `@joestump` by [`kimi-k3`](https://openrouter.ai/moonshotai/kimi-k3) using [Crush](https://github.com/charmbracelet/crush).