### PR TITLE
feat(mcp): respect A2UI audience annotations for LLM visibility

### DIFF
--- a/internal/agent/tools/mcp-tools.go
+++ b/internal/agent/tools/mcp-tools.go
@@ -181,28 +181,37 @@ func (m *Tool) Run(ctx context.Context, params fantasy.ToolCall) (fantasy.ToolRe
 // back into the model-facing content (except payloads the server annotated
 // for the user only — hiding those from the model is the annotation's whole
 // point), so the model can still relay or summarize the data.
+//
+// The audience annotation decides each surface's path (see a2uiAudience):
+// a ["user"]-only payload renders but never reaches the model; an
+// ["assistant"]-only payload reaches the model but is never rendered; an
+// empty audience does both (renders, and folds back to the model when no
+// chat UI is consuming it) — the established default.
 func splitMCPToolResult(result mcp.ToolResult, mcpName string, divert bool) (string, ReadMCPResourceResponseMetadata) {
 	var metadata ReadMCPResourceResponseMetadata
 	content := result.Content
-	for _, surface := range result.Surfaces {
-		if divert {
-			metadata.A2UISurfaces = append(metadata.A2UISurfaces, "<a2ui-json>"+surface.Payload+"</a2ui-json>")
-			metadata.MCPSurfaceProvenance = append(metadata.MCPSurfaceProvenance, mcpName)
-			uri := strings.NewReplacer("\n", " ", "\r", " ").Replace(surface.URI)
-			placeholder := A2UISurfacePlaceholderPrefix + uri + " from MCP server " + mcpName + " — the user can already see it; do not repeat or echo its JSON payload]"
-			if content != "" {
-				content += "\n"
-			}
-			content += placeholder
-			continue
-		}
-		if !surface.AssistantVisible {
-			continue
-		}
+	appendToContent := func(s string) {
 		if content != "" {
 			content += "\n"
 		}
-		content += surface.Payload
+		content += s
+	}
+	for _, surface := range result.Surfaces {
+		if divert && surface.RenderForUser {
+			// Render for the user via metadata; the model gets a
+			// placeholder so it cannot echo the JSON back and double-render.
+			metadata.A2UISurfaces = append(metadata.A2UISurfaces, "<a2ui-json>"+surface.Payload+"</a2ui-json>")
+			metadata.MCPSurfaceProvenance = append(metadata.MCPSurfaceProvenance, mcpName)
+			uri := strings.NewReplacer("\n", " ", "\r", " ").Replace(surface.URI)
+			appendToContent(A2UISurfacePlaceholderPrefix + uri + " from MCP server " + mcpName + " — the user can already see it; do not repeat or echo its JSON payload]")
+			continue
+		}
+		// Not rendered: either divert is off (no chat UI) or the surface is
+		// ["assistant"]-only. It reaches the model only when assistant-visible.
+		if !surface.AssistantVisible {
+			continue
+		}
+		appendToContent(surface.Payload)
 	}
 	return content, metadata
 }

--- a/internal/agent/tools/mcp/tools.go
+++ b/internal/agent/tools/mcp/tools.go
@@ -39,6 +39,10 @@ type A2UISurface struct {
 	Payload string
 	// URI is the embedded resource's URI, for display/diagnostics.
 	URI string
+	// RenderForUser reports whether the payload should be rendered for the
+	// user. False only when the audience is ["assistant"] alone: the spec's
+	// verbalization contract renders for every audience except that one.
+	RenderForUser bool
 	// AssistantVisible reports whether the server annotated the payload
 	// for the LLM as well as the user (empty audience or one containing
 	// "assistant"). An audience of ["user"] alone hides the raw JSON from
@@ -151,10 +155,12 @@ func extractToolResult(result *mcp.CallToolResult) ToolResult {
 					payload = string(content.Resource.Blob)
 				}
 				if payload != "" {
+					render, assistantVisible := a2uiAudience(content.Annotations)
 					surfaces = append(surfaces, A2UISurface{
 						Payload:          payload,
 						URI:              content.Resource.URI,
-						AssistantVisible: a2uiAssistantVisible(content.Annotations),
+						RenderForUser:    render,
+						AssistantVisible: assistantVisible,
 					})
 				}
 				continue
@@ -196,16 +202,22 @@ func extractToolResult(result *mcp.CallToolResult) ToolResult {
 	}
 }
 
-// a2uiAssistantVisible reports whether an A2UI embedded resource's audience
-// annotations leave the payload visible to the LLM. Per the A2UI-over-MCP
-// verbalization contract: an empty audience is visible to both user and
-// assistant; an audience of ["user"] alone renders for the user but hides
-// the raw JSON from the model.
-func a2uiAssistantVisible(annotations *mcp.Annotations) bool {
+// a2uiAudience resolves an A2UI embedded resource's audience annotations
+// into the spec's verbalization contract:
+//
+//	audience (empty)      → render for the user, visible to the model
+//	["user"]              → render for the user, hidden from the model
+//	["assistant"]         → visible to the model, NOT rendered
+//	["user","assistant"]  → both
+//
+// It returns (renderForUser, assistantVisible).
+func a2uiAudience(annotations *mcp.Annotations) (bool, bool) {
 	if annotations == nil || len(annotations.Audience) == 0 {
-		return true
+		return true, true
 	}
-	return slices.Contains(annotations.Audience, mcp.Role("assistant"))
+	forUser := slices.Contains(annotations.Audience, mcp.Role("user"))
+	forAssistant := slices.Contains(annotations.Audience, mcp.Role("assistant"))
+	return forUser, forAssistant
 }
 
 // RefreshTools gets the updated list of tools from the MCP and updates the

--- a/internal/agent/tools/mcp/tools_a2ui_test.go
+++ b/internal/agent/tools/mcp/tools_a2ui_test.go
@@ -109,6 +109,24 @@ func TestRunTool_A2UISurfaceExtraction(t *testing.T) {
 		res := runToolWithSession(t, sess, "get_card")
 		require.Len(t, res.Surfaces, 1)
 		require.False(t, res.Surfaces[0].AssistantVisible)
+		require.True(t, res.Surfaces[0].RenderForUser, "user audience still renders")
+	})
+
+	t.Run("assistant-only audience is visible to the model but not rendered", func(t *testing.T) {
+		sess := liveA2UIToolSession(t, "get_card", []mcp.Content{
+			&mcp.EmbeddedResource{
+				Resource: &mcp.ResourceContents{
+					URI:      "a2ui://card",
+					MIMEType: A2UIJSONMIMEType,
+					Text:     testA2UIToolPayload,
+				},
+				Annotations: &mcp.Annotations{Audience: []mcp.Role{"assistant"}},
+			},
+		})
+		res := runToolWithSession(t, sess, "get_card")
+		require.Len(t, res.Surfaces, 1)
+		require.True(t, res.Surfaces[0].AssistantVisible)
+		require.False(t, res.Surfaces[0].RenderForUser, "assistant-only audience must not render")
 	})
 
 	t.Run("blob-delivered surface is normalized to text", func(t *testing.T) {

--- a/internal/agent/tools/mcp_tools_a2ui_test.go
+++ b/internal/agent/tools/mcp_tools_a2ui_test.go
@@ -14,6 +14,7 @@ func TestSplitMCPToolResult(t *testing.T) {
 	surface := mcp.A2UISurface{
 		Payload:          testA2UIPayload,
 		URI:              "a2ui://recipe-card",
+		RenderForUser:    true,
 		AssistantVisible: true,
 	}
 
@@ -71,5 +72,59 @@ func TestSplitMCPToolResult(t *testing.T) {
 
 		require.Len(t, meta.A2UISurfaces, 1)
 		require.True(t, strings.HasPrefix(content, A2UISurfacePlaceholderPrefix))
+	})
+
+	t.Run("user-only surface renders but stays hidden from the model", func(t *testing.T) {
+		t.Parallel()
+		userOnly := surface
+		userOnly.RenderForUser = true
+		userOnly.AssistantVisible = false
+		content, meta := splitMCPToolResult(mcp.ToolResult{
+			Type:     "text",
+			Content:  "",
+			Surfaces: []mcp.A2UISurface{userOnly},
+		}, "recipe", true)
+
+		// Renders for the user via metadata, but the model sees a
+		// placeholder, not the JSON.
+		require.Len(t, meta.A2UISurfaces, 1)
+		require.True(t, strings.HasPrefix(content, A2UISurfacePlaceholderPrefix))
+		require.NotContains(t, content, "updateComponents")
+
+		// The model-facing content — what the next agent request's history
+		// carries — holds the placeholder and none of the raw payload.
+		require.NotContains(t, content, testA2UIPayload)
+		require.NotContains(t, content, `"surfaceId"`)
+	})
+
+	t.Run("assistant-only surface reaches the model but never renders", func(t *testing.T) {
+		t.Parallel()
+		assistantOnly := surface
+		assistantOnly.RenderForUser = false
+		assistantOnly.AssistantVisible = true
+		content, meta := splitMCPToolResult(mcp.ToolResult{
+			Type:     "text",
+			Content:  "",
+			Surfaces: []mcp.A2UISurface{assistantOnly},
+		}, "recipe", true)
+
+		// No surface for the UI; the JSON goes to the model for reasoning.
+		require.Empty(t, meta.A2UISurfaces)
+		require.Contains(t, content, testA2UIPayload)
+	})
+
+	t.Run("assistant-only surface reaches the model when not diverting too", func(t *testing.T) {
+		t.Parallel()
+		assistantOnly := surface
+		assistantOnly.RenderForUser = false
+		assistantOnly.AssistantVisible = true
+		content, meta := splitMCPToolResult(mcp.ToolResult{
+			Type:     "text",
+			Content:  "",
+			Surfaces: []mcp.A2UISurface{assistantOnly},
+		}, "recipe", false)
+
+		require.Empty(t, meta.A2UISurfaces)
+		require.Contains(t, content, testA2UIPayload)
 	})
 }


### PR DESCRIPTION
Part of #217. Closes #222. Builds on #219 (merged), which added the detection + audience extraction this refines.

## What

Respects the spec's [verbalization contract](https://a2ui.org/guides/a2ui_over_mcp/) for A2UI `EmbeddedResource` payloads. Before this, the detection path flattened audience to a single `assistantVisible` flag and rendered **every** payload regardless of annotation — so an `["assistant"]`-only payload (which should never render) rendered anyway.

| Audience | Behavior now |
|---|---|
| _(empty)_ | renders for the user; visible to the model (the established default) |
| `["user"]` | renders; the model-facing tool result carries the placeholder, not the JSON |
| `["assistant"]` | reaches the model for reasoning; **never creates a surface** |
| `["user","assistant"]` | both |

## Changes

- **`a2uiAudience`** (`internal/agent/tools/mcp/tools.go`): resolves `annotations.audience` into `(renderForUser, assistantVisible)` per the contract. `A2UISurface` gains `RenderForUser` alongside `AssistantVisible`.
- **`splitMCPToolResult`** (`internal/agent/tools/mcp-tools.go`): routes each surface per its audience — `["user"]`-only renders with a placeholder in the model-facing content (never the JSON); `["assistant"]`-only goes to the model without entering the render metadata; empty/default unchanged. The placeholder keeps preventing the model from echoing rendered JSON back and double-rendering.

Resource reads (`resources/read`) carry no `Annotations` field at the protocol level, so the contract applies to the tool-call path only — which is where it now lives.

## Verification

- Unit tests: the full audience matrix at both the extraction layer (`extractToolResult`: render/visible flags per annotation) and the split layer (`splitMCPToolResult`: `["user"]` placeholder + no JSON in model-facing content, `["assistant"]` no surface + JSON to model, empty default, non-divert fold-back).
- **End-to-end against a live server** annotating each payload: empty renders + model-visible; `["user"]` renders + hidden from model; `["assistant"]` not rendered + model-visible — all through crush's real extraction path.
- `go test ./internal/...` green; `gofumpt` and `go vet` clean.

🤖 Posted on behalf of `@joestump` by [`claude-opus-5`](https://openrouter.ai/anthropic/claude-opus-5) using [Crush](https://github.com/charmbracelet/crush).
