### PR TITLE
feat(a2ui): size resource surfaces to the chat content width

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -83,8 +83,13 @@ type SessionAgentCall struct {
 	// reliable completion contract (e.g. `crush run` against a
 	// session that may be busy) MUST set it; SessionID alone is
 	// ambiguous when concurrent turns share the same session.
-	RunID            string
-	Channel          string
+	RunID   string
+	Channel string
+	// ContentWidth is the UI's chat content width hint in cells (0 when
+	// the turn has no interactive UI). Tools rendering width-sensitive
+	// remote content (e.g. A2UI surfaces with pre-sized bar geometry)
+	// use it to ask the server for exactly the right size.
+	ContentWidth     int
 	Prompt           string
 	ProviderOptions  fantasy.ProviderOptions
 	Attachments      []message.Attachment
@@ -893,6 +898,7 @@ func (a *sessionAgent) Run(ctx context.Context, call SessionAgentCall) (result *
 			callContext = context.WithValue(callContext, tools.ChannelContextKey, call.Channel)
 			callContext = context.WithValue(callContext, tools.SupportsImagesContextKey, largeModel.CatwalkCfg.SupportsImages)
 			callContext = context.WithValue(callContext, tools.ModelNameContextKey, largeModel.CatwalkCfg.Name)
+			callContext = context.WithValue(callContext, tools.ContentWidthContextKey, call.ContentWidth)
 			currentAssistant = &assistantMsg
 			return callContext, prepared, err
 		},

--- a/internal/agent/content_width.go
+++ b/internal/agent/content_width.go
@@ -1,0 +1,23 @@
+package agent
+
+import "context"
+
+type contentWidthContextKey struct{}
+
+// WithContentWidth returns ctx tagged with the UI's current chat content
+// width in cells. Tools that read width-sensitive remote content (e.g. an
+// A2UI resource whose server pre-renders bar geometry) use it to ask the
+// server for exactly the right size. Zero means "no hint".
+func WithContentWidth(ctx context.Context, width int) context.Context {
+	return context.WithValue(ctx, contentWidthContextKey{}, width)
+}
+
+// ContentWidthFromContext returns the UI content width in cells, or 0 when
+// the turn did not originate from an interactive UI (remote clients, headless
+// runs, channels).
+func ContentWidthFromContext(ctx context.Context) int {
+	if w, ok := ctx.Value(contentWidthContextKey{}).(int); ok {
+		return w
+	}
+	return 0
+}

--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -1327,7 +1327,12 @@ func (c *coordinator) runSubAgent(ctx context.Context, params subAgentParams) (f
 	// Run the agent
 	run := func() (*fantasy.AgentResult, error) {
 		return params.Agent.Run(ctx, SessionAgentCall{
-			SessionID:        session.ID,
+			SessionID: session.ID,
+			// Inherit the parent turn's UI width hint: the sub-agent's
+			// PrepareStep stamps call.ContentWidth over the tool-call
+			// context unconditionally, so leaving this zero would clobber
+			// the value the parent already carries.
+			ContentWidth:     tools.GetContentWidthFromContext(ctx),
 			Prompt:           params.Prompt,
 			MaxOutputTokens:  maxTokens,
 			ProviderOptions:  getProviderOptions(model, providerCfg),

--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -277,6 +277,7 @@ func (c *coordinator) run(ctx context.Context, accept *AcceptedRun, sessionID st
 			SessionID:        sessionID,
 			RunID:            runID,
 			Channel:          ChannelFromContext(ctx),
+			ContentWidth:     ContentWidthFromContext(ctx),
 			Prompt:           prompt,
 			Attachments:      attachments,
 			MaxOutputTokens:  maxTokens,

--- a/internal/agent/tools/read_mcp_resource.go
+++ b/internal/agent/tools/read_mcp_resource.go
@@ -77,8 +77,13 @@ func splitMCPResourceContents(contents []*mcp.ResourceContents, divert bool) ([]
 			metadata.A2UISurfaces = append(metadata.A2UISurfaces, "<a2ui-json>"+text+"</a2ui-json>")
 			// The placeholder is a single-line protocol the chat renderer
 			// strips line-wise — a server-controlled URI must not be able
-			// to break out of it with embedded newlines.
+			// to break out of it with embedded newlines. The injected
+			// width hint is stripped too: servers echo the request URI
+			// verbatim, and a model that re-reads the echoed ?w=N URI
+			// after a terminal resize would freeze the surface at the old
+			// width (a2uiWidthHint respects an existing w=).
 			uri := strings.NewReplacer("\n", " ", "\r", " ").Replace(content.URI)
+			uri = stripA2UIWidthParam(uri)
 			textParts = append(textParts, A2UISurfacePlaceholderPrefix+uri+" — the user can already see it; do not repeat or echo its JSON payload]")
 			continue
 		}
@@ -115,6 +120,23 @@ func a2uiWidthHint(uri string, width int) string {
 		sep = "&"
 	}
 	return fmt.Sprintf("%s%sw=%d", uri, sep, width)
+}
+
+// stripA2UIWidthParam removes the w= query parameter from a URI for display
+// in the model-facing placeholder. This URI is informational (never
+// fetched), so re-encoding any remaining query parameters is harmless.
+func stripA2UIWidthParam(uri string) string {
+	u, err := url.Parse(uri)
+	if err != nil || !u.Query().Has("w") {
+		return uri
+	}
+	q := u.Query()
+	q.Del("w")
+	base, _, _ := strings.Cut(uri, "?")
+	if enc := q.Encode(); enc != "" {
+		return base + "?" + enc
+	}
+	return base
 }
 
 func NewReadMCPResourceTool(cfg *config.ConfigStore, permissions permission.Service) fantasy.AgentTool {
@@ -177,9 +199,13 @@ func NewReadMCPResourceTool(cfg *config.ConfigStore, permissions permission.Serv
 			// Divert A2UI payloads to UI-only metadata only when a chat UI
 			// will actually render them: on channel-originated turns the
 			// reply travels back over the channel and the model needs the
-			// payload to relay it, and disable_a2ui deployments opted out
-			// of surfaces entirely.
-			divert := GetChannelFromContext(ctx) == "" && !cfg.Config().Options.DisableA2UI
+			// payload to relay it, disable_a2ui deployments opted out of
+			// surfaces entirely, and a zero content width means no
+			// interactive UI tagged this turn (headless crush run, remote
+			// clients that predate the wire field).
+			divert := GetChannelFromContext(ctx) == "" &&
+				!cfg.Config().Options.DisableA2UI &&
+				GetContentWidthFromContext(ctx) > 0
 			textParts, metadata := splitMCPResourceContents(contents, divert)
 
 			if len(textParts) == 0 {

--- a/internal/agent/tools/read_mcp_resource.go
+++ b/internal/agent/tools/read_mcp_resource.go
@@ -6,6 +6,7 @@ import (
 	_ "embed"
 	"fmt"
 	"log/slog"
+	"net/url"
 	"strings"
 
 	"charm.land/fantasy"
@@ -89,17 +90,31 @@ func splitMCPResourceContents(contents []*mcp.ResourceContents, divert bool) ([]
 //go:embed read_mcp_resource.md
 var readMCPResourceDescription string
 
-// a2uiWidthHint appends ?w=N to an A2UI surface URI so the server sizes its
+// a2uiWidthHint appends w=N to an A2UI surface URI so the server sizes its
 // pre-rendered geometry to the host's content width. It is a no-op for
-// non-A2UI URIs and for URIs that already carry a width hint.
+// non-A2UI URIs and for URIs that already carry a width hint (an explicit
+// w= is respected wherever it came from). The /a2ui path suffix is the
+// convention the in-house A2UI resource templates share (cairn,
+// switchboard); the template registry's MIME types would be the
+// protocol-level signal, but templates can legitimately fail to list, so
+// the convention stays the trigger.
+//
+// The URI is parsed only to decide — the hint is appended to the original
+// string, never re-serialized, because MCP servers match URIs textually
+// against their templates.
 func a2uiWidthHint(uri string, width int) string {
-	if !strings.HasSuffix(uri, "/a2ui") && !strings.Contains(uri, "/a2ui?") {
+	u, err := url.Parse(uri)
+	if err != nil || !strings.HasSuffix(u.Path, "/a2ui") {
 		return uri
 	}
-	if strings.Contains(uri, "?") {
+	if u.Query().Has("w") {
 		return uri
 	}
-	return fmt.Sprintf("%s?w=%d", uri, width)
+	sep := "?"
+	if u.RawQuery != "" {
+		sep = "&"
+	}
+	return fmt.Sprintf("%s%sw=%d", uri, sep, width)
 }
 
 func NewReadMCPResourceTool(cfg *config.ConfigStore, permissions permission.Service) fantasy.AgentTool {

--- a/internal/agent/tools/read_mcp_resource.go
+++ b/internal/agent/tools/read_mcp_resource.go
@@ -89,6 +89,19 @@ func splitMCPResourceContents(contents []*mcp.ResourceContents, divert bool) ([]
 //go:embed read_mcp_resource.md
 var readMCPResourceDescription string
 
+// a2uiWidthHint appends ?w=N to an A2UI surface URI so the server sizes its
+// pre-rendered geometry to the host's content width. It is a no-op for
+// non-A2UI URIs and for URIs that already carry a width hint.
+func a2uiWidthHint(uri string, width int) string {
+	if !strings.HasSuffix(uri, "/a2ui") && !strings.Contains(uri, "/a2ui?") {
+		return uri
+	}
+	if strings.Contains(uri, "?") {
+		return uri
+	}
+	return fmt.Sprintf("%s?w=%d", uri, width)
+}
+
 func NewReadMCPResourceTool(cfg *config.ConfigStore, permissions permission.Service) fantasy.AgentTool {
 	return fantasy.NewParallelAgentTool(
 		ReadMCPResourceToolName,
@@ -126,6 +139,16 @@ func NewReadMCPResourceTool(cfg *config.ConfigStore, permissions permission.Serv
 			}
 			if !p {
 				return NewPermissionDeniedResponse(), nil
+			}
+
+			// A2UI surface templates (…/a2ui) pre-render their bar
+			// geometry server-side, so pass the UI's content width as
+			// the ?w= hint — the surface then fills the chat card
+			// instead of a fixed default budget. Only when the URI
+			// carries no width of its own and the turn has a UI width
+			// (0 = headless/remote turn).
+			if w := GetContentWidthFromContext(ctx); w > 0 {
+				params.URI = a2uiWidthHint(params.URI, w)
 			}
 
 			contents, err := mcp.ReadResource(ctx, cfg, params.MCPName, params.URI)

--- a/internal/agent/tools/read_mcp_resource_contents_test.go
+++ b/internal/agent/tools/read_mcp_resource_contents_test.go
@@ -71,6 +71,18 @@ func TestSplitMCPResourceContents(t *testing.T) {
 		require.True(t, strings.HasPrefix(textParts[1], A2UISurfacePlaceholderPrefix))
 	})
 
+	t.Run("placeholder hides the injected width hint", func(t *testing.T) {
+		t.Parallel()
+		// Servers echo the request URI verbatim, ?w=N included; the model
+		// must not learn a width-frozen URI it could reuse after a resize.
+		textParts, _ := splitMCPResourceContents([]*mcp.ResourceContents{
+			{URI: "cairn://run/x/a2ui?w=114", MIMEType: a2uiMIMEType, Text: testA2UIPayload},
+		}, true)
+		require.Len(t, textParts, 1)
+		require.Contains(t, textParts[0], "cairn://run/x/a2ui ")
+		require.NotContains(t, textParts[0], "w=114")
+	})
+
 	t.Run("nil and empty entries are skipped", func(t *testing.T) {
 		t.Parallel()
 		textParts, meta := splitMCPResourceContents([]*mcp.ResourceContents{

--- a/internal/agent/tools/read_mcp_resource_test.go
+++ b/internal/agent/tools/read_mcp_resource_test.go
@@ -1,0 +1,70 @@
+package tools
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestA2UIWidthHint(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name  string
+		uri   string
+		width int
+		want  string
+	}{
+		{
+			name:  "a2ui run template gets the width",
+			uri:   "mcp://cairn/run/vitkuUpp/a2ui",
+			width: 114,
+			want:  "mcp://cairn/run/vitkuUpp/a2ui?w=114",
+		},
+		{
+			name:  "cairn-scheme alias gets the width",
+			uri:   "cairn://run/abc123/a2ui",
+			width: 90,
+			want:  "cairn://run/abc123/a2ui?w=90",
+		},
+		{
+			name:  "artifact and bundle templates get the width",
+			uri:   "mcp://cairn/artifact/PIMfMan7/a2ui",
+			width: 80,
+			want:  "mcp://cairn/artifact/PIMfMan7/a2ui?w=80",
+		},
+		{
+			name:  "an existing width hint is left alone",
+			uri:   "mcp://cairn/run/vitkuUpp/a2ui?w=60",
+			width: 114,
+			want:  "mcp://cairn/run/vitkuUpp/a2ui?w=60",
+		},
+		{
+			name:  "non-a2ui resources are untouched",
+			uri:   "mcp://cairn/run/vitkuUpp",
+			width: 114,
+			want:  "mcp://cairn/run/vitkuUpp",
+		},
+		{
+			name:  "a2ui-looking substring outside the suffix is untouched",
+			uri:   "mcp://cairn/artifact/a2ui-notes",
+			width: 114,
+			want:  "mcp://cairn/artifact/a2ui-notes",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.want, a2uiWidthHint(tc.uri, tc.width))
+		})
+	}
+}
+
+func TestGetContentWidthFromContext(t *testing.T) {
+	t.Parallel()
+
+	require.Zero(t, GetContentWidthFromContext(context.Background()))
+	ctx := context.WithValue(context.Background(), ContentWidthContextKey, 114)
+	require.Equal(t, 114, GetContentWidthFromContext(ctx))
+}

--- a/internal/agent/tools/read_mcp_resource_test.go
+++ b/internal/agent/tools/read_mcp_resource_test.go
@@ -41,6 +41,12 @@ func TestA2UIWidthHint(t *testing.T) {
 			want:  "mcp://cairn/run/vitkuUpp/a2ui?w=60",
 		},
 		{
+			name:  "a non-width query still gets the width appended",
+			uri:   "mcp://cairn/run/vitkuUpp/a2ui?theme=dark",
+			width: 114,
+			want:  "mcp://cairn/run/vitkuUpp/a2ui?theme=dark&w=114",
+		},
+		{
 			name:  "non-a2ui resources are untouched",
 			uri:   "mcp://cairn/run/vitkuUpp",
 			width: 114,

--- a/internal/agent/tools/read_mcp_resource_test.go
+++ b/internal/agent/tools/read_mcp_resource_test.go
@@ -67,6 +67,15 @@ func TestA2UIWidthHint(t *testing.T) {
 	}
 }
 
+func TestStripA2UIWidthParam(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, "cairn://run/x/a2ui", stripA2UIWidthParam("cairn://run/x/a2ui?w=114"))
+	require.Equal(t, "cairn://run/x/a2ui?theme=dark", stripA2UIWidthParam("cairn://run/x/a2ui?theme=dark&w=114"))
+	require.Equal(t, "cairn://run/x/a2ui", stripA2UIWidthParam("cairn://run/x/a2ui"))
+	require.Equal(t, "mcp://cairn/artifact/y", stripA2UIWidthParam("mcp://cairn/artifact/y"))
+}
+
 func TestGetContentWidthFromContext(t *testing.T) {
 	t.Parallel()
 

--- a/internal/agent/tools/tools.go
+++ b/internal/agent/tools/tools.go
@@ -16,6 +16,7 @@ type (
 	supportsImagesKey   string
 	modelNameKey        string
 	channelContextKey   string
+	contentWidthKey     string
 )
 
 const (
@@ -29,6 +30,8 @@ const (
 	ModelNameContextKey modelNameKey = "model_name"
 	// ChannelContextKey is the key for the channel that originated the turn.
 	ChannelContextKey channelContextKey = "channel"
+	// ContentWidthContextKey is the key for the UI content width hint in cells.
+	ContentWidthContextKey contentWidthKey = "content_width"
 )
 
 // getContextValue is a generic helper that retrieves a typed value from context.
@@ -67,6 +70,12 @@ func GetSupportsImagesFromContext(ctx context.Context) bool {
 // GetModelNameFromContext retrieves the model name from the context.
 func GetModelNameFromContext(ctx context.Context) string {
 	return getContextValue(ctx, ModelNameContextKey, "")
+}
+
+// GetContentWidthFromContext retrieves the UI content width hint in cells,
+// or 0 when no hint was provided for this turn.
+func GetContentWidthFromContext(ctx context.Context) int {
+	return getContextValue(ctx, ContentWidthContextKey, 0)
 }
 
 // NewPermissionDeniedResponse returns a tool response indicating the user

--- a/internal/backend/agent.go
+++ b/internal/backend/agent.go
@@ -97,6 +97,9 @@ func (b *Backend) runAgent(ws *Workspace, msg proto.AgentMessage, accept *agent.
 	if msg.Channel != "" {
 		ctx = agent.WithChannel(ctx, msg.Channel)
 	}
+	if msg.ContentWidth > 0 {
+		ctx = agent.WithContentWidth(ctx, msg.ContentWidth)
+	}
 	_, err := ws.AgentCoordinator.RunAccepted(ctx, accept, msg.SessionID, msg.Prompt, proto.AttachmentsToMessage(msg.Attachments)...)
 	if err == nil || errors.Is(err, context.Canceled) {
 		return

--- a/internal/client/proto.go
+++ b/internal/client/proto.go
@@ -412,13 +412,14 @@ func (c *Client) UpdateAgent(ctx context.Context, id string) error {
 // for completion detection. Pass "" when the caller does not need
 // to distinguish its own turn's terminal event from any concurrent
 // turn on the same session (e.g. interactive TUI usage).
-func (c *Client) SendMessage(ctx context.Context, id string, sessionID, runID, channel, prompt string, attachments ...message.Attachment) error {
+func (c *Client) SendMessage(ctx context.Context, id string, sessionID, runID, channel string, contentWidth int, prompt string, attachments ...message.Attachment) error {
 	rsp, err := c.post(ctx, fmt.Sprintf("/workspaces/%s/agent", id), nil, jsonBody(proto.AgentMessage{
-		SessionID:   sessionID,
-		RunID:       runID,
-		Channel:     channel,
-		Prompt:      prompt,
-		Attachments: proto.AttachmentsFromMessage(attachments),
+		SessionID:    sessionID,
+		RunID:        runID,
+		Channel:      channel,
+		ContentWidth: contentWidth,
+		Prompt:       prompt,
+		Attachments:  proto.AttachmentsFromMessage(attachments),
 	}), http.Header{"Content-Type": []string{"application/json"}})
 	if err != nil {
 		return fmt.Errorf("failed to send message to agent: %w", err)

--- a/internal/client/proto_test.go
+++ b/internal/client/proto_test.go
@@ -97,7 +97,7 @@ func TestSendMessageAcceptsStatusAccepted(t *testing.T) {
 	defer srv.Close()
 
 	c := captureClient(t, srv)
-	require.NoError(t, c.SendMessage(context.Background(), "ws1", "sess1", "", "", "hello"))
+	require.NoError(t, c.SendMessage(context.Background(), "ws1", "sess1", "", "", 0, "hello"))
 }
 
 func TestSendMessageIncludesChannelOrigin(t *testing.T) {
@@ -111,8 +111,25 @@ func TestSendMessageIncludesChannelOrigin(t *testing.T) {
 	defer srv.Close()
 
 	c := captureClient(t, srv)
-	require.NoError(t, c.SendMessage(context.Background(), "ws1", "sess1", "", "signal", "hello"))
+	require.NoError(t, c.SendMessage(context.Background(), "ws1", "sess1", "", "signal", 0, "hello"))
 	require.Equal(t, "signal", got.Channel)
+}
+
+// The content-width hint must travel as a wire field: it is a context value
+// locally, and context values do not cross the HTTP boundary.
+func TestSendMessageIncludesContentWidth(t *testing.T) {
+	t.Parallel()
+
+	var got proto.AgentMessage
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&got))
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer srv.Close()
+
+	c := captureClient(t, srv)
+	require.NoError(t, c.SendMessage(context.Background(), "ws1", "sess1", "", "", 114, "hello"))
+	require.Equal(t, 114, got.ContentWidth)
 }
 
 func TestSendMessageAcceptsStatusOK(t *testing.T) {
@@ -124,7 +141,7 @@ func TestSendMessageAcceptsStatusOK(t *testing.T) {
 	defer srv.Close()
 
 	c := captureClient(t, srv)
-	require.NoError(t, c.SendMessage(context.Background(), "ws1", "sess1", "", "", "hello"))
+	require.NoError(t, c.SendMessage(context.Background(), "ws1", "sess1", "", "", 0, "hello"))
 }
 
 func TestSendMessageDecodesErrorBody(t *testing.T) {
@@ -137,7 +154,7 @@ func TestSendMessageDecodesErrorBody(t *testing.T) {
 	defer srv.Close()
 
 	c := captureClient(t, srv)
-	err := c.SendMessage(context.Background(), "ws1", "", "", "", "hello")
+	err := c.SendMessage(context.Background(), "ws1", "", "", "", 0, "hello")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "status code 400")
 	require.Contains(t, err.Error(), "session id is required")
@@ -153,7 +170,7 @@ func TestSendMessageFallsBackOnMalformedErrorBody(t *testing.T) {
 	defer srv.Close()
 
 	c := captureClient(t, srv)
-	err := c.SendMessage(context.Background(), "ws1", "sess1", "", "", "hello")
+	err := c.SendMessage(context.Background(), "ws1", "sess1", "", "", 0, "hello")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "status code 500")
 	require.NotContains(t, err.Error(), "not json")
@@ -168,7 +185,7 @@ func TestSendMessageFallsBackOnEmptyErrorBody(t *testing.T) {
 	defer srv.Close()
 
 	c := captureClient(t, srv)
-	err := c.SendMessage(context.Background(), "ws1", "sess1", "", "", "hello")
+	err := c.SendMessage(context.Background(), "ws1", "sess1", "", "", 0, "hello")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "status code 500")
 }

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -252,7 +252,7 @@ func runNonInteractive(
 	// loop would exit on whichever RunComplete arrived first for
 	// the same session and drop the queued prompt's output.
 	runID := uuid.New().String()
-	if err := c.SendMessage(ctx, ws.ID, sess.ID, runID, "", prompt); err != nil {
+	if err := c.SendMessage(ctx, ws.ID, sess.ID, runID, "", 0, prompt); err != nil {
 		return fmt.Errorf("failed to send message: %w", err)
 	}
 

--- a/internal/proto/proto.go
+++ b/internal/proto/proto.go
@@ -146,11 +146,17 @@ func (a AgentInfo) IsZero() bool {
 // remains correct only when no other turns are in flight for the
 // same session.
 type AgentMessage struct {
-	SessionID   string       `json:"session_id"`
-	RunID       string       `json:"run_id,omitempty"`
-	Channel     string       `json:"channel,omitempty"`
-	Prompt      string       `json:"prompt"`
-	Attachments []Attachment `json:"attachments,omitempty"`
+	SessionID string `json:"session_id"`
+	RunID     string `json:"run_id,omitempty"`
+	Channel   string `json:"channel,omitempty"`
+	// ContentWidth is the client UI's chat content width hint in cells
+	// (0 when the turn has no interactive UI). Like Channel it is a
+	// per-turn context value on the server side, so it must travel as an
+	// explicit wire field — context values do not cross the HTTP
+	// boundary. See ShellCommandRequest.TermWidth for the same pattern.
+	ContentWidth int          `json:"content_width,omitempty"`
+	Prompt       string       `json:"prompt"`
+	Attachments  []Attachment `json:"attachments,omitempty"`
 }
 
 // ShellCommandRequest represents a request to run a shell command directly.

--- a/internal/ui/chat/a2ui_width.go
+++ b/internal/ui/chat/a2ui_width.go
@@ -1,0 +1,25 @@
+package chat
+
+// a2uiCardChromeWidth is the border+padding chrome a2tea's Card renderer
+// subtracts from its budget (a2tea render/card.go: w := s.width - 4).
+const a2uiCardChromeWidth = 4
+
+// ToolA2UISurfaceWidth returns the interior width, in cells, of a generic
+// tool result's A2UI surface card for a chat viewport of the given width —
+// the number servers pre-rendering bar geometry should size rows to (the
+// ?w= hint read_mcp_resource sends).
+//
+// It mirrors the actual render chain rather than hand-summed constants:
+// the message list reserves one cell for its scrollbar, the tool item and
+// RenderTool each apply cappedMessageWidth, the body is indented by
+// toolBodyLeftPaddingTotal, and a2tea's card chrome takes the rest. Keeping
+// the computation here, next to the constants it depends on, is what stops
+// the hint drifting from the real card interior when the layout changes.
+//
+// Returns 0 (no hint) when the viewport is too small for a meaningful
+// width.
+func ToolA2UISurfaceWidth(chatWidth int) int {
+	listWidth := chatWidth - 1 // scrollbar reservation in model/chat.go SetSize
+	interior := cappedMessageWidth(cappedMessageWidth(listWidth)) - toolBodyLeftPaddingTotal - a2uiCardChromeWidth
+	return max(0, interior)
+}

--- a/internal/ui/chat/a2ui_width_test.go
+++ b/internal/ui/chat/a2ui_width_test.go
@@ -1,0 +1,22 @@
+package chat
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestToolA2UISurfaceWidth(t *testing.T) {
+	t.Parallel()
+
+	// Mirror of the real chain: listWidth = chatWidth-1 (scrollbar), two
+	// cappedMessageWidth passes (-2 each, 120/118 caps), tool body indent
+	// (-2), a2tea card chrome (-4).
+	require.Equal(t, 89, ToolA2UISurfaceWidth(100))
+	// Wide viewports saturate at maxTextWidth: min(...,120)-2-2-4 = 112.
+	require.Equal(t, 112, ToolA2UISurfaceWidth(140))
+	require.Equal(t, 112, ToolA2UISurfaceWidth(500))
+	// Degenerate viewports must yield 0 (no hint), never negative.
+	require.Equal(t, 0, ToolA2UISurfaceWidth(0))
+	require.Equal(t, 0, ToolA2UISurfaceWidth(8))
+}

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -27,6 +27,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"charm.land/catwalk/pkg/catwalk"
 	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/crush/internal/agent"
 	"github.com/charmbracelet/crush/internal/agent/hyper"
 	"github.com/charmbracelet/crush/internal/agent/notify"
 	agenttools "github.com/charmbracelet/crush/internal/agent/tools"
@@ -3873,6 +3874,11 @@ func (m *UI) sendMessage(content string, attachments ...message.Attachment) tea.
 
 	// Capture session ID to avoid race with main goroutine updating m.session.
 	sessionID := m.session.ID
+	// The turn's content width hint: tools that read width-sensitive remote
+	// content (A2UI surfaces with server-pre-rendered bar geometry) get the
+	// surface card's interior width so the server sizes its rows to fill the
+	// card — the message cap minus the tool-item indent and the card chrome.
+	contentWidth := min(m.layout.main.Dx()-2, 120) - 6
 	// Optimistically mark the agent busy: the prompt we are about to submit
 	// either starts a run or is enqueued behind one. This keeps esc pressed
 	// right after enter routing to cancelAgent instead of reading a stale
@@ -3884,7 +3890,7 @@ func (m *UI) sendMessage(content string, attachments ...message.Attachment) tea.
 		// been accepted (HTTP 202) or synchronously with a validation
 		// or transport error. Run failures and cancellation surface
 		// through SSE-derived events, not this return value.
-		err := m.com.Workspace.AgentRun(context.Background(), sessionID, content, attachments...)
+		err := m.com.Workspace.AgentRun(agent.WithContentWidth(context.Background(), contentWidth), sessionID, content, attachments...)
 		if err != nil {
 			return util.InfoMsg{
 				Type: util.InfoTypeError,

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -3876,9 +3876,10 @@ func (m *UI) sendMessage(content string, attachments ...message.Attachment) tea.
 	sessionID := m.session.ID
 	// The turn's content width hint: tools that read width-sensitive remote
 	// content (A2UI surfaces with server-pre-rendered bar geometry) get the
-	// surface card's interior width so the server sizes its rows to fill the
-	// card — the message cap minus the tool-item indent and the card chrome.
-	contentWidth := min(m.layout.main.Dx()-2, 120) - 6
+	// surface card's interior width so the server sizes its rows to fill
+	// the card. The chat package owns the computation — it must track the
+	// real render chain, not constants copied here.
+	contentWidth := chat.ToolA2UISurfaceWidth(m.layout.main.Dx())
 	// Optimistically mark the agent busy: the prompt we are about to submit
 	// either starts a run or is enqueued behind one. This keeps esc pressed
 	// right after enter routing to cancelAgent instead of reading a stale

--- a/internal/workspace/client_workspace.go
+++ b/internal/workspace/client_workspace.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/crush/internal/agent"
 	"github.com/charmbracelet/crush/internal/agent/notify"
 	"github.com/charmbracelet/crush/internal/agent/tools/mcp"
 	"github.com/charmbracelet/crush/internal/client"
@@ -216,11 +217,15 @@ func (w *ClientWorkspace) AgentRun(ctx context.Context, sessionID, prompt string
 	// completion detection (it observes message events directly),
 	// so passing an empty RunID is correct here: it skips the
 	// correlator stamping path without functional consequences.
-	return w.client.SendMessage(ctx, w.workspaceID(), sessionID, "", "", prompt, attachments...)
+	//
+	// The content-width hint rides the context locally but cannot cross
+	// the HTTP boundary as a context value, so it is lifted onto the wire
+	// message here and re-attached server-side (backend.runAgent).
+	return w.client.SendMessage(ctx, w.workspaceID(), sessionID, "", "", agent.ContentWidthFromContext(ctx), prompt, attachments...)
 }
 
 func (w *ClientWorkspace) AgentRunChannel(ctx context.Context, channel, sessionID, prompt string, attachments ...message.Attachment) error {
-	return w.client.SendMessage(ctx, w.workspaceID(), sessionID, "", channel, prompt, attachments...)
+	return w.client.SendMessage(ctx, w.workspaceID(), sessionID, "", channel, 0, prompt, attachments...)
 }
 
 func (w *ClientWorkspace) AgentRunShellCommand(ctx context.Context, sessionID, command string, termWidth int, _ func(string), _ bool) (proto.ShellCommandResponse, error) {


### PR DESCRIPTION
## Why

A2UI resource templates (`…/a2ui`) pre-render their bar geometry server-side against a fixed default budget (~96 cells for cairn's trace view). A wide terminal's card interior sat half-empty — the surface had no way to know how much room it actually had, and cairn's `?w=N` width hint (stump.wtf/cairn#98) had no client passing it.

## What

The UI tags each turn's context with the surface card's interior width:

1. `agent.WithContentWidth(ctx, w)` mirrors `WithChannel` — the UI computes `min(main.Dx()-2, 120) - 6` (message cap, tool-item indent, card chrome) at send time.
2. The coordinator carries it on `SessionAgentCall.ContentWidth`; `PrepareStep` injects `tools.ContentWidthContextKey`.
3. `read_mcp_resource` appends `?w=N` to `…/a2ui` URIs that don't already carry a width — servers that don't understand the query ignore it; turns without an interactive UI (channels, headless) send no hint and get the server default.

## Testing

- `TestA2UIWidthHint` — six URI shapes (run/artifact templates, cairn:// alias, pre-existing `?w=`, non-A2UI, lookalike substring).
- `TestGetContentWidthFromContext` — zero default + injected value round-trip.
- `internal/agent`, `internal/agent/tools` suites green; gofumpt clean.

🤖 Posted on behalf of `@joestump` by [`kimi-k3`](https://openrouter.ai/moonshotai/kimi-k3) using [Crush](https://github.com/charmbracelet/crush).