### PR TITLE
feat(ui): add /skill completions popup to the prompt editor

### DIFF
--- a/internal/ui/completions/completions.go
+++ b/internal/ui/completions/completions.go
@@ -44,6 +44,19 @@ type CompletionItemsLoadedMsg struct {
 	Resources []ResourceCompletionValue
 }
 
+// Trigger identifies which trigger character opened the completions popup.
+type Trigger rune
+
+const (
+	// TriggerNone means the completions popup is closed.
+	TriggerNone Trigger = 0
+	// TriggerFile is the '@' file-mention trigger.
+	TriggerFile Trigger = '@'
+	// TriggerSkill is the '/' skill trigger (mid-prompt only; at the start
+	// of an empty prompt '/' opens the commands dialog instead).
+	TriggerSkill Trigger = '/'
+)
+
 // Completions represents the completions popup component.
 type Completions struct {
 	// Popup dimensions
@@ -177,6 +190,38 @@ func (c *Completions) SetItems(files []FileCompletionValue, resources []Resource
 		item := NewCompletionItem(
 			resource.MCPName+"/"+cmp.Or(resource.Title, resource.URI),
 			resource,
+			c.normalStyle,
+			c.focusedStyle,
+			c.matchStyle,
+		)
+		items = append(items, item)
+	}
+
+	c.open = true
+	c.query = ""
+	c.allItems = items
+	c.filtered = append([]list.FilterableItem(nil), items...)
+	c.list.SetItems(c.filtered...)
+	c.list.SetFilter("")
+	c.list.Focus()
+
+	c.width = maxWidth
+	c.height = ordered.Clamp(len(items), int(minHeight), int(maxHeight))
+	c.list.SetSize(c.width, c.height)
+	c.list.SelectFirst()
+	c.list.ScrollToSelected()
+
+	c.updateSize()
+}
+
+// SetSkillItems sets skill items and opens the popup. Unlike files, skills
+// are already in memory, so no async load is needed.
+func (c *Completions) SetSkillItems(skills []SkillCompletionValue) {
+	items := make([]list.FilterableItem, 0, len(skills))
+	for _, skill := range skills {
+		item := NewCompletionItem(
+			skill.Name,
+			skill,
 			c.normalStyle,
 			c.focusedStyle,
 			c.matchStyle,
@@ -375,6 +420,11 @@ func (c *Completions) selectCurrent(keepOpen bool) tea.Msg {
 	}
 
 	switch item := item.Value().(type) {
+	case SkillCompletionValue:
+		return SelectionMsg[SkillCompletionValue]{
+			Value:    item,
+			KeepOpen: keepOpen,
+		}
 	case ResourceCompletionValue:
 		return SelectionMsg[ResourceCompletionValue]{
 			Value:    item,

--- a/internal/ui/completions/completions.go
+++ b/internal/ui/completions/completions.go
@@ -214,18 +214,49 @@ func (c *Completions) SetItems(files []FileCompletionValue, resources []Resource
 	c.updateSize()
 }
 
+// skillDetailSeparator sits between a skill's name and its description in
+// the popup row.
+const skillDetailSeparator = " - "
+
+// minSkillDetailWidth is the smallest description tail worth showing. Below
+// it the row is all ellipsis and the description only costs width, so long
+// skill names simply render bare.
+const minSkillDetailWidth = 12
+
 // SetSkillItems sets skill items and opens the popup. Unlike files, skills
 // are already in memory, so no async load is needed.
+//
+// Each row reads "/name - description", with the description truncated to
+// whatever width the name leaves behind. The description is part of the
+// item's text, so the fuzzy filter matches it too: typing "/pdf" finds a
+// skill described as "extract text from PDFs" even if it is named
+// "document-tools".
 func (c *Completions) SetSkillItems(skills []SkillCompletionValue) {
 	items := make([]list.FilterableItem, 0, len(skills))
 	for _, skill := range skills {
+		name := "/" + skill.Name
+		text := name
+		detailStart := -1
+		if desc := flattenSkillDescription(skill.Description); desc != "" {
+			// maxWidth is the popup's hard cap and renderItem reserves a
+			// cell of padding on each side, so that is the real budget the
+			// name and description share.
+			budget := maxWidth - 2 - ansi.StringWidth(name) - len(skillDetailSeparator)
+			if budget >= minSkillDetailWidth {
+				detailStart = len(name)
+				text = name + skillDetailSeparator + ansi.Truncate(desc, budget, "…")
+			}
+		}
 		item := NewCompletionItem(
-			skill.Name,
+			text,
 			skill,
 			c.normalStyle,
 			c.focusedStyle,
 			c.matchStyle,
 		)
+		if detailStart >= 0 {
+			item = item.withDetail(detailStart, name)
+		}
 		items = append(items, item)
 	}
 
@@ -288,10 +319,28 @@ func (c *Completions) applyNamePriorityFilter(query string) {
 
 	queryLower := strings.ToLower(strings.TrimSpace(query))
 	slices.SortStableFunc(filtered, func(a, b list.FilterableItem) int {
-		return namePriorityTier(a.Filter(), queryLower) - namePriorityTier(b.Filter(), queryLower)
+		return namePriorityTier(tierKey(a), queryLower) - namePriorityTier(tierKey(b), queryLower)
 	})
 	c.filtered = filtered
 	c.list.SetItems(c.filtered...)
+}
+
+// tierKey returns the string namePriorityTier should rank an item on. Items
+// whose display text carries a trailing detail (skills, which append their
+// description) expose the bare name via SortKey; everything else ranks on
+// its filter text, which is the path.
+func tierKey(item list.FilterableItem) string {
+	if s, ok := item.(interface{ SortKey() string }); ok {
+		return s.SortKey()
+	}
+	return item.Filter()
+}
+
+// flattenSkillDescription collapses a SKILL.md description onto one line.
+// Frontmatter descriptions are frequently wrapped across several lines, and
+// a popup row is exactly one.
+func flattenSkillDescription(desc string) string {
+	return strings.Join(strings.Fields(desc), " ")
 }
 
 func namePriorityTier(path, queryLower string) int {

--- a/internal/ui/completions/item.go
+++ b/internal/ui/completions/item.go
@@ -24,10 +24,14 @@ type ResourceCompletionValue struct {
 	MIMEType string
 }
 
-// SkillCompletionValue represents an agent skill completion value.
+// SkillCompletionValue represents an agent skill completion value. The
+// fields mirror the SKILL.md frontmatter: Description is shown after the
+// name in the popup and folded into the item's filter text, so a skill is
+// findable by what it does and not only by what it is called.
 type SkillCompletionValue struct {
-	Name string
-	Path string
+	Name        string
+	Description string
+	Path        string
 }
 
 // IsTemplate reports whether the completion's URI is an unexpanded RFC 6570
@@ -48,6 +52,16 @@ type CompletionItem struct {
 	focused bool
 	cache   map[int]string
 
+	// detailStart is the byte offset in text where the secondary detail
+	// (e.g. a skill's description) begins, or -1 when the item is all
+	// primary text. The detail renders dimmed so the name still leads.
+	detailStart int
+
+	// sortKey is what the name-priority tiering ranks on. It defaults to
+	// text, but items whose display text carries a trailing detail set it
+	// to the bare name so the description can't skew the tier.
+	sortKey string
+
 	// Styles
 	normalStyle  lipgloss.Style
 	focusedStyle lipgloss.Style
@@ -60,10 +74,25 @@ func NewCompletionItem(text string, value any, normalStyle, focusedStyle, matchS
 		Versioned:    list.NewVersioned(),
 		text:         text,
 		value:        value,
+		detailStart:  -1,
+		sortKey:      text,
 		normalStyle:  normalStyle,
 		focusedStyle: focusedStyle,
 		matchStyle:   matchStyle,
 	}
+}
+
+// withDetail marks everything from byte offset start onwards as secondary
+// detail text and ranks the item on sortKey instead of its full text.
+func (c *CompletionItem) withDetail(start int, sortKey string) *CompletionItem {
+	c.detailStart = start
+	c.sortKey = sortKey
+	return c
+}
+
+// SortKey returns the string the name-priority tiering ranks on.
+func (c *CompletionItem) SortKey() string {
+	return c.sortKey
 }
 
 // Finished implements list.Item. Completion items render purely from
@@ -129,6 +158,7 @@ func (c *CompletionItem) Render(width int) string {
 		c.focusedStyle,
 		c.matchStyle,
 		c.text,
+		c.detailStart,
 		c.focused,
 		width,
 		c.cache,
@@ -139,6 +169,7 @@ func (c *CompletionItem) Render(width int) string {
 func renderItem(
 	normalStyle, focusedStyle, matchStyle lipgloss.Style,
 	text string,
+	detailStart int,
 	focused bool,
 	width int,
 	cache map[int]string,
@@ -169,6 +200,17 @@ func renderItem(
 
 	// Render full-width text with background.
 	content := style.Padding(0, 1).Width(width).Render(text)
+
+	// Dim the trailing detail (a skill's description) so the name still
+	// leads the row. Applied before the match ranges so a fuzzy hit inside
+	// the description still reads as a match.
+	if detailStart >= 0 {
+		start, _ := bytePosToVisibleCharPos(text, [2]int{detailStart, detailStart})
+		if start+1 < width {
+			detailStyle := style.Faint(true)
+			content = lipgloss.StyleRanges(content, lipgloss.NewRange(start+1, width, detailStyle))
+		}
+	}
 
 	// Apply match highlighting using StyleRanges.
 	if len(match.MatchedIndexes) > 0 {

--- a/internal/ui/completions/item.go
+++ b/internal/ui/completions/item.go
@@ -24,6 +24,12 @@ type ResourceCompletionValue struct {
 	MIMEType string
 }
 
+// SkillCompletionValue represents an agent skill completion value.
+type SkillCompletionValue struct {
+	Name string
+	Path string
+}
+
 // IsTemplate reports whether the completion's URI is an unexpanded RFC 6570
 // URI template (it still contains a "{expression}") rather than a concrete,
 // readable resource URI. Templates come from resources/templates/list and

--- a/internal/ui/completions/skills_test.go
+++ b/internal/ui/completions/skills_test.go
@@ -1,9 +1,11 @@
 package completions
 
 import (
+	"strings"
 	"testing"
 
 	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/x/ansi"
 	"github.com/stretchr/testify/require"
 )
 
@@ -22,7 +24,7 @@ func TestSetSkillItemsOpensWithSkills(t *testing.T) {
 	require.Len(t, c.filtered, 2)
 	first, ok := c.filtered[0].(*CompletionItem)
 	require.True(t, ok)
-	require.Equal(t, "code-review", first.Text())
+	require.Equal(t, "/code-review", first.Text())
 }
 
 func TestSkillCompletionFilter(t *testing.T) {
@@ -41,7 +43,63 @@ func TestSkillCompletionFilter(t *testing.T) {
 	first, ok := c.filtered[0].(*CompletionItem)
 	require.True(t, ok)
 	// "coder" is an exact-stem/prefix tier winner over "code-review".
-	require.Equal(t, "coder", first.Text())
+	require.Equal(t, "/coder", first.Text())
+}
+
+func TestSkillDescriptionShownAndSearchable(t *testing.T) {
+	t.Parallel()
+
+	c := New(lipgloss.NewStyle(), lipgloss.NewStyle(), lipgloss.NewStyle())
+	c.SetSkillItems([]SkillCompletionValue{
+		{Name: "skill-creator", Description: "Use for naming skills\nand writing frontmatter."},
+		{Name: "commit", Description: "Write a conventional commit."},
+	})
+
+	first, ok := c.filtered[0].(*CompletionItem)
+	require.True(t, ok)
+	// The row reads "/name - description", with the frontmatter
+	// description flattened onto one line.
+	require.Equal(t, "/skill-creator - Use for naming skills and writing frontmatter.", first.Text())
+	// The name leads; the description renders as dimmed detail.
+	require.Equal(t, len("/skill-creator"), first.detailStart)
+	require.Equal(t, "/skill-creator", first.SortKey())
+
+	// The description is part of the filter text, so a skill is findable by
+	// what it does and not only by what it is named.
+	c.Filter("frontmatter")
+	require.Len(t, c.filtered, 1)
+	hit, ok := c.filtered[0].(*CompletionItem)
+	require.True(t, ok)
+	require.Equal(t, "skill-creator", hit.Value().(SkillCompletionValue).Name)
+}
+
+func TestSkillDescriptionTruncatedToPopupWidth(t *testing.T) {
+	t.Parallel()
+
+	c := New(lipgloss.NewStyle(), lipgloss.NewStyle(), lipgloss.NewStyle())
+	c.SetSkillItems([]SkillCompletionValue{
+		{Name: "commit", Description: strings.Repeat("long ", 200)},
+	})
+
+	first, ok := c.filtered[0].(*CompletionItem)
+	require.True(t, ok)
+	require.LessOrEqual(t, ansi.StringWidth(first.Text()), maxWidth-2)
+	require.True(t, strings.HasSuffix(first.Text(), "…"), "expected an ellipsis, got %q", first.Text())
+}
+
+func TestSkillDescriptionDroppedWhenNameEatsTheRow(t *testing.T) {
+	t.Parallel()
+
+	// A name long enough to leave no room for a useful description renders
+	// bare rather than as a row of ellipsis.
+	long := strings.Repeat("a", maxWidth)
+	c := New(lipgloss.NewStyle(), lipgloss.NewStyle(), lipgloss.NewStyle())
+	c.SetSkillItems([]SkillCompletionValue{{Name: long, Description: "does things"}})
+
+	first, ok := c.filtered[0].(*CompletionItem)
+	require.True(t, ok)
+	require.Equal(t, "/"+long, first.Text())
+	require.Equal(t, -1, first.detailStart)
 }
 
 func TestSelectCurrentReturnsSkillSelectionMsg(t *testing.T) {

--- a/internal/ui/completions/skills_test.go
+++ b/internal/ui/completions/skills_test.go
@@ -1,0 +1,100 @@
+package completions
+
+import (
+	"testing"
+
+	"charm.land/lipgloss/v2"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSetSkillItemsOpensWithSkills(t *testing.T) {
+	t.Parallel()
+
+	c := New(lipgloss.NewStyle(), lipgloss.NewStyle(), lipgloss.NewStyle())
+	require.False(t, c.IsOpen())
+
+	c.SetSkillItems([]SkillCompletionValue{
+		{Name: "code-review", Path: "/skills/code-review/SKILL.md"},
+		{Name: "commit", Path: "/skills/commit/SKILL.md"},
+	})
+
+	require.True(t, c.IsOpen())
+	require.Len(t, c.filtered, 2)
+	first, ok := c.filtered[0].(*CompletionItem)
+	require.True(t, ok)
+	require.Equal(t, "code-review", first.Text())
+}
+
+func TestSkillCompletionFilter(t *testing.T) {
+	t.Parallel()
+
+	c := New(lipgloss.NewStyle(), lipgloss.NewStyle(), lipgloss.NewStyle())
+	c.SetSkillItems([]SkillCompletionValue{
+		{Name: "code-review"},
+		{Name: "commit"},
+		{Name: "coder"},
+	})
+
+	c.Filter("cod")
+
+	require.NotEmpty(t, c.filtered)
+	first, ok := c.filtered[0].(*CompletionItem)
+	require.True(t, ok)
+	// "coder" is an exact-stem/prefix tier winner over "code-review".
+	require.Equal(t, "coder", first.Text())
+}
+
+func TestSelectCurrentReturnsSkillSelectionMsg(t *testing.T) {
+	t.Parallel()
+
+	c := New(lipgloss.NewStyle(), lipgloss.NewStyle(), lipgloss.NewStyle())
+	c.SetSkillItems([]SkillCompletionValue{
+		{Name: "commit", Path: "/skills/commit/SKILL.md"},
+	})
+
+	msg := c.selectCurrent(false)
+	sel, ok := msg.(SelectionMsg[SkillCompletionValue])
+	require.True(t, ok, "expected SelectionMsg[SkillCompletionValue], got %T", msg)
+	require.Equal(t, "commit", sel.Value.Name)
+	require.Equal(t, "/skills/commit/SKILL.md", sel.Value.Path)
+	require.False(t, sel.KeepOpen)
+	require.False(t, c.IsOpen(), "popup should close on non-keep-open select")
+}
+
+func TestSelectCurrentSkillKeepOpen(t *testing.T) {
+	t.Parallel()
+
+	c := New(lipgloss.NewStyle(), lipgloss.NewStyle(), lipgloss.NewStyle())
+	c.SetSkillItems([]SkillCompletionValue{{Name: "commit"}})
+
+	msg := c.selectCurrent(true)
+	sel, ok := msg.(SelectionMsg[SkillCompletionValue])
+	require.True(t, ok)
+	require.True(t, sel.KeepOpen)
+	require.True(t, c.IsOpen(), "popup should stay open on keep-open select")
+}
+
+func TestSetSkillItemsEmpty(t *testing.T) {
+	t.Parallel()
+
+	c := New(lipgloss.NewStyle(), lipgloss.NewStyle(), lipgloss.NewStyle())
+	c.SetSkillItems(nil)
+
+	require.True(t, c.IsOpen())
+	require.False(t, c.HasItems())
+	require.Nil(t, c.selectCurrent(false))
+}
+
+func TestSkillItemsDoNotAffectFileSelectionDispatch(t *testing.T) {
+	t.Parallel()
+
+	// Regression: file/resource values must still dispatch their own
+	// SelectionMsg types after the skill case was added.
+	c := New(lipgloss.NewStyle(), lipgloss.NewStyle(), lipgloss.NewStyle())
+	c.SetItems([]FileCompletionValue{{Path: "foo.go"}}, nil)
+
+	msg := c.selectCurrent(false)
+	sel, ok := msg.(SelectionMsg[FileCompletionValue])
+	require.True(t, ok, "expected SelectionMsg[FileCompletionValue], got %T", msg)
+	require.Equal(t, "foo.go", sel.Value.Path)
+}

--- a/internal/ui/model/skill_completion_test.go
+++ b/internal/ui/model/skill_completion_test.go
@@ -1,0 +1,170 @@
+package model
+
+import (
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"charm.land/bubbles/v2/textarea"
+
+	"github.com/charmbracelet/crush/internal/config"
+	"github.com/charmbracelet/crush/internal/skills"
+	"github.com/charmbracelet/crush/internal/ui/attachments"
+	"github.com/charmbracelet/crush/internal/ui/common"
+	"github.com/charmbracelet/crush/internal/ui/completions"
+	"github.com/stretchr/testify/require"
+)
+
+func newSkillCompletionUI() *UI {
+	com := common.DefaultCommon(&slashCommandWorkspace{ready: true})
+	m := &UI{
+		com:      com,
+		status:   NewStatus(com, nil),
+		chat:     NewChat(com, config.ScrollbarDefault),
+		textarea: textarea.New(),
+		state:    uiChat,
+		focus:    uiFocusEditor,
+		width:    140,
+		height:   45,
+	}
+	m.attachments = attachments.New(nil, attachments.Keymap{})
+	m.completions = completions.New(
+		com.Styles.Completions.Normal,
+		com.Styles.Completions.Focused,
+		com.Styles.Completions.Match,
+	)
+	return m
+}
+
+// TestOpenSkillCompletionsPopulatesFromSkillStates verifies the popup opens
+// in skill mode with items built from healthy skill states only.
+func TestOpenSkillCompletionsPopulatesFromSkillStates(t *testing.T) {
+	t.Parallel()
+
+	m := newSkillCompletionUI()
+	m.skillStates = []*skills.SkillState{
+		{Name: "commit", Path: "/skills/commit/SKILL.md", State: skills.StateNormal},
+		{Name: "code-review", Path: "/skills/code-review/SKILL.md", State: skills.StateNormal},
+		{Name: "broken", Path: "/skills/broken/SKILL.md", State: skills.StateError},
+		nil,
+	}
+
+	m.openSkillCompletions(5)
+
+	require.True(t, m.completionsOpen)
+	require.Equal(t, completions.TriggerSkill, m.completionsTrigger)
+	require.Equal(t, 5, m.completionsStartIndex)
+	require.True(t, m.completions.IsOpen())
+	require.True(t, m.completions.HasItems())
+}
+
+// TestOpenSkillCompletionsSortsByName pins alphabetical ordering of the
+// skill popup items: with no query the first selected item should be the
+// alphabetically-first skill.
+func TestOpenSkillCompletionsSortsByName(t *testing.T) {
+	t.Parallel()
+
+	m := newSkillCompletionUI()
+	m.skillStates = []*skills.SkillState{
+		{Name: "zebra", State: skills.StateNormal},
+		{Name: "alpha", State: skills.StateNormal},
+	}
+
+	m.openSkillCompletions(0)
+
+	// Select the first item without filtering: it should be "alpha".
+	msg, handled := m.completions.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	require.True(t, handled)
+	sel, ok := msg.(completions.SelectionMsg[completions.SkillCompletionValue])
+	require.True(t, ok, "expected skill selection, got %T", msg)
+	require.Equal(t, "alpha", sel.Value.Name)
+}
+
+// TestInsertSkillCompletion verifies selecting a skill replaces the /query
+// with "/skill-name" plus a trailing space.
+func TestInsertSkillCompletion(t *testing.T) {
+	t.Parallel()
+
+	m := newSkillCompletionUI()
+	m.textarea.SetValue("hello can you /cod")
+	m.completionsOpen = true
+	m.completionsTrigger = completions.TriggerSkill
+	m.completionsStartIndex = len("hello can you ")
+
+	m.insertSkillCompletion(completions.SkillCompletionValue{Name: "code-review"})
+
+	require.Equal(t, "hello can you /code-review ", m.textarea.Value())
+}
+
+// TestInsertSkillCompletionKeepsSlashRegression guards against the
+// double-slash bug: the replacement span includes the trigger '/', so the
+// inserted text must include exactly one.
+func TestInsertSkillCompletionKeepsSlashRegression(t *testing.T) {
+	t.Parallel()
+
+	m := newSkillCompletionUI()
+	m.textarea.SetValue("/com")
+	m.completionsOpen = true
+	m.completionsTrigger = completions.TriggerSkill
+	m.completionsStartIndex = 0
+
+	m.insertSkillCompletion(completions.SkillCompletionValue{Name: "commit"})
+
+	require.Equal(t, "/commit ", m.textarea.Value())
+}
+
+// TestCloseCompletionsResetsTrigger verifies closing the popup clears the
+// trigger mode so a stale async file load can't clobber a later skill popup.
+func TestCloseCompletionsResetsTrigger(t *testing.T) {
+	t.Parallel()
+
+	m := newSkillCompletionUI()
+	m.completionsOpen = true
+	m.completionsTrigger = completions.TriggerSkill
+	m.completionsQuery = "cod"
+	m.completionsStartIndex = 3
+
+	m.closeCompletions()
+
+	require.False(t, m.completionsOpen)
+	require.Equal(t, completions.TriggerNone, m.completionsTrigger)
+	require.Empty(t, m.completionsQuery)
+	require.Zero(t, m.completionsStartIndex)
+}
+
+// TestCompletionItemsLoadedIgnoredInSkillMode is the regression test for the
+// stale async load: a file-completion load that resolves while the popup is
+// in skill mode must not replace the skill items.
+func TestCompletionItemsLoadedIgnoredInSkillMode(t *testing.T) {
+	t.Parallel()
+
+	m := newSkillCompletionUI()
+	m.skillStates = []*skills.SkillState{{Name: "commit", State: skills.StateNormal}}
+	m.openSkillCompletions(0)
+	require.True(t, m.completions.HasItems())
+
+	// A stale async file load completing while in skill mode must be ignored.
+	m.Update(completions.CompletionItemsLoadedMsg{
+		Files: []completions.FileCompletionValue{{Path: "foo.go"}},
+	})
+
+	// Skill items survive: filtering by skill name still matches.
+	m.completions.Filter("commit")
+	require.True(t, m.completions.HasItems())
+}
+
+// TestCompletionItemsLoadedAppliesInFileMode is the counterpart regression:
+// the async file load must still populate the popup when in file mode.
+func TestCompletionItemsLoadedAppliesInFileMode(t *testing.T) {
+	t.Parallel()
+
+	m := newSkillCompletionUI()
+	m.completionsOpen = true
+	m.completionsTrigger = completions.TriggerFile
+
+	m.Update(completions.CompletionItemsLoadedMsg{
+		Files: []completions.FileCompletionValue{{Path: "foo.go"}},
+	})
+
+	m.completions.Filter("foo")
+	require.True(t, m.completions.HasItems())
+}

--- a/internal/ui/model/skill_completion_test.go
+++ b/internal/ui/model/skill_completion_test.go
@@ -3,8 +3,8 @@ package model
 import (
 	"testing"
 
-	tea "charm.land/bubbletea/v2"
 	"charm.land/bubbles/v2/textarea"
+	tea "charm.land/bubbletea/v2"
 
 	"github.com/charmbracelet/crush/internal/config"
 	"github.com/charmbracelet/crush/internal/skills"
@@ -55,6 +55,70 @@ func TestOpenSkillCompletionsPopulatesFromSkillStates(t *testing.T) {
 	require.Equal(t, 5, m.completionsStartIndex)
 	require.True(t, m.completions.IsOpen())
 	require.True(t, m.completions.HasItems())
+}
+
+// TestSkillCompletionValuesPrefersCatalog verifies the popup is built from
+// the effective skill catalog once it has loaded. The catalog is what
+// carries descriptions, includes builtin skills, and has already resolved
+// user-over-builtin overrides and the disabled-skills list — the raw
+// discovery states do none of that.
+func TestSkillCompletionValuesPrefersCatalog(t *testing.T) {
+	t.Parallel()
+
+	m := newSkillCompletionUI()
+	m.skillStates = []*skills.SkillState{
+		{Name: "only-a-state", Path: "/skills/only-a-state/SKILL.md", State: skills.StateNormal},
+	}
+	m.skillCatalog = []skills.CatalogEntry{
+		{ID: "crush://skills/commit/SKILL.md", Name: "commit", Description: "Write a conventional commit."},
+		{ID: "/skills/alpha/SKILL.md", Name: "alpha", Description: "Go first."},
+		{Name: ""}, // Nameless entries are not selectable; drop them.
+	}
+
+	values := m.skillCompletionValues()
+
+	require.Equal(t, []completions.SkillCompletionValue{
+		{Name: "alpha", Description: "Go first.", Path: "/skills/alpha/SKILL.md"},
+		{Name: "commit", Description: "Write a conventional commit.", Path: "crush://skills/commit/SKILL.md"},
+	}, values)
+}
+
+// TestSkillCompletionValuesFallsBackToStates covers the window between
+// startup and the first catalog load: a name-only list still beats an empty
+// popup. Duplicate names (a user skill shadowing a builtin) collapse to one.
+func TestSkillCompletionValuesFallsBackToStates(t *testing.T) {
+	t.Parallel()
+
+	m := newSkillCompletionUI()
+	m.skillStates = []*skills.SkillState{
+		{Name: "commit", Path: "/user/skills/commit/SKILL.md", State: skills.StateNormal},
+		{Name: "commit", Path: "crush://skills/commit/SKILL.md", State: skills.StateNormal},
+		{Name: "", Path: "/skills/unnamed/SKILL.md", State: skills.StateNormal},
+		{Name: "broken", State: skills.StateError},
+		nil,
+	}
+
+	values := m.skillCompletionValues()
+
+	require.Equal(t, []completions.SkillCompletionValue{
+		{Name: "commit", Path: "/user/skills/commit/SKILL.md"},
+	}, values)
+}
+
+// TestOpenSkillCompletionsNoopWithoutSkills guards the empty-popup trap: an
+// open completions popup consumes enter and the arrow keys, so opening one
+// with nothing in it would leave a user with no skills unable to submit a
+// prompt containing a '/'.
+func TestOpenSkillCompletionsNoopWithoutSkills(t *testing.T) {
+	t.Parallel()
+
+	m := newSkillCompletionUI()
+
+	m.openSkillCompletions(3)
+
+	require.False(t, m.completionsOpen)
+	require.Equal(t, completions.TriggerNone, m.completionsTrigger)
+	require.False(t, m.completions.IsOpen())
 }
 
 // TestOpenSkillCompletionsSortsByName pins alphabetical ordering of the

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -278,9 +278,10 @@ type UI struct {
 	// Completions state
 	completions              *completions.Completions
 	completionsOpen          bool
+	completionsTrigger       completions.Trigger
 	completionsStartIndex    int
 	completionsQuery         string
-	completionsPositionStart image.Point // x,y where user typed '@'
+	completionsPositionStart image.Point // x,y where user typed the trigger
 
 	// Chat components
 	chat *Chat
@@ -1352,7 +1353,9 @@ func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case util.ClearStatusMsg:
 		m.status.ClearInfoMsg()
 	case completions.CompletionItemsLoadedMsg:
-		if m.completionsOpen {
+		// Guard against a stale async file load landing after the popup
+		// switched to (or was reopened in) skill mode.
+		if m.completionsOpen && m.completionsTrigger == completions.TriggerFile {
 			m.completions.SetItems(msg.Files, msg.Resources)
 		}
 	case uv.KittyGraphicsEvent:
@@ -2474,6 +2477,11 @@ func (m *UI) handleKeyPressMsg(msg tea.KeyPressMsg) tea.Cmd {
 			if m.completionsOpen {
 				if msg, ok := m.completions.Update(msg); ok {
 					switch msg := msg.(type) {
+					case completions.SelectionMsg[completions.SkillCompletionValue]:
+						cmds = append(cmds, m.insertSkillCompletion(msg.Value))
+						if !msg.KeepOpen {
+							m.closeCompletions()
+						}
 					case completions.SelectionMsg[completions.FileCompletionValue]:
 						cmds = append(cmds, m.insertFileCompletion(msg.Value.Path))
 						if !msg.KeepOpen {
@@ -2486,6 +2494,7 @@ func (m *UI) handleKeyPressMsg(msg tea.KeyPressMsg) tea.Cmd {
 						}
 					case completions.ClosedMsg:
 						m.completionsOpen = false
+						m.completionsTrigger = completions.TriggerNone
 					}
 					return tea.Batch(cmds...)
 				}
@@ -2622,20 +2631,32 @@ func (m *UI) handleKeyPressMsg(msg tea.KeyPressMsg) tea.Cmd {
 					break
 				}
 
-				// Check for @ trigger before passing to textarea.
+				// Check for completion triggers before passing to textarea.
 				curValue := m.textarea.Value()
 				curIdx := len(curValue)
 
-				// Trigger completions on @.
+				// Trigger file completions on @.
 				if msg.String() == "@" && !m.completionsOpen {
 					// Only show if beginning of prompt or after whitespace.
 					if curIdx == 0 || (curIdx > 0 && isWhitespace(curValue[curIdx-1])) {
 						m.completionsOpen = true
+						m.completionsTrigger = completions.TriggerFile
 						m.completionsQuery = ""
 						m.completionsStartIndex = curIdx
 						m.completionsPositionStart = m.completionsPosition()
 						depth, limit := m.com.Config().Options.TUI.Completions.Limits()
 						cmds = append(cmds, m.completions.Open(depth, limit))
+					}
+				}
+
+				// Trigger skill completions on / mid-prompt. At the start of
+				// an empty prompt the commands dialog handles '/' instead
+				// (see the Editor.Commands binding above), so here we only
+				// fire when the textarea already has content and '/' begins
+				// a new word.
+				if msg.String() == "/" && !m.completionsOpen && !m.bangMode {
+					if curIdx > 0 && isWhitespace(curValue[curIdx-1]) {
+						m.openSkillCompletions(curIdx)
 					}
 				}
 
@@ -2679,8 +2700,9 @@ func (m *UI) handleKeyPressMsg(msg tea.KeyPressMsg) tea.Cmd {
 				m.updateHistoryDraft(curValue)
 
 				// After updating textarea, check if we need to filter completions.
-				// Skip filtering on the initial @ keystroke since items are loading async.
-				if m.completionsOpen && msg.String() != "@" {
+				// Skip filtering on the initial trigger keystroke since items
+				// are loading async.
+				if m.completionsOpen && msg.String() != string(m.completionsTrigger) {
 					newValue := m.textarea.Value()
 					newIdx := len(newValue)
 
@@ -2693,7 +2715,7 @@ func (m *UI) handleKeyPressMsg(msg tea.KeyPressMsg) tea.Cmd {
 					} else {
 						// Extract current word and filter.
 						word := m.textareaWord()
-						if strings.HasPrefix(word, "@") {
+						if strings.HasPrefix(word, string(m.completionsTrigger)) {
 							m.completionsQuery = word[1:]
 							m.completions.Filter(m.completionsQuery)
 						} else if m.completionsOpen {
@@ -3783,9 +3805,36 @@ func (m *UI) bangPromptFunc(info textarea.PromptInfo) string {
 // closeCompletions closes the completions popup and resets state.
 func (m *UI) closeCompletions() {
 	m.completionsOpen = false
+	m.completionsTrigger = completions.TriggerNone
 	m.completionsQuery = ""
 	m.completionsStartIndex = 0
 	m.completions.Close()
+}
+
+// openSkillCompletions opens the completions popup in skill mode at the
+// given trigger index. Skills are already in memory (m.skillStates), so no
+// async load is needed.
+func (m *UI) openSkillCompletions(startIndex int) {
+	var values []completions.SkillCompletionValue
+	for _, s := range m.skillStates {
+		if s == nil || s.State != skills.StateNormal {
+			continue
+		}
+		values = append(values, completions.SkillCompletionValue{
+			Name: s.Name,
+			Path: s.Path,
+		})
+	}
+	slices.SortFunc(values, func(a, b completions.SkillCompletionValue) int {
+		return strings.Compare(a.Name, b.Name)
+	})
+
+	m.completionsOpen = true
+	m.completionsTrigger = completions.TriggerSkill
+	m.completionsQuery = ""
+	m.completionsStartIndex = startIndex
+	m.completionsPositionStart = m.completionsPosition()
+	m.completions.SetSkillItems(values)
 }
 
 // insertCompletionText replaces the @query in the textarea with the given text.
@@ -3920,6 +3969,17 @@ func (m *UI) insertMCPResourceCompletion(item completions.ResourceCompletionValu
 		}
 	}
 	return tea.Batch(heightCmd, resourceCmd)
+}
+
+// insertSkillCompletion inserts the selected skill name into the textarea,
+// replacing the /query. Unlike files, skills are not attached — the
+// "/skill-name" text in the prompt is the signal to load the skill.
+func (m *UI) insertSkillCompletion(skill completions.SkillCompletionValue) tea.Cmd {
+	prevHeight := m.textarea.Height()
+	if !m.insertCompletionText("/" + skill.Name) {
+		return nil
+	}
+	return m.handleTextareaHeightChange(prevHeight)
 }
 
 // completionsPosition returns the X and Y position for the completions popup.

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -136,9 +136,12 @@ type shellStreamMsg struct {
 type (
 	// cancelTimerExpiredMsg is sent when the cancel timer expires.
 	cancelTimerExpiredMsg struct{}
-	// userCommandsLoadedMsg is sent when user commands are loaded.
+	// userCommandsLoadedMsg is sent when user commands are loaded. It also
+	// carries the skill catalog the command list was built from, so the
+	// '/' completions popup gets descriptions off the same single load.
 	userCommandsLoadedMsg struct {
-		Commands []commands.CustomCommand
+		Commands     []commands.CustomCommand
+		SkillEntries []skills.CatalogEntry
 	}
 	// mcpPromptsLoadedMsg is sent when mcp prompts are loaded.
 	mcpPromptsLoadedMsg struct {
@@ -299,6 +302,11 @@ type UI struct {
 
 	// skills
 	skillStates []*skills.SkillState
+
+	// skillCatalog is the effective visible skill set (post-override,
+	// post-disable) with frontmatter descriptions, refreshed alongside the
+	// custom commands. It backs the '/' completions popup.
+	skillCatalog []skills.CatalogEntry
 
 	// sidebarLogo keeps a cached version of the sidebar sidebarLogo.
 	sidebarLogo string
@@ -654,7 +662,7 @@ func (m *UI) loadCustomCommands() tea.Cmd {
 			slog.Error("Failed to load skill commands", "error", err)
 		}
 		customCommands = append(customCommands, commands.FromSkillCatalog(skillEntries)...)
-		return userCommandsLoadedMsg{Commands: customCommands}
+		return userCommandsLoadedMsg{Commands: customCommands, SkillEntries: skillEntries}
 	}
 }
 
@@ -795,6 +803,7 @@ func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case userCommandsLoadedMsg:
 		m.customCommands = msg.Commands
+		m.skillCatalog = msg.SkillEntries
 		dia := m.dialog.Dialog(dialog.CommandsID)
 		if dia == nil {
 			break
@@ -927,6 +936,11 @@ func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.lspStates = m.com.Workspace.LSPGetStates()
 	case pubsub.Event[skills.Event]:
 		m.skillStates = msg.Payload.States
+		// Discovery states carry no descriptions and no override/disable
+		// resolution, so re-read the catalog too: a ctrl+r reload in the
+		// skills dialog must move both the command palette and the '/'
+		// completions popup.
+		cmds = append(cmds, m.loadCustomCommands())
 	case pubsub.Event[mcp.Event]:
 		switch msg.Payload.Type {
 		case mcp.EventStateChanged:
@@ -3811,23 +3825,60 @@ func (m *UI) closeCompletions() {
 	m.completions.Close()
 }
 
-// openSkillCompletions opens the completions popup in skill mode at the
-// given trigger index. Skills are already in memory (m.skillStates), so no
-// async load is needed.
-func (m *UI) openSkillCompletions(startIndex int) {
+// skillCompletionValues returns the skills offered by the '/' popup.
+//
+// The catalog is the right source: it is the effective, post-dedup,
+// post-disable set, it includes the builtin skills the raw discovery states
+// omit, and it carries each skill's frontmatter description. The discovery
+// states are only a fallback for the window between startup and the first
+// catalog load, where a name-only list still beats an empty popup.
+func (m *UI) skillCompletionValues() []completions.SkillCompletionValue {
 	var values []completions.SkillCompletionValue
-	for _, s := range m.skillStates {
-		if s == nil || s.State != skills.StateNormal {
-			continue
+	if len(m.skillCatalog) > 0 {
+		for _, entry := range m.skillCatalog {
+			if entry.Name == "" {
+				continue
+			}
+			values = append(values, completions.SkillCompletionValue{
+				Name:        entry.Name,
+				Description: entry.Description,
+				Path:        entry.ID,
+			})
 		}
-		values = append(values, completions.SkillCompletionValue{
-			Name: s.Name,
-			Path: s.Path,
-		})
+	} else {
+		seen := make(map[string]struct{}, len(m.skillStates))
+		for _, s := range m.skillStates {
+			if s == nil || s.Name == "" || s.State != skills.StateNormal {
+				continue
+			}
+			if _, dup := seen[s.Name]; dup {
+				continue
+			}
+			seen[s.Name] = struct{}{}
+			values = append(values, completions.SkillCompletionValue{
+				Name: s.Name,
+				Path: s.Path,
+			})
+		}
 	}
 	slices.SortFunc(values, func(a, b completions.SkillCompletionValue) int {
 		return strings.Compare(a.Name, b.Name)
 	})
+	return values
+}
+
+// openSkillCompletions opens the completions popup in skill mode at the
+// given trigger index. Skills are already in memory, so no async load is
+// needed.
+func (m *UI) openSkillCompletions(startIndex int) {
+	values := m.skillCompletionValues()
+	if len(values) == 0 {
+		// An open-but-empty popup still consumes enter and the arrow keys,
+		// so a user with no skills configured could not submit a prompt
+		// containing a '/'. Unlike '@' there is nothing to wait on here —
+		// no skills means no popup.
+		return
+	}
 
 	m.completionsOpen = true
 	m.completionsTrigger = completions.TriggerSkill


### PR DESCRIPTION
## Summary

- Typing `/` at a word boundary **mid-prompt** now opens the completions popup in skill mode, listing discovered agent skills for type-ahead selection — the same UX as the existing `@` file-mention popup.
- Rows read `/skill-name - description`, sourced from the SKILL.md frontmatter, and **the description is searchable**: typing `/pdf` finds a skill described as "extract text from PDFs" whatever it is named.
- `/` at the start of an empty prompt still opens the commands dialog, and bang mode is unaffected.
- The popup now tracks which trigger character opened it (`@` vs `/`), so a stale async file load can no longer clobber skill items that replaced it.

## Implementation

- `internal/ui/completions`: new `SkillCompletionValue` (name + description + path), a synchronous `SetSkillItems`, and a `Trigger` enum plumbed through open/filter/close. Items carry an optional dimmed detail span and a separate sort key, so the description renders subordinate to the name, joins the fuzzy filter text, and stays out of the name-priority tiering.
- `internal/ui/model/ui.go`: `/` trigger in the editor key path (word-boundary, non-empty prompt, not bang mode), `openSkillCompletions`, `insertSkillCompletion` (inserts `/skill-name`; no attachment — the text token is the signal), and a guard on `CompletionItemsLoadedMsg` so stale file loads are dropped in skill mode.
- Skills come from the `ListSkills` catalog — the effective, post-override, post-disable set, which is also the only source that carries descriptions and includes the builtins. It is cached off the load the command palette already performs and refreshed on `skills.Event`, so a `ctrl+r` reload moves the palette and the popup together. Discovery states remain a name-only fallback before the first catalog load.
- The popup does not open when there are no skills at all: an open completions popup consumes enter and the arrow keys.

## Verification

- `internal/ui/completions/skills_test.go` (open/filter/select/keep-open/empty; description rendering, per-row truncation, drop-when-too-narrow, description-driven fuzzy match; file-dispatch regression) and `internal/ui/model/skill_completion_test.go` (catalog-preferred sourcing, fallback-with-dedup, empty-popup guard, trigger state, alphabetical order, insert incl. the double-slash regression, trigger reset, stale-load ignore + file-mode counterpart).
- Full `go test ./...` green; `-race` green on the touched packages; `golangci-lint run` 0 issues.

## Base

Stacked on `feat/a2ui-mcp-audience` (the A2UI stack this branch's tree was built against). `feat/prompt-token-highlighting` (#246) stacks on this PR.
