### PR TITLE
feat(mcp): route A2UI surface interactions back as a2ui_action calls

### DIFF
--- a/internal/agent/tools/mcp/tools.go
+++ b/internal/agent/tools/mcp/tools.go
@@ -65,6 +65,31 @@ func Tools() iter.Seq2[string, []*Tool] {
 	return allTools.Seq2()
 }
 
+// HasTool reports whether the named MCP server currently exposes a tool with
+// the given name. It backs the A2UI action round-trip: a server that serves
+// interactive surfaces may also expose the a2ui_action / a2ui_error tools
+// the client round-trips interactions through, and the client needs to know
+// before it commits to that path.
+func HasTool(name, toolName string) bool {
+	tools, ok := allTools.Get(name)
+	if !ok {
+		return false
+	}
+	return slices.ContainsFunc(tools, func(t *Tool) bool { return t.Name == toolName })
+}
+
+// SetToolsForTest installs the given tool names for an MCP server in the
+// shared registry and returns a cleanup that removes them. It exists for
+// tests outside this package that need HasTool to observe a server's tools.
+func SetToolsForTest(name string, toolNames ...string) func() {
+	tools := make([]*Tool, len(toolNames))
+	for i, n := range toolNames {
+		tools[i] = &Tool{Name: n}
+	}
+	allTools.Set(name, tools)
+	return func() { allTools.Del(name) }
+}
+
 // RunTool runs an MCP tool with the given input parameters.
 func RunTool(ctx context.Context, cfg *config.ConfigStore, name, toolName string, input string) (ToolResult, error) {
 	var args map[string]any

--- a/internal/backend/config.go
+++ b/internal/backend/config.go
@@ -2,6 +2,7 @@ package backend
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -36,6 +37,19 @@ type MCPResourceContents struct {
 	MIMEType string `json:"mime_type,omitempty"`
 	Text     string `json:"text,omitempty"`
 	Blob     []byte `json:"blob,omitempty"`
+}
+
+// MCPToolCallResult holds the model-facing text and any A2UI surface
+// payloads from an MCP tool call.
+type MCPToolCallResult struct {
+	Content  string               `json:"content"`
+	Surfaces []MCPToolCallSurface `json:"surfaces,omitempty"`
+}
+
+// MCPToolCallSurface is a single A2UI surface payload from a tool call.
+type MCPToolCallSurface struct {
+	Payload string `json:"payload"`
+	URI     string `json:"uri"`
 }
 
 // SetConfigField sets a key/value pair in the config file for the
@@ -321,6 +335,28 @@ func (b *Backend) ReadMCPResource(ctx context.Context, workspaceID, name, uri st
 		}
 	}
 	return result, nil
+}
+
+// CallMCPTool invokes a tool on a named MCP server and returns its text
+// content plus any A2UI surface payload it embedded.
+func (b *Backend) CallMCPTool(ctx context.Context, workspaceID, name, toolName string, args map[string]any) (MCPToolCallResult, error) {
+	ws, err := b.GetWorkspace(workspaceID)
+	if err != nil {
+		return MCPToolCallResult{}, err
+	}
+	input, err := json.Marshal(args)
+	if err != nil {
+		return MCPToolCallResult{}, fmt.Errorf("failed to encode tool arguments: %w", err)
+	}
+	res, err := mcptools.RunTool(ctx, ws.Cfg, name, toolName, string(input))
+	if err != nil {
+		return MCPToolCallResult{}, err
+	}
+	out := MCPToolCallResult{Content: res.Content}
+	for _, s := range res.Surfaces {
+		out.Surfaces = append(out.Surfaces, MCPToolCallSurface{Payload: s.Payload, URI: s.URI})
+	}
+	return out, nil
 }
 
 // GetMCPPrompt retrieves a prompt from a named MCP server.

--- a/internal/client/config.go
+++ b/internal/client/config.go
@@ -291,6 +291,19 @@ type MCPResourceContents struct {
 	Blob     []byte `json:"blob,omitempty"`
 }
 
+// MCPToolCallResult holds the model-facing text and any A2UI surface
+// payloads from an MCP tool call.
+type MCPToolCallResult struct {
+	Content  string               `json:"content"`
+	Surfaces []MCPToolCallSurface `json:"surfaces,omitempty"`
+}
+
+// MCPToolCallSurface is a single A2UI surface payload from a tool call.
+type MCPToolCallSurface struct {
+	Payload string `json:"payload"`
+	URI     string `json:"uri"`
+}
+
 // EnableDockerMCP enables the Docker MCP server on the workspace.
 func (c *Client) EnableDockerMCP(ctx context.Context, id string) error {
 	rsp, err := c.post(ctx, fmt.Sprintf("/workspaces/%s/mcp/docker/enable", id), nil, nil, nil)
@@ -365,6 +378,27 @@ func (c *Client) ReadMCPResource(ctx context.Context, id, name, uri string) ([]M
 		return nil, fmt.Errorf("failed to decode MCP resource: %w", err)
 	}
 	return contents, nil
+}
+
+// CallMCPTool calls a tool on a named MCP server.
+func (c *Client) CallMCPTool(ctx context.Context, id, name, toolName string, args map[string]any) (MCPToolCallResult, error) {
+	rsp, err := c.post(ctx, fmt.Sprintf("/workspaces/%s/mcp/call-tool", id), nil, jsonBody(struct {
+		Name     string         `json:"name"`
+		ToolName string         `json:"tool_name"`
+		Args     map[string]any `json:"args"`
+	}{Name: name, ToolName: toolName, Args: args}), http.Header{"Content-Type": []string{"application/json"}})
+	if err != nil {
+		return MCPToolCallResult{}, fmt.Errorf("failed to call MCP tool: %w", err)
+	}
+	defer rsp.Body.Close()
+	if rsp.StatusCode != http.StatusOK {
+		return MCPToolCallResult{}, fmt.Errorf("failed to call MCP tool: status code %d", rsp.StatusCode)
+	}
+	var result MCPToolCallResult
+	if err := json.NewDecoder(rsp.Body).Decode(&result); err != nil {
+		return MCPToolCallResult{}, fmt.Errorf("failed to decode MCP tool result: %w", err)
+	}
+	return result, nil
 }
 
 // GetMCPPrompt retrieves a prompt from a named MCP server.

--- a/internal/proto/requests.go
+++ b/internal/proto/requests.go
@@ -124,6 +124,13 @@ type MCPReadResourceRequest struct {
 	URI  string `json:"uri"`
 }
 
+// MCPCallToolRequest represents a request to call a tool on an MCP server.
+type MCPCallToolRequest struct {
+	Name     string         `json:"name"`
+	ToolName string         `json:"tool_name"`
+	Args     map[string]any `json:"args"`
+}
+
 // MCPGetPromptRequest represents a request to get an MCP prompt.
 type MCPGetPromptRequest struct {
 	ClientID string            `json:"client_id"`

--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -479,7 +479,19 @@ func (c *controllerV1) handlePostWorkspaceMCPReadResource(w http.ResponseWriter,
 	jsonEncode(w, contents)
 }
 
-// handlePostWorkspaceMCPCallTool calls a tool on an MCP server.
+// a2uiCallableTools is the allow-list this route will invoke. The route
+// exists solely for the A2UI surface round-trip, which is not gated on the
+// agent's permission system (a button press is its own consent). Accepting an
+// arbitrary tool name here would turn it into remote execution of any tool on
+// any configured MCP server — file writes, shell-backed tools, network calls —
+// with no permission prompt at all.
+var a2uiCallableTools = map[string]bool{
+	"a2ui_action": true,
+	"a2ui_error":  true,
+}
+
+// handlePostWorkspaceMCPCallTool calls a tool on an MCP server. Only the A2UI
+// round-trip tools are callable; see [a2uiCallableTools].
 //
 //	@Summary		Call MCP tool
 //	@Tags			mcp
@@ -489,6 +501,7 @@ func (c *controllerV1) handlePostWorkspaceMCPReadResource(w http.ResponseWriter,
 //	@Param			request	body		proto.MCPCallToolRequest	true	"MCP call tool request"
 //	@Success		200		{object}	object
 //	@Failure		400		{object}	proto.Error
+//	@Failure		403		{object}	proto.Error
 //	@Failure		404		{object}	proto.Error
 //	@Failure		500		{object}	proto.Error
 //	@Router			/workspaces/{id}/mcp/call-tool [post]
@@ -499,6 +512,12 @@ func (c *controllerV1) handlePostWorkspaceMCPCallTool(w http.ResponseWriter, r *
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		c.server.logError(r, "Failed to decode request", "error", err)
 		jsonError(w, http.StatusBadRequest, "failed to decode request")
+		return
+	}
+
+	if !a2uiCallableTools[req.ToolName] {
+		c.server.logError(r, "Rejected non-A2UI MCP tool call", "tool", req.ToolName)
+		jsonError(w, http.StatusForbidden, "only the A2UI round-trip tools may be called over this route")
 		return
 	}
 

--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -479,6 +479,37 @@ func (c *controllerV1) handlePostWorkspaceMCPReadResource(w http.ResponseWriter,
 	jsonEncode(w, contents)
 }
 
+// handlePostWorkspaceMCPCallTool calls a tool on an MCP server.
+//
+//	@Summary		Call MCP tool
+//	@Tags			mcp
+//	@Accept			json
+//	@Produce		json
+//	@Param			id		path		string					true	"Workspace ID"
+//	@Param			request	body		proto.MCPCallToolRequest	true	"MCP call tool request"
+//	@Success		200		{object}	object
+//	@Failure		400		{object}	proto.Error
+//	@Failure		404		{object}	proto.Error
+//	@Failure		500		{object}	proto.Error
+//	@Router			/workspaces/{id}/mcp/call-tool [post]
+func (c *controllerV1) handlePostWorkspaceMCPCallTool(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+
+	var req proto.MCPCallToolRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		c.server.logError(r, "Failed to decode request", "error", err)
+		jsonError(w, http.StatusBadRequest, "failed to decode request")
+		return
+	}
+
+	result, err := c.backend.CallMCPTool(r.Context(), id, req.Name, req.ToolName, req.Args)
+	if err != nil {
+		c.handleError(w, r, err)
+		return
+	}
+	jsonEncode(w, result)
+}
+
 // handlePostWorkspaceMCPGetPrompt retrieves a prompt from an MCP server.
 //
 //	@Summary		Get MCP prompt

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -207,6 +207,7 @@ func (s *Server) installHandler() {
 	mux.HandleFunc("POST /v1/workspaces/{id}/config/reload-discovery", c.handlePostWorkspaceConfigReloadDiscovery)
 	mux.HandleFunc("POST /v1/workspaces/{id}/mcp/refresh-tools", c.handlePostWorkspaceMCPRefreshTools)
 	mux.HandleFunc("POST /v1/workspaces/{id}/mcp/read-resource", c.handlePostWorkspaceMCPReadResource)
+	mux.HandleFunc("POST /v1/workspaces/{id}/mcp/call-tool", c.handlePostWorkspaceMCPCallTool)
 	mux.HandleFunc("POST /v1/workspaces/{id}/mcp/get-prompt", c.handlePostWorkspaceMCPGetPrompt)
 	mux.HandleFunc("GET /v1/workspaces/{id}/mcp/states", c.handleGetWorkspaceMCPStates)
 	mux.HandleFunc("POST /v1/workspaces/{id}/mcp/refresh-prompts", c.handlePostWorkspaceMCPRefreshPrompts)

--- a/internal/ui/chat/a2ui.go
+++ b/internal/ui/chat/a2ui.go
@@ -731,6 +731,24 @@ func a2uiPartSurfaceID(msgs []a2ui.ServerMessage) string {
 	return ""
 }
 
+// A2UIMessagesFromPayload converts a raw A2UI JSON payload (the body of an
+// MCP-served surface) into the server messages it encodes, so a follow-up
+// payload can be applied to a live surface. The payload is wrapped in the
+// wire tags before scanning because a2tea's scanner treats a bare JSON array
+// of messages as several separate bare objects; the tags make it one block.
+// An error means the payload could not be parsed at all.
+func A2UIMessagesFromPayload(payload string) ([]a2ui.ServerMessage, error) {
+	parts, err := a2tea.Scan(a2uiOpenTag + payload + a2uiCloseTag)
+	if err != nil {
+		return nil, err
+	}
+	var msgs []a2ui.ServerMessage
+	for _, p := range parts {
+		msgs = append(msgs, p.Messages...)
+	}
+	return msgs, nil
+}
+
 // a2uiSurfaceRetired reports whether the surface at part-index i has been
 // retired after a submission (#45). Retired surfaces still render (showing
 // their final state) but no longer receive focus or keys.

--- a/internal/ui/chat/a2ui.go
+++ b/internal/ui/chat/a2ui.go
@@ -749,6 +749,39 @@ func A2UIMessagesFromPayload(payload string) ([]a2ui.ServerMessage, error) {
 	return msgs, nil
 }
 
+// A2UIMessagesSurfaceID reports the surface a batch of server messages
+// targets — the first surfaceId any of them names, whichever payload field
+// carries it. A response to an a2ui_action may update a sibling surface
+// rather than the clicked one, so the payload's own target wins over the
+// surface the interaction came from. Empty means the batch names none.
+func A2UIMessagesSurfaceID(msgs []a2ui.ServerMessage) string {
+	for _, m := range msgs {
+		switch {
+		case m.UpdateComponents != nil:
+			return m.UpdateComponents.SurfaceID
+		case m.CreateSurface != nil:
+			return m.CreateSurface.SurfaceID
+		case m.DeleteSurface != nil:
+			return m.DeleteSurface.SurfaceID
+		case m.UpdateDataModel != nil:
+			return m.UpdateDataModel.SurfaceID
+		}
+	}
+	return ""
+}
+
+// A2UIMessagesDeleteSurface reports whether a batch of server messages
+// deletes a surface. A delete that lands on a surface already gone is the
+// expected end of its life, not a mismatch worth reporting to the server.
+func A2UIMessagesDeleteSurface(msgs []a2ui.ServerMessage) bool {
+	for _, m := range msgs {
+		if m.DeleteSurface != nil {
+			return true
+		}
+	}
+	return false
+}
+
 // a2uiSurfaceRetired reports whether the surface at part-index i has been
 // retired after a submission (#45). Retired surfaces still render (showing
 // their final state) but no longer receive focus or keys.

--- a/internal/ui/chat/a2ui_surface_host.go
+++ b/internal/ui/chat/a2ui_surface_host.go
@@ -28,8 +28,33 @@ type a2uiSurfaceHost struct {
 	// part has no renderable surface), so a ButtonClicked event's
 	// SurfaceID can be routed back to the model that emitted it.
 	surfaceIDs []string
+	// surfaceOwners holds the MCP server that served each entry (empty for
+	// chat-scanned surfaces). It is the item-scoped provenance the action
+	// round-trip resolves through, so two servers using the same surface ID
+	// cannot route each other's clicks.
+	surfaceOwners []string
 	// sty themes the surfaces with the crush palette.
 	sty *styles.Styles
+}
+
+// ownerFor returns the MCP server that served the surface at index i, and
+// whether one is known.
+func (h *a2uiSurfaceHost) ownerFor(i int) (string, bool) {
+	if i < 0 || i >= len(h.surfaceOwners) {
+		return "", false
+	}
+	name := h.surfaceOwners[i]
+	return name, name != ""
+}
+
+// drop releases the surface at index i, which the server deleted. The entry
+// is kept (indexes stay parallel to surfaceIDs) but nils out, so hasLive and
+// findByID stop reporting it and it can no longer take focus or keys.
+func (h *a2uiSurfaceHost) drop(i int) {
+	if i < 0 || i >= len(h.surfaces) {
+		return
+	}
+	h.surfaces[i] = nil
 }
 
 // buildSurfaces renders each part's messages into a live a2tea model,

--- a/internal/ui/chat/tool_a2ui.go
+++ b/internal/ui/chat/tool_a2ui.go
@@ -8,6 +8,7 @@ import (
 	"github.com/charmbracelet/crush/internal/agent/tools"
 	"github.com/joestump-agent/a2tea"
 	"github.com/joestump-agent/a2tea/render"
+	a2ui "github.com/tmc/a2ui"
 )
 
 // syncToolA2UISurfaces builds — or reuses — the live a2tea models for the
@@ -76,9 +77,63 @@ func (t *baseToolMessageItem) syncToolA2UISurfaces() {
 	}
 }
 
+// A2UISurfaceItem is implemented by message items that hold live MCP A2UI
+// surfaces (tool message items carrying an MCP-served payload). It lets the
+// UI model locate a surface by ID, read its input values for an a2ui_action
+// context, and feed a server's response back into the surface.
+type A2UISurfaceItem interface {
+	// HasA2UISurface reports whether the item holds the named surface.
+	HasA2UISurface(surfaceID string) bool
+	// ToolA2UIFieldValues reads the named surface's current input values.
+	ToolA2UIFieldValues(surfaceID string) map[string]any
+	// ApplyToolA2UIUpdate feeds server messages back into the named
+	// surface, reporting whether it still has renderable state.
+	ApplyToolA2UIUpdate(surfaceID string, msgs []a2ui.ServerMessage) bool
+}
+
 // hasToolA2UISurfaces reports whether this item carries live MCP surfaces.
 func (t *baseToolMessageItem) hasToolA2UISurfaces() bool {
 	return t.a2ui.hasLive()
+}
+
+// HasA2UISurface reports whether this item holds the named surface.
+func (t *baseToolMessageItem) HasA2UISurface(surfaceID string) bool {
+	return t.a2ui.findByID(surfaceID) >= 0
+}
+
+// toolA2UISurfaceByID returns the live surface model with the given A2UI
+// surface ID, or nil when this item does not hold it.
+func (t *baseToolMessageItem) toolA2UISurfaceByID(surfaceID string) render.Model {
+	idx := t.a2ui.findByID(surfaceID)
+	return t.a2ui.surfaceAt(idx)
+}
+
+// ToolA2UIFieldValues reads the named surface's current input values, for
+// building an a2ui_action context.
+func (t *baseToolMessageItem) ToolA2UIFieldValues(surfaceID string) map[string]any {
+	idx := t.a2ui.findByID(surfaceID)
+	return t.a2ui.fieldValues(idx)
+}
+
+// ApplyToolA2UIUpdate feeds a batch of A2UI server messages back into the
+// named surface (the response to an a2ui_action round-trip): the surface
+// updates in place rather than being replaced, preserving focus and edited
+// state the server did not touch. It reports whether the surface still has
+// renderable state afterward (false means the server deleted it).
+func (t *baseToolMessageItem) ApplyToolA2UIUpdate(surfaceID string, msgs []a2ui.ServerMessage) bool {
+	s := t.toolA2UISurfaceByID(surfaceID)
+	if s == nil {
+		return false
+	}
+	applier, ok := s.(interface {
+		Apply([]a2ui.ServerMessage) bool
+	})
+	if !ok {
+		return false
+	}
+	alive := applier.Apply(msgs)
+	t.Bump()
+	return alive
 }
 
 // focusToolA2UISurfaces grants focus to the first live surface and blurs the

--- a/internal/ui/chat/tool_a2ui.go
+++ b/internal/ui/chat/tool_a2ui.go
@@ -21,6 +21,7 @@ func (t *baseToolMessageItem) syncToolA2UISurfaces() {
 	if t.result == nil || t.result.Metadata == "" {
 		t.a2ui.surfaces = nil
 		t.a2ui.surfaceIDs = nil
+		t.a2ui.surfaceOwners = nil
 		t.surfaceScanned = false
 		return
 	}
@@ -28,6 +29,7 @@ func (t *baseToolMessageItem) syncToolA2UISurfaces() {
 	if err := json.Unmarshal([]byte(t.result.Metadata), &meta); err != nil || len(meta.A2UISurfaces) == 0 {
 		t.a2ui.surfaces = nil
 		t.a2ui.surfaceIDs = nil
+		t.a2ui.surfaceOwners = nil
 		t.surfaceScanned = false
 		return
 	}
@@ -37,6 +39,7 @@ func (t *baseToolMessageItem) syncToolA2UISurfaces() {
 	}
 	var surfaces []render.Model
 	var ids []string
+	var owners []string
 	failed := 0
 	for i, surfJSON := range meta.A2UISurfaces {
 		parts, err := a2tea.Scan(surfJSON)
@@ -55,10 +58,17 @@ func (t *baseToolMessageItem) syncToolA2UISurfaces() {
 			id := builtIDs[j]
 			ids = append(ids, id)
 			// Provenance is parallel to A2UISurfaces; a missing or short
-			// slice (older persisted results) means unknown origin.
+			// slice (older persisted results) means unknown origin. It is
+			// recorded per surface on the item — the round-trip resolves
+			// through that, so two servers sharing a surface ID stay
+			// distinct — and mirrored into the global registry for callers
+			// that only hold an ID.
+			owner := ""
 			if i < len(meta.MCPSurfaceProvenance) {
-				registerA2UISurfaceProvenance(id, meta.MCPSurfaceProvenance[i])
+				owner = meta.MCPSurfaceProvenance[i]
+				registerA2UISurfaceProvenance(id, owner)
 			}
+			owners = append(owners, owner)
 		}
 		// A payload that scanned but drew nothing (unsupported components,
 		// bare data-model update) failed just like a scan error: the model
@@ -69,6 +79,7 @@ func (t *baseToolMessageItem) syncToolA2UISurfaces() {
 	}
 	t.a2ui.surfaces = surfaces
 	t.a2ui.surfaceIDs = ids
+	t.a2ui.surfaceOwners = owners
 	t.surfaceBuildFailed = failed
 	t.surfaceSrcHash = h
 	t.surfaceScanned = true
@@ -84,6 +95,14 @@ func (t *baseToolMessageItem) syncToolA2UISurfaces() {
 type A2UISurfaceItem interface {
 	// HasA2UISurface reports whether the item holds the named surface.
 	HasA2UISurface(surfaceID string) bool
+	// A2UISurfaceIsFocused reports whether the item holds the named surface
+	// AND that surface currently has keyboard focus. Surface IDs are only
+	// unique within a server, so two items can hold the same ID; the
+	// focused one is the one the user is actually interacting with.
+	A2UISurfaceIsFocused(surfaceID string) bool
+	// A2UISurfaceOwner returns the MCP server that served the named
+	// surface, and whether one is known.
+	A2UISurfaceOwner(surfaceID string) (string, bool)
 	// ToolA2UIFieldValues reads the named surface's current input values.
 	ToolA2UIFieldValues(surfaceID string) map[string]any
 	// ApplyToolA2UIUpdate feeds server messages back into the named
@@ -101,11 +120,16 @@ func (t *baseToolMessageItem) HasA2UISurface(surfaceID string) bool {
 	return t.a2ui.findByID(surfaceID) >= 0
 }
 
-// toolA2UISurfaceByID returns the live surface model with the given A2UI
-// surface ID, or nil when this item does not hold it.
-func (t *baseToolMessageItem) toolA2UISurfaceByID(surfaceID string) render.Model {
+// A2UISurfaceIsFocused reports whether this item holds the named surface and
+// that surface currently has keyboard focus.
+func (t *baseToolMessageItem) A2UISurfaceIsFocused(surfaceID string) bool {
 	idx := t.a2ui.findByID(surfaceID)
-	return t.a2ui.surfaceAt(idx)
+	return idx >= 0 && idx == t.a2ui.focusedIndex()
+}
+
+// A2UISurfaceOwner returns the MCP server that served the named surface.
+func (t *baseToolMessageItem) A2UISurfaceOwner(surfaceID string) (string, bool) {
+	return t.a2ui.ownerFor(t.a2ui.findByID(surfaceID))
 }
 
 // ToolA2UIFieldValues reads the named surface's current input values, for
@@ -121,7 +145,8 @@ func (t *baseToolMessageItem) ToolA2UIFieldValues(surfaceID string) map[string]a
 // state the server did not touch. It reports whether the surface still has
 // renderable state afterward (false means the server deleted it).
 func (t *baseToolMessageItem) ApplyToolA2UIUpdate(surfaceID string, msgs []a2ui.ServerMessage) bool {
-	s := t.toolA2UISurfaceByID(surfaceID)
+	idx := t.a2ui.findByID(surfaceID)
+	s := t.a2ui.surfaceAt(idx)
 	if s == nil {
 		return false
 	}
@@ -132,6 +157,15 @@ func (t *baseToolMessageItem) ApplyToolA2UIUpdate(surfaceID string, msgs []a2ui.
 		return false
 	}
 	alive := applier.Apply(msgs)
+	if !alive {
+		// The server deleted the surface. Release the model so it stops
+		// claiming focus and swallowing keys for something that draws
+		// nothing, and re-focus whatever is left.
+		t.a2ui.drop(idx)
+		if t.isFocused() {
+			t.focusToolA2UISurfaces()
+		}
+	}
 	t.Bump()
 	return alive
 }

--- a/internal/ui/model/a2ui_action_test.go
+++ b/internal/ui/model/a2ui_action_test.go
@@ -34,12 +34,16 @@ type a2uiActionWorkspace struct {
 	response workspace.MCPToolCallResult
 	// err is returned from CallMCPTool when set.
 	err error
+	// lastPrompt records the content of the most recent AgentRun, so the
+	// fallback path's submission prompt can be asserted on.
+	lastPrompt string
 }
 
 func (w *a2uiActionWorkspace) AgentIsReady() bool     { return true }
 func (w *a2uiActionWorkspace) Config() *config.Config { return nil }
 
-func (w *a2uiActionWorkspace) AgentRun(_ context.Context, _, _ string, _ ...message.Attachment) error {
+func (w *a2uiActionWorkspace) AgentRun(_ context.Context, _, content string, _ ...message.Attachment) error {
+	w.lastPrompt = content
 	return nil
 }
 
@@ -62,6 +66,14 @@ const a2uiActionForm = `{"version":"v0.9","updateComponents":{"surfaceId":"booki
 // newA2UIActionUI builds a UI whose chat holds a tool message item carrying
 // an MCP-served A2UI surface with provenance registered to mcpName.
 func newA2UIActionUI(t *testing.T, ws *a2uiActionWorkspace, mcpName string) *UI {
+	t.Helper()
+	m, _ := newA2UIActionUIItem(t, ws, mcpName)
+	return m
+}
+
+// newA2UIActionUIItem is newA2UIActionUI, also handing back the tool item so
+// a test can assert on what the surface actually renders.
+func newA2UIActionUIItem(t *testing.T, ws *a2uiActionWorkspace, mcpName string) (*UI, chat.ToolMessageItem) {
 	t.Helper()
 	com := common.DefaultCommon(ws)
 	m := &UI{
@@ -96,17 +108,21 @@ func newA2UIActionUI(t *testing.T, ws *a2uiActionWorkspace, mcpName string) *UI 
 	// Render once so the item builds its live surface models and registers
 	// provenance.
 	_ = item.RawRender(100)
-	return m
+	return m, item
 }
 
 func TestHandleA2UIButtonClickedMCPSurfaceRoundTrips(t *testing.T) {
 	t.Parallel()
 
+	// The MCP tool registry is process-global; a per-test server name keeps
+	// parallel tests from overwriting each other's capabilities.
+	srv := t.Name()
+
 	ws := &a2uiActionWorkspace{
 		response: workspace.MCPToolCallResult{Content: "Booking confirmed"},
 	}
-	m := newA2UIActionUI(t, ws, "recipe")
-	cleanup := mcptools.SetToolsForTest("recipe", "a2ui_action")
+	m := newA2UIActionUI(t, ws, srv)
+	cleanup := mcptools.SetToolsForTest(srv, "a2ui_action")
 	t.Cleanup(cleanup)
 
 	cmd := m.handleA2UIButtonClicked(event.ButtonClicked{
@@ -124,7 +140,7 @@ func TestHandleA2UIButtonClickedMCPSurfaceRoundTrips(t *testing.T) {
 	// The server got the action name and the surface's field values as the
 	// context.
 	require.Len(t, ws.toolCalls, 1)
-	require.Equal(t, [2]string{"recipe", "a2ui_action"}, ws.toolCalls[0])
+	require.Equal(t, [2]string{srv, "a2ui_action"}, ws.toolCalls[0])
 	require.Equal(t, "confirm_booking", ws.lastArgs["name"])
 	ctx, ok := ws.lastArgs["context"].(map[string]any)
 	require.True(t, ok)
@@ -138,10 +154,14 @@ func TestHandleA2UIButtonClickedMCPSurfaceRoundTrips(t *testing.T) {
 func TestHandleA2UIButtonClickedMCPSurfaceWithoutActionToolFallsBack(t *testing.T) {
 	t.Parallel()
 
+	// The MCP tool registry is process-global; a per-test server name keeps
+	// parallel tests from overwriting each other's capabilities.
+	srv := t.Name()
+
 	ws := &a2uiActionWorkspace{}
-	m := newA2UIActionUI(t, ws, "recipe")
+	m := newA2UIActionUI(t, ws, srv)
 	// Server serves surfaces but NOT a2ui_action.
-	cleanup := mcptools.SetToolsForTest("recipe", "some_other_tool")
+	cleanup := mcptools.SetToolsForTest(srv, "some_other_tool")
 	t.Cleanup(cleanup)
 
 	cmd := m.handleA2UIButtonClicked(event.ButtonClicked{
@@ -153,40 +173,155 @@ func TestHandleA2UIButtonClickedMCPSurfaceWithoutActionToolFallsBack(t *testing.
 	runCmdTree(cmd)
 
 	require.Empty(t, ws.toolCalls, "no a2ui_action call without the tool")
+
+	// The prompt must carry what the user typed. RetireA2UISurface only
+	// matches assistant items, so an MCP surface's values have to come from
+	// the tool item that holds them — otherwise the whole form is silently
+	// dropped before the agent ever sees it.
+	require.Contains(t, ws.lastPrompt, "2026-03-20",
+		"the fallback submission must carry the surface's field values")
+	require.Contains(t, ws.lastPrompt, "confirm_booking")
 }
 
 func TestHandleA2UIActionResultAppliesSurfacePayload(t *testing.T) {
 	t.Parallel()
 
+	// The MCP tool registry is process-global; a per-test server name keeps
+	// parallel tests from overwriting each other's capabilities.
+	srv := t.Name()
+
 	ws := &a2uiActionWorkspace{}
-	m := newA2UIActionUI(t, ws, "recipe")
-	cleanup := mcptools.SetToolsForTest("recipe", "a2ui_action")
+	m, item := newA2UIActionUIItem(t, ws, srv)
+	cleanup := mcptools.SetToolsForTest(srv, "a2ui_action")
 	t.Cleanup(cleanup)
+
+	require.Contains(t, item.RawRender(100), "Confirm", "precondition: the original label renders")
 
 	// A response carrying an A2UI payload updates the surface in place.
 	update := `{"version":"v0.9","updateComponents":{"surfaceId":"booking","components":[` +
 		`{"component":"Text","id":"btn-confirm-t","text":"Booked!"}]}}`
 	cmd := m.handleA2UIActionResult(a2uiActionResultMsg{
 		surfaceID: "booking",
-		mcpName:   "recipe",
+		mcpName:   srv,
 		surfaces:  []string{update},
 	})
 	require.Nil(t, cmd)
 
-	// The surface still exists after the in-place update.
-	_, found := m.chat.A2UISurfaceFieldValues("booking")
+	// The update actually reached the live surface — not just "no error".
+	rendered := item.RawRender(100)
+	require.Contains(t, rendered, "Booked!", "the payload must update the surface in place")
+	require.NotContains(t, rendered, "Confirm", "the old label must be replaced")
+
+	// The surface still exists after the in-place update, and the edited
+	// field the server did not touch is preserved.
+	values, found := m.chat.A2UISurfaceFieldValues("booking")
 	require.True(t, found)
+	require.Equal(t, "2026-03-20", values["start"], "untouched field values must survive")
+}
+
+func TestHandleA2UIActionResultInvalidPayloadReportsToServer(t *testing.T) {
+	t.Parallel()
+
+	// The MCP tool registry is process-global; a per-test server name keeps
+	// parallel tests from overwriting each other's capabilities.
+	srv := t.Name()
+
+	ws := &a2uiActionWorkspace{}
+	m := newA2UIActionUI(t, ws, srv)
+	cleanup := mcptools.SetToolsForTest(srv, "a2ui_action", "a2ui_error")
+	t.Cleanup(cleanup)
+
+	// A malformed payload must round-trip an a2ui_error back to the server:
+	// the command reportA2UIError builds has to actually reach Bubble Tea.
+	cmd := m.handleA2UIActionResult(a2uiActionResultMsg{
+		surfaceID: "booking",
+		mcpName:   srv,
+		surfaces:  []string{`{"version":"v0.9","updateComponents":{`},
+	})
+	require.NotNil(t, cmd, "a malformed payload must produce an a2ui_error command")
+	runCmdTree(cmd)
+
+	require.Len(t, ws.toolCalls, 1)
+	require.Equal(t, [2]string{srv, "a2ui_error"}, ws.toolCalls[0])
+	// Truncated JSON scans as prose rather than failing outright, so it
+	// lands as INVALID_PAYLOAD (parsed, but no server messages) rather than
+	// INVALID_JSON. Either way it must not be a silent no-op.
+	require.Equal(t, "INVALID_PAYLOAD", ws.lastArgs["code"])
+	require.Equal(t, "booking", ws.lastArgs["surfaceId"])
+}
+
+func TestHandleA2UIActionResultHonorsPayloadSurfaceID(t *testing.T) {
+	t.Parallel()
+
+	// The MCP tool registry is process-global; a per-test server name keeps
+	// parallel tests from overwriting each other's capabilities.
+	srv := t.Name()
+
+	ws := &a2uiActionWorkspace{}
+	m, item := newA2UIActionUIItem(t, ws, srv)
+	cleanup := mcptools.SetToolsForTest(srv, "a2ui_action", "a2ui_error")
+	t.Cleanup(cleanup)
+
+	// The server answers the "booking" click by targeting a DIFFERENT
+	// surface. That payload must not be forced onto "booking".
+	update := `{"version":"v0.9","updateComponents":{"surfaceId":"receipt","components":[` +
+		`{"component":"Text","id":"btn-confirm-t","text":"Booked!"}]}}`
+	cmd := m.handleA2UIActionResult(a2uiActionResultMsg{
+		surfaceID: "booking",
+		mcpName:   srv,
+		surfaces:  []string{update},
+	})
+	require.NotNil(t, cmd, "a payload for an unheld surface must be reported back")
+	runCmdTree(cmd)
+
+	require.Contains(t, item.RawRender(100), "Confirm",
+		"a payload aimed at another surface must not corrupt the clicked one")
+	require.Len(t, ws.toolCalls, 1)
+	require.Equal(t, [2]string{srv, "a2ui_error"}, ws.toolCalls[0])
+	require.Equal(t, "SURFACE_NOT_FOUND", ws.lastArgs["code"])
+	require.Equal(t, "receipt", ws.lastArgs["surfaceId"])
+}
+
+func TestHandleA2UIActionResultDeletedSurfaceGoesAway(t *testing.T) {
+	t.Parallel()
+
+	// The MCP tool registry is process-global; a per-test server name keeps
+	// parallel tests from overwriting each other's capabilities.
+	srv := t.Name()
+
+	ws := &a2uiActionWorkspace{}
+	m := newA2UIActionUI(t, ws, srv)
+	cleanup := mcptools.SetToolsForTest(srv, "a2ui_action", "a2ui_error")
+	t.Cleanup(cleanup)
+
+	// The server dismisses the form. The surface must be released, not left
+	// behind as a dead widget that still takes focus and swallows keys —
+	// and a delete is not an error worth reporting back.
+	cmd := m.handleA2UIActionResult(a2uiActionResultMsg{
+		surfaceID: "booking",
+		mcpName:   srv,
+		surfaces:  []string{`{"version":"v0.9","deleteSurface":{"surfaceId":"booking"}}`},
+	})
+	runCmdTree(cmd)
+
+	_, found := m.chat.A2UISurfaceFieldValues("booking")
+	require.False(t, found, "a deleted surface must no longer be live")
+	require.Empty(t, ws.toolCalls, "deleting a surface is not an error to report")
 }
 
 func TestHandleA2UIActionResultErrorReports(t *testing.T) {
 	t.Parallel()
 
+	// The MCP tool registry is process-global; a per-test server name keeps
+	// parallel tests from overwriting each other's capabilities.
+	srv := t.Name()
+
 	ws := &a2uiActionWorkspace{}
-	m := newA2UIActionUI(t, ws, "recipe")
+	m := newA2UIActionUI(t, ws, srv)
 
 	cmd := m.handleA2UIActionResult(a2uiActionResultMsg{
 		surfaceID: "booking",
-		mcpName:   "recipe",
+		mcpName:   srv,
 		err:       context.DeadlineExceeded,
 	})
 	require.NotNil(t, cmd, "an error must surface as a note")
@@ -195,18 +330,23 @@ func TestHandleA2UIActionResultErrorReports(t *testing.T) {
 func TestReportA2UIErrorCallsErrorTool(t *testing.T) {
 	t.Parallel()
 
+	// The MCP tool registry is process-global; a per-test server name keeps
+	// parallel tests from overwriting each other's capabilities.
+	srv := t.Name()
+
 	ws := &a2uiActionWorkspace{}
-	m := newA2UIActionUI(t, ws, "recipe")
-	cleanup := mcptools.SetToolsForTest("recipe", "a2ui_error")
+	m := newA2UIActionUI(t, ws, srv)
+	cleanup := mcptools.SetToolsForTest(srv, "a2ui_error")
 	t.Cleanup(cleanup)
 
-	cmd := m.reportA2UIError("booking", "INVALID_JSON", "bad payload")
+	// An empty server name exercises the surface-owner resolution path.
+	cmd := m.reportA2UIError("", "booking", "INVALID_JSON", "bad payload")
 	require.NotNil(t, cmd)
 	msg := cmd()
 	require.Nil(t, msg, "a successful a2ui_error call produces no message")
 
 	require.Len(t, ws.toolCalls, 1)
-	require.Equal(t, [2]string{"recipe", "a2ui_error"}, ws.toolCalls[0])
+	require.Equal(t, [2]string{srv, "a2ui_error"}, ws.toolCalls[0])
 	require.Equal(t, "INVALID_JSON", ws.lastArgs["code"])
 	require.Equal(t, "booking", ws.lastArgs["surfaceId"])
 }

--- a/internal/ui/model/a2ui_action_test.go
+++ b/internal/ui/model/a2ui_action_test.go
@@ -1,0 +1,212 @@
+package model
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"charm.land/bubbles/v2/textarea"
+
+	"github.com/charmbracelet/crush/internal/agent/tools"
+	mcptools "github.com/charmbracelet/crush/internal/agent/tools/mcp"
+	"github.com/charmbracelet/crush/internal/config"
+	"github.com/charmbracelet/crush/internal/message"
+	"github.com/charmbracelet/crush/internal/session"
+	"github.com/charmbracelet/crush/internal/ui/chat"
+	"github.com/charmbracelet/crush/internal/ui/common"
+	"github.com/charmbracelet/crush/internal/workspace"
+	"github.com/joestump-agent/a2tea/event"
+	"github.com/stretchr/testify/require"
+	a2ui "github.com/tmc/a2ui"
+)
+
+// a2uiActionWorkspace stubs the workspace calls the A2UI action round-trip
+// touches, recording a2ui_action / a2ui_error calls and serving canned
+// responses.
+type a2uiActionWorkspace struct {
+	workspace.Workspace
+
+	// toolCalls records (name, toolName) pairs in call order.
+	toolCalls [][2]string
+	// lastArgs records the args of the most recent call.
+	lastArgs map[string]any
+	// response is the canned CallMCPTool result.
+	response workspace.MCPToolCallResult
+	// err is returned from CallMCPTool when set.
+	err error
+}
+
+func (w *a2uiActionWorkspace) AgentIsReady() bool     { return true }
+func (w *a2uiActionWorkspace) Config() *config.Config { return nil }
+
+func (w *a2uiActionWorkspace) AgentRun(_ context.Context, _, _ string, _ ...message.Attachment) error {
+	return nil
+}
+
+func (w *a2uiActionWorkspace) CallMCPTool(_ context.Context, name, toolName string, args map[string]any) (workspace.MCPToolCallResult, error) {
+	w.toolCalls = append(w.toolCalls, [2]string{name, toolName})
+	w.lastArgs = args
+	return w.response, w.err
+}
+
+// a2uiActionForm is an MCP-served surface with a submit button carrying a
+// server-side action, plus a TextField whose value feeds the action context.
+const a2uiActionForm = `{"version":"v0.9","updateComponents":{"surfaceId":"booking","components":[` +
+	`{"component":"Card","id":"root","child":"col"},` +
+	`{"component":"Column","id":"col","children":["start","btn-confirm"]},` +
+	`{"component":"TextField","id":"start","label":"Start","value":"2026-03-20"},` +
+	`{"component":"Button","id":"btn-confirm","child":"btn-confirm-t","action":{"event":{"name":"confirm_booking"}}},` +
+	`{"component":"Text","id":"btn-confirm-t","text":"Confirm"}` +
+	`]}}`
+
+// newA2UIActionUI builds a UI whose chat holds a tool message item carrying
+// an MCP-served A2UI surface with provenance registered to mcpName.
+func newA2UIActionUI(t *testing.T, ws *a2uiActionWorkspace, mcpName string) *UI {
+	t.Helper()
+	com := common.DefaultCommon(ws)
+	m := &UI{
+		com:      com,
+		status:   NewStatus(com, nil),
+		chat:     NewChat(com, config.ScrollbarDefault),
+		textarea: textarea.New(),
+		state:    uiChat,
+		focus:    uiFocusMain,
+		width:    140,
+		height:   45,
+		session:  &session.Session{ID: "sess-1"},
+	}
+
+	meta, err := json.Marshal(tools.ReadMCPResourceResponseMetadata{
+		A2UISurfaces:         []string{"<a2ui-json>" + a2uiActionForm + "</a2ui-json>"},
+		MCPSurfaceProvenance: []string{mcpName},
+	})
+	require.NoError(t, err)
+
+	item := chat.NewMCPToolMessageItem(com.Styles, message.ToolCall{
+		ID:       "call-1",
+		Name:     "mcp_" + mcpName + "_get_form",
+		Input:    `{}`,
+		Finished: true,
+	}, &message.ToolResult{
+		ToolCallID: "call-1",
+		Content:    "form",
+		Metadata:   string(meta),
+	}, false)
+	m.chat.AppendMessages(item)
+	// Render once so the item builds its live surface models and registers
+	// provenance.
+	_ = item.RawRender(100)
+	return m
+}
+
+func TestHandleA2UIButtonClickedMCPSurfaceRoundTrips(t *testing.T) {
+	t.Parallel()
+
+	ws := &a2uiActionWorkspace{
+		response: workspace.MCPToolCallResult{Content: "Booking confirmed"},
+	}
+	m := newA2UIActionUI(t, ws, "recipe")
+	cleanup := mcptools.SetToolsForTest("recipe", "a2ui_action")
+	t.Cleanup(cleanup)
+
+	cmd := m.handleA2UIButtonClicked(event.ButtonClicked{
+		Source: event.Source{ComponentID: "btn-confirm", SurfaceID: "booking"},
+		ID:     "btn-confirm",
+		Action: &a2ui.EventAction{Name: "confirm_booking"},
+	})
+	require.NotNil(t, cmd, "an MCP surface with a2ui_action must round-trip")
+	msg := cmd()
+	result, ok := msg.(a2uiActionResultMsg)
+	require.True(t, ok, "the cmd must produce an a2uiActionResultMsg")
+	require.NoError(t, result.err)
+	require.Equal(t, "booking", result.surfaceID)
+
+	// The server got the action name and the surface's field values as the
+	// context.
+	require.Len(t, ws.toolCalls, 1)
+	require.Equal(t, [2]string{"recipe", "a2ui_action"}, ws.toolCalls[0])
+	require.Equal(t, "confirm_booking", ws.lastArgs["name"])
+	ctx, ok := ws.lastArgs["context"].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "2026-03-20", ctx["start"])
+
+	// The surface is NOT retired — MCP surfaces are long-lived.
+	_, found := m.chat.A2UISurfaceFieldValues("booking")
+	require.True(t, found, "the surface must stay live after the round-trip")
+}
+
+func TestHandleA2UIButtonClickedMCPSurfaceWithoutActionToolFallsBack(t *testing.T) {
+	t.Parallel()
+
+	ws := &a2uiActionWorkspace{}
+	m := newA2UIActionUI(t, ws, "recipe")
+	// Server serves surfaces but NOT a2ui_action.
+	cleanup := mcptools.SetToolsForTest("recipe", "some_other_tool")
+	t.Cleanup(cleanup)
+
+	cmd := m.handleA2UIButtonClicked(event.ButtonClicked{
+		Source: event.Source{ComponentID: "btn-confirm", SurfaceID: "booking"},
+		ID:     "btn-confirm",
+		Action: &a2ui.EventAction{Name: "confirm_booking"},
+	})
+	require.NotNil(t, cmd, "fallback must start an agent turn")
+	runCmdTree(cmd)
+
+	require.Empty(t, ws.toolCalls, "no a2ui_action call without the tool")
+}
+
+func TestHandleA2UIActionResultAppliesSurfacePayload(t *testing.T) {
+	t.Parallel()
+
+	ws := &a2uiActionWorkspace{}
+	m := newA2UIActionUI(t, ws, "recipe")
+	cleanup := mcptools.SetToolsForTest("recipe", "a2ui_action")
+	t.Cleanup(cleanup)
+
+	// A response carrying an A2UI payload updates the surface in place.
+	update := `{"version":"v0.9","updateComponents":{"surfaceId":"booking","components":[` +
+		`{"component":"Text","id":"btn-confirm-t","text":"Booked!"}]}}`
+	cmd := m.handleA2UIActionResult(a2uiActionResultMsg{
+		surfaceID: "booking",
+		mcpName:   "recipe",
+		surfaces:  []string{update},
+	})
+	require.Nil(t, cmd)
+
+	// The surface still exists after the in-place update.
+	_, found := m.chat.A2UISurfaceFieldValues("booking")
+	require.True(t, found)
+}
+
+func TestHandleA2UIActionResultErrorReports(t *testing.T) {
+	t.Parallel()
+
+	ws := &a2uiActionWorkspace{}
+	m := newA2UIActionUI(t, ws, "recipe")
+
+	cmd := m.handleA2UIActionResult(a2uiActionResultMsg{
+		surfaceID: "booking",
+		mcpName:   "recipe",
+		err:       context.DeadlineExceeded,
+	})
+	require.NotNil(t, cmd, "an error must surface as a note")
+}
+
+func TestReportA2UIErrorCallsErrorTool(t *testing.T) {
+	t.Parallel()
+
+	ws := &a2uiActionWorkspace{}
+	m := newA2UIActionUI(t, ws, "recipe")
+	cleanup := mcptools.SetToolsForTest("recipe", "a2ui_error")
+	t.Cleanup(cleanup)
+
+	cmd := m.reportA2UIError("booking", "INVALID_JSON", "bad payload")
+	require.NotNil(t, cmd)
+	msg := cmd()
+	require.Nil(t, msg, "a successful a2ui_error call produces no message")
+
+	require.Len(t, ws.toolCalls, 1)
+	require.Equal(t, [2]string{"recipe", "a2ui_error"}, ws.toolCalls[0])
+	require.Equal(t, "INVALID_JSON", ws.lastArgs["code"])
+	require.Equal(t, "booking", ws.lastArgs["surfaceId"])
+}

--- a/internal/ui/model/chat.go
+++ b/internal/ui/model/chat.go
@@ -16,6 +16,7 @@ import (
 	"github.com/charmbracelet/x/ansi"
 	"github.com/clipperhouse/displaywidth"
 	"github.com/clipperhouse/uax29/v2/words"
+	a2ui "github.com/tmc/a2ui"
 )
 
 // Constants for multi-click detection.
@@ -718,6 +719,35 @@ func (m *Chat) RetireA2UISurface(surfaceID string) (map[string]any, bool) {
 		}
 	}
 	return nil, false
+}
+
+// A2UISurfaceFieldValues reads the named MCP surface's current input values,
+// for building an a2ui_action context. It reports whether a tool item held
+// the surface.
+func (m *Chat) A2UISurfaceFieldValues(surfaceID string) (map[string]any, bool) {
+	for i := range m.list.Len() {
+		item, ok := m.list.ItemAt(i).(chat.A2UISurfaceItem)
+		if !ok || !item.HasA2UISurface(surfaceID) {
+			continue
+		}
+		return item.ToolA2UIFieldValues(surfaceID), true
+	}
+	return nil, false
+}
+
+// ApplyA2UISurfaceUpdate feeds a batch of A2UI server messages back into the
+// named MCP surface (the response to an a2ui_action round-trip). It reports
+// whether a tool item held the surface.
+func (m *Chat) ApplyA2UISurfaceUpdate(surfaceID string, msgs []a2ui.ServerMessage) bool {
+	for i := range m.list.Len() {
+		item, ok := m.list.ItemAt(i).(chat.A2UISurfaceItem)
+		if !ok || !item.HasA2UISurface(surfaceID) {
+			continue
+		}
+		item.ApplyToolA2UIUpdate(surfaceID, msgs)
+		return true
+	}
+	return false
 }
 
 // ToggleExpandedSelectedItem expands the selected message item if it is expandable.

--- a/internal/ui/model/chat.go
+++ b/internal/ui/model/chat.go
@@ -721,33 +721,61 @@ func (m *Chat) RetireA2UISurface(surfaceID string) (map[string]any, bool) {
 	return nil, false
 }
 
+// a2uiSurfaceItem locates the chat item holding the named MCP surface.
+// Surface IDs are only unique within a server — invoking the same tool twice
+// appends two items carrying the same ID — so the focused surface wins: that
+// is the one the user is actually interacting with. Only when nothing is
+// focused does it fall back to the first match.
+func (m *Chat) a2uiSurfaceItem(surfaceID string) (chat.A2UISurfaceItem, bool) {
+	var first chat.A2UISurfaceItem
+	for i := range m.list.Len() {
+		item, ok := m.list.ItemAt(i).(chat.A2UISurfaceItem)
+		if !ok || !item.HasA2UISurface(surfaceID) {
+			continue
+		}
+		if item.A2UISurfaceIsFocused(surfaceID) {
+			return item, true
+		}
+		if first == nil {
+			first = item
+		}
+	}
+	return first, first != nil
+}
+
+// A2UISurfaceOwner returns the MCP server that served the named surface,
+// resolved through the item that owns it rather than the global
+// surfaceID-keyed registry, so two servers using the same surface ID cannot
+// route each other's interactions.
+func (m *Chat) A2UISurfaceOwner(surfaceID string) (string, bool) {
+	item, ok := m.a2uiSurfaceItem(surfaceID)
+	if !ok {
+		return "", false
+	}
+	return item.A2UISurfaceOwner(surfaceID)
+}
+
 // A2UISurfaceFieldValues reads the named MCP surface's current input values,
 // for building an a2ui_action context. It reports whether a tool item held
 // the surface.
 func (m *Chat) A2UISurfaceFieldValues(surfaceID string) (map[string]any, bool) {
-	for i := range m.list.Len() {
-		item, ok := m.list.ItemAt(i).(chat.A2UISurfaceItem)
-		if !ok || !item.HasA2UISurface(surfaceID) {
-			continue
-		}
-		return item.ToolA2UIFieldValues(surfaceID), true
+	item, ok := m.a2uiSurfaceItem(surfaceID)
+	if !ok {
+		return nil, false
 	}
-	return nil, false
+	return item.ToolA2UIFieldValues(surfaceID), true
 }
 
 // ApplyA2UISurfaceUpdate feeds a batch of A2UI server messages back into the
 // named MCP surface (the response to an a2ui_action round-trip). It reports
-// whether a tool item held the surface.
+// whether the surface still has renderable state afterward — false means no
+// item held it, or the server deleted it.
 func (m *Chat) ApplyA2UISurfaceUpdate(surfaceID string, msgs []a2ui.ServerMessage) bool {
-	for i := range m.list.Len() {
-		item, ok := m.list.ItemAt(i).(chat.A2UISurfaceItem)
-		if !ok || !item.HasA2UISurface(surfaceID) {
-			continue
-		}
-		item.ApplyToolA2UIUpdate(surfaceID, msgs)
-		return true
+	item, ok := m.a2uiSurfaceItem(surfaceID)
+	if !ok {
+		return false
 	}
-	return false
+	return item.ApplyToolA2UIUpdate(surfaceID, msgs)
 }
 
 // ToggleExpandedSelectedItem expands the selected message item if it is expandable.

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -747,6 +747,13 @@ func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			cmds = append(cmds, cmd)
 		}
 
+	case a2uiActionResultMsg:
+		// An a2ui_action round-trip returned: update the originating
+		// surface in place (or land plain text) without an agent turn.
+		if cmd := m.handleA2UIActionResult(msg); cmd != nil {
+			cmds = append(cmds, cmd)
+		}
+
 	case userCommandsLoadedMsg:
 		m.customCommands = msg.Commands
 		dia := m.dialog.Dialog(dialog.CommandsID)
@@ -3916,11 +3923,120 @@ func (m *UI) sendMessage(content string, attachments ...message.Attachment) tea.
 // the surface rebuilt without an ID — in which case the submission still
 // goes out with just the button identity rather than being dropped.
 func (m *UI) handleA2UIButtonClicked(clicked a2uievent.ButtonClicked) tea.Cmd {
-	values, _ := m.chat.RetireA2UISurface(clicked.SurfaceID)
+	// A cancel/dismiss button only ever dismisses the surface locally —
+	// it never starts an agent turn nor round-trips to an MCP server.
+	// Checked first, before any provenance branch.
 	if chat.A2UIButtonIsCancel(clicked) {
+		m.chat.RetireA2UISurface(clicked.SurfaceID)
 		return nil
 	}
+	// MCP-served surface: route the interaction back to the owning server
+	// when it speaks the action round-trip, instead of starting an agent
+	// turn. The button press is itself the consent, so the a2ui_action
+	// call is not gated on permission. The surface is long-lived — it is
+	// NOT retired, and a surface payload in the response updates it in
+	// place.
+	if mcpName, ok := chat.A2UISurfaceProvenance(clicked.SurfaceID); ok && clicked.Action != nil {
+		if mcp.HasTool(mcpName, "a2ui_action") {
+			return m.runA2UIAction(mcpName, clicked)
+		}
+		// The server serves surfaces but not the action round-trip: keep
+		// today's behavior so a dumb server still works.
+	}
+	values, _ := m.chat.RetireA2UISurface(clicked.SurfaceID)
 	return m.sendMessage(chat.A2UISubmissionPrompt(clicked, values))
+}
+
+// a2uiActionResultMsg carries the outcome of an a2ui_action round-trip back
+// to the UI so the surface updates in place (or a plain-text reply lands as
+// tool output) without an agent turn.
+type a2uiActionResultMsg struct {
+	surfaceID string
+	mcpName   string
+	// surfaces holds any A2UI payloads the response embedded, applied to
+	// the surface in place. content holds plain text from the response.
+	surfaces []string
+	content  string
+	err      error
+}
+
+// runA2UIAction calls the owning server's a2ui_action tool with the
+// button's action name and the surface's resolved input values as the
+// context. The call runs off the UI goroutine; the result returns as an
+// a2uiActionResultMsg.
+func (m *UI) runA2UIAction(mcpName string, clicked a2uievent.ButtonClicked) tea.Cmd {
+	values, _ := m.chat.A2UISurfaceFieldValues(clicked.SurfaceID)
+	if values == nil {
+		values = map[string]any{}
+	}
+	args := map[string]any{
+		"name":    clicked.Action.Name,
+		"context": values,
+	}
+	surfaceID := clicked.SurfaceID
+	return func() tea.Msg {
+		res, err := m.com.Workspace.CallMCPTool(context.Background(), mcpName, "a2ui_action", args)
+		if err != nil {
+			return a2uiActionResultMsg{surfaceID: surfaceID, mcpName: mcpName, err: err}
+		}
+		out := a2uiActionResultMsg{surfaceID: surfaceID, mcpName: mcpName, content: res.Content}
+		for _, s := range res.Surfaces {
+			out.surfaces = append(out.surfaces, s.Payload)
+		}
+		return out
+	}
+}
+
+// handleA2UIActionResult applies an a2ui_action response: any A2UI payload
+// updates the originating surface in place (the surface stays live), and any
+// plain text lands as an informational note. A transport/server error is
+// surfaced as an error note — the surface is left untouched.
+func (m *UI) handleA2UIActionResult(msg a2uiActionResultMsg) tea.Cmd {
+	if msg.err != nil {
+		return util.ReportError(fmt.Errorf("A2UI action failed: %w", msg.err))
+	}
+	for _, payload := range msg.surfaces {
+		m.applyA2UIPayloadToSurface(msg.surfaceID, payload)
+	}
+	if msg.content != "" {
+		return util.ReportInfo(msg.content)
+	}
+	return nil
+}
+
+// applyA2UIPayloadToSurface scans an A2UI payload and feeds its server
+// messages into the named surface, which updates in place. A payload that
+// does not scan is reported back to the owning server as an a2ui_error when
+// it exposes that tool.
+func (m *UI) applyA2UIPayloadToSurface(surfaceID, payload string) {
+	msgs, err := chat.A2UIMessagesFromPayload(payload)
+	if err != nil {
+		m.reportA2UIError(surfaceID, "INVALID_JSON", "Failed to parse A2UI payload.")
+		return
+	}
+	if !m.chat.ApplyA2UISurfaceUpdate(surfaceID, msgs) {
+		// The surface is gone (the server may have deleted it) — nothing
+		// to update; not an error worth surfacing.
+		return
+	}
+}
+
+// reportA2UIError reports a render failure to the owning server via its
+// a2ui_error tool, when it exposes one. Otherwise the failure is only shown
+// to the user (the existing render-failure alert path).
+func (m *UI) reportA2UIError(surfaceID, code, message string) tea.Cmd {
+	mcpName, ok := chat.A2UISurfaceProvenance(surfaceID)
+	if !ok || !mcp.HasTool(mcpName, "a2ui_error") {
+		return nil
+	}
+	args := map[string]any{"code": code, "message": message, "surfaceId": surfaceID}
+	return func() tea.Msg {
+		_, err := m.com.Workspace.CallMCPTool(context.Background(), mcpName, "a2ui_error", args)
+		if err != nil {
+			return util.InfoMsg{Type: util.InfoTypeError, Msg: fmt.Sprintf("A2UI error report failed: %v", err)}
+		}
+		return nil
+	}
 }
 
 // handleChannelMessage injects a channel event pushed by an MCP server into a

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -3936,14 +3936,30 @@ func (m *UI) handleA2UIButtonClicked(clicked a2uievent.ButtonClicked) tea.Cmd {
 	// call is not gated on permission. The surface is long-lived — it is
 	// NOT retired, and a surface payload in the response updates it in
 	// place.
-	if mcpName, ok := chat.A2UISurfaceProvenance(clicked.SurfaceID); ok && clicked.Action != nil {
+	// Provenance resolves through the item that owns the surface, falling
+	// back to the global surfaceID-keyed registry only when no live item
+	// claims it: surface IDs are server-scoped (typically "default"), so two
+	// servers would otherwise clobber each other in that registry and route
+	// one another's clicks.
+	mcpName, isMCP := m.chat.A2UISurfaceOwner(clicked.SurfaceID)
+	if !isMCP {
+		mcpName, isMCP = chat.A2UISurfaceProvenance(clicked.SurfaceID)
+	}
+	if isMCP && clicked.Action != nil {
 		if mcp.HasTool(mcpName, "a2ui_action") {
 			return m.runA2UIAction(mcpName, clicked)
 		}
 		// The server serves surfaces but not the action round-trip: keep
 		// today's behavior so a dumb server still works.
 	}
-	values, _ := m.chat.RetireA2UISurface(clicked.SurfaceID)
+	// RetireA2UISurface only matches assistant items, so an MCP surface's
+	// values must be read from the tool item that holds it — otherwise the
+	// fallback submits the button identity with everything the user typed
+	// silently dropped.
+	values, ok := m.chat.RetireA2UISurface(clicked.SurfaceID)
+	if !ok {
+		values, _ = m.chat.A2UISurfaceFieldValues(clicked.SurfaceID)
+	}
 	return m.sendMessage(chat.A2UISubmissionPrompt(clicked, values))
 }
 
@@ -3995,37 +4011,75 @@ func (m *UI) handleA2UIActionResult(msg a2uiActionResultMsg) tea.Cmd {
 	if msg.err != nil {
 		return util.ReportError(fmt.Errorf("A2UI action failed: %w", msg.err))
 	}
+	var cmds []tea.Cmd
 	for _, payload := range msg.surfaces {
-		m.applyA2UIPayloadToSurface(msg.surfaceID, payload)
+		if cmd := m.applyA2UIPayloadToSurface(msg.mcpName, msg.surfaceID, payload); cmd != nil {
+			cmds = append(cmds, cmd)
+		}
 	}
 	if msg.content != "" {
-		return util.ReportInfo(msg.content)
+		cmds = append(cmds, util.ReportInfo(msg.content))
+	}
+	if len(cmds) == 0 {
+		return nil
+	}
+	return tea.Batch(cmds...)
+}
+
+// applyA2UIPayloadToSurface scans an A2UI payload and feeds its server
+// messages into the surface the payload targets, which updates in place. A
+// payload that does not scan, or that targets a surface nothing holds, is
+// reported back to the owning server as an a2ui_error when it exposes that
+// tool. clickedID is the surface the interaction came from — the fallback
+// target for a payload that declares no surface of its own — and mcpName is
+// the server that sent it, which is who any error is reported to.
+func (m *UI) applyA2UIPayloadToSurface(mcpName, clickedID, payload string) tea.Cmd {
+	msgs, err := chat.A2UIMessagesFromPayload(payload)
+	if err != nil {
+		return m.reportA2UIError(mcpName, clickedID, "INVALID_JSON",
+			"Failed to parse A2UI payload.")
+	}
+	if len(msgs) == 0 {
+		// The payload parsed but carried no server messages — it scanned
+		// as prose, not A2UI. Applying it would be a silent no-op, which
+		// looks to the user like a dead button.
+		return m.reportA2UIError(mcpName, clickedID, "INVALID_PAYLOAD",
+			"Payload carried no A2UI server messages.")
+	}
+	// Honor the surface the payload itself declares: a server may answer an
+	// action by updating a sibling surface, not the clicked one. Forcing
+	// every payload onto the clicked ID would corrupt that surface instead.
+	target := chat.A2UIMessagesSurfaceID(msgs)
+	if target == "" {
+		target = clickedID
+	}
+	if !m.chat.ApplyA2UISurfaceUpdate(target, msgs) {
+		// Either nothing holds that surface, or the server just deleted
+		// it. A delete is the expected end of a surface's life; a payload
+		// aimed at a surface we never had is a real mismatch worth
+		// reporting back.
+		if !chat.A2UIMessagesDeleteSurface(msgs) {
+			return m.reportA2UIError(mcpName, target, "SURFACE_NOT_FOUND",
+				fmt.Sprintf("No live surface %q to apply the payload to.", target))
+		}
 	}
 	return nil
 }
 
-// applyA2UIPayloadToSurface scans an A2UI payload and feeds its server
-// messages into the named surface, which updates in place. A payload that
-// does not scan is reported back to the owning server as an a2ui_error when
-// it exposes that tool.
-func (m *UI) applyA2UIPayloadToSurface(surfaceID, payload string) {
-	msgs, err := chat.A2UIMessagesFromPayload(payload)
-	if err != nil {
-		m.reportA2UIError(surfaceID, "INVALID_JSON", "Failed to parse A2UI payload.")
-		return
+// reportA2UIError reports a render failure to mcpName via its a2ui_error
+// tool, when it exposes one. Otherwise the failure is only shown to the user
+// (the existing render-failure alert path). mcpName may be empty when the
+// caller only holds a surface ID, in which case the owner is resolved from
+// the surface — item-scoped first, same as the action path, because the
+// global registry is keyed by surface ID alone and two servers sharing an ID
+// clobber each other there.
+func (m *UI) reportA2UIError(mcpName, surfaceID, code, message string) tea.Cmd {
+	ok := mcpName != ""
+	if !ok {
+		if mcpName, ok = m.chat.A2UISurfaceOwner(surfaceID); !ok {
+			mcpName, ok = chat.A2UISurfaceProvenance(surfaceID)
+		}
 	}
-	if !m.chat.ApplyA2UISurfaceUpdate(surfaceID, msgs) {
-		// The surface is gone (the server may have deleted it) — nothing
-		// to update; not an error worth surfacing.
-		return
-	}
-}
-
-// reportA2UIError reports a render failure to the owning server via its
-// a2ui_error tool, when it exposes one. Otherwise the failure is only shown
-// to the user (the existing render-failure alert path).
-func (m *UI) reportA2UIError(surfaceID, code, message string) tea.Cmd {
-	mcpName, ok := chat.A2UISurfaceProvenance(surfaceID)
 	if !ok || !mcp.HasTool(mcpName, "a2ui_error") {
 		return nil
 	}

--- a/internal/workspace/app_workspace.go
+++ b/internal/workspace/app_workspace.go
@@ -2,6 +2,7 @@ package workspace
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -451,6 +452,24 @@ func (w *AppWorkspace) ReadMCPResource(ctx context.Context, name, uri string) ([
 		}
 	}
 	return result, nil
+}
+
+// CallMCPTool invokes a tool on a named MCP server and returns its text
+// content plus any A2UI surface payload it embedded.
+func (w *AppWorkspace) CallMCPTool(ctx context.Context, name, toolName string, args map[string]any) (MCPToolCallResult, error) {
+	input, err := json.Marshal(args)
+	if err != nil {
+		return MCPToolCallResult{}, fmt.Errorf("failed to encode tool arguments: %w", err)
+	}
+	res, err := mcptools.RunTool(ctx, w.store, name, toolName, string(input))
+	if err != nil {
+		return MCPToolCallResult{}, err
+	}
+	out := MCPToolCallResult{Content: res.Content}
+	for _, s := range res.Surfaces {
+		out.Surfaces = append(out.Surfaces, MCPToolCallSurface{Payload: s.Payload, URI: s.URI})
+	}
+	return out, nil
 }
 
 func (w *AppWorkspace) GetMCPPrompt(clientID, promptID string, args map[string]string) (string, error) {

--- a/internal/workspace/client_workspace.go
+++ b/internal/workspace/client_workspace.go
@@ -664,6 +664,20 @@ func (w *ClientWorkspace) GetMCPPrompt(clientID, promptID string, args map[strin
 	return w.client.GetMCPPrompt(context.Background(), w.workspaceID(), clientID, promptID, args)
 }
 
+// CallMCPTool invokes a tool on a named MCP server via the server and
+// returns its text content plus any A2UI surface payload it embedded.
+func (w *ClientWorkspace) CallMCPTool(ctx context.Context, name, toolName string, args map[string]any) (MCPToolCallResult, error) {
+	res, err := w.client.CallMCPTool(ctx, w.workspaceID(), name, toolName, args)
+	if err != nil {
+		return MCPToolCallResult{}, err
+	}
+	out := MCPToolCallResult{Content: res.Content}
+	for _, s := range res.Surfaces {
+		out.Surfaces = append(out.Surfaces, MCPToolCallSurface{Payload: s.Payload, URI: s.URI})
+	}
+	return out, nil
+}
+
 func (w *ClientWorkspace) EnableDockerMCP(ctx context.Context) error {
 	return w.client.EnableDockerMCP(ctx, w.workspaceID())
 }

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -173,6 +173,12 @@ type Workspace interface {
 	MCPRefreshResources(ctx context.Context, name string)
 	RefreshMCPTools(ctx context.Context, name string)
 	ReadMCPResource(ctx context.Context, name, uri string) ([]MCPResourceContents, error)
+	// CallMCPTool invokes a tool on a named MCP server and returns its
+	// text content plus any A2UI surface payload it embedded. It backs the
+	// A2UI action round-trip: a button press on an MCP-served surface
+	// routes back to the owning server as an a2ui_action (or a render
+	// failure as an a2ui_error) without an agent turn.
+	CallMCPTool(ctx context.Context, name, toolName string, args map[string]any) (MCPToolCallResult, error)
 	GetMCPPrompt(clientID, promptID string, args map[string]string) (string, error)
 	EnableDockerMCP(ctx context.Context) error
 	DisableDockerMCP() error
@@ -194,4 +200,19 @@ type MCPResourceContents struct {
 	MIMEType string `json:"mime_type,omitempty"`
 	Text     string `json:"text,omitempty"`
 	Blob     []byte `json:"blob,omitempty"`
+}
+
+// MCPToolCallResult holds the model-facing text and any A2UI surface
+// payloads from an MCP tool call.
+type MCPToolCallResult struct {
+	// Content is the result's text (its TextContent, joined).
+	Content string `json:"content"`
+	// Surfaces carries any A2UI surface payloads the result embedded.
+	Surfaces []MCPToolCallSurface `json:"surfaces,omitempty"`
+}
+
+// MCPToolCallSurface is a single A2UI surface payload from a tool call.
+type MCPToolCallSurface struct {
+	Payload string `json:"payload"`
+	URI     string `json:"uri"`
 }


### PR DESCRIPTION
Part of #217. Closes #221. Builds on #233 (merged), which added the A2UI-over-MCP detection/rendering and surface provenance this depends on.

## What

Interactions on an MCP-served surface now flow back to the owning server as an **`a2ui_action` tool call**, with the surface's resolved input values as the `context` — per the [A2UI-over-MCP contract](https://a2ui.org/guides/a2ui_over_mcp/). Render failures are reported back via **`a2ui_error`** (`{code, message, surfaceId}`).

## Behavior

- **MCP-owned surface + server exposes `a2ui_action`**: a button press calls the tool with `{name: <action name>, context: <resolved surface state>}`. The press is itself the consent, so the call is not gated on permission (the user pressing the button *is* the approval). The surface is **long-lived** — it is not retired, and an A2UI payload in the response is **applied to it in place** (preserving focus and edited values the server did not touch). A plain-text response lands as an informational note.
- **Server serves surfaces but lacks `a2ui_action`**: today's behavior — retire + `A2UISubmissionPrompt` as an agent turn — so dumb servers still work.
- **Chat-scanned surfaces**: unchanged.
- **Cancel-button heuristic**: applies locally first, before any provenance branch or tool call.

## Changes

- **`handleA2UIButtonClicked`** (`internal/ui/model/ui.go`): branches on surface provenance (from the registry added in #233). Cancel first, then the MCP round-trip, then the existing fallbacks.
- **`runA2UIAction` / `handleA2UIActionResult` / `applyA2UIPayloadToSurface` / `reportA2UIError`** (`internal/ui/model/ui.go`): the async round-trip — gathers `FieldValues()` for the context, calls the tool off the UI goroutine, applies response payloads in place, and reports parse failures via `a2ui_error` when the server exposes it.
- **`CallMCPTool`** workspace operation: returns the result's text + embedded A2UI surfaces. Implemented in-process on `AppWorkspace`, and over a new `POST /workspaces/{id}/mcp/call-tool` RPC (proto request, server handler, backend method, client method) for client/server mode.
- **`mcp.HasTool` / `SetToolsForTest`**: capability check for whether a server exposes `a2ui_action` / `a2ui_error`.
- **Chat model + tool item** (`A2UISurfaceItem`): locate a live surface by ID, read its `FieldValues()`, and `Apply` server messages to it in place.

## Verification

- Unit tests cover the round-trip (action name + field-value context sent, surface not retired), the no-`a2ui_action` fallback (agent turn, no tool call), in-place surface updates from a response payload, error reporting, and `a2ui_error` calls.
- **End-to-end against a live MCP server** implementing the contract: `get_recipe_a2ui` returns an A2UI `EmbeddedResource`; `a2ui_action` with a resolved context returns an updated surface payload that parses into applicable server messages; `a2ui_error` round-trips.
- `go test ./...` green; `gofumpt` and `go vet` clean on the touched packages.

🤖 Posted on behalf of `@joestump` by [`claude-opus-5`](https://openrouter.ai/anthropic/claude-opus-5) using [Crush](https://github.com/charmbracelet/crush).
