### PR TITLE
feat(a2ui): render MCP resource surfaces inline + Markdown body text

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -43,7 +43,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/invopop/jsonschema v0.14.0
 	github.com/itchyny/gojq v0.12.19
-	github.com/joestump-agent/a2tea v0.0.0-20260718201420-b797da386eaf
+	github.com/joestump-agent/a2tea v0.1.0
 	github.com/joho/godotenv v1.5.1
 	github.com/jordanella/go-ansi-paintbrush v0.0.0-20240728195301-b7ad996ecf3d
 	github.com/lucasb-eyer/go-colorful v1.4.0
@@ -221,5 +221,3 @@ require (
 	modernc.org/mathutil v1.7.1 // indirect
 	modernc.org/memory v1.11.0 // indirect
 )
-
-replace github.com/joestump-agent/a2tea => /Users/joestump/src/a2tea

--- a/go.mod
+++ b/go.mod
@@ -221,3 +221,5 @@ require (
 	modernc.org/mathutil v1.7.1 // indirect
 	modernc.org/memory v1.11.0 // indirect
 )
+
+replace github.com/joestump-agent/a2tea => /Users/joestump/src/a2tea

--- a/go.sum
+++ b/go.sum
@@ -256,6 +256,8 @@ github.com/jackmordaunt/icns/v3 v3.0.1 h1:xxot6aNuGrU+lNgxz5I5H0qSeCjNKp8uTXB1j8
 github.com/jackmordaunt/icns/v3 v3.0.1/go.mod h1:5sHL59nqTd2ynTnowxB/MDQFhKNqkK8X687uKNygaSQ=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
+github.com/joestump-agent/a2tea v0.1.0 h1:pIlPNDSB3HV4Tz8KqoAVlwwF0YSdaX5S8Rta/ISEdNI=
+github.com/joestump-agent/a2tea v0.1.0/go.mod h1:pg6ATa4oTrJfhPmfQ9a/Y/5xU9DTXZ8rGVvLj3NpEaE=
 github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
 github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/jordanella/go-ansi-paintbrush v0.0.0-20240728195301-b7ad996ecf3d h1:on25kP+Sx7sxUMRQiA8gdcToAGet4DK/EIA30mXre+4=

--- a/go.sum
+++ b/go.sum
@@ -256,8 +256,6 @@ github.com/jackmordaunt/icns/v3 v3.0.1 h1:xxot6aNuGrU+lNgxz5I5H0qSeCjNKp8uTXB1j8
 github.com/jackmordaunt/icns/v3 v3.0.1/go.mod h1:5sHL59nqTd2ynTnowxB/MDQFhKNqkK8X687uKNygaSQ=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
-github.com/joestump-agent/a2tea v0.0.0-20260718201420-b797da386eaf h1:Yw8XzyZXewOiewpHLd4SQPhu7CeWlFeqjpz7uE7f5as=
-github.com/joestump-agent/a2tea v0.0.0-20260718201420-b797da386eaf/go.mod h1:pg6ATa4oTrJfhPmfQ9a/Y/5xU9DTXZ8rGVvLj3NpEaE=
 github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
 github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/jordanella/go-ansi-paintbrush v0.0.0-20240728195301-b7ad996ecf3d h1:on25kP+Sx7sxUMRQiA8gdcToAGet4DK/EIA30mXre+4=

--- a/internal/agent/tools/read_mcp_resource.go
+++ b/internal/agent/tools/read_mcp_resource.go
@@ -39,6 +39,49 @@ type ReadMCPResourceResponseMetadata struct {
 	A2UISurfaces []string `json:"a2ui_surfaces,omitempty"`
 }
 
+// A2UISurfacePlaceholderPrefix starts every model-facing placeholder that
+// stands in for a diverted A2UI surface. The chat renderer uses it to strip
+// placeholder lines from the tool content it shows the user.
+const A2UISurfacePlaceholderPrefix = "[A2UI surface rendered in the chat UI from "
+
+// splitMCPResourceContents partitions resource contents into model-facing
+// text parts and, when divert is set, UI-only A2UI surface payloads carried
+// in response metadata. divert is false when no chat UI will render the
+// metadata (channel-originated turns, disable_a2ui deployments): the raw
+// payload then stays in the model-facing content so the model can still
+// relay or summarize the data.
+func splitMCPResourceContents(contents []*mcp.ResourceContents, divert bool) ([]string, ReadMCPResourceResponseMetadata) {
+	var textParts []string
+	var metadata ReadMCPResourceResponseMetadata
+	for _, content := range contents {
+		if content == nil {
+			continue
+		}
+		text := content.Text
+		if text == "" && len(content.Blob) > 0 {
+			// Blob is a legal delivery for any MIME type, including
+			// application/a2ui+json — normalize it to text here so a
+			// blob-delivered surface cannot slip past the diversion below.
+			text = string(content.Blob)
+		}
+		if text == "" {
+			slog.Debug("MCP resource content missing text/blob", "uri", content.URI)
+			continue
+		}
+		// A2UI surfaces go to the UI via metadata, not the model-facing
+		// content: the chat renderer draws the surface itself, and the
+		// model only ever echoed the raw JSON back, double-rendering the
+		// surface.
+		if divert && content.MIMEType == a2uiMIMEType {
+			metadata.A2UISurfaces = append(metadata.A2UISurfaces, "<a2ui-json>"+text+"</a2ui-json>")
+			textParts = append(textParts, A2UISurfacePlaceholderPrefix+content.URI+" — the user can already see it; do not repeat or echo its JSON payload]")
+			continue
+		}
+		textParts = append(textParts, text)
+	}
+	return textParts, metadata
+}
+
 //go:embed read_mcp_resource.md
 var readMCPResourceDescription string
 
@@ -89,32 +132,13 @@ func NewReadMCPResourceTool(cfg *config.ConfigStore, permissions permission.Serv
 				return fantasy.NewTextResponse(""), nil
 			}
 
-			var textParts []string
-			var metadata ReadMCPResourceResponseMetadata
-			for _, content := range contents {
-				if content == nil {
-					continue
-				}
-				if content.Text != "" {
-					// A2UI surfaces go to the UI via metadata, not the
-					// model-facing content: the chat renderer renders
-					// the surface itself, and the raw JSON is
-					// unreadable to the model anyway — it only ever
-					// echoed it back, double-rendering the surface.
-					if content.MIMEType == a2uiMIMEType {
-						metadata.A2UISurfaces = append(metadata.A2UISurfaces, "<a2ui-json>"+content.Text+"</a2ui-json>")
-						textParts = append(textParts, "[A2UI surface rendered in the chat UI from "+content.URI+" — the user can already see it; do not repeat or echo its JSON payload]")
-						continue
-					}
-					textParts = append(textParts, content.Text)
-					continue
-				}
-				if len(content.Blob) > 0 {
-					textParts = append(textParts, string(content.Blob))
-					continue
-				}
-				slog.Debug("MCP resource content missing text/blob", "uri", content.URI)
-			}
+			// Divert A2UI payloads to UI-only metadata only when a chat UI
+			// will actually render them: on channel-originated turns the
+			// reply travels back over the channel and the model needs the
+			// payload to relay it, and disable_a2ui deployments opted out
+			// of surfaces entirely.
+			divert := GetChannelFromContext(ctx) == "" && !cfg.Config().Options.DisableA2UI
+			textParts, metadata := splitMCPResourceContents(contents, divert)
 
 			if len(textParts) == 0 {
 				return fantasy.NewTextResponse(""), nil

--- a/internal/agent/tools/read_mcp_resource.go
+++ b/internal/agent/tools/read_mcp_resource.go
@@ -74,7 +74,11 @@ func splitMCPResourceContents(contents []*mcp.ResourceContents, divert bool) ([]
 		// surface.
 		if divert && content.MIMEType == a2uiMIMEType {
 			metadata.A2UISurfaces = append(metadata.A2UISurfaces, "<a2ui-json>"+text+"</a2ui-json>")
-			textParts = append(textParts, A2UISurfacePlaceholderPrefix+content.URI+" — the user can already see it; do not repeat or echo its JSON payload]")
+			// The placeholder is a single-line protocol the chat renderer
+			// strips line-wise — a server-controlled URI must not be able
+			// to break out of it with embedded newlines.
+			uri := strings.NewReplacer("\n", " ", "\r", " ").Replace(content.URI)
+			textParts = append(textParts, A2UISurfacePlaceholderPrefix+uri+" — the user can already see it; do not repeat or echo its JSON payload]")
 			continue
 		}
 		textParts = append(textParts, text)

--- a/internal/agent/tools/read_mcp_resource.go
+++ b/internal/agent/tools/read_mcp_resource.go
@@ -27,6 +27,11 @@ type ReadMCPResourcePermissionsParams struct {
 
 const ReadMCPResourceToolName = "read_mcp_resource"
 
+// a2uiMIMEType is the MIME type MCP resource templates use for A2UI surfaces.
+// When a resource read returns this type, the payload is wrapped in inline
+// <a2ui-json> tags so the chat renderer renders it as a live surface.
+const a2uiMIMEType = "application/a2ui+json"
+
 //go:embed read_mcp_resource.md
 var readMCPResourceDescription string
 
@@ -83,6 +88,15 @@ func NewReadMCPResourceTool(cfg *config.ConfigStore, permissions permission.Serv
 					continue
 				}
 				if content.Text != "" {
+					// If the resource is an A2UI surface, wrap it in
+					// the inline tags so the chat renderer picks it up
+					// as a live surface instead of raw JSON. The model
+					// never needs to copy/paste the payload — the tool
+					// result itself renders as an interactive surface.
+					if content.MIMEType == a2uiMIMEType {
+						textParts = append(textParts, "<a2ui-json>"+content.Text+"</a2ui-json>")
+						continue
+					}
 					textParts = append(textParts, content.Text)
 					continue
 				}

--- a/internal/agent/tools/read_mcp_resource.go
+++ b/internal/agent/tools/read_mcp_resource.go
@@ -28,9 +28,16 @@ type ReadMCPResourcePermissionsParams struct {
 const ReadMCPResourceToolName = "read_mcp_resource"
 
 // a2uiMIMEType is the MIME type MCP resource templates use for A2UI surfaces.
-// When a resource read returns this type, the payload is wrapped in inline
-// <a2ui-json> tags so the chat renderer renders it as a live surface.
+// A2UI payloads are delivered to the UI through response metadata (never to
+// the model): the model gets a compact placeholder instead of the raw JSON,
+// so it cannot echo the payload back and double-render the surface.
 const a2uiMIMEType = "application/a2ui+json"
+
+// ReadMCPResourceResponseMetadata carries the UI-only A2UI surface payload
+// for a resource whose MIME type is application/a2ui+json.
+type ReadMCPResourceResponseMetadata struct {
+	A2UISurfaces []string `json:"a2ui_surfaces,omitempty"`
+}
 
 //go:embed read_mcp_resource.md
 var readMCPResourceDescription string
@@ -83,18 +90,20 @@ func NewReadMCPResourceTool(cfg *config.ConfigStore, permissions permission.Serv
 			}
 
 			var textParts []string
+			var metadata ReadMCPResourceResponseMetadata
 			for _, content := range contents {
 				if content == nil {
 					continue
 				}
 				if content.Text != "" {
-					// If the resource is an A2UI surface, wrap it in
-					// the inline tags so the chat renderer picks it up
-					// as a live surface instead of raw JSON. The model
-					// never needs to copy/paste the payload — the tool
-					// result itself renders as an interactive surface.
+					// A2UI surfaces go to the UI via metadata, not the
+					// model-facing content: the chat renderer renders
+					// the surface itself, and the raw JSON is
+					// unreadable to the model anyway — it only ever
+					// echoed it back, double-rendering the surface.
 					if content.MIMEType == a2uiMIMEType {
-						textParts = append(textParts, "<a2ui-json>"+content.Text+"</a2ui-json>")
+						metadata.A2UISurfaces = append(metadata.A2UISurfaces, "<a2ui-json>"+content.Text+"</a2ui-json>")
+						textParts = append(textParts, "[A2UI surface rendered in the chat UI from "+content.URI+" — the user can already see it; do not repeat or echo its JSON payload]")
 						continue
 					}
 					textParts = append(textParts, content.Text)
@@ -111,7 +120,11 @@ func NewReadMCPResourceTool(cfg *config.ConfigStore, permissions permission.Serv
 				return fantasy.NewTextResponse(""), nil
 			}
 
-			return fantasy.NewTextResponse(strings.Join(textParts, "\n")), nil
+			resp := fantasy.NewTextResponse(strings.Join(textParts, "\n"))
+			if len(metadata.A2UISurfaces) > 0 {
+				resp = fantasy.WithResponseMetadata(resp, metadata)
+			}
+			return resp, nil
 		},
 	)
 }

--- a/internal/agent/tools/read_mcp_resource_contents_test.go
+++ b/internal/agent/tools/read_mcp_resource_contents_test.go
@@ -1,0 +1,83 @@
+package tools
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/crush/internal/agent/tools/mcp"
+	"github.com/stretchr/testify/require"
+)
+
+const testA2UIPayload = `{"version":"v0.9","updateComponents":{"surfaceId":"s","components":[` +
+	`{"component":"Text","id":"t","text":"hi"}]}}`
+
+func TestSplitMCPResourceContents(t *testing.T) {
+	t.Parallel()
+
+	t.Run("a2ui text content is diverted to metadata", func(t *testing.T) {
+		t.Parallel()
+		textParts, meta := splitMCPResourceContents([]*mcp.ResourceContents{
+			{URI: "cairn://run/x/a2ui", MIMEType: a2uiMIMEType, Text: testA2UIPayload},
+		}, true)
+		require.Len(t, meta.A2UISurfaces, 1)
+		require.Equal(t, "<a2ui-json>"+testA2UIPayload+"</a2ui-json>", meta.A2UISurfaces[0])
+		require.Len(t, textParts, 1)
+		require.True(t, strings.HasPrefix(textParts[0], A2UISurfacePlaceholderPrefix))
+		require.NotContains(t, textParts[0], "updateComponents")
+	})
+
+	t.Run("a2ui blob content is diverted too", func(t *testing.T) {
+		t.Parallel()
+		// Blob is a legal delivery for any MIME type — a blob-delivered
+		// surface must not leak raw JSON into the model-facing content.
+		textParts, meta := splitMCPResourceContents([]*mcp.ResourceContents{
+			{URI: "cairn://run/x/a2ui", MIMEType: a2uiMIMEType, Blob: []byte(testA2UIPayload)},
+		}, true)
+		require.Len(t, meta.A2UISurfaces, 1)
+		require.Len(t, textParts, 1)
+		require.True(t, strings.HasPrefix(textParts[0], A2UISurfacePlaceholderPrefix))
+		require.NotContains(t, textParts[0], "updateComponents")
+	})
+
+	t.Run("no diversion when no UI renders metadata", func(t *testing.T) {
+		t.Parallel()
+		// Channel-originated and disable_a2ui turns keep the raw payload so
+		// the model can relay or summarize the data.
+		textParts, meta := splitMCPResourceContents([]*mcp.ResourceContents{
+			{URI: "cairn://run/x/a2ui", MIMEType: a2uiMIMEType, Text: testA2UIPayload},
+		}, false)
+		require.Empty(t, meta.A2UISurfaces)
+		require.Equal(t, []string{testA2UIPayload}, textParts)
+	})
+
+	t.Run("plain text passes through", func(t *testing.T) {
+		t.Parallel()
+		textParts, meta := splitMCPResourceContents([]*mcp.ResourceContents{
+			{URI: "cairn://artifact/x", MIMEType: "text/markdown", Text: "# hello"},
+		}, true)
+		require.Empty(t, meta.A2UISurfaces)
+		require.Equal(t, []string{"# hello"}, textParts)
+	})
+
+	t.Run("mixed text and a2ui keeps both", func(t *testing.T) {
+		t.Parallel()
+		textParts, meta := splitMCPResourceContents([]*mcp.ResourceContents{
+			{URI: "cairn://artifact/x", MIMEType: "text/markdown", Text: "summary"},
+			{URI: "cairn://artifact/x/a2ui", MIMEType: a2uiMIMEType, Text: testA2UIPayload},
+		}, true)
+		require.Len(t, meta.A2UISurfaces, 1)
+		require.Len(t, textParts, 2)
+		require.Equal(t, "summary", textParts[0])
+		require.True(t, strings.HasPrefix(textParts[1], A2UISurfacePlaceholderPrefix))
+	})
+
+	t.Run("nil and empty entries are skipped", func(t *testing.T) {
+		t.Parallel()
+		textParts, meta := splitMCPResourceContents([]*mcp.ResourceContents{
+			nil,
+			{URI: "cairn://artifact/empty"},
+		}, true)
+		require.Empty(t, meta.A2UISurfaces)
+		require.Empty(t, textParts)
+	})
+}

--- a/internal/ui/chat/a2ui.go
+++ b/internal/ui/chat/a2ui.go
@@ -583,6 +583,21 @@ func a2uiThemeStyles(sty *styles.Styles) render.Styles {
 		Background(sty.Dialog.SelectedItem.GetBackground()).
 		Foreground(sty.Dialog.SelectedItem.GetForeground()).
 		Reverse(false)
+	// Inject Crush's glamour renderer so body-variant Text containing
+	// Markdown (tables, lists, bold, code) renders with the same styling
+	// as the rest of the chat. The renderer is created per-width inside
+	// the callback; glamour memoizes per width internally.
+	st.MarkdownRenderer = func(text string, width int) string {
+		renderer := common.MarkdownRenderer(sty, width)
+		mu := common.LockMarkdownRenderer(renderer)
+		mu.Lock()
+		defer mu.Unlock()
+		out, err := renderer.Render(text)
+		if err != nil {
+			return text
+		}
+		return strings.TrimSpace(out)
+	}
 	return st
 }
 

--- a/internal/ui/chat/a2ui.go
+++ b/internal/ui/chat/a2ui.go
@@ -9,9 +9,11 @@ import (
 	"regexp"
 	"slices"
 	"strings"
+	"sync"
 	"unicode"
 
 	tea "charm.land/bubbletea/v2"
+	"charm.land/glamour/v2"
 	"charm.land/lipgloss/v2"
 	"github.com/charmbracelet/crush/internal/ui/common"
 	"github.com/charmbracelet/crush/internal/ui/styles"
@@ -585,20 +587,61 @@ func a2uiThemeStyles(sty *styles.Styles) render.Styles {
 		Reverse(false)
 	// Inject Crush's glamour renderer so body-variant Text containing
 	// Markdown (tables, lists, bold, code) renders with the same styling
-	// as the rest of the chat. The renderer is created per-width inside
-	// the callback; glamour memoizes per width internally.
+	// as the rest of the chat. Rendered output is memoized per
+	// (renderer, text): items holding live surfaces bypass the chat render
+	// caches, so without a memo every repaint re-runs a full glamour parse
+	// per markdown body. The renderer lock is scoped to the Render call —
+	// callers must never hold the same renderer's lock while a surface
+	// View runs (see renderContentWithA2UI), or this hook would deadlock.
 	st.MarkdownRenderer = func(text string, width int) string {
 		renderer := common.MarkdownRenderer(sty, width)
+		if out, ok := a2uiMarkdownMemoGet(renderer, text); ok {
+			return out
+		}
 		mu := common.LockMarkdownRenderer(renderer)
 		mu.Lock()
-		defer mu.Unlock()
 		out, err := renderer.Render(text)
+		mu.Unlock()
 		if err != nil {
 			return text
 		}
-		return strings.TrimSpace(out)
+		out = strings.TrimSpace(out)
+		a2uiMarkdownMemoPut(renderer, text, out)
+		return out
 	}
 	return st
+}
+
+// a2uiMarkdownMemo caches glamour output for surface body Text. Keyed by the
+// memoized renderer pointer — which already encodes the width and is dropped
+// on theme change via InvalidateMarkdownRendererCache — plus the source text.
+// Bounded crudely: the map resets once it grows past a2uiMarkdownMemoMax.
+var (
+	a2uiMarkdownMemoMu sync.Mutex
+	a2uiMarkdownMemo   = map[a2uiMarkdownMemoKey]string{}
+)
+
+type a2uiMarkdownMemoKey struct {
+	renderer *glamour.TermRenderer
+	text     string
+}
+
+const a2uiMarkdownMemoMax = 512
+
+func a2uiMarkdownMemoGet(r *glamour.TermRenderer, text string) (string, bool) {
+	a2uiMarkdownMemoMu.Lock()
+	defer a2uiMarkdownMemoMu.Unlock()
+	out, ok := a2uiMarkdownMemo[a2uiMarkdownMemoKey{r, text}]
+	return out, ok
+}
+
+func a2uiMarkdownMemoPut(r *glamour.TermRenderer, text, out string) {
+	a2uiMarkdownMemoMu.Lock()
+	defer a2uiMarkdownMemoMu.Unlock()
+	if len(a2uiMarkdownMemo) >= a2uiMarkdownMemoMax {
+		clear(a2uiMarkdownMemo)
+	}
+	a2uiMarkdownMemo[a2uiMarkdownMemoKey{r, text}] = out
 }
 
 // renderA2UILoading renders a "✨ Rendering UI…" placeholder for when an
@@ -933,7 +976,10 @@ func a2uiSurfaceWantsKey(s render.Model, key tea.KeyMsg) bool {
 //
 // This deliberately bypasses the streaming-markdown prefix cache (which assumes
 // a single glamour render per item) and renders each segment directly. The
-// renderer is shared, so the whole multi-render sequence holds its lock.
+// renderer is shared, so each Render call takes its lock — scoped to the call,
+// never held across model.View(): a surface body Text re-enters the same
+// memoized renderer through the a2uiThemeStyles MarkdownRenderer hook, and
+// holding the lock across View would self-deadlock the UI goroutine.
 func (a *AssistantMessageItem) renderContentWithA2UI(content string, width int, finished bool) string {
 	masked, codeReps := maskMarkdownCode(content)
 	// Repair childless-but-labeled buttons on the raw JSON before parsing —
@@ -956,8 +1002,6 @@ func (a *AssistantMessageItem) renderContentWithA2UI(content string, width int, 
 
 	renderer := common.MarkdownRenderer(a.sty, width)
 	mu := common.LockMarkdownRenderer(renderer)
-	mu.Lock()
-	defer mu.Unlock()
 
 	renderMarkdown := func(text string) string {
 		if strings.TrimSpace(text) == "" {
@@ -965,7 +1009,9 @@ func (a *AssistantMessageItem) renderContentWithA2UI(content string, width int, 
 		}
 		// Restore masked code before markdown rendering.
 		text = unmaskMarkdownCode(text, codeReps)
+		mu.Lock()
 		out, err := renderer.Render(text)
+		mu.Unlock()
 		if err != nil {
 			return strings.TrimSpace(text)
 		}

--- a/internal/ui/chat/a2ui_test.go
+++ b/internal/ui/chat/a2ui_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
+	"time"
 
 	tea "charm.land/bubbletea/v2"
 	"github.com/charmbracelet/crush/internal/message"
@@ -1036,4 +1037,32 @@ func TestA2UIStreamingLoadingPlaceholderComplete(t *testing.T) {
 
 	require.Contains(t, out, "Hello from A2UI", "complete surface should render its content")
 	require.NotContains(t, out, "Rendering UI", "complete surface should not show loading placeholder")
+}
+
+// Regression: a markdown-looking body Text rendered at the surface's
+// un-narrowed width re-enters the shared glamour renderer through the
+// a2uiThemeStyles MarkdownRenderer hook. renderContentWithA2UI used to hold
+// that renderer's lock across model.View(), so the hook's Lock() on the same
+// non-reentrant mutex froze the UI goroutine permanently.
+func TestRenderContentWithA2UIMarkdownBodyNoDeadlock(t *testing.T) {
+	t.Parallel()
+
+	sty := styles.CharmtonePantera()
+	item := &AssistantMessageItem{sty: &sty}
+	// Root-level Text (no Card): a2tea passes the full host width to the
+	// markdown hook, matching the outer renderer's width bucket.
+	content := `<a2ui-json>{"version":"v0.9","updateComponents":{"surfaceId":"s","components":[` +
+		`{"component":"Text","id":"t","text":"This is **bold** markdown"}` +
+		`]}}</a2ui-json>`
+
+	done := make(chan string, 1)
+	go func() {
+		done <- item.renderContentWithA2UI(content, 80, true)
+	}()
+	select {
+	case out := <-done:
+		require.Contains(t, ansi.Strip(out), "bold")
+	case <-time.After(15 * time.Second):
+		t.Fatal("renderContentWithA2UI deadlocked rendering a markdown body Text")
+	}
 }

--- a/internal/ui/chat/generic.go
+++ b/internal/ui/chat/generic.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"strings"
 
+	"github.com/charmbracelet/crush/internal/agent/tools"
 	"github.com/charmbracelet/crush/internal/message"
 	"github.com/charmbracelet/crush/internal/ui/styles"
 	"github.com/joestump-agent/a2tea"
@@ -70,10 +71,29 @@ func (g *GenericToolRenderContext) RenderTool(sty *styles.Styles, width int, opt
 		return joinToolParts(header, body)
 	}
 
-	// If the tool result contains an A2UI surface (e.g. a read_mcp_resource
-	// that returned application/a2ui+json), render it as a live surface
-	// instead of raw text. This is what makes cairn://artifact/{id}/a2ui
-	// and similar resource reads render inline — no JSON barf.
+	// If the tool result carries an A2UI surface (a read_mcp_resource that
+	// returned application/a2ui+json), render it as a live surface instead
+	// of raw text. The payload arrives via response metadata — the model
+	// only sees a placeholder, so it cannot echo the JSON back and
+	// double-render the surface. This is what makes
+	// cairn://artifact/{id}/a2ui and similar resource reads render inline.
+	if opts.Result.Metadata != "" {
+		var meta tools.ReadMCPResourceResponseMetadata
+		if err := json.Unmarshal([]byte(opts.Result.Metadata), &meta); err == nil && len(meta.A2UISurfaces) > 0 {
+			var b strings.Builder
+			for _, surf := range meta.A2UISurfaces {
+				rendered, err := renderToolA2UI(sty, surf, bodyWidth)
+				if err != nil || rendered == "" {
+					continue
+				}
+				b.WriteString(rendered)
+				b.WriteString("\n")
+			}
+			if s := strings.TrimRight(b.String(), "\n"); s != "" {
+				return joinToolParts(header, s)
+			}
+		}
+	}
 	if a2tea.Contains(opts.Result.Content) {
 		surf, err := renderToolA2UI(sty, opts.Result.Content, bodyWidth)
 		if err == nil && surf != "" {

--- a/internal/ui/chat/generic.go
+++ b/internal/ui/chat/generic.go
@@ -2,6 +2,7 @@ package chat
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
 
 	"github.com/charmbracelet/crush/internal/agent/tools"
@@ -67,42 +68,111 @@ func (g *GenericToolRenderContext) RenderTool(sty *styles.Styles, width int, opt
 	bodyWidth := cappedWidth - toolBodyLeftPaddingTotal
 
 	if opts.Result.Data != "" && strings.HasPrefix(opts.Result.MIMEType, "image/") {
-		body := sty.Tool.Body.Render(toolOutputImageContent(sty, opts.Result.Data, opts.Result.MIMEType))
-		return joinToolParts(header, body)
+		// toolOutputImageContent applies sty.Tool.Body itself — wrapping it
+		// again here double-indented image results.
+		return joinToolParts(header, toolOutputImageContent(sty, opts.Result.Data, opts.Result.MIMEType))
 	}
 
+	widths := toolResultContentWidths{Body: bodyWidth, Diff: cappedWidth}
+
 	// If the tool result carries an A2UI surface (a read_mcp_resource that
-	// returned application/a2ui+json), render it as a live surface instead
-	// of raw text. The payload arrives via response metadata — the model
-	// only sees a placeholder, so it cannot echo the JSON back and
+	// returned application/a2ui+json), render it as a surface snapshot
+	// instead of raw text. The payload arrives via response metadata — the
+	// model only sees a placeholder, so it cannot echo the JSON back and
 	// double-render the surface. This is what makes
 	// cairn://artifact/{id}/a2ui and similar resource reads render inline.
 	if opts.Result.Metadata != "" {
 		var meta tools.ReadMCPResourceResponseMetadata
 		if err := json.Unmarshal([]byte(opts.Result.Metadata), &meta); err == nil && len(meta.A2UISurfaces) > 0 {
-			var b strings.Builder
-			for _, surf := range meta.A2UISurfaces {
-				rendered, err := renderToolA2UI(sty, surf, bodyWidth)
-				if err != nil || rendered == "" {
-					continue
-				}
-				b.WriteString(rendered)
-				b.WriteString("\n")
-			}
-			if s := strings.TrimRight(b.String(), "\n"); s != "" {
-				return joinToolParts(header, s)
-			}
+			return joinToolParts(header, renderToolA2UIResultBody(sty, meta.A2UISurfaces, opts, widths))
 		}
 	}
-	if a2tea.Contains(opts.Result.Content) {
+	// Pre-change read_mcp_resource results persisted the raw payload in the
+	// content itself — scan for it so old sessions still render as surfaces.
+	// Scoped to this tool (crush_logs and friends share this renderer and
+	// must keep payload-shaped text as text), and gated on contentHasA2UI so
+	// A2UI examples inside markdown code stay code (#6, #96).
+	if opts.ToolCall.Name == tools.ReadMCPResourceToolName && contentHasA2UI(opts.Result.Content) {
 		surf, err := renderToolA2UI(sty, opts.Result.Content, bodyWidth)
 		if err == nil && surf != "" {
-			return joinToolParts(header, surf)
+			return joinToolParts(header, sty.Tool.Body.Render(clampToolA2UI(sty, surf, bodyWidth, opts.ExpandedContent)))
 		}
 	}
 
-	body := renderToolResultTextContent(sty, opts.Result.Content, toolResultContentWidths{Body: bodyWidth, Diff: cappedWidth}, opts.ExpandedContent)
+	body := renderToolResultTextContent(sty, opts.Result.Content, widths, opts.ExpandedContent)
 	return joinToolParts(header, body)
+}
+
+// renderToolA2UIResultBody renders the metadata-delivered surfaces plus any
+// real text content the resource returned alongside them. When every surface
+// fails to render, an alert replaces the body — the model-facing placeholder
+// claims the user can already see the surface, which would be false here.
+func renderToolA2UIResultBody(sty *styles.Styles, surfaces []string, opts *ToolRenderOpts, widths toolResultContentWidths) string {
+	var b strings.Builder
+	for _, surf := range surfaces {
+		rendered, err := renderToolA2UI(sty, surf, widths.Body)
+		if err != nil || rendered == "" {
+			continue
+		}
+		if b.Len() > 0 {
+			b.WriteString("\n")
+		}
+		b.WriteString(rendered)
+	}
+
+	var chunks []string
+	if b.Len() > 0 {
+		chunks = append(chunks, sty.Tool.Body.Render(clampToolA2UI(sty, b.String(), widths.Body, opts.ExpandedContent)))
+	} else {
+		chunks = append(chunks, sty.Tool.Body.Render(renderToolA2UIAlert(sty, widths.Body)))
+	}
+	// Show any real text the resource returned alongside its surfaces — the
+	// model-facing placeholder lines are stripped, the rest belongs to the
+	// user just as much as the surfaces do.
+	if text := stripA2UIPlaceholders(opts.Result.Content); text != "" {
+		chunks = append(chunks, renderToolResultTextContent(sty, text, widths, opts.ExpandedContent))
+	}
+	return strings.Join(chunks, "\n")
+}
+
+// stripA2UIPlaceholders removes the model-facing surface placeholder lines
+// from tool content, leaving only text the user should see.
+func stripA2UIPlaceholders(content string) string {
+	var out []string
+	for _, ln := range strings.Split(content, "\n") {
+		if strings.HasPrefix(strings.TrimSpace(ln), tools.A2UISurfacePlaceholderPrefix) {
+			continue
+		}
+		out = append(out, ln)
+	}
+	return strings.TrimSpace(strings.Join(out, "\n"))
+}
+
+// clampToolA2UI applies the collapsed-height budget every other tool body
+// gets from responseContextHeight. The surface is pre-rendered ANSI, so the
+// clamp slices whole lines and appends the standard truncation footer;
+// expanding the tool result restores the full surface.
+func clampToolA2UI(sty *styles.Styles, body string, width int, expanded bool) string {
+	lines := strings.Split(body, "\n")
+	if expanded || len(lines) <= responseContextHeight {
+		return body
+	}
+	out := append([]string{}, lines[:responseContextHeight]...)
+	out = append(out, sty.Tool.ContentTruncation.
+		Width(width).
+		Render(fmt.Sprintf(assistantMessageTruncateFormat, len(lines)-responseContextHeight)))
+	return strings.Join(out, "\n")
+}
+
+// renderToolA2UIAlert mirrors the assistant path's renderA2UIAlert for tool
+// results: the resource advertised A2UI but a2tea could not draw a surface.
+func renderToolA2UIAlert(sty *styles.Styles, width int) string {
+	inner := max(width-2, 1)
+	tag := sty.Messages.ErrorTag.Render("A2UI")
+	title := sty.Messages.ErrorTitle.Render("couldn't render this resource's UI surface")
+	reason := sty.Messages.ErrorDetails.Width(inner).Render(
+		"The A2UI content was malformed or used unsupported components.")
+	return tag + " " + title + "\n\n" + reason
 }
 
 // renderToolA2UI renders a static (non-interactive) A2UI surface from tool
@@ -117,6 +187,13 @@ func renderToolA2UI(sty *styles.Styles, content string, width int) (string, erro
 	var b strings.Builder
 	themedStyles := a2uiThemeStyles(sty)
 	for _, p := range parts {
+		// Keep each part's prose: pre-change persisted results interleave
+		// text with surfaces, and dropping it would lose content the model
+		// (and user) saw.
+		if text := strings.TrimSpace(p.Text); text != "" {
+			b.WriteString(text)
+			b.WriteString("\n")
+		}
 		if len(p.Messages) == 0 {
 			continue
 		}

--- a/internal/ui/chat/generic.go
+++ b/internal/ui/chat/generic.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"charm.land/lipgloss/v2"
 	"github.com/charmbracelet/crush/internal/agent/tools"
 	"github.com/charmbracelet/crush/internal/message"
 	"github.com/charmbracelet/crush/internal/ui/styles"
@@ -109,9 +110,11 @@ func (g *GenericToolRenderContext) RenderTool(sty *styles.Styles, width int, opt
 // claims the user can already see the surface, which would be false here.
 func renderToolA2UIResultBody(sty *styles.Styles, surfaces []string, opts *ToolRenderOpts, widths toolResultContentWidths) string {
 	var b strings.Builder
+	failed := 0
 	for _, surf := range surfaces {
 		rendered, err := renderToolA2UI(sty, surf, widths.Body)
 		if err != nil || rendered == "" {
+			failed++
 			continue
 		}
 		if b.Len() > 0 {
@@ -123,7 +126,11 @@ func renderToolA2UIResultBody(sty *styles.Styles, surfaces []string, opts *ToolR
 	var chunks []string
 	if b.Len() > 0 {
 		chunks = append(chunks, sty.Tool.Body.Render(clampToolA2UI(sty, b.String(), widths.Body, opts.ExpandedContent)))
-	} else {
+	}
+	// Alert on ANY failed surface, not only when all fail: a sibling
+	// surface rendering fine must not hide that another one vanished —
+	// the model was told the user can see every one of them.
+	if failed > 0 {
 		chunks = append(chunks, sty.Tool.Body.Render(renderToolA2UIAlert(sty, widths.Body)))
 	}
 	// Show any real text the resource returned alongside its surfaces — the
@@ -186,12 +193,13 @@ func renderToolA2UI(sty *styles.Styles, content string, width int) (string, erro
 	}
 	var b strings.Builder
 	themedStyles := a2uiThemeStyles(sty)
+	proseStyle := lipgloss.NewStyle().Width(width)
 	for _, p := range parts {
-		// Keep each part's prose: pre-change persisted results interleave
-		// text with surfaces, and dropping it would lose content the model
-		// (and user) saw.
+		// Keep each part's prose, wrapped to the body budget: pre-change
+		// persisted results interleave text with surfaces, and dropping
+		// (or overflowing) it would corrupt content the model saw.
 		if text := strings.TrimSpace(p.Text); text != "" {
-			b.WriteString(text)
+			b.WriteString(proseStyle.Render(text))
 			b.WriteString("\n")
 		}
 		if len(p.Messages) == 0 {

--- a/internal/ui/chat/generic.go
+++ b/internal/ui/chat/generic.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/charmbracelet/crush/internal/message"
 	"github.com/charmbracelet/crush/internal/ui/styles"
+	"github.com/joestump-agent/a2tea"
+	"github.com/joestump-agent/a2tea/render"
 )
 
 // GenericToolMessageItem is a message item that represents an unknown tool call.
@@ -68,6 +70,45 @@ func (g *GenericToolRenderContext) RenderTool(sty *styles.Styles, width int, opt
 		return joinToolParts(header, body)
 	}
 
+	// If the tool result contains an A2UI surface (e.g. a read_mcp_resource
+	// that returned application/a2ui+json), render it as a live surface
+	// instead of raw text. This is what makes cairn://artifact/{id}/a2ui
+	// and similar resource reads render inline — no JSON barf.
+	if a2tea.Contains(opts.Result.Content) {
+		surf, err := renderToolA2UI(sty, opts.Result.Content, bodyWidth)
+		if err == nil && surf != "" {
+			return joinToolParts(header, surf)
+		}
+	}
+
 	body := renderToolResultTextContent(sty, opts.Result.Content, toolResultContentWidths{Body: bodyWidth, Diff: cappedWidth}, opts.ExpandedContent)
 	return joinToolParts(header, body)
+}
+
+// renderToolA2UI renders a static (non-interactive) A2UI surface from tool
+// result content. Unlike the live surfaces on AssistantMessageItem, this does
+// not support focus/button interaction — it renders a snapshot of the surface
+// using the same themed styles.
+func renderToolA2UI(sty *styles.Styles, content string, width int) (string, error) {
+	parts, err := a2tea.Scan(content)
+	if err != nil {
+		return "", err
+	}
+	var b strings.Builder
+	themedStyles := a2uiThemeStyles(sty)
+	for _, p := range parts {
+		if len(p.Messages) == 0 {
+			continue
+		}
+		model, err := a2tea.Render(p.Messages, render.WithStyles(themedStyles))
+		if err != nil {
+			continue
+		}
+		if rm, ok := model.(render.Model); ok {
+			rm.SetSize(width, 0)
+			b.WriteString(strings.TrimRight(rm.View().Content, "\n"))
+			b.WriteString("\n")
+		}
+	}
+	return strings.TrimRight(b.String(), "\n"), nil
 }

--- a/internal/ui/chat/generic_test.go
+++ b/internal/ui/chat/generic_test.go
@@ -120,6 +120,28 @@ func TestGenericToolMetadataAllFailShowsAlert(t *testing.T) {
 	require.NotContains(t, plain, "do not repeat")
 }
 
+// A failed surface next to a healthy sibling still surfaces an alert — the
+// model was told the user can see every surface.
+func TestGenericToolMetadataPartialFailShowsAlert(t *testing.T) {
+	t.Parallel()
+
+	meta, err := json.Marshal(tools.ReadMCPResourceResponseMetadata{
+		A2UISurfaces: []string{a2uiSurface, "<a2ui-json>{malformed</a2ui-json>"},
+	})
+	require.NoError(t, err)
+
+	sty := styles.CharmtonePantera()
+	ctx := &GenericToolRenderContext{}
+	out := ctx.RenderTool(&sty, 80, genericToolOpts(t, &message.ToolResult{
+		Content:  a2uiTestPlaceholder,
+		Metadata: string(meta),
+	}))
+	plain := ansi.Strip(out)
+
+	require.Contains(t, plain, "Hello from A2UI")
+	require.Contains(t, plain, "couldn't render this resource's UI surface")
+}
+
 // The content-scan fallback exists for pre-change persisted read_mcp_resource
 // results only — other tools sharing the generic renderer must keep
 // payload-shaped text as text.

--- a/internal/ui/chat/generic_test.go
+++ b/internal/ui/chat/generic_test.go
@@ -2,6 +2,7 @@ package chat
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/charmbracelet/crush/internal/agent/tools"
@@ -11,12 +12,20 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const a2uiTestPlaceholder = tools.A2UISurfacePlaceholderPrefix +
+	"mcp://cairn/run/abc123/a2ui — the user can already see it; do not repeat or echo its JSON payload]"
+
 func genericToolOpts(t *testing.T, result *message.ToolResult) *ToolRenderOpts {
+	t.Helper()
+	return genericToolOptsFor(t, tools.ReadMCPResourceToolName, result)
+}
+
+func genericToolOptsFor(t *testing.T, name string, result *message.ToolResult) *ToolRenderOpts {
 	t.Helper()
 	return &ToolRenderOpts{
 		ToolCall: message.ToolCall{
 			ID:       "call-1",
-			Name:     tools.ReadMCPResourceToolName,
+			Name:     name,
 			Input:    `{"mcp_name":"cairn","uri":"mcp://cairn/run/abc123/a2ui"}`,
 			Finished: true,
 		},
@@ -39,7 +48,7 @@ func TestGenericToolRendersA2UIFromMetadata(t *testing.T) {
 	sty := styles.CharmtonePantera()
 	ctx := &GenericToolRenderContext{}
 	out := ctx.RenderTool(&sty, 80, genericToolOpts(t, &message.ToolResult{
-		Content:  "[A2UI surface rendered in the chat UI]",
+		Content:  a2uiTestPlaceholder,
 		Metadata: string(meta),
 	}))
 	plain := ansi.Strip(out)
@@ -47,6 +56,8 @@ func TestGenericToolRendersA2UIFromMetadata(t *testing.T) {
 	require.Contains(t, plain, "Hello from A2UI")
 	require.NotContains(t, plain, "a2ui-json")
 	require.NotContains(t, plain, "updateComponents")
+	// The model-facing placeholder is not shown to the user.
+	require.NotContains(t, plain, "do not repeat")
 }
 
 // A result with no A2UI metadata renders its text content as before.
@@ -61,4 +72,151 @@ func TestGenericToolNoMetadataRendersText(t *testing.T) {
 	plain := ansi.Strip(out)
 
 	require.Contains(t, plain, "plain resource text")
+}
+
+// A mixed resource read (text/markdown alongside application/a2ui+json)
+// shows both the surface and the real text — only the model-facing
+// placeholder lines are stripped.
+func TestGenericToolMetadataMixedContentShowsText(t *testing.T) {
+	t.Parallel()
+
+	meta, err := json.Marshal(tools.ReadMCPResourceResponseMetadata{
+		A2UISurfaces: []string{a2uiSurface},
+	})
+	require.NoError(t, err)
+
+	sty := styles.CharmtonePantera()
+	ctx := &GenericToolRenderContext{}
+	out := ctx.RenderTool(&sty, 80, genericToolOpts(t, &message.ToolResult{
+		Content:  "the artifact summary text\n" + a2uiTestPlaceholder,
+		Metadata: string(meta),
+	}))
+	plain := ansi.Strip(out)
+
+	require.Contains(t, plain, "Hello from A2UI")
+	require.Contains(t, plain, "the artifact summary text")
+	require.NotContains(t, plain, "do not repeat")
+}
+
+// When every metadata surface fails to render, the user sees an alert — not
+// the model-facing placeholder claiming the surface is already visible.
+func TestGenericToolMetadataAllFailShowsAlert(t *testing.T) {
+	t.Parallel()
+
+	meta, err := json.Marshal(tools.ReadMCPResourceResponseMetadata{
+		A2UISurfaces: []string{"<a2ui-json>{malformed</a2ui-json>"},
+	})
+	require.NoError(t, err)
+
+	sty := styles.CharmtonePantera()
+	ctx := &GenericToolRenderContext{}
+	out := ctx.RenderTool(&sty, 80, genericToolOpts(t, &message.ToolResult{
+		Content:  a2uiTestPlaceholder,
+		Metadata: string(meta),
+	}))
+	plain := ansi.Strip(out)
+
+	require.Contains(t, plain, "couldn't render this resource's UI surface")
+	require.NotContains(t, plain, "do not repeat")
+}
+
+// The content-scan fallback exists for pre-change persisted read_mcp_resource
+// results only — other tools sharing the generic renderer must keep
+// payload-shaped text as text.
+func TestGenericToolFallbackScopedToReadMCPResource(t *testing.T) {
+	t.Parallel()
+
+	sty := styles.CharmtonePantera()
+	ctx := &GenericToolRenderContext{}
+	out := ctx.RenderTool(&sty, 80, genericToolOptsFor(t, "crush_logs", &message.ToolResult{
+		Content: "log line before\n" + a2uiSurface + "\nlog line after",
+	}))
+	plain := ansi.Strip(out)
+
+	// Rendered as text (the raw payload stays visible), not as a surface.
+	require.Contains(t, plain, "log line before")
+	require.NotContains(t, plain, "Hello from A2UI")
+}
+
+// A fenced A2UI example inside a read_mcp_resource result is documentation,
+// not live UI (#6, #96) — the masked scan must not extract it.
+func TestGenericToolFallbackIgnoresFencedExample(t *testing.T) {
+	t.Parallel()
+
+	sty := styles.CharmtonePantera()
+	ctx := &GenericToolRenderContext{}
+	out := ctx.RenderTool(&sty, 80, genericToolOpts(t, &message.ToolResult{
+		Content: "Example:\n\n```json\n" + a2uiSurface + "\n```\n\nDone.",
+	}))
+	plain := ansi.Strip(out)
+
+	require.Contains(t, plain, "Example:")
+	require.NotContains(t, plain, "Hello from A2UI")
+}
+
+// Pre-change persisted results interleave prose with tagged surfaces — the
+// fallback render keeps the prose.
+func TestGenericToolFallbackPreservesProse(t *testing.T) {
+	t.Parallel()
+
+	sty := styles.CharmtonePantera()
+	ctx := &GenericToolRenderContext{}
+	out := ctx.RenderTool(&sty, 80, genericToolOpts(t, &message.ToolResult{
+		Content: "intro prose\n" + a2uiSurface + "\nfooter prose",
+	}))
+	plain := ansi.Strip(out)
+
+	require.Contains(t, plain, "Hello from A2UI")
+	require.Contains(t, plain, "intro prose")
+	require.Contains(t, plain, "footer prose")
+}
+
+// tallA2UISurface builds a surface whose rendered height exceeds the
+// collapsed tool-body budget.
+func tallA2UISurface(t *testing.T) string {
+	t.Helper()
+	var comps []string
+	var children []string
+	for i := 0; i < 20; i++ {
+		id := string(rune('a' + i%26))
+		id += string(rune('0' + i/26))
+		children = append(children, `"`+id+`"`)
+		comps = append(comps, `{"component":"Text","id":"`+id+`","text":"row `+id+`"}`)
+	}
+	comps = append([]string{
+		`{"component":"Card","id":"root","child":"col"}`,
+		`{"component":"Column","id":"col","children":[` + strings.Join(children, ",") + `]}`,
+	}, comps...)
+	return `<a2ui-json>{"version":"v0.9","updateComponents":{"surfaceId":"s","components":[` +
+		strings.Join(comps, ",") + `]}}</a2ui-json>`
+}
+
+// A tall surface honors the same collapsed-height budget as every other tool
+// body, and expanding restores the full surface.
+func TestGenericToolA2UICollapse(t *testing.T) {
+	t.Parallel()
+
+	meta, err := json.Marshal(tools.ReadMCPResourceResponseMetadata{
+		A2UISurfaces: []string{tallA2UISurface(t)},
+	})
+	require.NoError(t, err)
+
+	sty := styles.CharmtonePantera()
+	ctx := &GenericToolRenderContext{}
+
+	collapsed := genericToolOpts(t, &message.ToolResult{
+		Content:  a2uiTestPlaceholder,
+		Metadata: string(meta),
+	})
+	out := ansi.Strip(ctx.RenderTool(&sty, 80, collapsed))
+	require.Contains(t, out, "lines hidden")
+
+	expanded := genericToolOpts(t, &message.ToolResult{
+		Content:  a2uiTestPlaceholder,
+		Metadata: string(meta),
+	})
+	expanded.ExpandedContent = true
+	outExpanded := ansi.Strip(ctx.RenderTool(&sty, 80, expanded))
+	require.NotContains(t, outExpanded, "lines hidden")
+	require.Contains(t, outExpanded, "row a0")
 }

--- a/internal/ui/chat/generic_test.go
+++ b/internal/ui/chat/generic_test.go
@@ -1,0 +1,64 @@
+package chat
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/charmbracelet/crush/internal/agent/tools"
+	"github.com/charmbracelet/crush/internal/message"
+	"github.com/charmbracelet/crush/internal/ui/styles"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/stretchr/testify/require"
+)
+
+func genericToolOpts(t *testing.T, result *message.ToolResult) *ToolRenderOpts {
+	t.Helper()
+	return &ToolRenderOpts{
+		ToolCall: message.ToolCall{
+			ID:       "call-1",
+			Name:     tools.ReadMCPResourceToolName,
+			Input:    `{"mcp_name":"cairn","uri":"mcp://cairn/run/abc123/a2ui"}`,
+			Finished: true,
+		},
+		Result: result,
+		Status: ToolStatusSuccess,
+	}
+}
+
+// The A2UI payload lives in result metadata (UI-only), not in the content
+// the model sees — the model only gets a placeholder, so it cannot echo the
+// JSON back and double-render the surface.
+func TestGenericToolRendersA2UIFromMetadata(t *testing.T) {
+	t.Parallel()
+
+	meta, err := json.Marshal(tools.ReadMCPResourceResponseMetadata{
+		A2UISurfaces: []string{a2uiSurface},
+	})
+	require.NoError(t, err)
+
+	sty := styles.CharmtonePantera()
+	ctx := &GenericToolRenderContext{}
+	out := ctx.RenderTool(&sty, 80, genericToolOpts(t, &message.ToolResult{
+		Content:  "[A2UI surface rendered in the chat UI]",
+		Metadata: string(meta),
+	}))
+	plain := ansi.Strip(out)
+
+	require.Contains(t, plain, "Hello from A2UI")
+	require.NotContains(t, plain, "a2ui-json")
+	require.NotContains(t, plain, "updateComponents")
+}
+
+// A result with no A2UI metadata renders its text content as before.
+func TestGenericToolNoMetadataRendersText(t *testing.T) {
+	t.Parallel()
+
+	sty := styles.CharmtonePantera()
+	ctx := &GenericToolRenderContext{}
+	out := ctx.RenderTool(&sty, 80, genericToolOpts(t, &message.ToolResult{
+		Content: "plain resource text",
+	}))
+	plain := ansi.Strip(out)
+
+	require.Contains(t, plain, "plain resource text")
+}


### PR DESCRIPTION
Changes that together make `cairn://artifact/{id}/a2ui` and similar A2UI resource reads render as live surfaces inside the chat — no JSON barf, no model middleman, no double render.

## What changes

**1. `read_mcp_resource` detects A2UI surfaces** — When a resource read returns `application/a2ui+json`, the payload is delivered to the UI via tool-response metadata (`ReadMCPResourceResponseMetadata.A2UISurfaces`), a channel providers never serialize. The model sees a one-line placeholder ("the surface is already on screen — do not echo it"), so it cannot parrot the JSON back into its reply. (Initially this wrapped the payload in `<a2ui-json>` tags in the content; that made the model echo the block and double-render the surface — hence the metadata channel.)

**2. Tool results render A2UI inline** — `GenericToolRenderContext` renders the surface from result metadata (falling back to content scanning for pre-change results) instead of pretty-printing raw JSON. Uses the same `a2uiThemeStyles` as live assistant-message surfaces.

**3. Glamour injected into a2tea body text** — `a2uiThemeStyles` passes Crush's glamour renderer as the `MarkdownRenderer` hook, so body-variant Text components containing Markdown (tables, lists, bold, code blocks) render with full chat-quality formatting.

## Dependency

Requires a2tea with the `MarkdownRenderer` hook (stump.wtf/a2tea PR #1, merged as v0.1.0). Uses a local `replace` directive until GitHub push access is restored for `joestump-agent/a2tea`.

## Testing

Built and tested locally at `/tmp/crush`. New `TestGenericToolRendersA2UIFromMetadata` / `TestGenericToolNoMetadataRendersText` cover the metadata render path; `internal/ui/chat` and `internal/agent/tools` suites green. The `go.mod` replace directive points at the local a2tea checkout — CI will need the replace resolved before it can build. This PR is against `feat/a2ui` (not main) since it depends on the A2UI infrastructure in that branch.