### PR TITLE
fix(paste): warn when pasting an image on an image-incapable model

### DIFF
--- a/internal/ui/model/paste_image_test.go
+++ b/internal/ui/model/paste_image_test.go
@@ -4,11 +4,13 @@ import (
 	"reflect"
 	"testing"
 
-	"charm.land/catwalk/pkg/catwalk"
 	tea "charm.land/bubbletea/v2"
+	"charm.land/catwalk/pkg/catwalk"
 	"github.com/charmbracelet/crush/internal/config"
 	"github.com/charmbracelet/crush/internal/csync"
+	"github.com/charmbracelet/crush/internal/ui/attachments"
 	"github.com/charmbracelet/crush/internal/ui/dialog"
+	"github.com/charmbracelet/crush/internal/ui/util"
 	"github.com/stretchr/testify/require"
 )
 
@@ -94,12 +96,14 @@ func TestHandlePasteMsg_EmptyContentRoutesToClipboardImage(t *testing.T) {
 		"empty paste must route to pasteImageFromClipboard, not the text insertion path")
 }
 
-// TestHandlePasteMsg_EmptyContentOnImageIncapableModelReturnsNil ensures the
+// TestHandlePasteMsg_EmptyContentOnImageIncapableModelWarns ensures the
 // clipboard-image fallback is gated to image-capable models, mirroring the
 // key-bound path (ui.go:2476-2480). On a text-only model, an empty paste must
 // not attach an image chip that preparePrompt would silently drop at send
-// time — it should no-op (return nil) instead.
-func TestHandlePasteMsg_EmptyContentOnImageIncapableModelReturnsNil(t *testing.T) {
+// time — but it must not silently no-op either: it returns a warning command
+// so the user can see why nothing landed (the silent nil return is what made
+// #197 undiagnosable from the UX).
+func TestHandlePasteMsg_EmptyContentOnImageIncapableModelWarns(t *testing.T) {
 	t.Parallel()
 
 	// Start from the fully wired newTestUI (focus, textarea, layout) and
@@ -117,10 +121,62 @@ func TestHandlePasteMsg_EmptyContentOnImageIncapableModelReturnsNil(t *testing.T
 
 	cmd := u.handlePasteMsg(tea.PasteMsg{Content: ""})
 
-	require.Nil(t, cmd,
+	require.NotNil(t, cmd,
+		"empty paste on an image-incapable model must return a warning command, not nil")
+	msg := cmd()
+	infoMsg, ok := msg.(util.InfoMsg)
+	require.True(t, ok, "expected util.InfoMsg, got %T", msg)
+	require.Equal(t, util.InfoTypeWarn, infoMsg.Type,
+		"incapable-model paste must warn the user")
+	require.Contains(t, infoMsg.Msg, "doesn't support images")
+	require.NotEqual(t, clipboardCmdPointer(u), reflect.ValueOf(cmd).Pointer(),
 		"empty paste on an image-incapable model must not route to clipboard image fallback")
 	require.Equal(t, "existing text", u.textarea.Value(),
 		"empty paste must not modify textarea content")
+}
+
+// TestPasteImageKeyOnImageIncapableModelWarns exercises the key-bound path
+// (ctrl+v / super+v): on a text-only model it must not attach an image, but
+// must surface a warning instead of silently doing nothing.
+func TestPasteImageKeyOnImageIncapableModelWarns(t *testing.T) {
+	t.Parallel()
+
+	u := newSidebarTestUI()
+	u.com.Workspace = &testWorkspace{cfg: &config.Config{
+		Providers: csync.NewMap[string, config.ProviderConfig](),
+		Agents:    map[string]config.Agent{},
+	}}
+	u.attachments = attachments.New(nil, attachments.Keymap{})
+	require.False(t, u.currentModelSupportsImages(),
+		"test precondition: the stub config must be image-incapable")
+
+	cmd := u.handleKeyPressMsg(tea.KeyPressMsg{Code: 'v', Mod: tea.ModCtrl})
+
+	require.NotNil(t, cmd,
+		"paste-image key on an image-incapable model must return a warning command, not nil")
+	msg := cmd()
+	// The editor path batches commands; unwrap to find the warning.
+	var infoMsg util.InfoMsg
+	found := false
+	if batch, ok := msg.(tea.BatchMsg); ok {
+		for _, c := range batch {
+			if c == nil {
+				continue
+			}
+			if im, ok := c().(util.InfoMsg); ok {
+				infoMsg = im
+				found = true
+				break
+			}
+		}
+	} else if im, ok := msg.(util.InfoMsg); ok {
+		infoMsg = im
+		found = true
+	}
+	require.True(t, found, "expected a util.InfoMsg warning, got %T", msg)
+	require.Equal(t, util.InfoTypeWarn, infoMsg.Type,
+		"paste-image key on an image-incapable model must warn the user")
+	require.Contains(t, infoMsg.Msg, "doesn't support images")
 }
 
 // TestHandlePasteMsg_WhitespaceOnlyContentInsertsText ensures that a

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -2490,6 +2490,7 @@ func (m *UI) handleKeyPressMsg(msg tea.KeyPressMsg) tea.Cmd {
 
 			case key.Matches(msg, m.keyMap.Editor.PasteImage):
 				if !m.currentModelSupportsImages() {
+					cmds = append(cmds, util.ReportWarn(fmt.Sprintf("%s doesn't support images", m.currentModelName())))
 					break
 				}
 				cmds = append(cmds, m.pasteImageFromClipboard)
@@ -3297,6 +3298,25 @@ func (m *UI) currentModelSupportsImages() bool {
 	}
 	model := cfg.GetModelByType(agentCfg.Model)
 	return model != nil && model.SupportsImages
+}
+
+// currentModelName returns the display name of the coder agent's current
+// model for user-facing messages, falling back to "current model" when the
+// selection cannot be resolved.
+func (m *UI) currentModelName() string {
+	cfg := m.com.Config()
+	if cfg == nil {
+		return "current model"
+	}
+	agentCfg, ok := cfg.Agents[config.AgentCoder]
+	if !ok {
+		return "current model"
+	}
+	selected, ok := cfg.Models[agentCfg.Model]
+	if !ok || selected.Model == "" {
+		return "current model"
+	}
+	return selected.Model
 }
 
 // toggleCompactMode toggles compact mode between uiChat and uiChatCompact states.
@@ -4867,7 +4887,12 @@ func (m *UI) handlePasteMsg(msg tea.PasteMsg) tea.Cmd {
 		if m.currentModelSupportsImages() {
 			return m.pasteImageFromClipboard
 		}
-		return nil
+		// An empty paste on an image-incapable model means the clipboard
+		// holds something the model can't use (most commonly an image) or
+		// nothing at all; either way the paste would otherwise vanish with
+		// zero feedback, which made #197 undiagnosable from the UX. Warn
+		// instead of returning nil so the user knows why nothing landed.
+		return util.ReportWarn(fmt.Sprintf("Paste ignored: %s doesn't support images", m.currentModelName()))
 	}
 
 	if hasPasteExceededThreshold(msg) {


### PR DESCRIPTION
## Why

Follow-up to #198 (itself fixing #197). That fix routed empty pastes to the clipboard-image fallback, but **both** image-paste entry points are gated on `currentModelSupportsImages()` and silently `return nil` when the gate fails:

- `ui.go` PasteImage key path (`ctrl+v`/`super+v`)
- `ui.go` empty-`PasteMsg` fallback in `handlePasteMsg`

On a model whose *effective* config says no images, pasting an image vanished with zero feedback, which is exactly what made #197 undiagnosable from the UX.

## What changed

- Both gated sites now emit a warning toast naming the current model (`"kimi-k3 doesn't support images"` / `"Paste ignored: …"`) instead of returning nil.
- New `currentModelName()` helper resolves the coder agent's selected model for the message.
- Tests: the incapable-model empty-paste test now asserts a `util.InfoMsg` warning (not nil), and a new test covers the key-bound path. All existing image-capable routing tests still pass.

## kimi-k3 image capability — corrected diagnosis

`GET https://hyper.charm.land/v1/models` reports `kimi-k3` with `"capabilities": {"vision": true}` — the model **does** accept images. I initially suspected catwalk's `moonshot.json` was missing a `supports_images` field for kimi-k3. **That was wrong**: catwalk v0.51.1 tags `Model.SupportsImages` as `json:"supports_attachments"` (pkg/catwalk/provider.go:100), and kimi-k3 already has `supports_attachments: true`. The embedded Hyper provider (`internal/agent/hyper/provider.json`) also has it `true`. So the upstream metadata is correct.

The real reason a kimi-k3 paste still hit the incapable branch in the reported session is that the installed Crush binary predated any paste-image handling at all — verified with `strings` (the binary contained no paste-image code). After rebuilding/reinstalling, kimi-k3 resolves image-capable from the known-provider metadata.

**Residual risk (not fixed here):** for a *custom* (non-known) provider whose models arrive via `discover_models`, `internal/discover/discover.go` populates discovered models with only `ID`/`Name` — `SupportsImages` defaults to `false` and the `/v1/models` payload has no capability fields to recover it. If a kimi-k3 ever reaches the editor through that path, it will read image-incapable until pinned under the provider's `models:` in config (user models win over discovery). A local config override was applied separately for this.

## Notes for macOS terminal users

- **Ghostty**: CMD+V is bound to `paste_from_clipboard`, which returns early on an image-only clipboard (`src/Surface.zig`), so the empty-`PasteMsg` fallback never fires. **Use Ctrl+V** — it is unbound in Ghostty, which forwards byte `0x16` to the TUI and hits the PasteImage key path.
- **macOS Terminal.app**: CMD+V with an image clipboard just beeps and delivers nothing to the app. Same answer — Ctrl+V.

## Verification

- `go test ./internal/ui/...` — pass (incl. 5 paste tests)
- `go vet ./internal/ui/...` — clean
- `gofumpt -l internal/ui/` — clean
- `golangci-lint run ./internal/ui/...` — 0 issues
- Confirmed the toast string is compiled into the installed binary via `strings`
