### PR TITLE
docs(a2ui): teach the resource-read path + A2UI-over-MCP contract in the skill

### DIFF
--- a/internal/skills/builtin/a2ui/SKILL.md
+++ b/internal/skills/builtin/a2ui/SKILL.md
@@ -6,15 +6,30 @@ user-invocable: true
 
 # A2UI / a2tea Communication Guide
 
-Crush supports rendering rich, interactive terminal UI components embedded directly in your markdown responses using **a2tea** (a bridge to the [A2UI](https://a2ui.org) protocol).
+Crush renders rich, interactive terminal UI from **A2UI** (the [A2UI protocol](https://a2ui.org), via the a2tea bridge). A surface is a compact visual — a status card, an option list, a progress readout, a short form. Most replies should stay prose; reach for a surface only when the structure genuinely helps.
 
-You can emit an A2UI surface when a compact visual genuinely helps — such as a status card, an option list, a progress readout, or a form. Most of your replies should remain prose, but when a visual structure adds value, use A2UI.
+## Two delivery paths — pick the right one
 
-## Wire Format
+There are two ways an A2UI surface reaches the user. **Prefer reading an MCP resource when the data lives on a server**; emit inline JSON only for ad-hoc visuals no server provides.
 
-Embed a single inline `<a2ui-json>{...}</a2ui-json>` block in your response. Inside, provide an A2UI v0.9 payload containing an `updateComponents` message.
+### 1. Read an MCP `/a2ui` resource (preferred for server data)
 
-### Example Payload
+Servers that own data (a todo queue, a bundle, a trace, a dashboard) expose **A2UI resource templates** — URIs ending in `/a2ui` — that render their data as a surface. Read one with `read_mcp_resource`:
+
+```
+read_mcp_resource(mcp_name="todos", uri="todos://queue/<name>/a2ui")
+```
+
+What happens:
+- The host renders the surface for the **user** (audience `user`) and hands **you** a one-line placeholder, e.g. `[A2UI surface rendered in the chat UI from todos://queue/<name>/a2ui — the user can already see it; do not repeat or echo its JSON payload]`.
+- You do **not** receive the surface JSON. **Never re-echo, re-emit, or paraphrase the surface** — the user can already see it. Continue in prose.
+- Resource templates are listed by `list_mcp_resources`. A template with `{id}` is filled by you (e.g. `.../artifact/<id>/a2ui`); one with `{?w}` accepts an optional width hint the host manages — **do not** append `?w=` yourself.
+
+Use this path whenever a server offers an `/a2ui` view of its data. It is richer (server-rendered, sized to the host) and cheaper (no JSON through your context) than reconstructing the same view inline.
+
+### 2. Emit your own inline surface (ad-hoc visuals)
+
+For a visual no server provides, embed a single inline `<a2ui-json>{...}</a2ui-json>` block containing one `updateComponents` message:
 
 ```json
 <a2ui-json>{
@@ -22,121 +37,49 @@ Embed a single inline `<a2ui-json>{...}</a2ui-json>` block in your response. Ins
   "updateComponents": {
     "surfaceId": "s1",
     "components": [
-      {
-        "component": "Card",
-        "id": "root",
-        "child": "col"
-      },
-      {
-        "component": "Column",
-        "id": "col",
-        "children": ["title", "body", "btn-ok"]
-      },
-      {
-        "component": "Text",
-        "id": "title",
-        "variant": "h2",
-        "text": "Build passed"
-      },
-      {
-        "component": "Text",
-        "id": "body",
-        "text": "142 tests, 0 failures."
-      },
-      {
-        "component": "Button",
-        "id": "btn-ok",
-        "child": "btn-ok-label"
-      },
-      {
-        "component": "Text",
-        "id": "btn-ok-label",
-        "text": "Acknowledge"
-      }
+      {"component": "Card", "id": "root", "child": "col"},
+      {"component": "Column", "id": "col", "children": ["title", "body", "btn-ok"]},
+      {"component": "Text", "id": "title", "variant": "h2", "text": "Build passed"},
+      {"component": "Text", "id": "body", "text": "142 tests, 0 failures."},
+      {"component": "Button", "id": "btn-ok", "child": "btn-ok-label"},
+      {"component": "Text", "id": "btn-ok-label", "text": "Acknowledge"}
     ]
   }
 }</a2ui-json>
 ```
 
-## Component Architecture
+This is the **chat-scanned** path: the surface is part of your reply. Use it for summaries, dashboards, and one-shot forms you author yourself.
 
-A2UI components live in a flat list (adjacency list) and reference their children by `id`. The renderer resolves the tree from the root (the component that nothing else references as a child).
+## Component architecture
 
-### Core Catalog (Fully Supported)
+Components live in a **flat adjacency list** and reference children by `id`. The renderer resolves the tree from the root (the component nothing else references as a child).
 
-These components render beautifully with full styling and layout:
-- `Text`: Text display. Options: `text` (string), `variant` (h1-h5, caption).
-- `Card`: A rounded border container. Expects a single `child` ID.
-- `Column`: Lays out children vertically. Expects a `children` array of IDs.
-- `Row`: Lays out children horizontally. Expects a `children` array of IDs.
-- `List`: Lays out children as a list. Expects a `children` array of IDs.
-- `Divider`: A horizontal rule.
-- `Button`: Focusable button. Its label comes from a single `child` ID pointing at a `Text` component (there is no `label` field). When the user presses it, you receive a new message naming the pressed button and carrying the surface's current field values — a button whose id reads as a cancel (e.g. `btn-cancel`, `dismiss`, `close`) just dismisses the form instead.
+### Core catalog (fully supported)
 
-### Input Components (Editable)
+- `Text`: text display. Fields: `text` (string), `variant` (`h1`–`h5`, `caption`; omit for body).
+- `Card`: rounded-border container. Single `child` id.
+- `Column`: lays out `children` (array of ids) vertically.
+- `Row`: lays out `children` horizontally.
+- `List`: lays out `children` as a list (divider between rows).
+- `Divider`: a horizontal rule.
+- `Button`: focusable button. Its label is a single `child` id pointing at a `Text` component — there is **no** `label`/`text` field on `Button`. On press, the surface's current field values come back to you; a button whose id reads as cancel (`btn-cancel`, `dismiss`, `close`) just dismisses the form.
 
-These components render their current values and the user can edit them; their values (keyed by component `id`) are sent back to you when a button on the surface is pressed:
-- `TextField`
-- `CheckBox`
-- `ChoicePicker`
-- `Slider`
-- `DateTimeInput`
+### Input components (editable)
 
-### Media & Layout Placeholders
+Render their current value; the user can edit; values (keyed by component `id`) return when a button on the surface is pressed:
+- `TextField`, `CheckBox`, `ChoicePicker`, `Slider`, `DateTimeInput`
 
-- `Image`, `Icon`, `Video`, `AudioPlayer`: Render as compact one-line placeholders.
-- `Tabs`: Render the title bar and only the *first* tab's content.
-- `Modal`: Renders only its trigger, content stays hidden.
+### Media & layout placeholders
 
-## Best Practices
+- `Image`, `Icon`, `Video`, `AudioPlayer`: compact one-line placeholders.
+- `Tabs`: renders the title bar and only the *first* tab's content.
+- `Modal`: renders only its trigger; content stays hidden.
 
-1. **Keep it compact:** A2UI surfaces should be concise summaries, controls, or dashboards. Use standard markdown fences for code or long logs.
-2. **One surface per block:** Provide all components inside the `components` array of a single `updateComponents` message.
-3. **Link correctly:** Ensure every ID in `child` or `children` corresponds to a component in your array. Dangling IDs will break the render.
-4. **Mix with Markdown:** You can put markdown text before and after the `<a2ui-json>` block.
+## Forms (the submission loop)
 
-## Common Mistakes (Anti-Patterns)
+A form is a surface with input components plus a `Button`. When the user presses the button you receive a message naming the button and carrying the field values keyed by component `id`. A cancel-reading button dismisses without a submission.
 
-These are errors that models frequently make. Read carefully.
-
-### Buttons do NOT have a `text` or `label` field
-
-**NEVER put `text` or `label` on a `Button`** — the A2UI spec has **no** `text`, `label`, or `name` field on `Button` in any schema version. A button's label comes exclusively from its `child` ID pointing at a separate `Text` component. A stray `text`/`label` key is dropped at parse time and the button renders unlabeled.
-
-**Wrong — the label will be empty:**
-```json
-{
-  "component": "Button",
-  "id": "btn",
-  "text": "Submit"
-}
-```
-The `"text"` key is silently ignored and the button renders with no visible label.
-
-**Wrong — `label` is not a real field either:**
-```json
-{
-  "component": "Button",
-  "id": "btn",
-  "label": "Submit"
-}
-```
-
-**Correct — use a child Text component:**
-```json
-{
-  "component": "Button",
-  "id": "btn",
-  "child": "btn-label"
-},
-{
-  "component": "Text",
-  "id": "btn-label",
-  "text": "Submit"
-}
-```
-
-**Complete form template — copy this shape.** Two inputs and two buttons; note how *each* button gets its own child `Text` for its label:
+**Complete form template — copy this shape.** Two inputs, two buttons; each button gets its own child `Text` label:
 
 ```json
 <a2ui-json>{
@@ -158,51 +101,65 @@ The `"text"` key is silently ignored and the button renders with no visible labe
 }</a2ui-json>
 ```
 
-### Every `child` / `children` ID must exist in the components array
+## A2UI over MCP (the contract)
+
+When you build or reason about server-side surfaces, the A2UI-over-MCP contract (https://a2ui.org/guides/a2ui_over_mcp/) governs:
+
+- **MIME type** `application/a2ui+json` (legacy `application/json+a2ui`) identifies a surface, delivered by `resources/read` (an `/a2ui` resource) or by a `tools/call` result carrying an `EmbeddedResource` of that type.
+- **Audience**: a surface annotated `["user"]` renders for the human and its raw JSON is kept out of your context; `["assistant"]` is for your reasoning and is not rendered; empty means both.
+- **Interactivity round-trip**: a surface's `Button` carries an `action` = `{event: {name, context}}`. When the user clicks, the host calls the owning server's `a2ui_action` tool with `{name, context}` (data bindings resolved against surface state) and feeds any returned A2UI payload back into the **same** surface — no agent turn. Render failures go back via an `a2ui_error` tool call.
+- **Width hint**: a server may size pre-rendered geometry (e.g. a flame graph) to an optional `?w=N` hint the **host** appends. Never add `?w=` yourself; only templates declaring `{?w}` accept it.
+
+You normally only *consume* server surfaces (path 1). Build them only when you are authoring an MCP server.
+
+## Best practices
+
+1. **Keep it compact.** Surfaces are concise summaries, controls, or dashboards. Use fenced code blocks for code or long logs.
+2. **One surface per block.** All components inside the `components` array of a single `updateComponents` message.
+3. **Link correctly.** Every `child`/`children` id must exist in your array — a dangling id renders `[a2tea: missing component ...]`.
+4. **Mix with Markdown.** Prose before and after the `<a2ui-json>` block is fine.
+5. **Don't re-emit server surfaces.** If you read an `/a2ui` resource, the user already sees it — move on in prose.
+
+## Common mistakes (anti-patterns)
+
+### Buttons do NOT have a `text` or `label` field
+
+**NEVER put `text`/`label` on a `Button`** — the spec has no such field; the label comes only from a child `Text`. A stray key is dropped and the button renders unlabeled.
+
+**Wrong — the label will be empty:**
+```json
+{"component": "Button", "id": "btn", "text": "Submit"}
+```
+
+**Correct — a child Text component:**
+```json
+{"component": "Button", "id": "btn", "child": "btn-label"},
+{"component": "Text", "id": "btn-label", "text": "Submit"}
+```
+
+### Every `child` / `children` id must exist
 
 **Wrong — dangling reference:**
 ```json
-{
-  "component": "Card",
-  "id": "root",
-  "child": "missing-id"
-}
+{"component": "Card", "id": "root", "child": "missing-id"}
 ```
-There is no component with `id: "missing-id"` in the array, so the card renders `[a2tea: missing component "missing-id"]`.
-
-**Correct:** Always include a matching component for every referenced ID.
+No component `missing-id` exists, so the card renders `[a2tea: missing component "missing-id"]`. Always include a matching component for every referenced id.
 
 ### Do not nest components inline
 
-Components are a **flat list** (adjacency list). Do not embed component objects inside other components.
+Components are a **flat list**; `child` is a **string id**, not an object.
 
 **Wrong — inline nesting:**
 ```json
-{
-  "component": "Card",
-  "id": "root",
-  "child": {
-    "component": "Text",
-    "text": "Hello"
-  }
-}
+{"component": "Card", "id": "root", "child": {"component": "Text", "text": "Hello"}}
 ```
-The `child` field is a **string ID**, not an object. Inline nesting will break the parser.
 
-**Correct:** Define each component separately and link by ID:
+**Correct — define separately, link by id:**
 ```json
-{
-  "component": "Card",
-  "id": "root",
-  "child": "body"
-},
-{
-  "component": "Text",
-  "id": "body",
-  "text": "Hello"
-}
+{"component": "Card", "id": "root", "child": "body"},
+{"component": "Text", "id": "body", "text": "Hello"}
 ```
 
-### Do not put code in an A2UI surface
+### Do not put code in a surface
 
-A2UI surfaces are for compact visual structures. Use standard markdown fenced code blocks (`` ``` ``) for code snippets, command output, or logs. Do not try to render code inside a `Text` component — it will not syntax-highlight.
+A2UI surfaces are for compact visual structure. Use fenced code blocks (`` ``` ``) for code, command output, or logs — a `Text` component will not syntax-highlight.


### PR DESCRIPTION
## Why

The builtin a2ui skill predates everything we learned shipping A2UI-over-MCP (server-provided `/a2ui` resource surfaces, the `{?w}` width-hint, the `a2ui_action` round-trip). It only documented the inline `<a2ui-json>` path, so the model never learned to prefer reading a server's `/a2ui` resource for server-owned data — or that it must not re-echo a rendered surface.

## What changed (body only — frontmatter untouched)

- **Lead with the two delivery paths, prefer the richer one.** Path 1: read an MCP `/a2ui` resource template (`read_mcp_resource`) for server data — the host renders it for the user (audience `user`) and hands the model a one-line placeholder, so **never re-echo/re-emit** the surface; `list_mcp_resources` discovers templates, `{id}` is model-filled, `{?w}` is host-managed (don't append `?w=`). Path 2: emit inline `<a2ui-json>` only for ad-hoc visuals no server provides.
- **New "A2UI over MCP (the contract)" section**: MIME types, audience semantics, the `a2ui_action`/`a2ui_error` round-trip, and the host-managed `?w=` width hint.
- Tightened component catalog + forms loop; kept the anti-patterns (Button child-Text, no dangling refs, flat adjacency, no code in surfaces).

## Constraint honored (VCR cassettes)

The frontmatter `description` is **byte-identical** to the original. The system prompt embeds the `<available_skills>` catalog (with descriptions) in the request body that `TestCoderAgent`'s VCR cassettes match exactly — a description edit invalidates them and a live provider key is required to re-record. Only the skill *body* changed, which is loaded on demand and not baked into the cassettes.

## Tests

- `TestA2UISkillExampleRenders` (golden): PASS — the kept example still renders (Button labeled via child Text, "Acknowledge" + "Build passed").
- `TestCoderAgent` (VCR): PASS — cassettes still match (description unchanged).

## Follow-up (separate issue)

Improving the `<a2ui>` **system-prompt section** in `coder.md.tpl` (same guidance, terser) is staged but NOT in this PR — it changes the request body and requires re-recording the `TestCoderAgent` cassettes with live credentials. Tracked separately.
