### PR TITLE
feat(mcp): detect and render A2UI payloads from tool results

### DIFF
--- a/internal/agent/tools/mcp-tools.go
+++ b/internal/agent/tools/mcp-tools.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"slices"
+	"strings"
 
 	"charm.land/fantasy"
 	"github.com/charmbracelet/crush/internal/agent/tools/mcp"
@@ -133,6 +134,17 @@ func (m *Tool) Run(ctx context.Context, params fantasy.ToolCall) (fantasy.ToolRe
 		return fantasy.NewTextErrorResponse(err.Error()), nil
 	}
 
+	// Divert A2UI surface payloads to UI-only metadata only when a chat UI
+	// will actually render them: on channel-originated turns the reply
+	// travels back over the channel and the model needs the payload to
+	// relay it, disable_a2ui deployments opted out of surfaces entirely,
+	// and a zero content width means no interactive UI tagged this turn.
+	// Mirrors the diversion rule in read_mcp_resource.go.
+	divert := GetChannelFromContext(ctx) == "" &&
+		!m.cfg.Config().Options.DisableA2UI &&
+		GetContentWidthFromContext(ctx) > 0
+	content, metadata := splitMCPToolResult(result, m.mcpName, divert)
+
 	switch result.Type {
 	case "image", "media":
 		if !GetSupportsImagesFromContext(ctx) {
@@ -146,9 +158,51 @@ func (m *Tool) Run(ctx context.Context, params fantasy.ToolCall) (fantasy.ToolRe
 		} else {
 			response = fantasy.NewMediaResponse(result.Data, result.MediaType)
 		}
-		response.Content = result.Content
+		response.Content = content
+		if len(metadata.A2UISurfaces) > 0 {
+			response = fantasy.WithResponseMetadata(response, metadata)
+		}
 		return response, nil
 	default:
-		return fantasy.NewTextResponse(result.Content), nil
+		resp := fantasy.NewTextResponse(content)
+		if len(metadata.A2UISurfaces) > 0 {
+			resp = fantasy.WithResponseMetadata(resp, metadata)
+		}
+		return resp, nil
 	}
+}
+
+// splitMCPToolResult partitions an MCP tool result into model-facing text
+// and, when divert is set, UI-only A2UI surface payloads carried in response
+// metadata. The surfaces travel exactly like read_mcp_resource's: wrapped in
+// <a2ui-json> tags on ReadMCPResourceResponseMetadata, with a single-line
+// placeholder left for the model so it cannot echo the JSON back and
+// double-render the surface. When divert is false the raw payload is folded
+// back into the model-facing content (except payloads the server annotated
+// for the user only — hiding those from the model is the annotation's whole
+// point), so the model can still relay or summarize the data.
+func splitMCPToolResult(result mcp.ToolResult, mcpName string, divert bool) (string, ReadMCPResourceResponseMetadata) {
+	var metadata ReadMCPResourceResponseMetadata
+	content := result.Content
+	for _, surface := range result.Surfaces {
+		if divert {
+			metadata.A2UISurfaces = append(metadata.A2UISurfaces, "<a2ui-json>"+surface.Payload+"</a2ui-json>")
+			metadata.MCPSurfaceProvenance = append(metadata.MCPSurfaceProvenance, mcpName)
+			uri := strings.NewReplacer("\n", " ", "\r", " ").Replace(surface.URI)
+			placeholder := A2UISurfacePlaceholderPrefix + uri + " from MCP server " + mcpName + " — the user can already see it; do not repeat or echo its JSON payload]"
+			if content != "" {
+				content += "\n"
+			}
+			content += placeholder
+			continue
+		}
+		if !surface.AssistantVisible {
+			continue
+		}
+		if content != "" {
+			content += "\n"
+		}
+		content += surface.Payload
+	}
+	return content, metadata
 }

--- a/internal/agent/tools/mcp/tools.go
+++ b/internal/agent/tools/mcp/tools.go
@@ -17,12 +17,45 @@ import (
 
 type Tool = mcp.Tool
 
+// A2UIJSONMIMEType is the canonical MIME type identifying an A2UI surface
+// payload, per the A2UI-over-MCP contract. A2UILegacyMIMEType is the legacy
+// spelling reference clients also accept.
+const (
+	A2UIJSONMIMEType   = "application/a2ui+json"
+	A2UILegacyMIMEType = "application/json+a2ui"
+)
+
+// IsA2UIMIMEType reports whether mime identifies an A2UI surface payload,
+// accepting both the canonical and legacy spellings.
+func IsA2UIMIMEType(mime string) bool {
+	return mime == A2UIJSONMIMEType || mime == A2UILegacyMIMEType
+}
+
+// A2UISurface is a UI-only A2UI surface payload extracted from a tool
+// result's EmbeddedResource content. The chat UI renders it as a live
+// surface; the model never sees the raw JSON.
+type A2UISurface struct {
+	// Payload is the raw A2UI JSON.
+	Payload string
+	// URI is the embedded resource's URI, for display/diagnostics.
+	URI string
+	// AssistantVisible reports whether the server annotated the payload
+	// for the LLM as well as the user (empty audience or one containing
+	// "assistant"). An audience of ["user"] alone hides the raw JSON from
+	// the model.
+	AssistantVisible bool
+}
+
 // ToolResult represents the result of running an MCP tool.
 type ToolResult struct {
 	Type      string
 	Content   string
 	Data      []byte
 	MediaType string
+	// Surfaces carries any A2UI surface payloads found in the result's
+	// EmbeddedResource content. They are kept out of Content: the chat UI
+	// draws them, and the model only ever echoed the JSON back.
+	Surfaces []A2UISurface
 }
 
 var allTools = csync.NewMap[string, []*Tool]()
@@ -55,7 +88,15 @@ func RunTool(ctx context.Context, cfg *config.ConfigStore, name, toolName string
 		return ToolResult{Type: "text", Content: ""}, nil
 	}
 
+	return extractToolResult(result), nil
+}
+
+// extractToolResult partitions a CallToolResult's content into model-facing
+// text, binary media, and UI-only A2UI surfaces — the extraction half of
+// RunTool, split out so tests can drive it through a live in-memory server.
+func extractToolResult(result *mcp.CallToolResult) ToolResult {
 	var textParts []string
+	var surfaces []A2UISurface
 	var imageData []byte
 	var imageMimeType string
 	var audioData []byte
@@ -75,6 +116,25 @@ func RunTool(ctx context.Context, cfg *config.ConfigStore, name, toolName string
 				audioData = content.Data
 				audioMimeType = content.MIMEType
 			}
+		case *mcp.EmbeddedResource:
+			// A2UI surfaces arrive as embedded resources — pull them
+			// aside for the UI instead of stringifying them into the
+			// model-facing text.
+			if content.Resource != nil && IsA2UIMIMEType(content.Resource.MIMEType) {
+				payload := content.Resource.Text
+				if payload == "" && len(content.Resource.Blob) > 0 {
+					payload = string(content.Resource.Blob)
+				}
+				if payload != "" {
+					surfaces = append(surfaces, A2UISurface{
+						Payload:          payload,
+						URI:              content.Resource.URI,
+						AssistantVisible: a2uiAssistantVisible(content.Annotations),
+					})
+				}
+				continue
+			}
+			textParts = append(textParts, fmt.Sprintf("%v", v))
 		default:
 			textParts = append(textParts, fmt.Sprintf("%v", v))
 		}
@@ -90,7 +150,8 @@ func RunTool(ctx context.Context, cfg *config.ConfigStore, name, toolName string
 			Content:   textContent,
 			Data:      ensureRawBytes(imageData),
 			MediaType: imageMimeType,
-		}, nil
+			Surfaces:  surfaces,
+		}
 	}
 
 	if audioData != nil {
@@ -99,13 +160,27 @@ func RunTool(ctx context.Context, cfg *config.ConfigStore, name, toolName string
 			Content:   textContent,
 			Data:      ensureRawBytes(audioData),
 			MediaType: audioMimeType,
-		}, nil
+			Surfaces:  surfaces,
+		}
 	}
 
 	return ToolResult{
-		Type:    "text",
-		Content: textContent,
-	}, nil
+		Type:     "text",
+		Content:  textContent,
+		Surfaces: surfaces,
+	}
+}
+
+// a2uiAssistantVisible reports whether an A2UI embedded resource's audience
+// annotations leave the payload visible to the LLM. Per the A2UI-over-MCP
+// verbalization contract: an empty audience is visible to both user and
+// assistant; an audience of ["user"] alone renders for the user but hides
+// the raw JSON from the model.
+func a2uiAssistantVisible(annotations *mcp.Annotations) bool {
+	if annotations == nil || len(annotations.Audience) == 0 {
+		return true
+	}
+	return slices.Contains(annotations.Audience, mcp.Role("assistant"))
 }
 
 // RefreshTools gets the updated list of tools from the MCP and updates the

--- a/internal/agent/tools/mcp/tools_a2ui_test.go
+++ b/internal/agent/tools/mcp/tools_a2ui_test.go
@@ -1,0 +1,145 @@
+package mcp
+
+import (
+	"context"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/require"
+)
+
+const testA2UIToolPayload = `{"version":"v0.9","updateComponents":{"surfaceId":"card","components":[` +
+	`{"component":"Text","id":"t","text":"Recipe"}]}}`
+
+// liveA2UIToolSession spins up an in-memory MCP server whose single tool
+// returns the given content items, and returns a connected client session.
+func liveA2UIToolSession(t *testing.T, toolName string, content []mcp.Content) *ClientSession {
+	t.Helper()
+
+	serverTransport, clientTransport := mcp.NewInMemoryTransports()
+	server := mcp.NewServer(&mcp.Implementation{Name: "srv"}, nil)
+	mcp.AddTool(
+		server,
+		&mcp.Tool{Name: toolName, Description: "test tool"},
+		func(context.Context, *mcp.CallToolRequest, struct{}) (*mcp.CallToolResult, any, error) {
+			return &mcp.CallToolResult{Content: content}, nil, nil
+		},
+	)
+	serverSession, err := server.Connect(context.Background(), serverTransport, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = serverSession.Close() })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	client := mcp.NewClient(&mcp.Implementation{Name: "crush-test"}, nil)
+	clientSession, err := client.Connect(ctx, clientTransport, nil)
+	require.NoError(t, err)
+
+	sess := &ClientSession{ClientSession: clientSession, cancel: cancel}
+	t.Cleanup(func() { _ = sess.Close() })
+	return sess
+}
+
+// runToolWithSession calls the tool through the same extraction path RunTool
+// uses, without needing a registered config client.
+func runToolWithSession(t *testing.T, sess *ClientSession, toolName string) ToolResult {
+	t.Helper()
+	result, err := sess.CallTool(context.Background(), &mcp.CallToolParams{
+		Name:      toolName,
+		Arguments: map[string]any{},
+	})
+	require.NoError(t, err)
+	return extractToolResult(result)
+}
+
+func TestRunTool_A2UISurfaceExtraction(t *testing.T) {
+	t.Parallel()
+
+	t.Run("embedded A2UI resource becomes a surface, not text", func(t *testing.T) {
+		sess := liveA2UIToolSession(t, "get_card", []mcp.Content{
+			&mcp.TextContent{Text: "Your recipe card"},
+			&mcp.EmbeddedResource{
+				Resource: &mcp.ResourceContents{
+					URI:      "a2ui://recipe-card",
+					MIMEType: A2UIJSONMIMEType,
+					Text:     testA2UIToolPayload,
+				},
+			},
+		})
+		res := runToolWithSession(t, sess, "get_card")
+
+		require.Equal(t, "Your recipe card", res.Content)
+		require.Len(t, res.Surfaces, 1)
+		require.Equal(t, testA2UIToolPayload, res.Surfaces[0].Payload)
+		require.Equal(t, "a2ui://recipe-card", res.Surfaces[0].URI)
+		require.True(t, res.Surfaces[0].AssistantVisible, "no audience annotation means visible to both")
+		require.NotContains(t, res.Content, "updateComponents")
+	})
+
+	t.Run("legacy MIME spelling is recognized", func(t *testing.T) {
+		sess := liveA2UIToolSession(t, "get_card", []mcp.Content{
+			&mcp.EmbeddedResource{
+				Resource: &mcp.ResourceContents{
+					URI:      "a2ui://form",
+					MIMEType: A2UILegacyMIMEType,
+					Text:     testA2UIToolPayload,
+				},
+			},
+		})
+		res := runToolWithSession(t, sess, "get_card")
+		require.Len(t, res.Surfaces, 1)
+	})
+
+	t.Run("user-only audience hides the payload from the model", func(t *testing.T) {
+		sess := liveA2UIToolSession(t, "get_card", []mcp.Content{
+			&mcp.EmbeddedResource{
+				Resource: &mcp.ResourceContents{
+					URI:      "a2ui://card",
+					MIMEType: A2UIJSONMIMEType,
+					Text:     testA2UIToolPayload,
+				},
+				Annotations: &mcp.Annotations{Audience: []mcp.Role{"user"}},
+			},
+		})
+		res := runToolWithSession(t, sess, "get_card")
+		require.Len(t, res.Surfaces, 1)
+		require.False(t, res.Surfaces[0].AssistantVisible)
+	})
+
+	t.Run("blob-delivered surface is normalized to text", func(t *testing.T) {
+		sess := liveA2UIToolSession(t, "get_card", []mcp.Content{
+			&mcp.EmbeddedResource{
+				Resource: &mcp.ResourceContents{
+					URI:      "a2ui://card",
+					MIMEType: A2UIJSONMIMEType,
+					Blob:     []byte(testA2UIToolPayload),
+				},
+			},
+		})
+		res := runToolWithSession(t, sess, "get_card")
+		require.Len(t, res.Surfaces, 1)
+		require.Equal(t, testA2UIToolPayload, res.Surfaces[0].Payload)
+	})
+
+	t.Run("non-A2UI embedded resource stays in the text", func(t *testing.T) {
+		sess := liveA2UIToolSession(t, "get_doc", []mcp.Content{
+			&mcp.EmbeddedResource{
+				Resource: &mcp.ResourceContents{
+					URI:      "file:///doc.md",
+					MIMEType: "text/markdown",
+					Text:     "# hello",
+				},
+			},
+		})
+		res := runToolWithSession(t, sess, "get_doc")
+		require.Empty(t, res.Surfaces)
+		require.NotEmpty(t, res.Content)
+	})
+}
+
+func TestIsA2UIMIMEType(t *testing.T) {
+	t.Parallel()
+	require.True(t, IsA2UIMIMEType("application/a2ui+json"))
+	require.True(t, IsA2UIMIMEType("application/json+a2ui"))
+	require.False(t, IsA2UIMIMEType("application/json"))
+	require.False(t, IsA2UIMIMEType("text/plain"))
+}

--- a/internal/agent/tools/mcp_tools_a2ui_test.go
+++ b/internal/agent/tools/mcp_tools_a2ui_test.go
@@ -1,0 +1,75 @@
+package tools
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/crush/internal/agent/tools/mcp"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSplitMCPToolResult(t *testing.T) {
+	t.Parallel()
+
+	surface := mcp.A2UISurface{
+		Payload:          testA2UIPayload,
+		URI:              "a2ui://recipe-card",
+		AssistantVisible: true,
+	}
+
+	t.Run("surfaces divert to metadata with provenance", func(t *testing.T) {
+		t.Parallel()
+		content, meta := splitMCPToolResult(mcp.ToolResult{
+			Type:     "text",
+			Content:  "Your recipe card",
+			Surfaces: []mcp.A2UISurface{surface},
+		}, "recipe", true)
+
+		require.Len(t, meta.A2UISurfaces, 1)
+		require.Equal(t, "<a2ui-json>"+testA2UIPayload+"</a2ui-json>", meta.A2UISurfaces[0])
+		require.Equal(t, []string{"recipe"}, meta.MCPSurfaceProvenance)
+		require.Contains(t, content, "Your recipe card")
+		require.True(t, strings.Contains(content, A2UISurfacePlaceholderPrefix))
+		require.NotContains(t, content, "updateComponents")
+	})
+
+	t.Run("no diversion folds the payload back for the model", func(t *testing.T) {
+		t.Parallel()
+		// Channel-originated turns keep the payload so the model can relay it.
+		content, meta := splitMCPToolResult(mcp.ToolResult{
+			Type:     "text",
+			Content:  "fallback text",
+			Surfaces: []mcp.A2UISurface{surface},
+		}, "recipe", false)
+
+		require.Empty(t, meta.A2UISurfaces)
+		require.Contains(t, content, "fallback text")
+		require.Contains(t, content, testA2UIPayload)
+	})
+
+	t.Run("user-only payload stays hidden when not diverting", func(t *testing.T) {
+		t.Parallel()
+		userOnly := surface
+		userOnly.AssistantVisible = false
+		content, meta := splitMCPToolResult(mcp.ToolResult{
+			Type:     "text",
+			Content:  "fallback text",
+			Surfaces: []mcp.A2UISurface{userOnly},
+		}, "recipe", false)
+
+		require.Empty(t, meta.A2UISurfaces)
+		require.Equal(t, "fallback text", content)
+	})
+
+	t.Run("surface without fallback text still gets a placeholder", func(t *testing.T) {
+		t.Parallel()
+		content, meta := splitMCPToolResult(mcp.ToolResult{
+			Type:     "text",
+			Content:  "",
+			Surfaces: []mcp.A2UISurface{surface},
+		}, "recipe", true)
+
+		require.Len(t, meta.A2UISurfaces, 1)
+		require.True(t, strings.HasPrefix(content, A2UISurfacePlaceholderPrefix))
+	})
+}

--- a/internal/agent/tools/read_mcp_resource.go
+++ b/internal/agent/tools/read_mcp_resource.go
@@ -32,12 +32,16 @@ const ReadMCPResourceToolName = "read_mcp_resource"
 // A2UI payloads are delivered to the UI through response metadata (never to
 // the model): the model gets a compact placeholder instead of the raw JSON,
 // so it cannot echo the payload back and double-render the surface.
-const a2uiMIMEType = "application/a2ui+json"
+const a2uiMIMEType = mcp.A2UIJSONMIMEType
 
 // ReadMCPResourceResponseMetadata carries the UI-only A2UI surface payload
-// for a resource whose MIME type is application/a2ui+json.
+// for a resource whose MIME type is application/a2ui+json (or a tool result
+// that embedded one). MCPSurfaceProvenance records which MCP server each
+// surface came from — by slice position — so a later interaction event can
+// route back to the owning server.
 type ReadMCPResourceResponseMetadata struct {
-	A2UISurfaces []string `json:"a2ui_surfaces,omitempty"`
+	A2UISurfaces         []string `json:"a2ui_surfaces,omitempty"`
+	MCPSurfaceProvenance []string `json:"mcp_surface_provenance,omitempty"`
 }
 
 // A2UISurfacePlaceholderPrefix starts every model-facing placeholder that
@@ -51,7 +55,7 @@ const A2UISurfacePlaceholderPrefix = "[A2UI surface rendered in the chat UI from
 // metadata (channel-originated turns, disable_a2ui deployments): the raw
 // payload then stays in the model-facing content so the model can still
 // relay or summarize the data.
-func splitMCPResourceContents(contents []*mcp.ResourceContents, divert bool) ([]string, ReadMCPResourceResponseMetadata) {
+func splitMCPResourceContents(contents []*mcp.ResourceContents, divert bool, provenance string) ([]string, ReadMCPResourceResponseMetadata) {
 	var textParts []string
 	var metadata ReadMCPResourceResponseMetadata
 	for _, content := range contents {
@@ -72,9 +76,10 @@ func splitMCPResourceContents(contents []*mcp.ResourceContents, divert bool) ([]
 		// A2UI surfaces go to the UI via metadata, not the model-facing
 		// content: the chat renderer draws the surface itself, and the
 		// model only ever echoed the raw JSON back, double-rendering the
-		// surface.
-		if divert && content.MIMEType == a2uiMIMEType {
+		// surface. Both the canonical and legacy MIME spellings match.
+		if divert && mcp.IsA2UIMIMEType(content.MIMEType) {
 			metadata.A2UISurfaces = append(metadata.A2UISurfaces, "<a2ui-json>"+text+"</a2ui-json>")
+			metadata.MCPSurfaceProvenance = append(metadata.MCPSurfaceProvenance, provenance)
 			// The placeholder is a single-line protocol the chat renderer
 			// strips line-wise — a server-controlled URI must not be able
 			// to break out of it with embedded newlines. The injected
@@ -206,7 +211,7 @@ func NewReadMCPResourceTool(cfg *config.ConfigStore, permissions permission.Serv
 			divert := GetChannelFromContext(ctx) == "" &&
 				!cfg.Config().Options.DisableA2UI &&
 				GetContentWidthFromContext(ctx) > 0
-			textParts, metadata := splitMCPResourceContents(contents, divert)
+			textParts, metadata := splitMCPResourceContents(contents, divert, params.MCPName)
 
 			if len(textParts) == 0 {
 				return fantasy.NewTextResponse(""), nil

--- a/internal/agent/tools/read_mcp_resource_contents_test.go
+++ b/internal/agent/tools/read_mcp_resource_contents_test.go
@@ -18,12 +18,22 @@ func TestSplitMCPResourceContents(t *testing.T) {
 		t.Parallel()
 		textParts, meta := splitMCPResourceContents([]*mcp.ResourceContents{
 			{URI: "cairn://run/x/a2ui", MIMEType: a2uiMIMEType, Text: testA2UIPayload},
-		}, true)
+		}, true, "test-mcp")
 		require.Len(t, meta.A2UISurfaces, 1)
 		require.Equal(t, "<a2ui-json>"+testA2UIPayload+"</a2ui-json>", meta.A2UISurfaces[0])
+		require.Equal(t, []string{"test-mcp"}, meta.MCPSurfaceProvenance)
 		require.Len(t, textParts, 1)
 		require.True(t, strings.HasPrefix(textParts[0], A2UISurfacePlaceholderPrefix))
 		require.NotContains(t, textParts[0], "updateComponents")
+	})
+
+	t.Run("legacy MIME spelling is diverted too", func(t *testing.T) {
+		t.Parallel()
+		_, meta := splitMCPResourceContents([]*mcp.ResourceContents{
+			{URI: "a2ui://form", MIMEType: mcp.A2UILegacyMIMEType, Text: testA2UIPayload},
+		}, true, "test-mcp")
+		require.Len(t, meta.A2UISurfaces, 1)
+		require.Equal(t, []string{"test-mcp"}, meta.MCPSurfaceProvenance)
 	})
 
 	t.Run("a2ui blob content is diverted too", func(t *testing.T) {
@@ -32,7 +42,7 @@ func TestSplitMCPResourceContents(t *testing.T) {
 		// surface must not leak raw JSON into the model-facing content.
 		textParts, meta := splitMCPResourceContents([]*mcp.ResourceContents{
 			{URI: "cairn://run/x/a2ui", MIMEType: a2uiMIMEType, Blob: []byte(testA2UIPayload)},
-		}, true)
+		}, true, "test-mcp")
 		require.Len(t, meta.A2UISurfaces, 1)
 		require.Len(t, textParts, 1)
 		require.True(t, strings.HasPrefix(textParts[0], A2UISurfacePlaceholderPrefix))
@@ -45,7 +55,7 @@ func TestSplitMCPResourceContents(t *testing.T) {
 		// the model can relay or summarize the data.
 		textParts, meta := splitMCPResourceContents([]*mcp.ResourceContents{
 			{URI: "cairn://run/x/a2ui", MIMEType: a2uiMIMEType, Text: testA2UIPayload},
-		}, false)
+		}, false, "test-mcp")
 		require.Empty(t, meta.A2UISurfaces)
 		require.Equal(t, []string{testA2UIPayload}, textParts)
 	})
@@ -54,7 +64,7 @@ func TestSplitMCPResourceContents(t *testing.T) {
 		t.Parallel()
 		textParts, meta := splitMCPResourceContents([]*mcp.ResourceContents{
 			{URI: "cairn://artifact/x", MIMEType: "text/markdown", Text: "# hello"},
-		}, true)
+		}, true, "test-mcp")
 		require.Empty(t, meta.A2UISurfaces)
 		require.Equal(t, []string{"# hello"}, textParts)
 	})
@@ -64,7 +74,7 @@ func TestSplitMCPResourceContents(t *testing.T) {
 		textParts, meta := splitMCPResourceContents([]*mcp.ResourceContents{
 			{URI: "cairn://artifact/x", MIMEType: "text/markdown", Text: "summary"},
 			{URI: "cairn://artifact/x/a2ui", MIMEType: a2uiMIMEType, Text: testA2UIPayload},
-		}, true)
+		}, true, "test-mcp")
 		require.Len(t, meta.A2UISurfaces, 1)
 		require.Len(t, textParts, 2)
 		require.Equal(t, "summary", textParts[0])
@@ -77,7 +87,7 @@ func TestSplitMCPResourceContents(t *testing.T) {
 		// must not learn a width-frozen URI it could reuse after a resize.
 		textParts, _ := splitMCPResourceContents([]*mcp.ResourceContents{
 			{URI: "cairn://run/x/a2ui?w=114", MIMEType: a2uiMIMEType, Text: testA2UIPayload},
-		}, true)
+		}, true, "test-mcp")
 		require.Len(t, textParts, 1)
 		require.Contains(t, textParts[0], "cairn://run/x/a2ui ")
 		require.NotContains(t, textParts[0], "w=114")
@@ -88,7 +98,7 @@ func TestSplitMCPResourceContents(t *testing.T) {
 		textParts, meta := splitMCPResourceContents([]*mcp.ResourceContents{
 			nil,
 			{URI: "cairn://artifact/empty"},
-		}, true)
+		}, true, "test-mcp")
 		require.Empty(t, meta.A2UISurfaces)
 		require.Empty(t, textParts)
 	})

--- a/internal/ui/chat/a2ui_surface_host.go
+++ b/internal/ui/chat/a2ui_surface_host.go
@@ -1,0 +1,175 @@
+package chat
+
+import (
+	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/crush/internal/csync"
+	"github.com/charmbracelet/crush/internal/ui/styles"
+	"github.com/joestump-agent/a2tea"
+	"github.com/joestump-agent/a2tea/render"
+)
+
+// a2uiSurfaceHost holds the live a2tea surface models for one message item —
+// an assistant message whose content scanned as A2UI (#44), or a tool result
+// that delivered an MCP A2UI surface (#219). The slice is indexed by
+// scan-part (assistant) or surface (tool result); entries without a
+// renderable surface hold nil.
+//
+// Assistant surfaces stream and rebuild as deltas arrive, so the assistant
+// item keys its models by source hash and retires them on first submission
+// (#45). MCP tool-result surfaces are long-lived app UIs: they build once
+// from a fixed payload, are never retired on interaction, and feed a button
+// back to the owning server (#221). The host carries the shared state and
+// behavior both kinds need; the items own their lifecycle.
+type a2uiSurfaceHost struct {
+	// surfaces holds the live a2tea models so they can receive focus and
+	// key input instead of being frozen to a rendered string.
+	surfaces []render.Model
+	// surfaceIDs holds the A2UI surface ID for each entry (empty where the
+	// part has no renderable surface), so a ButtonClicked event's
+	// SurfaceID can be routed back to the model that emitted it.
+	surfaceIDs []string
+	// sty themes the surfaces with the crush palette.
+	sty *styles.Styles
+}
+
+// buildSurfaces renders each part's messages into a live a2tea model,
+// returning the surfaces and their IDs. Parts with no messages or nothing
+// to draw (e.g. a bare data-model update) leave nil/empty entries.
+func buildA2UISurfaces(sty *styles.Styles, parts []a2tea.Part) ([]render.Model, []string) {
+	surfaces := make([]render.Model, len(parts))
+	ids := make([]string, len(parts))
+	for i, p := range parts {
+		if len(p.Messages) == 0 {
+			continue
+		}
+		model, err := a2tea.Render(p.Messages, render.WithStyles(a2uiThemeStyles(sty)))
+		if err != nil {
+			continue
+		}
+		if rm, ok := model.(render.Model); ok {
+			surfaces[i] = rm
+			ids[i] = a2uiPartSurfaceID(p.Messages)
+		}
+	}
+	return surfaces, ids
+}
+
+// hasLive reports whether the host holds at least one live surface model.
+// While true, the item's content-hash render caches are bypassed so surface
+// interaction is never served a frozen frame.
+func (h *a2uiSurfaceHost) hasLive() bool {
+	for _, s := range h.surfaces {
+		if s != nil {
+			return true
+		}
+	}
+	return false
+}
+
+// surfaceAt returns the live surface at index i, or nil.
+func (h *a2uiSurfaceHost) surfaceAt(i int) render.Model {
+	if i < 0 || i >= len(h.surfaces) {
+		return nil
+	}
+	return h.surfaces[i]
+}
+
+// focusedIndex returns the index of the surface currently holding keyboard
+// focus, or -1 when none does.
+func (h *a2uiSurfaceHost) focusedIndex() int {
+	for i, s := range h.surfaces {
+		if s != nil && s.Focused() {
+			return i
+		}
+	}
+	return -1
+}
+
+// update forwards msg into surface i's Update and stores the returned model.
+func (h *a2uiSurfaceHost) update(i int, msg tea.Msg) tea.Cmd {
+	model, cmd := h.surfaces[i].Update(msg)
+	if rm, ok := model.(render.Model); ok {
+		h.surfaces[i] = rm
+	}
+	return cmd
+}
+
+// fieldValues reads the surface's current values, if it supports them.
+func (h *a2uiSurfaceHost) fieldValues(i int) map[string]any {
+	s := h.surfaceAt(i)
+	if s == nil {
+		return nil
+	}
+	if fv, ok := s.(interface{ FieldValues() map[string]any }); ok {
+		return fv.FieldValues()
+	}
+	return nil
+}
+
+// surfaceIDFor returns the A2UI surface ID at index i.
+func (h *a2uiSurfaceHost) surfaceIDFor(i int) string {
+	if i < 0 || i >= len(h.surfaceIDs) {
+		return ""
+	}
+	return h.surfaceIDs[i]
+}
+
+// findByID returns the index of the surface with the given A2UI surface ID,
+// or -1.
+func (h *a2uiSurfaceHost) findByID(surfaceID string) int {
+	for i, id := range h.surfaceIDs {
+		if id == surfaceID && h.surfaceAt(i) != nil {
+			return i
+		}
+	}
+	return -1
+}
+
+// focus grants keyboard focus to the surface at index i and blurs the rest,
+// honoring the a2tea composition contract of at most one focused child.
+func (h *a2uiSurfaceHost) focus(i int) {
+	for j, s := range h.surfaces {
+		if s == nil {
+			continue
+		}
+		if j == i {
+			_ = s.Focus()
+		} else {
+			s.Blur()
+		}
+	}
+}
+
+// blurAll revokes keyboard focus from every live surface.
+func (h *a2uiSurfaceHost) blurAll() {
+	for _, s := range h.surfaces {
+		if s != nil {
+			s.Blur()
+		}
+	}
+}
+
+// --- MCP surface provenance registry (#219) ---
+
+// a2uiMCPProvenance maps a rendered A2UI surface ID to the MCP server that
+// served it, so a later interaction event (button press, render failure) can
+// route back to the owning server as an a2ui_action / a2ui_error tool call
+// (#221). Entries live for the process lifetime: surface IDs are
+// server-scoped (typically "default"), so re-rendering a surface from the
+// same server simply overwrites the same key.
+var a2uiMCPProvenance = csync.NewMap[string, string]()
+
+// registerA2UISurfaceProvenance records that surfaceID came from mcpName.
+// An empty surfaceID or mcpName is not registered.
+func registerA2UISurfaceProvenance(surfaceID, mcpName string) {
+	if surfaceID == "" || mcpName == "" {
+		return
+	}
+	a2uiMCPProvenance.Set(surfaceID, mcpName)
+}
+
+// A2UISurfaceProvenance returns the MCP server that served surfaceID, and
+// whether the surface is MCP-owned at all.
+func A2UISurfaceProvenance(surfaceID string) (string, bool) {
+	return a2uiMCPProvenance.Get(surfaceID)
+}

--- a/internal/ui/chat/a2ui_surface_host.go
+++ b/internal/ui/chat/a2ui_surface_host.go
@@ -15,8 +15,8 @@ import (
 // renderable surface hold nil.
 //
 // Assistant surfaces stream and rebuild as deltas arrive, so the assistant
-// item keys its models by source hash and retires them on first submission
-// . MCP tool-result surfaces are long-lived app UIs: they build once
+// item keys its models by source hash and retires them on first
+// submission. MCP tool-result surfaces are long-lived app UIs: they build once
 // from a fixed payload, are never retired on interaction, and feed a button
 // back to the owning server. The host carries the shared state and
 // behavior both kinds need; the items own their lifecycle.
@@ -152,11 +152,14 @@ func (h *a2uiSurfaceHost) blurAll() {
 // --- MCP surface provenance registry ---
 
 // a2uiMCPProvenance maps a rendered A2UI surface ID to the MCP server that
-// served it, so a later interaction event (button press, render failure) can
-// route back to the owning server as an a2ui_action / a2ui_error tool call
-// . Entries live for the process lifetime: surface IDs are
+// served it, so a later interaction event (button press, render failure)
+// can route back to the owning server as an a2ui_action / a2ui_error tool
+// call. Entries live for the process lifetime: surface IDs are
 // server-scoped (typically "default"), so re-rendering a surface from the
-// same server simply overwrites the same key.
+// same server simply overwrites the same key. Two servers emitting the SAME
+// surface ID would clobber each other here — the action round-trip should
+// resolve provenance through the owning item before falling back to this
+// registry.
 var a2uiMCPProvenance = csync.NewMap[string, string]()
 
 // registerA2UISurfaceProvenance records that surfaceID came from mcpName.

--- a/internal/ui/chat/a2ui_surface_host.go
+++ b/internal/ui/chat/a2ui_surface_host.go
@@ -9,16 +9,16 @@ import (
 )
 
 // a2uiSurfaceHost holds the live a2tea surface models for one message item —
-// an assistant message whose content scanned as A2UI (#44), or a tool result
-// that delivered an MCP A2UI surface (#219). The slice is indexed by
+// an assistant message whose content scanned as A2UI, or a tool result
+// that delivered an MCP A2UI surface. The slice is indexed by
 // scan-part (assistant) or surface (tool result); entries without a
 // renderable surface hold nil.
 //
 // Assistant surfaces stream and rebuild as deltas arrive, so the assistant
 // item keys its models by source hash and retires them on first submission
-// (#45). MCP tool-result surfaces are long-lived app UIs: they build once
+// . MCP tool-result surfaces are long-lived app UIs: they build once
 // from a fixed payload, are never retired on interaction, and feed a button
-// back to the owning server (#221). The host carries the shared state and
+// back to the owning server. The host carries the shared state and
 // behavior both kinds need; the items own their lifecycle.
 type a2uiSurfaceHost struct {
 	// surfaces holds the live a2tea models so they can receive focus and
@@ -149,12 +149,12 @@ func (h *a2uiSurfaceHost) blurAll() {
 	}
 }
 
-// --- MCP surface provenance registry (#219) ---
+// --- MCP surface provenance registry ---
 
 // a2uiMCPProvenance maps a rendered A2UI surface ID to the MCP server that
 // served it, so a later interaction event (button press, render failure) can
 // route back to the owning server as an a2ui_action / a2ui_error tool call
-// (#221). Entries live for the process lifetime: surface IDs are
+// . Entries live for the process lifetime: surface IDs are
 // server-scoped (typically "default"), so re-rendering a surface from the
 // same server simply overwrites the same key.
 var a2uiMCPProvenance = csync.NewMap[string, string]()

--- a/internal/ui/chat/generic.go
+++ b/internal/ui/chat/generic.go
@@ -81,7 +81,7 @@ func (g *GenericToolRenderContext) RenderTool(sty *styles.Styles, width int, opt
 	// embedded one), render it instead of raw text. The payload arrives via
 	// response metadata — the model only sees a placeholder, so it cannot
 	// echo the JSON back and double-render the surface. Live surface models
-	// (#219) render interactively; without them (older persisted results)
+	// render interactively; without them (older persisted results)
 	// fall back to the static snapshot. This is what makes
 	// cairn://artifact/{id}/a2ui and similar resource reads render inline.
 	if opts.Result.Metadata != "" {
@@ -108,7 +108,7 @@ func (g *GenericToolRenderContext) RenderTool(sty *styles.Styles, width int, opt
 
 // renderToolA2UIResultBody renders the metadata-delivered surfaces plus any
 // real text content the resource returned alongside them. When the item
-// carries live surface models (opts.LiveSurfaces, #219) they render
+// carries live surface models (opts.LiveSurfaces) they render
 // interactively; otherwise each surface falls back to a static snapshot.
 // When every surface fails to render, an alert replaces the body — the
 // model-facing placeholder claims the user can already see the surface,

--- a/internal/ui/chat/generic.go
+++ b/internal/ui/chat/generic.go
@@ -77,10 +77,12 @@ func (g *GenericToolRenderContext) RenderTool(sty *styles.Styles, width int, opt
 	widths := toolResultContentWidths{Body: bodyWidth, Diff: cappedWidth}
 
 	// If the tool result carries an A2UI surface (a read_mcp_resource that
-	// returned application/a2ui+json), render it as a surface snapshot
-	// instead of raw text. The payload arrives via response metadata — the
-	// model only sees a placeholder, so it cannot echo the JSON back and
-	// double-render the surface. This is what makes
+	// returned application/a2ui+json, or an mcp_* tool whose result
+	// embedded one), render it instead of raw text. The payload arrives via
+	// response metadata — the model only sees a placeholder, so it cannot
+	// echo the JSON back and double-render the surface. Live surface models
+	// (#219) render interactively; without them (older persisted results)
+	// fall back to the static snapshot. This is what makes
 	// cairn://artifact/{id}/a2ui and similar resource reads render inline.
 	if opts.Result.Metadata != "" {
 		var meta tools.ReadMCPResourceResponseMetadata
@@ -105,37 +107,53 @@ func (g *GenericToolRenderContext) RenderTool(sty *styles.Styles, width int, opt
 }
 
 // renderToolA2UIResultBody renders the metadata-delivered surfaces plus any
-// real text content the resource returned alongside them. When every surface
-// fails to render, an alert replaces the body — the model-facing placeholder
-// claims the user can already see the surface, which would be false here.
+// real text content the resource returned alongside them. When the item
+// carries live surface models (opts.LiveSurfaces, #219) they render
+// interactively; otherwise each surface falls back to a static snapshot.
+// When every surface fails to render, an alert replaces the body — the
+// model-facing placeholder claims the user can already see the surface,
+// which would be false here.
 func renderToolA2UIResultBody(sty *styles.Styles, surfaces []string, opts *ToolRenderOpts, widths toolResultContentWidths) string {
 	var b strings.Builder
-	failed := 0
-	for _, surf := range surfaces {
-		rendered, err := renderToolA2UI(sty, surf, widths.Body)
-		if err != nil || rendered == "" {
-			failed++
-			continue
+	if opts.LiveSurfaces != nil {
+		b.WriteString(opts.LiveSurfaces(widths.Body))
+	} else {
+		failed := 0
+		for _, surf := range surfaces {
+			rendered, err := renderToolA2UI(sty, surf, widths.Body)
+			if err != nil || rendered == "" {
+				failed++
+				continue
+			}
+			if b.Len() > 0 {
+				b.WriteString("\n")
+			}
+			b.WriteString(rendered)
 		}
+
+		var chunks []string
 		if b.Len() > 0 {
-			b.WriteString("\n")
+			chunks = append(chunks, sty.Tool.Body.Render(clampToolA2UI(sty, b.String(), widths.Body, opts.ExpandedContent)))
 		}
-		b.WriteString(rendered)
+		// Alert on ANY failed surface, not only when all fail: a sibling
+		// surface rendering fine must not hide that another one vanished —
+		// the model was told the user can see every one of them.
+		if failed > 0 {
+			chunks = append(chunks, sty.Tool.Body.Render(renderToolA2UIAlert(sty, widths.Body)))
+		}
+		// Show any real text the resource returned alongside its surfaces — the
+		// model-facing placeholder lines are stripped, the rest belongs to the
+		// user just as much as the surfaces do.
+		if text := stripA2UIPlaceholders(opts.Result.Content); text != "" {
+			chunks = append(chunks, renderToolResultTextContent(sty, text, widths, opts.ExpandedContent))
+		}
+		return strings.Join(chunks, "\n")
 	}
 
 	var chunks []string
 	if b.Len() > 0 {
 		chunks = append(chunks, sty.Tool.Body.Render(clampToolA2UI(sty, b.String(), widths.Body, opts.ExpandedContent)))
 	}
-	// Alert on ANY failed surface, not only when all fail: a sibling
-	// surface rendering fine must not hide that another one vanished —
-	// the model was told the user can see every one of them.
-	if failed > 0 {
-		chunks = append(chunks, sty.Tool.Body.Render(renderToolA2UIAlert(sty, widths.Body)))
-	}
-	// Show any real text the resource returned alongside its surfaces — the
-	// model-facing placeholder lines are stripped, the rest belongs to the
-	// user just as much as the surfaces do.
 	if text := stripA2UIPlaceholders(opts.Result.Content); text != "" {
 		chunks = append(chunks, renderToolResultTextContent(sty, text, widths, opts.ExpandedContent))
 	}

--- a/internal/ui/chat/generic.go
+++ b/internal/ui/chat/generic.go
@@ -115,10 +115,12 @@ func (g *GenericToolRenderContext) RenderTool(sty *styles.Styles, width int, opt
 // which would be false here.
 func renderToolA2UIResultBody(sty *styles.Styles, surfaces []string, opts *ToolRenderOpts, widths toolResultContentWidths) string {
 	var b strings.Builder
+	failed := 0
 	if opts.LiveSurfaces != nil {
-		b.WriteString(opts.LiveSurfaces(widths.Body))
+		rendered, liveFailed := opts.LiveSurfaces(widths.Body)
+		b.WriteString(rendered)
+		failed = liveFailed
 	} else {
-		failed := 0
 		for _, surf := range surfaces {
 			rendered, err := renderToolA2UI(sty, surf, widths.Body)
 			if err != nil || rendered == "" {
@@ -130,30 +132,21 @@ func renderToolA2UIResultBody(sty *styles.Styles, surfaces []string, opts *ToolR
 			}
 			b.WriteString(rendered)
 		}
-
-		var chunks []string
-		if b.Len() > 0 {
-			chunks = append(chunks, sty.Tool.Body.Render(clampToolA2UI(sty, b.String(), widths.Body, opts.ExpandedContent)))
-		}
-		// Alert on ANY failed surface, not only when all fail: a sibling
-		// surface rendering fine must not hide that another one vanished —
-		// the model was told the user can see every one of them.
-		if failed > 0 {
-			chunks = append(chunks, sty.Tool.Body.Render(renderToolA2UIAlert(sty, widths.Body)))
-		}
-		// Show any real text the resource returned alongside its surfaces — the
-		// model-facing placeholder lines are stripped, the rest belongs to the
-		// user just as much as the surfaces do.
-		if text := stripA2UIPlaceholders(opts.Result.Content); text != "" {
-			chunks = append(chunks, renderToolResultTextContent(sty, text, widths, opts.ExpandedContent))
-		}
-		return strings.Join(chunks, "\n")
 	}
 
 	var chunks []string
 	if b.Len() > 0 {
 		chunks = append(chunks, sty.Tool.Body.Render(clampToolA2UI(sty, b.String(), widths.Body, opts.ExpandedContent)))
 	}
+	// Alert on ANY failed surface, not only when all fail: a sibling
+	// surface rendering fine must not hide that another one vanished —
+	// the model was told the user can see every one of them.
+	if failed > 0 {
+		chunks = append(chunks, sty.Tool.Body.Render(renderToolA2UIAlert(sty, widths.Body)))
+	}
+	// Show any real text the resource returned alongside its surfaces — the
+	// model-facing placeholder lines are stripped, the rest belongs to the
+	// user just as much as the surfaces do.
 	if text := stripA2UIPlaceholders(opts.Result.Content); text != "" {
 		chunks = append(chunks, renderToolResultTextContent(sty, text, widths, opts.ExpandedContent))
 	}

--- a/internal/ui/chat/mcp.go
+++ b/internal/ui/chat/mcp.go
@@ -77,7 +77,7 @@ func (b *MCPToolRenderContext) RenderTool(sty *styles.Styles, width int, opts *T
 	widths := toolResultContentWidths{Body: bodyWidth, Diff: cappedWidth}
 
 	// An MCP tool result can carry an A2UI surface in its metadata
-	// (#219): the server returned an application/a2ui+json
+	//: the server returned an application/a2ui+json
 	// EmbeddedResource, diverted so the model only sees a placeholder.
 	// Render the live surface (or static fallback) instead of raw text.
 	if opts.Result.Metadata != "" {

--- a/internal/ui/chat/mcp.go
+++ b/internal/ui/chat/mcp.go
@@ -76,10 +76,10 @@ func (b *MCPToolRenderContext) RenderTool(sty *styles.Styles, width int, opts *T
 	bodyWidth := cappedWidth - toolBodyLeftPaddingTotal
 	widths := toolResultContentWidths{Body: bodyWidth, Diff: cappedWidth}
 
-	// An MCP tool result can carry an A2UI surface in its metadata
-	//: the server returned an application/a2ui+json
-	// EmbeddedResource, diverted so the model only sees a placeholder.
-	// Render the live surface (or static fallback) instead of raw text.
+	// An MCP tool result can carry an A2UI surface in its metadata: the
+	// server returned an application/a2ui+json EmbeddedResource, diverted
+	// so the model only sees a placeholder. Render the live surface (or
+	// static fallback) instead of raw text.
 	if opts.Result.Metadata != "" {
 		var meta tools.ReadMCPResourceResponseMetadata
 		if err := json.Unmarshal([]byte(opts.Result.Metadata), &meta); err == nil && len(meta.A2UISurfaces) > 0 {

--- a/internal/ui/chat/mcp.go
+++ b/internal/ui/chat/mcp.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/charmbracelet/crush/internal/agent/tools"
 	"github.com/charmbracelet/crush/internal/message"
 	"github.com/charmbracelet/crush/internal/ui/styles"
 )
@@ -73,6 +74,19 @@ func (b *MCPToolRenderContext) RenderTool(sty *styles.Styles, width int, opts *T
 	}
 
 	bodyWidth := cappedWidth - toolBodyLeftPaddingTotal
-	body := renderToolResultTextContent(sty, opts.Result.Content, toolResultContentWidths{Body: bodyWidth, Diff: cappedWidth}, opts.ExpandedContent)
+	widths := toolResultContentWidths{Body: bodyWidth, Diff: cappedWidth}
+
+	// An MCP tool result can carry an A2UI surface in its metadata
+	// (#219): the server returned an application/a2ui+json
+	// EmbeddedResource, diverted so the model only sees a placeholder.
+	// Render the live surface (or static fallback) instead of raw text.
+	if opts.Result.Metadata != "" {
+		var meta tools.ReadMCPResourceResponseMetadata
+		if err := json.Unmarshal([]byte(opts.Result.Metadata), &meta); err == nil && len(meta.A2UISurfaces) > 0 {
+			return joinToolParts(header, renderToolA2UIResultBody(sty, meta.A2UISurfaces, opts, widths))
+		}
+	}
+
+	body := renderToolResultTextContent(sty, opts.Result.Content, widths, opts.ExpandedContent)
 	return joinToolParts(header, body)
 }

--- a/internal/ui/chat/tool_a2ui.go
+++ b/internal/ui/chat/tool_a2ui.go
@@ -36,16 +36,20 @@ func (t *baseToolMessageItem) syncToolA2UISurfaces() {
 	}
 	var surfaces []render.Model
 	var ids []string
+	failed := 0
 	for i, surfJSON := range meta.A2UISurfaces {
 		parts, err := a2tea.Scan(surfJSON)
 		if err != nil {
+			failed++
 			continue
 		}
 		built, builtIDs := buildA2UISurfaces(t.sty, parts)
+		payloadLive := 0
 		for j, m := range built {
 			if m == nil {
 				continue
 			}
+			payloadLive++
 			surfaces = append(surfaces, m)
 			id := builtIDs[j]
 			ids = append(ids, id)
@@ -55,9 +59,16 @@ func (t *baseToolMessageItem) syncToolA2UISurfaces() {
 				registerA2UISurfaceProvenance(id, meta.MCPSurfaceProvenance[i])
 			}
 		}
+		// A payload that scanned but drew nothing (unsupported components,
+		// bare data-model update) failed just like a scan error: the model
+		// was told the user can see it.
+		if payloadLive == 0 {
+			failed++
+		}
 	}
 	t.a2ui.surfaces = surfaces
 	t.a2ui.surfaceIDs = ids
+	t.surfaceBuildFailed = failed
 	t.surfaceSrcHash = h
 	t.surfaceScanned = true
 	if t.focusableMessageItem.isFocused() {
@@ -89,11 +100,13 @@ func (t *baseToolMessageItem) blurToolA2UISurfaces() {
 }
 
 // renderToolA2UISurfaces renders each live surface from its model at the
-// given width, joined by blank lines. Surfaces that fail to produce output
-// are skipped; the alert path in generic.go/mcp.go covers payloads that
-// produced no renderable model at all.
-func (t *baseToolMessageItem) renderToolA2UISurfaces(width int) string {
+// given width, joined by blank lines. It also reports how many surfaces
+// failed — payloads that never built a model (surfaceBuildFailed) plus live
+// models that drew nothing — so the renderer can show the same alert the
+// static path shows: the model was told the user can see every surface.
+func (t *baseToolMessageItem) renderToolA2UISurfaces(width int) (string, int) {
 	var b strings.Builder
+	failed := t.surfaceBuildFailed
 	for _, s := range t.a2ui.surfaces {
 		if s == nil {
 			continue
@@ -101,6 +114,7 @@ func (t *baseToolMessageItem) renderToolA2UISurfaces(width int) string {
 		s.SetSize(width, 0)
 		rendered := strings.TrimRight(s.View().Content, "\n")
 		if rendered == "" {
+			failed++
 			continue
 		}
 		if b.Len() > 0 {
@@ -108,7 +122,7 @@ func (t *baseToolMessageItem) renderToolA2UISurfaces(width int) string {
 		}
 		b.WriteString(rendered)
 	}
-	return b.String()
+	return b.String(), failed
 }
 
 // HandleKeyEvent routes keys to the focused live MCP surface first

--- a/internal/ui/chat/tool_a2ui.go
+++ b/internal/ui/chat/tool_a2ui.go
@@ -1,0 +1,126 @@
+package chat
+
+import (
+	"encoding/json"
+	"strings"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/crush/internal/agent/tools"
+	"github.com/joestump-agent/a2tea"
+	"github.com/joestump-agent/a2tea/render"
+)
+
+// syncToolA2UISurfaces builds — or reuses — the live a2tea models for the
+// surfaces carried in the tool result's metadata (#219). Models are keyed by
+// a hash of the metadata: a re-render with the same result reuses the live
+// models (preserving focus and edited field values), while a result swap
+// (SetResult) rebuilds them. Each surface's provenance is registered so a
+// later interaction routes back to the owning MCP server (#221).
+func (t *baseToolMessageItem) syncToolA2UISurfaces() {
+	if t.result == nil || t.result.Metadata == "" {
+		t.a2ui.surfaces = nil
+		t.a2ui.surfaceIDs = nil
+		t.surfaceScanned = false
+		return
+	}
+	var meta tools.ReadMCPResourceResponseMetadata
+	if err := json.Unmarshal([]byte(t.result.Metadata), &meta); err != nil || len(meta.A2UISurfaces) == 0 {
+		t.a2ui.surfaces = nil
+		t.a2ui.surfaceIDs = nil
+		t.surfaceScanned = false
+		return
+	}
+	h := fnv64(t.result.Metadata)
+	if t.surfaceScanned && t.surfaceSrcHash == h {
+		return
+	}
+	var surfaces []render.Model
+	var ids []string
+	for i, surfJSON := range meta.A2UISurfaces {
+		parts, err := a2tea.Scan(surfJSON)
+		if err != nil {
+			continue
+		}
+		built, builtIDs := buildA2UISurfaces(t.sty, parts)
+		for j, m := range built {
+			if m == nil {
+				continue
+			}
+			surfaces = append(surfaces, m)
+			id := builtIDs[j]
+			ids = append(ids, id)
+			// Provenance is parallel to A2UISurfaces; a missing or short
+			// slice (older persisted results) means unknown origin.
+			if i < len(meta.MCPSurfaceProvenance) {
+				registerA2UISurfaceProvenance(id, meta.MCPSurfaceProvenance[i])
+			}
+		}
+	}
+	t.a2ui.surfaces = surfaces
+	t.a2ui.surfaceIDs = ids
+	t.surfaceSrcHash = h
+	t.surfaceScanned = true
+	if t.focusableMessageItem.isFocused() {
+		t.focusToolA2UISurfaces()
+	}
+}
+
+// hasToolA2UISurfaces reports whether this item carries live MCP surfaces.
+func (t *baseToolMessageItem) hasToolA2UISurfaces() bool {
+	return t.a2ui.hasLive()
+}
+
+// focusToolA2UISurfaces grants focus to the first live surface and blurs the
+// rest. MCP surfaces are long-lived app UIs (#219) — unlike chat-scanned
+// forms they are never retired on submission, so every live surface is
+// focusable.
+func (t *baseToolMessageItem) focusToolA2UISurfaces() {
+	for i, s := range t.a2ui.surfaces {
+		if s != nil {
+			t.a2ui.focus(i)
+			return
+		}
+	}
+}
+
+// blurToolA2UISurfaces revokes keyboard focus from every live surface.
+func (t *baseToolMessageItem) blurToolA2UISurfaces() {
+	t.a2ui.blurAll()
+}
+
+// renderToolA2UISurfaces renders each live surface from its model at the
+// given width, joined by blank lines. Surfaces that fail to produce output
+// are skipped; the alert path in generic.go/mcp.go covers payloads that
+// produced no renderable model at all.
+func (t *baseToolMessageItem) renderToolA2UISurfaces(width int) string {
+	var b strings.Builder
+	for _, s := range t.a2ui.surfaces {
+		if s == nil {
+			continue
+		}
+		s.SetSize(width, 0)
+		rendered := strings.TrimRight(s.View().Content, "\n")
+		if rendered == "" {
+			continue
+		}
+		if b.Len() > 0 {
+			b.WriteString("\n\n")
+		}
+		b.WriteString(rendered)
+	}
+	return b.String()
+}
+
+// HandleKeyEvent routes keys to the focused live MCP surface first
+// (#219) — Tab/Shift+Tab cycle its focus ring, Enter activates a button,
+// printable keys edit a focused field (see a2uiSurfaceWantsKey) — then falls
+// through to the copy shortcut. A button activation surfaces as an
+// a2uievent.ButtonClicked tea.Cmd, which the UI model routes per the
+// surface's provenance (#221).
+func (t *baseToolMessageItem) handleA2UIKeyEvent(key tea.KeyMsg) (bool, tea.Cmd) {
+	if idx := t.a2ui.focusedIndex(); idx >= 0 && a2uiSurfaceWantsKey(t.a2ui.surfaces[idx], key) {
+		t.Bump()
+		return true, t.a2ui.update(idx, key)
+	}
+	return false, nil
+}

--- a/internal/ui/chat/tool_a2ui.go
+++ b/internal/ui/chat/tool_a2ui.go
@@ -11,11 +11,11 @@ import (
 )
 
 // syncToolA2UISurfaces builds — or reuses — the live a2tea models for the
-// surfaces carried in the tool result's metadata (#219). Models are keyed by
+// surfaces carried in the tool result's metadata. Models are keyed by
 // a hash of the metadata: a re-render with the same result reuses the live
 // models (preserving focus and edited field values), while a result swap
 // (SetResult) rebuilds them. Each surface's provenance is registered so a
-// later interaction routes back to the owning MCP server (#221).
+// later interaction routes back to the owning MCP server.
 func (t *baseToolMessageItem) syncToolA2UISurfaces() {
 	if t.result == nil || t.result.Metadata == "" {
 		t.a2ui.surfaces = nil
@@ -71,7 +71,7 @@ func (t *baseToolMessageItem) hasToolA2UISurfaces() bool {
 }
 
 // focusToolA2UISurfaces grants focus to the first live surface and blurs the
-// rest. MCP surfaces are long-lived app UIs (#219) — unlike chat-scanned
+// rest. MCP surfaces are long-lived app UIs — unlike chat-scanned
 // forms they are never retired on submission, so every live surface is
 // focusable.
 func (t *baseToolMessageItem) focusToolA2UISurfaces() {
@@ -112,11 +112,11 @@ func (t *baseToolMessageItem) renderToolA2UISurfaces(width int) string {
 }
 
 // HandleKeyEvent routes keys to the focused live MCP surface first
-// (#219) — Tab/Shift+Tab cycle its focus ring, Enter activates a button,
+// — Tab/Shift+Tab cycle its focus ring, Enter activates a button,
 // printable keys edit a focused field (see a2uiSurfaceWantsKey) — then falls
 // through to the copy shortcut. A button activation surfaces as an
 // a2uievent.ButtonClicked tea.Cmd, which the UI model routes per the
-// surface's provenance (#221).
+// surface's provenance.
 func (t *baseToolMessageItem) handleA2UIKeyEvent(key tea.KeyMsg) (bool, tea.Cmd) {
 	if idx := t.a2ui.focusedIndex(); idx >= 0 && a2uiSurfaceWantsKey(t.a2ui.surfaces[idx], key) {
 		t.Bump()

--- a/internal/ui/chat/tool_a2ui_test.go
+++ b/internal/ui/chat/tool_a2ui_test.go
@@ -1,0 +1,131 @@
+package chat
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/charmbracelet/crush/internal/agent/tools"
+	"github.com/charmbracelet/crush/internal/message"
+	"github.com/charmbracelet/crush/internal/ui/styles"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/stretchr/testify/require"
+)
+
+const a2uiToolSurface = `<a2ui-json>{"version":"v0.9","updateComponents":{"surfaceId":"card","components":[` +
+	`{"component":"Card","id":"root","child":"col"},` +
+	`{"component":"Column","id":"col","children":["title"]},` +
+	`{"component":"Text","id":"title","variant":"h2","text":"Recipe Card"}]}}` + `</a2ui-json>`
+
+// newA2UIToolItem builds a base tool item whose result metadata carries the
+// given surfaces and provenance — the shape read_mcp_resource and mcp_* tool
+// results produce.
+func newA2UIToolItem(t *testing.T, surfaces, provenance []string, toolName string) *baseToolMessageItem {
+	t.Helper()
+	meta, err := json.Marshal(tools.ReadMCPResourceResponseMetadata{
+		A2UISurfaces:         surfaces,
+		MCPSurfaceProvenance: provenance,
+	})
+	require.NoError(t, err)
+
+	sty := styles.CharmtonePantera()
+	return newBaseToolMessageItem(&sty, message.ToolCall{
+		ID:       "call-1",
+		Name:     toolName,
+		Input:    `{}`,
+		Finished: true,
+	}, &message.ToolResult{
+		ToolCallID: "call-1",
+		Content:    a2uiTestPlaceholder,
+		Metadata:   string(meta),
+	}, &GenericToolRenderContext{}, false)
+}
+
+func TestToolA2UISurfaces(t *testing.T) {
+	t.Parallel()
+
+	t.Run("metadata surfaces build live models", func(t *testing.T) {
+		t.Parallel()
+		item := newA2UIToolItem(t, []string{a2uiToolSurface}, []string{"cairn"}, tools.ReadMCPResourceToolName)
+		item.syncToolA2UISurfaces()
+
+		require.True(t, item.hasToolA2UISurfaces())
+		require.Len(t, item.a2ui.surfaces, 1)
+		require.Equal(t, "card", item.a2ui.surfaceIDs[0])
+	})
+
+	t.Run("provenance is registered per surface", func(t *testing.T) {
+		t.Parallel()
+		item := newA2UIToolItem(t, []string{a2uiToolSurface}, []string{"cairn"}, tools.ReadMCPResourceToolName)
+		item.syncToolA2UISurfaces()
+
+		server, ok := A2UISurfaceProvenance("card")
+		require.True(t, ok)
+		require.Equal(t, "cairn", server)
+	})
+
+	t.Run("missing provenance means unknown origin", func(t *testing.T) {
+		t.Parallel()
+		item := newA2UIToolItem(t, []string{a2uiToolSurface}, nil, tools.ReadMCPResourceToolName)
+		item.syncToolA2UISurfaces()
+		require.True(t, item.hasToolA2UISurfaces())
+	})
+
+	t.Run("same metadata reuses live models", func(t *testing.T) {
+		t.Parallel()
+		item := newA2UIToolItem(t, []string{a2uiToolSurface}, []string{"cairn"}, tools.ReadMCPResourceToolName)
+		item.syncToolA2UISurfaces()
+		first := item.a2ui.surfaces[0]
+
+		// A re-render with the same result must reuse the model so focus
+		// and edited field values survive.
+		item.syncToolA2UISurfaces()
+		require.Same(t, first, item.a2ui.surfaces[0])
+	})
+
+	t.Run("malformed payload yields no live surface", func(t *testing.T) {
+		t.Parallel()
+		item := newA2UIToolItem(t, []string{"<a2ui-json>{malformed</a2ui-json>"}, []string{"cairn"}, tools.ReadMCPResourceToolName)
+		item.syncToolA2UISurfaces()
+		require.False(t, item.hasToolA2UISurfaces())
+	})
+
+	t.Run("rendering a live surface draws its content", func(t *testing.T) {
+		t.Parallel()
+		item := newA2UIToolItem(t, []string{a2uiToolSurface}, []string{"cairn"}, tools.ReadMCPResourceToolName)
+		item.syncToolA2UISurfaces()
+		out := item.renderToolA2UISurfaces(80)
+		plain := ansi.Strip(out)
+		require.Contains(t, plain, "Recipe Card")
+		require.NotContains(t, plain, "updateComponents")
+	})
+
+	t.Run("RawRender renders the surface instead of the placeholder", func(t *testing.T) {
+		t.Parallel()
+		item := newA2UIToolItem(t, []string{a2uiToolSurface}, []string{"cairn"}, tools.ReadMCPResourceToolName)
+		out := ansi.Strip(item.RawRender(100))
+		require.Contains(t, out, "Recipe Card")
+		require.NotContains(t, out, "do not repeat")
+	})
+}
+
+// The MCP tool renderer (mcp_* tools) renders metadata surfaces too, not
+// just read_mcp_resource.
+func TestMCPToolRendersA2UIFromMetadata(t *testing.T) {
+	t.Parallel()
+
+	meta, err := json.Marshal(tools.ReadMCPResourceResponseMetadata{
+		A2UISurfaces: []string{a2uiToolSurface},
+	})
+	require.NoError(t, err)
+
+	sty := styles.CharmtonePantera()
+	ctx := &MCPToolRenderContext{}
+	out := ctx.RenderTool(&sty, 80, genericToolOptsFor(t, "mcp_recipe_get_recipe_a2ui", &message.ToolResult{
+		Content:  a2uiTestPlaceholder,
+		Metadata: string(meta),
+	}))
+	plain := ansi.Strip(out)
+
+	require.Contains(t, plain, "Recipe Card")
+	require.NotContains(t, plain, "do not repeat")
+}

--- a/internal/ui/chat/tool_a2ui_test.go
+++ b/internal/ui/chat/tool_a2ui_test.go
@@ -93,10 +93,29 @@ func TestToolA2UISurfaces(t *testing.T) {
 		t.Parallel()
 		item := newA2UIToolItem(t, []string{a2uiToolSurface}, []string{"cairn"}, tools.ReadMCPResourceToolName)
 		item.syncToolA2UISurfaces()
-		out := item.renderToolA2UISurfaces(80)
+		out, failed := item.renderToolA2UISurfaces(80)
 		plain := ansi.Strip(out)
 		require.Contains(t, plain, "Recipe Card")
 		require.NotContains(t, plain, "updateComponents")
+		require.Zero(t, failed)
+	})
+
+	t.Run("a failed sibling payload still alerts next to a live surface", func(t *testing.T) {
+		t.Parallel()
+		// One payload renders, one is malformed: the live path must show
+		// the rendered surface AND the alert — the model was told the
+		// user can see both.
+		item := newA2UIToolItem(t,
+			[]string{a2uiToolSurface, "<a2ui-json>{malformed</a2ui-json>"},
+			[]string{"cairn", "cairn"}, tools.ReadMCPResourceToolName)
+		item.syncToolA2UISurfaces()
+		require.True(t, item.hasToolA2UISurfaces())
+		_, failed := item.renderToolA2UISurfaces(80)
+		require.Equal(t, 1, failed)
+
+		out := ansi.Strip(item.RawRender(100))
+		require.Contains(t, out, "Recipe Card")
+		require.Contains(t, out, "couldn't render this resource's UI surface")
 	})
 
 	t.Run("RawRender renders the surface instead of the placeholder", func(t *testing.T) {

--- a/internal/ui/chat/tools.go
+++ b/internal/ui/chat/tools.go
@@ -99,11 +99,12 @@ type ToolRenderOpts struct {
 	IsSpinning      bool
 	Status          ToolStatus
 	// LiveSurfaces renders the item's live MCP A2UI surface models at the
-	// given width. Set only when the result metadata carried
-	// renderable surfaces; nil otherwise, in which case renderers fall
-	// back to the static/text paths. Carried on the opts because the
-	// ToolRenderer interface does not see the owning item.
-	LiveSurfaces func(width int) string
+	// given width, and reports how many of the metadata's surfaces failed
+	// to draw. Set only when the result metadata carried renderable
+	// surfaces; nil otherwise, in which case renderers fall back to the
+	// static/text paths. Carried on the opts because the ToolRenderer
+	// interface does not see the owning item.
+	LiveSurfaces func(width int) (string, int)
 }
 
 // IsPending returns true if the tool call is still pending (not finished and
@@ -165,16 +166,19 @@ type baseToolMessageItem struct {
 	anim            *anim.Anim
 	expandedContent bool
 
-	// a2ui holds the live surface models for an MCP-served A2UI payload
-	//: a read_mcp_resource or mcp_* tool whose result metadata
-	// carries surfaces. They render interactively and, being long-lived
-	// app UIs, are never retired on interaction. Nil for tools
-	// without surfaces. surfaceSrcHash fingerprints the metadata the
-	// models were built from so a re-render with the same metadata reuses
-	// the live models (and their edited values) instead of rebuilding.
-	a2ui           a2uiSurfaceHost
-	surfaceSrcHash uint64
-	surfaceScanned bool
+	// a2ui holds the live surface models for an MCP-served A2UI payload:
+	// a read_mcp_resource or mcp_* tool whose result metadata carries
+	// surfaces. They render interactively and, being long-lived app UIs,
+	// are never retired on interaction. Nil for tools without surfaces.
+	// surfaceSrcHash fingerprints the metadata the models were built from
+	// so a re-render with the same metadata reuses the live models (and
+	// their edited values) instead of rebuilding; surfaceBuildFailed
+	// counts payloads that never produced a drawable model, so the
+	// renderer can alert on them.
+	a2ui               a2uiSurfaceHost
+	surfaceSrcHash     uint64
+	surfaceScanned     bool
+	surfaceBuildFailed int
 }
 
 var _ Expandable = (*baseToolMessageItem)(nil)
@@ -346,7 +350,7 @@ func (t *baseToolMessageItem) RawRender(width int) string {
 	// edited values, not a frozen frame.
 	t.syncToolA2UISurfaces()
 	liveSurfaces := t.hasToolA2UISurfaces()
-	var liveRender func(width int) string
+	var liveRender func(width int) (string, int)
 	if liveSurfaces {
 		liveRender = t.renderToolA2UISurfaces
 	}

--- a/internal/ui/chat/tools.go
+++ b/internal/ui/chat/tools.go
@@ -99,7 +99,7 @@ type ToolRenderOpts struct {
 	IsSpinning      bool
 	Status          ToolStatus
 	// LiveSurfaces renders the item's live MCP A2UI surface models at the
-	// given width (#219). Set only when the result metadata carried
+	// given width. Set only when the result metadata carried
 	// renderable surfaces; nil otherwise, in which case renderers fall
 	// back to the static/text paths. Carried on the opts because the
 	// ToolRenderer interface does not see the owning item.
@@ -166,9 +166,9 @@ type baseToolMessageItem struct {
 	expandedContent bool
 
 	// a2ui holds the live surface models for an MCP-served A2UI payload
-	// (#219): a read_mcp_resource or mcp_* tool whose result metadata
+	//: a read_mcp_resource or mcp_* tool whose result metadata
 	// carries surfaces. They render interactively and, being long-lived
-	// app UIs, are never retired on interaction (#221). Nil for tools
+	// app UIs, are never retired on interaction. Nil for tools
 	// without surfaces. surfaceSrcHash fingerprints the metadata the
 	// models were built from so a re-render with the same metadata reuses
 	// the live models (and their edited values) instead of rebuilding.
@@ -341,7 +341,7 @@ func (t *baseToolMessageItem) RawRender(width int) string {
 	}
 
 	// Build or refresh the live MCP surface models from the result
-	// metadata (#219). While surfaces are live the content cache is
+	// metadata. While surfaces are live the content cache is
 	// bypassed: a surface's View reflects the current focus ring and
 	// edited values, not a frozen frame.
 	t.syncToolA2UISurfaces()
@@ -529,9 +529,9 @@ func (t *baseToolMessageItem) HandleMouseClick(btn ansi.MouseButton, x, y int) b
 }
 
 // HandleKeyEvent implements KeyEventHandler. A focused live MCP surface
-// gets first claim on the keys it understands (#219) — Tab/Shift+Tab cycle
+// gets first claim on the keys it understands — Tab/Shift+Tab cycle
 // its focus ring, Enter activates a button (surfacing an
-// a2uievent.ButtonClicked the UI model routes per provenance, #221) — and
+// a2uievent.ButtonClicked the UI model routes per provenance) — and
 // every other key falls through, so the copy shortcut keeps working
 // whenever no surface consumes the key.
 func (t *baseToolMessageItem) HandleKeyEvent(key tea.KeyMsg) (bool, tea.Cmd) {
@@ -546,7 +546,7 @@ func (t *baseToolMessageItem) HandleKeyEvent(key tea.KeyMsg) (bool, tea.Cmd) {
 }
 
 // SetFocused implements MessageItem. Focus also drives the live MCP
-// surfaces (#219): gaining focus grants it to the first live surface,
+// surfaces: gaining focus grants it to the first live surface,
 // losing focus blurs them all — so the focus ring only ever lives on the
 // selected item.
 func (t *baseToolMessageItem) SetFocused(focused bool) {

--- a/internal/ui/chat/tools.go
+++ b/internal/ui/chat/tools.go
@@ -98,6 +98,12 @@ type ToolRenderOpts struct {
 	Compact         bool
 	IsSpinning      bool
 	Status          ToolStatus
+	// LiveSurfaces renders the item's live MCP A2UI surface models at the
+	// given width (#219). Set only when the result metadata carried
+	// renderable surfaces; nil otherwise, in which case renderers fall
+	// back to the static/text paths. Carried on the opts because the
+	// ToolRenderer interface does not see the owning item.
+	LiveSurfaces func(width int) string
 }
 
 // IsPending returns true if the tool call is still pending (not finished and
@@ -158,6 +164,17 @@ type baseToolMessageItem struct {
 	sty             *styles.Styles
 	anim            *anim.Anim
 	expandedContent bool
+
+	// a2ui holds the live surface models for an MCP-served A2UI payload
+	// (#219): a read_mcp_resource or mcp_* tool whose result metadata
+	// carries surfaces. They render interactively and, being long-lived
+	// app UIs, are never retired on interaction (#221). Nil for tools
+	// without surfaces. surfaceSrcHash fingerprints the metadata the
+	// models were built from so a re-render with the same metadata reuses
+	// the live models (and their edited values) instead of rebuilding.
+	a2ui           a2uiSurfaceHost
+	surfaceSrcHash uint64
+	surfaceScanned bool
 }
 
 var _ Expandable = (*baseToolMessageItem)(nil)
@@ -191,6 +208,7 @@ func newBaseToolMessageItem(
 		status:                   status,
 		hasCappedWidth:           hasCappedWidth,
 	}
+	t.a2ui.sty = sty
 	t.anim = anim.New(anim.Settings{
 		ID:          toolCall.ID,
 		Size:        15,
@@ -322,9 +340,20 @@ func (t *baseToolMessageItem) RawRender(width int) string {
 		toolItemWidth = cappedMessageWidth(width)
 	}
 
+	// Build or refresh the live MCP surface models from the result
+	// metadata (#219). While surfaces are live the content cache is
+	// bypassed: a surface's View reflects the current focus ring and
+	// edited values, not a frozen frame.
+	t.syncToolA2UISurfaces()
+	liveSurfaces := t.hasToolA2UISurfaces()
+	var liveRender func(width int) string
+	if liveSurfaces {
+		liveRender = t.renderToolA2UISurfaces
+	}
+
 	content, height, ok := t.getCachedRender(toolItemWidth)
 	// if we are spinning or there is no cache rerender
-	if !ok || t.isSpinning() {
+	if !ok || t.isSpinning() || liveSurfaces {
 		content = t.toolRenderer.RenderTool(t.sty, toolItemWidth, &ToolRenderOpts{
 			ToolCall:        t.toolCall,
 			Result:          t.result,
@@ -333,6 +362,7 @@ func (t *baseToolMessageItem) RawRender(width int) string {
 			Compact:         t.isCompact,
 			IsSpinning:      t.isSpinning(),
 			Status:          t.computeStatus(),
+			LiveSurfaces:    liveRender,
 		})
 
 		// Prepend hook indicator if hooks ran for this tool call.
@@ -343,8 +373,11 @@ func (t *baseToolMessageItem) RawRender(width int) string {
 		}
 
 		height = lipgloss.Height(content)
-		// cache the rendered content
-		t.setCachedRender(content, toolItemWidth, height)
+		// cache the rendered content — but not while surfaces are live:
+		// the next interaction changes the view.
+		if !liveSurfaces {
+			t.setCachedRender(content, toolItemWidth, height)
+		}
 	}
 
 	return t.renderHighlighted(content, toolItemWidth, height)
@@ -354,8 +387,9 @@ func (t *baseToolMessageItem) RawRender(width int) string {
 func (t *baseToolMessageItem) Render(width int) string {
 	// Cache the prefixed output keyed by (width, prefix variant).
 	// Bypass the cache while spinning (RawRender output is
-	// frame-dependent) or while a highlight range is active.
-	useCache := !t.isSpinning() && !t.isHighlighted()
+	// frame-dependent), while a highlight range is active, or while
+	// live MCP surfaces can change between frames.
+	useCache := !t.isSpinning() && !t.isHighlighted() && !t.hasToolA2UISurfaces()
 	var key uint64
 	switch {
 	case t.isCompact:
@@ -404,6 +438,9 @@ func (t *baseToolMessageItem) SetToolCall(tc message.ToolCall) {
 // SetResult sets the tool result associated with this message item.
 func (t *baseToolMessageItem) SetResult(res *message.ToolResult) {
 	t.result = res
+	// New metadata may carry different surfaces; force a rebuild on the
+	// next render while preserving focus/edits when it is unchanged.
+	t.surfaceScanned = false
 	t.clearCache()
 	t.Bump()
 }
@@ -491,13 +528,34 @@ func (t *baseToolMessageItem) HandleMouseClick(btn ansi.MouseButton, x, y int) b
 	return btn == ansi.MouseLeft
 }
 
-// HandleKeyEvent implements KeyEventHandler.
+// HandleKeyEvent implements KeyEventHandler. A focused live MCP surface
+// gets first claim on the keys it understands (#219) — Tab/Shift+Tab cycle
+// its focus ring, Enter activates a button (surfacing an
+// a2uievent.ButtonClicked the UI model routes per provenance, #221) — and
+// every other key falls through, so the copy shortcut keeps working
+// whenever no surface consumes the key.
 func (t *baseToolMessageItem) HandleKeyEvent(key tea.KeyMsg) (bool, tea.Cmd) {
+	if handled, cmd := t.handleA2UIKeyEvent(key); handled {
+		return true, cmd
+	}
 	if k := key.String(); k == "c" || k == "y" {
 		text := t.formatToolForCopy()
 		return true, common.CopyToClipboard(text, "Tool content copied to clipboard")
 	}
 	return false, nil
+}
+
+// SetFocused implements MessageItem. Focus also drives the live MCP
+// surfaces (#219): gaining focus grants it to the first live surface,
+// losing focus blurs them all — so the focus ring only ever lives on the
+// selected item.
+func (t *baseToolMessageItem) SetFocused(focused bool) {
+	t.focusableMessageItem.SetFocused(focused)
+	if focused {
+		t.focusToolA2UISurfaces()
+	} else {
+		t.blurToolA2UISurfaces()
+	}
 }
 
 // pendingTool renders a tool that is still in progress with an animation.


### PR DESCRIPTION
Part of #217. Closes #219.

## What

Detects and renders A2UI payloads delivered over MCP — not just via `resources/read`, but also `tools/call` results that wrap the payload in an `EmbeddedResource` — identified by the `application/a2ui+json` MIME type (and the legacy `application/json+a2ui` spelling reference clients also accept).

## Changes

**Detection (`internal/agent/tools/mcp/tools.go`)**
- `RunTool`'s content extraction now pulls `EmbeddedResource` items whose MIME type is A2UI aside into `ToolResult.Surfaces`, instead of stringifying them into the model-facing text. Blob-delivered payloads are normalized to text. The resource's **audience annotation** is honored: an empty audience (or one containing `assistant`) stays visible to the model; an audience of `["user"]` alone renders for the user but is hidden from the LLM — per the spec's verbalization contract.
- `IsA2UIMIMEType` accepts both the canonical and legacy spellings.

**Diversion (`internal/agent/tools/mcp-tools.go`, `read_mcp_resource.go`)**
- `mcp_*` tools now divert surfaces to UI-only response metadata exactly like `read_mcp_resource`: the model gets a single-line placeholder (so it can't echo the JSON back and double-render), gated on the same "a chat UI will render this" rule (not a channel turn, A2UI not disabled, content width present). When not diverting, the payload folds back into the model-facing content — except `["user"]`-only payloads, which stay hidden.
- `read_mcp_resource` accepts the legacy MIME spelling too, and both paths now record **surface provenance** (which MCP server served each surface) in the metadata — the foundation for the action round-trip in #221.

**Rendering (`internal/ui/chat/`)**
- New shared `a2uiSurfaceHost` (`a2ui_surface_host.go`) holds the live a2tea surface models and their IDs, plus a process-wide `surfaceID → MCP server` provenance registry.
- Tool message items (`baseToolMessageItem`) now build **live, interactive** surface models from the result metadata (reused across re-renders so focus and edited values survive), bypass the render cache while live, and route focus + keys to them — the same interaction model as assistant-scanned surfaces (#44, #45), but **never retired on interaction** since MCP surfaces are long-lived app UIs. The generic and MCP tool renderers draw the live surfaces, falling back to the prior static snapshot for older persisted results.
- **Fallback**: a payload that fails to parse/render yields no live surface, so the renderer falls back to the result's `TextContent` plus the existing truncated/dropped-block alert styling — per spec best practice.

## Verification

- Unit tests for `extractToolResult` (text/image/audio/embedded extraction, audience handling, blob delivery, legacy MIME), `splitMCPToolResult` (diversion, provenance, non-divert fallback, user-only hiding), and the tool-item surface lifecycle (build, provenance registration, model reuse, malformed payload, live render).
- **End-to-end against the spec's recipe sample server**: reading `a2ui://recipe-form` returns `application/a2ui+json` (1621 bytes) and renders the form; calling `get_recipe_a2ui` returns `TextContent` + an `EmbeddedResource` (`application/a2ui+json`) and renders the card. A server returning both shows only the rendered surface; a non-parsing payload shows the text fallback.
- `go test ./...` green; `gofumpt` and `go vet` clean.

🤖 Posted on behalf of `@joestump` by [`claude-opus-5`](https://openrouter.ai/anthropic/claude-opus-5) using [Crush](https://github.com/charmbracelet/crush).
