### PR TITLE
fix(mcp): resource-template registry hygiene + review findings

### DIFF
--- a/internal/agent/tools/mcp/init.go
+++ b/internal/agent/tools/mcp/init.go
@@ -400,6 +400,13 @@ func getOrRenewClient(ctx context.Context, cfg *config.ConfigStore, name string)
 	updatePrompts(name, prompts)
 	counts.Prompts = len(prompts)
 
+	// The StateError transition also purged this server's resources and
+	// resource templates, but counts still carries the pre-error value.
+	// Re-fetch both on the fresh session so the registries and the status
+	// count agree with what the reconnected server actually serves,
+	// instead of advertising N resources over an empty registry.
+	counts.Resources = refreshSessionResources(ctx, name, fresh)
+
 	sessions.Set(name, fresh)
 	updateState(name, StateConnected, nil, fresh, counts)
 	return fresh, nil

--- a/internal/agent/tools/mcp/init.go
+++ b/internal/agent/tools/mcp/init.go
@@ -345,10 +345,11 @@ func DisableSingle(cfg *config.ConfigStore, name string) error {
 		closeSession(name, session)
 	}
 
-	// Clear tools, prompts, and resources for this MCP.
+	// Clear tools, prompts, resources, and resource templates for this MCP.
 	updateTools(cfg, name, nil)
 	updatePrompts(name, nil)
 	updateResources(name, nil)
+	updateResourceTemplates(name, nil)
 
 	// Update state to disabled.
 	updateState(name, StateDisabled, nil, nil, Counts{})
@@ -458,6 +459,7 @@ func updateState(name string, state State, err error, client *ClientSession, cou
 				allTools.Del(name)
 				updatePrompts(name, nil)
 				updateResources(name, nil)
+				updateResourceTemplates(name, nil)
 			}
 			closeSession(name, client)
 		default:
@@ -469,6 +471,7 @@ func updateState(name string, state State, err error, client *ClientSession, cou
 			allTools.Del(name)
 			updatePrompts(name, nil)
 			updateResources(name, nil)
+			updateResourceTemplates(name, nil)
 		}
 		// Never publish a dead session on the state.
 		info.Client = nil

--- a/internal/agent/tools/mcp/init.go
+++ b/internal/agent/tools/mcp/init.go
@@ -306,8 +306,15 @@ func initClient(ctx context.Context, cfg *config.ConfigStore, name string, m con
 	// Fetch resources and templates eagerly so the status display reflects
 	// the real count from the first connection, not a stale zero.  Both
 	// helpers are no-ops when the server doesn't advertise the resources
-	// capability, and gracefully handle "method not found".
-	resourceCount := refreshSessionResources(ctx, name, session)
+	// capability, and gracefully handle "method not found". Bound the
+	// listing with the same per-server timeout createSession enforces:
+	// initClient runs on the startup critical path under the per-name
+	// lock, and a server that connects but then hangs on resources/list
+	// would otherwise stall WaitForInit indefinitely — with the bound it
+	// degrades to a warn and a zero count.
+	listCtx, cancelList := context.WithTimeout(ctx, mcpTimeout(m))
+	resourceCount := refreshSessionResources(listCtx, name, session)
+	cancelList()
 
 	// A repeated init (e.g. enable called twice) must not overwrite a live
 	// session without closing it — that leaks the child process and pipes.

--- a/internal/agent/tools/mcp/init.go
+++ b/internal/agent/tools/mcp/init.go
@@ -307,17 +307,7 @@ func initClient(ctx context.Context, cfg *config.ConfigStore, name string, m con
 	// the real count from the first connection, not a stale zero.  Both
 	// helpers are no-ops when the server doesn't advertise the resources
 	// capability, and gracefully handle "method not found".
-	resources, err := getResources(ctx, session)
-	if err != nil {
-		slog.Warn("Error listing resources", "name", name, "error", err)
-	}
-	templates, err := getResourceTemplates(ctx, session)
-	if err != nil {
-		slog.Warn("MCP server does not support resources/templates/list", "name", name, "error", err)
-		templates = nil
-	}
-	resourceCount := updateResources(name, resources)
-	templateCount := updateResourceTemplates(name, templates)
+	resourceCount := refreshSessionResources(ctx, name, session)
 
 	// A repeated init (e.g. enable called twice) must not overwrite a live
 	// session without closing it — that leaks the child process and pipes.
@@ -329,7 +319,7 @@ func initClient(ctx context.Context, cfg *config.ConfigStore, name string, m con
 	updateState(name, StateConnected, nil, session, Counts{
 		Tools:     toolCount,
 		Prompts:   len(prompts),
-		Resources: resourceCount + templateCount,
+		Resources: resourceCount,
 	})
 
 	return nil

--- a/internal/agent/tools/mcp/lifecycle_test.go
+++ b/internal/agent/tools/mcp/lifecycle_test.go
@@ -275,14 +275,16 @@ func TestNameLock_ConcurrentFirstUseReturnsOneMutex(t *testing.T) {
 }
 
 // TestUpdateState_ErrorClearsResources pins that both StateError teardown
-// branches clear the resources registry alongside tools and prompts — a
-// dead server must not keep advertising resources it can no longer serve.
+// branches clear the resources and resource-template registries alongside
+// tools and prompts — a dead server must not keep advertising resources
+// (or templates) it can no longer serve.
 func TestUpdateState_ErrorClearsResources(t *testing.T) {
 	const name = "test-error-clears-resources"
 	t.Cleanup(func() {
 		sessions.Del(name)
 		allTools.Del(name)
 		allResources.Del(name)
+		allResourceTemplates.Del(name)
 		states.Del(name)
 	})
 
@@ -290,18 +292,58 @@ func TestUpdateState_ErrorClearsResources(t *testing.T) {
 	sess, _ := liveSession(t, "res_tool")
 	sessions.Set(name, sess)
 	allResources.Set(name, []*Resource{{Name: "doc"}})
+	allResourceTemplates.Set(name, []*ResourceTemplate{{Name: "tmpl"}})
 
 	updateState(name, StateError, errors.New("listing broke"), sess, Counts{})
 	_, ok := allResources.Get(name)
 	require.False(t, ok, "current-session error must clear the resources registry")
+	_, ok = allResourceTemplates.Get(name)
+	require.False(t, ok, "current-session error must clear the resource-template registry")
 
 	// Branch 2: no specific session (connect failed); anything registered
 	// under the name is unusable.
 	sess2, _ := liveSession(t, "res_tool2")
 	sessions.Set(name, sess2)
 	allResources.Set(name, []*Resource{{Name: "doc2"}})
+	allResourceTemplates.Set(name, []*ResourceTemplate{{Name: "tmpl2"}})
 
 	updateState(name, StateError, errors.New("connect broke"), nil, Counts{})
 	_, ok = allResources.Get(name)
 	require.False(t, ok, "no-session error must clear the resources registry")
+	_, ok = allResourceTemplates.Get(name)
+	require.False(t, ok, "no-session error must clear the resource-template registry")
+}
+
+// TestDisableSingle_ClearsResourceTemplates pins that disabling a server
+// removes its resource templates (alongside tools, prompts, and resources)
+// from the registries — a disabled server's templates must stop appearing
+// as @-completions.
+func TestDisableSingle_ClearsResourceTemplates(t *testing.T) {
+	const name = "test-disable-clears-templates"
+	t.Cleanup(func() {
+		sessions.Del(name)
+		allTools.Del(name)
+		allResources.Del(name)
+		allResourceTemplates.Del(name)
+		states.Del(name)
+	})
+
+	cfg := config.NewTestStore(&config.Config{MCP: config.MCPs{name: {Type: config.MCPStdio}}})
+
+	sess, sessCtx := liveSession(t, "tmpl_tool")
+	sessions.Set(name, sess)
+	allResources.Set(name, []*Resource{{Name: "doc"}})
+	allResourceTemplates.Set(name, []*ResourceTemplate{{Name: "tmpl", URITemplate: "x://{id}"}})
+
+	require.NoError(t, DisableSingle(cfg, name))
+
+	require.ErrorIs(t, sessCtx.Err(), context.Canceled, "disable must close the session")
+	_, ok := allResources.Get(name)
+	require.False(t, ok, "disable must clear the resources registry")
+	_, ok = allResourceTemplates.Get(name)
+	require.False(t, ok, "disable must clear the resource-template registry")
+
+	info, ok := GetState(name)
+	require.True(t, ok)
+	require.Equal(t, StateDisabled, info.State)
 }

--- a/internal/agent/tools/mcp/resources.go
+++ b/internal/agent/tools/mcp/resources.go
@@ -45,12 +45,7 @@ func ListResources(ctx context.Context, cfg *config.ConfigStore, name string) ([
 		return nil, nil, err
 	}
 
-	templates, err := getResourceTemplates(ctx, session)
-	if err != nil {
-		// Templates are best-effort; some servers may not support resources/templates/list.
-		slog.Warn("MCP server does not support resources/templates/list", "error", err)
-		templates = nil
-	}
+	templates := listTemplatesBestEffort(ctx, session, name)
 
 	resourceCount := updateResources(name, resources)
 	templateCount := updateResourceTemplates(name, templates)
@@ -94,11 +89,7 @@ func RefreshResources(ctx context.Context, name string) {
 		return
 	}
 
-	templates, err := getResourceTemplates(ctx, session)
-	if err != nil {
-		slog.Warn("MCP server does not support resources/templates/list", "error", err)
-		templates = nil
-	}
+	templates := listTemplatesBestEffort(ctx, session, name)
 
 	resourceCount := updateResources(name, resources)
 	templateCount := updateResourceTemplates(name, templates)
@@ -122,6 +113,36 @@ func getResources(ctx context.Context, c *ClientSession) ([]*Resource, error) {
 		return nil, err
 	}
 	return result.Resources, nil
+}
+
+// refreshSessionResources re-fetches a session's resources and resource
+// templates (best-effort: a listing failure degrades to an empty registry
+// and a warn, never an error) and installs them in the registries. It
+// returns the combined count for ClientInfo.Counts.Resources, so callers
+// publishing a StateConnected transition report exactly what the
+// registries hold.
+func refreshSessionResources(ctx context.Context, name string, session *ClientSession) int {
+	resources, err := getResources(ctx, session)
+	if err != nil {
+		slog.Warn("Error listing MCP resources", "name", name, "error", err)
+		resources = nil
+	}
+	templates := listTemplatesBestEffort(ctx, session, name)
+	return updateResources(name, resources) + updateResourceTemplates(name, templates)
+}
+
+// listTemplatesBestEffort lists a session's resource templates, treating any
+// failure as "no templates". getResourceTemplates already swallows
+// method-not-found, so an error reaching here is a timeout, transport
+// failure, or server bug — never lack of support — and is logged as such,
+// with the server name so a multi-server config stays debuggable.
+func listTemplatesBestEffort(ctx context.Context, session *ClientSession, name string) []*ResourceTemplate {
+	templates, err := getResourceTemplates(ctx, session)
+	if err != nil {
+		slog.Warn("Error listing MCP resource templates", "name", name, "error", err)
+		return nil
+	}
+	return templates
 }
 
 func getResourceTemplates(ctx context.Context, c *ClientSession) ([]*ResourceTemplate, error) {

--- a/internal/agent/tools/mcp/resources_test.go
+++ b/internal/agent/tools/mcp/resources_test.go
@@ -1,0 +1,154 @@
+package mcp
+
+import (
+	"context"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/require"
+)
+
+// liveResourceSession spins up a real in-memory MCP server advertising the
+// given resources and resource templates and returns a connected client
+// session, mirroring liveSession for the resources side of the protocol.
+func liveResourceSession(t *testing.T, resources []*mcp.Resource, templates []*mcp.ResourceTemplate) *ClientSession {
+	t.Helper()
+
+	serverTransport, clientTransport := mcp.NewInMemoryTransports()
+	server := mcp.NewServer(&mcp.Implementation{Name: "srv"}, nil)
+	handler := func(context.Context, *mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
+		return &mcp.ReadResourceResult{}, nil
+	}
+	for _, r := range resources {
+		server.AddResource(r, handler)
+	}
+	for _, tmpl := range templates {
+		server.AddResourceTemplate(tmpl, handler)
+	}
+	serverSession, err := server.Connect(context.Background(), serverTransport, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = serverSession.Close() })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	client := mcp.NewClient(&mcp.Implementation{Name: "crush-test"}, nil)
+	clientSession, err := client.Connect(ctx, clientTransport, nil)
+	require.NoError(t, err)
+
+	sess := &ClientSession{ClientSession: clientSession, cancel: cancel}
+	t.Cleanup(func() { _ = sess.Close() })
+	return sess
+}
+
+// TestUpdateResourceTemplates_SetAndDelOnEmpty pins the registry-write
+// semantics updateResourceTemplates shares with updateResources: a non-empty
+// list is installed and counted, an empty (or nil) list deletes the entry
+// outright — so a server that stops advertising templates does not linger
+// with an empty-but-present registry row.
+func TestUpdateResourceTemplates_SetAndDelOnEmpty(t *testing.T) {
+	const name = "test-update-resource-templates"
+	t.Cleanup(func() { allResourceTemplates.Del(name) })
+
+	count := updateResourceTemplates(name, []*ResourceTemplate{
+		{Name: "run", URITemplate: "cairn://run/{id}"},
+		{Name: "bundle", URITemplate: "cairn://bundle/{id}"},
+	})
+	require.Equal(t, 2, count)
+	got, ok := allResourceTemplates.Get(name)
+	require.True(t, ok)
+	require.Len(t, got, 2)
+
+	count = updateResourceTemplates(name, nil)
+	require.Equal(t, 0, count)
+	_, ok = allResourceTemplates.Get(name)
+	require.False(t, ok, "an empty template list must delete the registry entry")
+}
+
+// TestGetResourceTemplates_NoResourcesCapability pins the capability gate: a
+// server that does not advertise the resources capability yields (nil, nil)
+// without a wire call, so servers with no resources at all never produce
+// warns or errors from the template fetch.
+func TestGetResourceTemplates_NoResourcesCapability(t *testing.T) {
+	sess, _ := liveSession(t, "no_resources_tool")
+	t.Cleanup(func() { _ = sess.Close() })
+
+	templates, err := getResourceTemplates(context.Background(), sess)
+	require.NoError(t, err)
+	require.Nil(t, templates)
+}
+
+// TestGetResourceTemplates_ListsTemplates pins the happy path over a real
+// in-memory server: the declared templates come back with their URI
+// templates intact.
+func TestGetResourceTemplates_ListsTemplates(t *testing.T) {
+	sess := liveResourceSession(t, nil, []*mcp.ResourceTemplate{
+		{Name: "run", URITemplate: "cairn://run/{id}/a2ui"},
+	})
+
+	templates, err := getResourceTemplates(context.Background(), sess)
+	require.NoError(t, err)
+	require.Len(t, templates, 1)
+	require.Equal(t, "cairn://run/{id}/a2ui", templates[0].URITemplate)
+}
+
+// TestRefreshSessionResources_CountsSumResourcesAndTemplates pins the seam
+// initClient and the renewal path share: both registries are populated from
+// the session and the returned count — what Counts.Resources reports — is
+// the sum of concrete resources and templates.
+func TestRefreshSessionResources_CountsSumResourcesAndTemplates(t *testing.T) {
+	const name = "test-refresh-session-resources"
+	t.Cleanup(func() {
+		allResources.Del(name)
+		allResourceTemplates.Del(name)
+	})
+
+	sess := liveResourceSession(t,
+		[]*mcp.Resource{
+			{Name: "doc-a", URI: "test://doc-a"},
+			{Name: "doc-b", URI: "test://doc-b"},
+		},
+		[]*mcp.ResourceTemplate{
+			{Name: "run", URITemplate: "test://run/{id}"},
+		},
+	)
+
+	count := refreshSessionResources(context.Background(), name, sess)
+	require.Equal(t, 3, count, "count must sum resources and templates")
+
+	resources, ok := allResources.Get(name)
+	require.True(t, ok)
+	require.Len(t, resources, 2)
+	templates, ok := allResourceTemplates.Get(name)
+	require.True(t, ok)
+	require.Len(t, templates, 1)
+}
+
+// TestRefreshResources_UpdatesRegistriesAndCount pins the notification-driven
+// refresh path end to end: RefreshResources lists both resources and
+// templates from the live session and publishes their sum on the state.
+func TestRefreshResources_UpdatesRegistriesAndCount(t *testing.T) {
+	const name = "test-refresh-resources"
+	t.Cleanup(func() {
+		sessions.Del(name)
+		allResources.Del(name)
+		allResourceTemplates.Del(name)
+		states.Del(name)
+	})
+
+	sess := liveResourceSession(t,
+		[]*mcp.Resource{{Name: "doc", URI: "test://doc"}},
+		[]*mcp.ResourceTemplate{{Name: "run", URITemplate: "test://run/{id}"}},
+	)
+	sessions.Set(name, sess)
+
+	RefreshResources(context.Background(), name)
+
+	_, ok := allResources.Get(name)
+	require.True(t, ok, "refresh must install the listed resources")
+	_, ok = allResourceTemplates.Get(name)
+	require.True(t, ok, "refresh must install the listed templates")
+
+	info, ok := GetState(name)
+	require.True(t, ok)
+	require.Equal(t, StateConnected, info.State)
+	require.Equal(t, 2, info.Counts.Resources, "state count must sum resources and templates")
+}

--- a/internal/ui/chat/a2ui_test.go
+++ b/internal/ui/chat/a2ui_test.go
@@ -769,6 +769,30 @@ func TestA2UISurfaceModelStableAcrossRenders(t *testing.T) {
 		"re-renders must reuse the live model — rebuilding would drop interaction state")
 }
 
+// TestA2UIClearCacheDropsSurfacesForRestyle pins the theme-swap path: a
+// style change reaches items as clearCache (applyTheme → refreshStyles →
+// InvalidateRenderCaches → ClearItemCaches), and the surface models baked
+// the old theme's render.Styles in at build time. clearCache must drop them
+// so the next render rebuilds the surfaces with the current theme instead
+// of drawing the previous palette next to newly-themed chat.
+func TestA2UIClearCacheDropsSurfacesForRestyle(t *testing.T) {
+	t.Parallel()
+
+	item := newA2UIFormItem(t)
+	_ = item.RawRender(80)
+	require.True(t, item.hasLiveA2UISurfaces())
+	first := firstLiveA2UISurface(t, item)
+
+	item.clearCache()
+	require.False(t, item.hasLiveA2UISurfaces(),
+		"a style change must drop surface models carrying baked-in styles")
+
+	_ = item.RawRender(80)
+	require.True(t, item.hasLiveA2UISurfaces(), "the next render must rebuild the surfaces")
+	require.NotSame(t, first, firstLiveA2UISurface(t, item),
+		"the rebuilt surface must be a fresh model, not the stale-styled one")
+}
+
 func TestA2UIContentCacheBypassedForLiveSurfaces(t *testing.T) {
 	t.Parallel()
 

--- a/internal/ui/chat/assistant.go
+++ b/internal/ui/chat/assistant.go
@@ -647,6 +647,15 @@ func (a *AssistantMessageItem) clearCache() {
 	a.errorSec.reset()
 	a.streamingContent.Reset()
 	a.streamingThinking.Reset()
+	// A2UI surface models bake the theme's render.Styles in at build time
+	// (a2uiThemeStyles), so after a theme swap a kept model would draw the
+	// old palette next to newly-themed chat. Drop them and let the next
+	// render rebuild from the message with the current theme; retirement
+	// marks are keyed by surface ID and survive the rebuild. The cost is
+	// losing in-progress field values on an explicit theme change —
+	// clearCache is only reached via ClearItemCaches (style change) — until
+	// a2tea grows a restyle-in-place.
+	a.dropA2UISurfaces()
 }
 
 // ToggleExpanded advances the F5 thinking view-mode cycle and returns

--- a/internal/ui/completions/item.go
+++ b/internal/ui/completions/item.go
@@ -2,6 +2,7 @@ package completions
 
 import (
 	"slices"
+	"strings"
 
 	"charm.land/lipgloss/v2"
 	"github.com/charmbracelet/crush/internal/ui/list"
@@ -21,6 +22,14 @@ type ResourceCompletionValue struct {
 	URI      string
 	Title    string
 	MIMEType string
+}
+
+// IsTemplate reports whether the completion's URI is an unexpanded RFC 6570
+// URI template (it still contains a "{expression}") rather than a concrete,
+// readable resource URI. Templates come from resources/templates/list and
+// cannot be read until their placeholders are filled in.
+func (r ResourceCompletionValue) IsTemplate() bool {
+	return strings.Contains(r.URI, "{")
 }
 
 // CompletionItem represents an item in the completions list.

--- a/internal/ui/completions/item_test.go
+++ b/internal/ui/completions/item_test.go
@@ -1,0 +1,20 @@
+package completions
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestResourceCompletionValueIsTemplate pins the concrete-vs-template
+// distinction the insertion path relies on: a URI still carrying an RFC 6570
+// placeholder must not be read eagerly (the server would see the literal
+// braces), while a concrete URI must keep the auto-attachment read.
+func TestResourceCompletionValueIsTemplate(t *testing.T) {
+	t.Parallel()
+
+	require.True(t, ResourceCompletionValue{URI: "cairn://run/{id}/a2ui"}.IsTemplate())
+	require.True(t, ResourceCompletionValue{URI: "switchboard://queue/{name}"}.IsTemplate())
+	require.False(t, ResourceCompletionValue{URI: "cairn://run/abc123/a2ui"}.IsTemplate())
+	require.False(t, ResourceCompletionValue{URI: ""}.IsTemplate())
+}

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -3563,15 +3563,27 @@ func (m *UI) insertFileCompletion(path string) tea.Cmd {
 }
 
 // insertMCPResourceCompletion inserts the selected resource into the textarea,
-// replacing the @query, and adds the resource as an attachment.
+// replacing the @query, and adds the resource as an attachment. An unexpanded
+// resource template is only inserted as text: its URI still carries RFC 6570
+// placeholders ("cairn://run/{id}"), so reading it now would send the literal
+// braces to the server and fail — the read happens once someone (user or
+// agent) has substituted real values.
 func (m *UI) insertMCPResourceCompletion(item completions.ResourceCompletionValue) tea.Cmd {
 	displayText := cmp.Or(item.Title, item.URI)
+	if item.IsTemplate() {
+		// Insert the raw template URI, not the title: the placeholders are
+		// the point — they show what needs filling in.
+		displayText = item.URI
+	}
 
 	prevHeight := m.textarea.Height()
 	if !m.insertCompletionText(displayText) {
 		return nil
 	}
 	heightCmd := m.handleTextareaHeightChange(prevHeight)
+	if item.IsTemplate() {
+		return heightCmd
+	}
 
 	resourceCmd := func() tea.Msg {
 		contents, err := m.com.Workspace.ReadMCPResource(


### PR DESCRIPTION
Review-driven fixes for the MCP resource-template plumbing and A2UI theming that landed on `feat/a2ui`.

## What changed

- **resource-templates-leak-on-error-disable** (high): `DisableSingle` and both `StateError` teardown branches in `updateState` now clear `allResourceTemplates` alongside tools/prompts/resources; the error-teardown lifecycle test is extended to templates and a new `DisableSingle` test pins the disable path.
- **renewal-stale-resource-counts**: `getOrRenewClient`'s renewal path re-fetches resources and resource templates on the fresh session and publishes the real combined count instead of the pre-error one.
- **template-completion-reads-unexpanded-uri**: selecting a resource-template completion no longer calls `ReadMCPResource` with the literal `{id}` URI (a guaranteed silent failure). Templates insert their raw URI into the editor — placeholders visible for filling in — and skip the auto-attachment read; `ResourceCompletionValue.IsTemplate` carries the distinction.
- **misleading-template-warn-triplicated**: the copy-pasted best-effort template-fetch block (`resources.go` x2, `init.go`) is extracted into `listTemplatesBestEffort` / `refreshSessionResources`; the warn now says "Error listing MCP resource templates" (method-not-found is already swallowed, so the old "does not support" text was wrong by construction) and always includes the server name.
- **mcp-template-plumbing-untested**: new `resources_test.go` with an in-memory resource/template server covering `updateResourceTemplates` del-on-empty, the `getResourceTemplates` capability gate and happy path, `refreshSessionResources` count summing, and `RefreshResources` publishing the summed count on the state.
- **eager-init-fetch-unbounded** (low): the eager resources/templates listing in `initClient` is bounded by `mcpTimeout(m)`, matching `createSession`, so a server that connects and then hangs on `resources/list` degrades to a warn + zero count instead of stalling `WaitForInit`.
- **theme-swap-stale-surfaces** (low): `AssistantMessageItem.clearCache` (the style-change path) now drops A2UI surface models so a runtime theme swap rebuilds them with the current palette instead of keeping build-time-baked styles. Retirement marks survive; in-progress field values are lost on an explicit theme swap — the documented tradeoff until a2tea grows a restyle-in-place.

## Why

A dead or disabled server must not keep advertising capabilities it can no longer serve (the invariant the package's own lifecycle tests pin), status counts must match the registries, template completions were unusable as wired, the triplicated warn sent debuggers down the wrong path, the new plumbing shipped with zero tests, the eager fetch could wedge startup, and theme swaps left stale-palette surfaces on screen.

## How verified

- `go build ./...` — clean.
- `go test ./internal/agent/tools/mcp/... ./internal/ui/... -count=1` — all packages `ok` (mcp 2.5s, chat 8.8s, completions 1.6s, model 3.2s, plus attachments/common/dialog/diffview/image/list/notification).
- `golangci-lint run` on the touched packages — 4 findings, all pre-existing on `feat/a2ui` in files/lines this branch does not modify (`oauth.go`, `oauth_test.go`, the old `TestMaybeStdioErr` noctx, and a staticcheck QF1008 in `a2ui.go` which this branch leaves untouched).

## Review notes (not addressed here)

- **commands-test-deleted-upstream** (process): branch `fix/commands-filter-shortcut-upstream` tip (a856ff466) deletes `internal/ui/dialog/commands_test.go` with no replacement, dropping the only regression guard for the "New Session vanishes when typing clear" bug and the shortcut-out-of-Filter revert. The test should be restored on that branch (or carried in the fork) before it merges anywhere.
- **duplicate-double-border-fix-branches** (process): `fix/a2ui-double-bounded-width` (e21f8d934) and `feat/a2ui` carry opposite fixes for the same double-border bug under the same regression-test names. `feat/a2ui`'s `WithStyles` approach supersedes the side branch; recommend deleting `fix/a2ui-double-bounded-width` so a later merge cannot reintroduce the second frame.

🤖 Posted on behalf of `@joestump` by [`claude-fable-5`](https://openrouter.ai/anthropic/claude-fable-5) using [Claude Code](https://claude.ai).
