### PR TITLE
fix: correct skill error source labeling in /skills dialog

### DIFF
--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -1598,6 +1598,7 @@ func discoverSkills(cfg *config.ConfigStore) (allSkills, activeSkills []*skills.
 	allSkills, activeSkills, states := skills.DiscoverFromConfig(skills.DiscoveryConfig{
 		SkillsPaths:    paths,
 		DisabledSkills: disabled,
+		WorkingDir:     cfg.WorkingDir(),
 		Resolver:       resolver,
 	})
 	logDiscoveryStats(states, paths, allSkills, activeSkills, disabled)

--- a/internal/skills/diagnostics_test.go
+++ b/internal/skills/diagnostics_test.go
@@ -59,7 +59,7 @@ func TestDiscoverWithStates_MissingPath(t *testing.T) {
 	t.Parallel()
 
 	// A clearly nonexistent path should not panic; it may log an error.
-	skills, _ := DiscoverWithStates([]string{"/nonexistent/crush/skills/path"})
+	skills, _ := DiscoverWithStates([]string{"/nonexistent/crush/skills/path"}, "")
 	require.Empty(t, skills)
 }
 
@@ -80,7 +80,7 @@ func TestGetLatestStates(t *testing.T) {
 		0o644,
 	))
 
-	_, states := DiscoverWithStates([]string{dir})
+	_, states := DiscoverWithStates([]string{dir}, "")
 	SetLatestStates(states)
 
 	got := GetLatestStates()

--- a/internal/skills/manager.go
+++ b/internal/skills/manager.go
@@ -191,7 +191,7 @@ func DiscoverFromConfig(cfg DiscoveryConfig) (allSkills, activeSkills []*Skill, 
 	userPaths := cfg.ResolvePaths()
 	if len(userPaths) > 0 {
 		var userSkills []*Skill
-		userSkills, userStates = DiscoverWithStates(userPaths)
+		userSkills, userStates = DiscoverWithStates(userPaths, cfg.WorkingDir)
 		discovered = append(discovered, userSkills...)
 	}
 

--- a/internal/skills/skills.go
+++ b/internal/skills/skills.go
@@ -61,10 +61,11 @@ const (
 
 // SkillState represents the latest discovery status of a skill file.
 type SkillState struct {
-	Name  string
-	Path  string
-	State DiscoveryState
-	Err   error
+	Name   string
+	Path   string
+	Source SourceType
+	State  DiscoveryState
+	Err    error
 }
 
 // Event is published when skill discovery completes.
@@ -226,10 +227,11 @@ func DiscoverWithStates(paths []string) ([]*Skill, []*SkillState) {
 	addState := func(name, path string, state DiscoveryState, err error) {
 		mu.Lock()
 		states = append(states, &SkillState{
-			Name:  name,
-			Path:  path,
-			State: state,
-			Err:   err,
+			Name:   name,
+			Path:   path,
+			Source: sourceFromPath(path, paths),
+			State:  state,
+			Err:    err,
 		})
 		mu.Unlock()
 	}
@@ -292,6 +294,13 @@ func DiscoverWithStates(paths []string) ([]*Skill, []*SkillState) {
 	})
 
 	return skills, states
+}
+
+// sourceFromPath determines the source type of a skill file. Since
+// DiscoverWithStates only discovers from user-configured paths (not project
+// paths, which are handled separately), all discovered skills are SourceUser.
+func sourceFromPath(filePath string, discoveryPaths []string) SourceType {
+	return SourceUser
 }
 
 // ToPromptXML generates XML for injection into the system prompt.

--- a/internal/skills/skills.go
+++ b/internal/skills/skills.go
@@ -212,14 +212,16 @@ func splitFrontmatter(content string) (frontmatter, body string, err error) {
 
 // Discover finds all valid skills in the given paths.
 func Discover(paths []string) []*Skill {
-	skills, _ := DiscoverWithStates(paths)
+	skills, _ := DiscoverWithStates(paths, "")
 	return skills
 }
 
 // DiscoverWithStates finds all valid skills in the given paths and also
 // returns a per-file state slice describing parse/validation outcomes. Useful
-// for diagnostics and UI reporting.
-func DiscoverWithStates(paths []string) ([]*Skill, []*SkillState) {
+// for diagnostics and UI reporting. workingDir is used only to classify each
+// state's Source (paths under the working directory are project skills); pass
+// "" when source labels are not needed.
+func DiscoverWithStates(paths []string, workingDir string) ([]*Skill, []*SkillState) {
 	var skills []*Skill
 	var states []*SkillState
 	var mu sync.Mutex
@@ -229,7 +231,7 @@ func DiscoverWithStates(paths []string) ([]*Skill, []*SkillState) {
 		states = append(states, &SkillState{
 			Name:   name,
 			Path:   path,
-			Source: sourceFromPath(path, paths),
+			Source: sourceFromPath(path, paths, workingDir),
 			State:  state,
 			Err:    err,
 		})
@@ -296,10 +298,26 @@ func DiscoverWithStates(paths []string) ([]*Skill, []*SkillState) {
 	return skills, states
 }
 
-// sourceFromPath determines the source type of a skill file. Since
-// DiscoverWithStates only discovers from user-configured paths (not project
-// paths, which are handled separately), all discovered skills are SourceUser.
-func sourceFromPath(filePath string, discoveryPaths []string) SourceType {
+// sourceFromPath determines the source type of a skill file by matching it
+// against the discovery path it was found under. Discovery paths mix
+// user-configured directories with the project skill dirs config loading
+// appends (e.g. <workingDir>/.crush/skills), so a base inside workingDir
+// classifies as SourceProject and everything else as SourceUser — the same
+// rule catalog.go's skillLabel applies to active skills, so a broken skill's
+// diagnostics row and its healthy sibling always agree on the label.
+func sourceFromPath(filePath string, discoveryPaths []string, workingDir string) SourceType {
+	cleanFile := filepath.Clean(filePath)
+	for _, base := range discoveryPaths {
+		cleanBase := filepath.Clean(base)
+		rel, err := filepath.Rel(cleanBase, cleanFile)
+		if err != nil || escapesParent(rel) {
+			continue
+		}
+		if isProjectSkillPath(cleanBase, workingDir) {
+			return SourceProject
+		}
+		return SourceUser
+	}
 	return SourceUser
 }
 

--- a/internal/skills/skills_test.go
+++ b/internal/skills/skills_test.go
@@ -248,7 +248,7 @@ description: Name doesn't match directory.
 ---
 `), 0o644))
 
-	skills, states := DiscoverWithStates([]string{tmpDir})
+	skills, states := DiscoverWithStates([]string{tmpDir}, "")
 
 	var normalCount int
 	var errorCount int
@@ -283,7 +283,7 @@ func TestDiscoverEmptyDir(t *testing.T) {
 
 	tmpDir := t.TempDir()
 
-	skills, states := DiscoverWithStates([]string{tmpDir})
+	skills, states := DiscoverWithStates([]string{tmpDir}, "")
 	require.Empty(t, states)
 	require.Empty(t, skills)
 }
@@ -291,9 +291,78 @@ func TestDiscoverEmptyDir(t *testing.T) {
 func TestDiscoverMissingPath(t *testing.T) {
 	t.Parallel()
 
-	skills, states := DiscoverWithStates([]string{filepath.Join(t.TempDir(), "missing")})
+	skills, states := DiscoverWithStates([]string{filepath.Join(t.TempDir(), "missing")}, "")
 	require.Empty(t, states)
 	require.Empty(t, skills)
+}
+
+// TestDiscoverWithStates_SourceClassification pins that a state's Source is
+// derived from where the skill actually lives: discovery paths under the
+// working directory (the project skill dirs config loading appends, e.g.
+// .crush/skills) label as "project", everything else as "user" — for broken
+// and healthy skills alike. Regression: sourceFromPath used to hardcode
+// SourceUser, so a broken project skill showed as "user error" in the
+// /skills dialog.
+func TestDiscoverWithStates_SourceClassification(t *testing.T) {
+	t.Parallel()
+
+	workingDir := t.TempDir()
+	projectBase := filepath.Join(workingDir, ".crush", "skills")
+	userBase := filepath.Join(t.TempDir(), "user-skills")
+
+	writeSkill := func(base, dir, content string) {
+		t.Helper()
+		skillDir := filepath.Join(base, dir)
+		require.NoError(t, os.MkdirAll(skillDir, 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte(content), 0o644))
+	}
+
+	// A broken skill in each location: parse fails, so only the state's
+	// path and source identify where it came from.
+	writeSkill(projectBase, "broken-project", "not a skill at all")
+	writeSkill(userBase, "broken-user", "not a skill at all")
+	// And a healthy project skill, which must classify the same way.
+	writeSkill(projectBase, "good-project", `---
+name: good-project
+description: A healthy project skill.
+---
+Body.
+`)
+
+	_, states := DiscoverWithStates([]string{userBase, projectBase}, workingDir)
+
+	sources := make(map[string]SourceType, len(states))
+	for _, st := range states {
+		sources[filepath.Base(filepath.Dir(st.Path))] = st.Source
+	}
+	require.Equal(t, SourceProject, sources["broken-project"],
+		"a broken skill under the working dir must label as a project error")
+	require.Equal(t, SourceUser, sources["broken-user"],
+		"a broken skill under a user path must label as a user error")
+	require.Equal(t, SourceProject, sources["good-project"])
+}
+
+// TestSourceFromPath covers the classification edges directly: first
+// matching base wins, unmatched files default to user, and an empty
+// workingDir (no project context) classifies everything as user.
+func TestSourceFromPath(t *testing.T) {
+	t.Parallel()
+
+	wd := t.TempDir()
+	projectBase := filepath.Join(wd, ".crush", "skills")
+	userBase := filepath.Join(t.TempDir(), "skills")
+
+	paths := []string{userBase, projectBase}
+	require.Equal(t, SourceProject,
+		sourceFromPath(filepath.Join(projectBase, "x", "SKILL.md"), paths, wd))
+	require.Equal(t, SourceUser,
+		sourceFromPath(filepath.Join(userBase, "x", "SKILL.md"), paths, wd))
+	require.Equal(t, SourceUser,
+		sourceFromPath(filepath.Join(t.TempDir(), "elsewhere", "SKILL.md"), paths, wd),
+		"a file under no discovery path defaults to user")
+	require.Equal(t, SourceUser,
+		sourceFromPath(filepath.Join(projectBase, "x", "SKILL.md"), paths, ""),
+		"without a working dir nothing can classify as project")
 }
 
 func TestToPromptXML(t *testing.T) {

--- a/internal/ui/dialog/skills.go
+++ b/internal/ui/dialog/skills.go
@@ -230,7 +230,7 @@ func (d *Skills) skillItems() []list.FilterableItem {
 			entry := skills.CatalogEntry{
 				ID:     st.Path,
 				Name:   filepath.Base(filepath.Dir(st.Path)),
-				Source: skills.SourceProject,
+				Source: st.Source,
 			}
 			items = append(items, NewSkillItem(d.com.Styles, entry, st, false))
 			continue
@@ -242,7 +242,7 @@ func (d *Skills) skillItems() []list.FilterableItem {
 			ID:          st.Name,
 			Name:        st.Name,
 			Description: "",
-			Source:      skills.SourceProject,
+			Source:      st.Source,
 		}
 		items = append(items, NewSkillItem(d.com.Styles, entry, st, true))
 	}


### PR DESCRIPTION
## Problem

When a skill fails validation, the `/skills` dialog shows it with source label "project error" — but this is wrong for user-level skills. The code in `internal/ui/dialog/skills.go:233,245` hardcoded `Source: skills.SourceProject` for any broken skill, regardless of where the skill file actually lives.

**Expected:** The label should reflect the actual source (user/system/project), or just say "error" without a misleading source prefix.

## Changes

1. **Added `Source` field to `SkillState`** in `internal/skills/skills.go`
   - Tracks whether a skill came from user paths or project paths
   - Set via `sourceFromPath()` during discovery in `DiscoverWithStates`

2. **Updated `/skills` dialog** in `internal/ui/dialog/skills.go`
   - Broken skills now show their actual source ("user error" or "project error") instead of always "project error"
   - Uses `st.Source` from the discovery state instead of hardcoded `skills.SourceProject`

## Note on description length

The description length limit (1024) is per the [Agent Skills specification](https://agentskills.io/specification) and remains unchanged. The skills that failed validation (chezmoi, cgg) need their descriptions trimmed to fit the spec limit, not a limit increase.

## Testing

- All tests pass (`go test ./...`)
- `go vet` clean (pre-existing csync issue unrelated)

## Related

- Fixes joestump/crush-issues#3

🤖 Posted on behalf of `@joestump` by [`claude-opus-5`](https://openrouter.ai/anthropic/claude-opus-5) using [Crush](https://github.com/charmbracelet/crush).