### PR TITLE
ci: run lint in-repo so it actually gates pull requests

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,10 +4,36 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
+concurrency:
+  group: lint-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
+  # Self-contained on purpose. This used to call
+  # charmbracelet/meta/.github/workflows/lint.yml@main, which resolved to a
+  # startup_failure in this fork — producing no check at all rather than a
+  # red one, so lint silently stopped gating. A cross-repo reusable workflow
+  # is also a ref this fork does not control: upstream can change it at any
+  # time and the gate disappears again, without a diff here to explain why.
   lint:
-    uses: charmbracelet/meta/.github/workflows/lint.yml@main
-    with:
-      golangci_path: .golangci.yml
-      golangci_version: v2.11
-      timeout: 10m
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+      # Mirrors the `lint:log` task.
+      - name: Check log message capitalization
+        run: ./scripts/check_log_capitalization.sh
+      # Mirrors the `lint` task: same config, same flags, same pinned
+      # golangci-lint version, so a local run and CI cannot disagree.
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
+        with:
+          version: v2.11
+          args: --path-mode=abs --config=.golangci.yml --timeout=10m ./...


### PR DESCRIPTION
## Problem

`lint` has not gated a pull request in this fork for at least a month. Every run since 2026-07-31 — including on `main` — concluded `startup_failure`:

```
$ gh run list --workflow lint --branch main --limit 5 --json conclusion
startup_failure  startup_failure  startup_failure  startup_failure  startup_failure
```

A startup failure produces **no check runs at all** rather than a red one, so `gh pr checks` never listed a `lint` row and a PR looked green with zero lint coverage. #245 shipped a `gofumpt` violation straight through that hole.

The cause is the delegation to `charmbracelet/meta/.github/workflows/lint.yml@main`. That reusable workflow still exists and its inputs still match, so this is an environmental resolution/permission failure specific to the fork — not something a version bump fixes.

## Fix

Inline the job rather than repoint the reusable workflow.

A cross-repo workflow ref is one this fork does not control. Upstream can change, move, or tighten it at any time and the gate disappears again — silently, with no diff here to explain why. That is exactly the failure mode being fixed, so re-introducing the dependency would just reset the clock.

The job mirrors the Taskfile's `lint` and `lint:log` tasks exactly — same `.golangci.yml`, same `--path-mode=abs --timeout`, same pinned `v2.11` — so a local `task lint` and CI cannot drift.

Single `ubuntu-latest` runner rather than upstream's three-OS matrix, so the check name stays a plain `lint`. A matrix would produce `lint (ubuntu-latest)` and friends, which is three separate names for branch protection to require and three times the minutes for a linter whose only OS-specific finding is CRLF formatting.

All three actions are pinned to full SHAs; `checkout` and `setup-go` match what `build.yml` in this repo already uses, and `ba0d7d2` genuinely dereferences to `golangci-lint-action` `v9.3.0`.

## Verification

Both halves pass clean on `main` at `66f2d55`, so switching the gate back on does not immediately block the branch:

```
$ ./scripts/check_log_capitalization.sh          # ok
$ golangci-lint run --path-mode=abs --config=.golangci.yml --timeout=10m ./...
0 issues.
```

Local `golangci-lint` is 2.11.4, matching the pinned `v2.11`.

## Follow-ups, deliberately not in this PR

- **`lint` needs to be marked a required status check on `main`.** The workflow being fixed is necessary but not sufficient — a check that runs but is not required still leaves a red PR mergeable. It can only be required once it has reported at least once, which this PR provides.
- **`lint-sync.yml` calls the same `charmbracelet/meta` reusable workflow** and is presumably broken the same way. It is `workflow_dispatch`-only so it gates nothing, and it would sync `.golangci.yml` from upstream — which may not be wanted now that this fork pins its own linter setup. Left alone rather than guessed at.

🤖 Posted on behalf of `@joestump` by [`claude-opus-5[1m]`](https://openrouter.ai/anthropic/claude-opus-5) using [Claude Code](https://claude.ai).
