### PR TITLE
fix(ui): atomic backspace for completions and dismiss commands dialog on /

### DIFF
--- a/internal/ui/dialog/commands.go
+++ b/internal/ui/dialog/commands.go
@@ -234,6 +234,11 @@ func (c *Commands) HandleMsg(msg tea.Msg) Action {
 				c.setCommandItems(c.selected)
 			}
 		default:
+			// Typing '/' while the filter is empty closes the dialog
+			// so the user can dismiss it without reaching for Escape.
+			if msg.String() == "/" && c.input.Value() == "" {
+				return ActionClose{}
+			}
 			var cmd tea.Cmd
 			for _, item := range c.list.FilteredItems() {
 				if item, ok := item.(*CommandItem); ok && item != nil {

--- a/internal/ui/dialog/commands_test.go
+++ b/internal/ui/dialog/commands_test.go
@@ -354,3 +354,29 @@ func setupMenuHierarchy(t *testing.T) *Commands {
 	c.list.SetSelected(0)
 	return c
 }
+
+// TestCommandsDialogClosesOnSlashWithEmptyFilter covers the dismiss-on-'/'
+// behaviour, which shipped without a test.
+func TestCommandsDialogClosesOnSlashWithEmptyFilter(t *testing.T) {
+	t.Parallel()
+	c := newTestCommands(t)
+
+	action := c.HandleMsg(tea.KeyPressMsg{Code: '/', Text: "/"})
+
+	_, ok := action.(ActionClose)
+	require.True(t, ok, "expected ActionClose, got %T", action)
+}
+
+// TestCommandsDialogSlashFiltersOnceFilterIsNonEmpty pins the other half
+// of the rule: '/' only dismisses as the very first keystroke, so it stays
+// usable inside a filter string rather than closing the dialog mid-typing.
+func TestCommandsDialogSlashFiltersOnceFilterIsNonEmpty(t *testing.T) {
+	t.Parallel()
+	c := newTestCommands(t)
+
+	c.HandleMsg(tea.KeyPressMsg{Code: 'a', Text: "a"})
+	action := c.HandleMsg(tea.KeyPressMsg{Code: '/', Text: "/"})
+
+	_, closed := action.(ActionClose)
+	require.False(t, closed, "'/' after a filter character must not close the dialog")
+}

--- a/internal/ui/model/completion_backspace_test.go
+++ b/internal/ui/model/completion_backspace_test.go
@@ -1,0 +1,111 @@
+package model
+
+import (
+	"testing"
+
+	"charm.land/bubbles/v2/textarea"
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+
+	"github.com/charmbracelet/crush/internal/config"
+	"github.com/charmbracelet/crush/internal/ui/attachments"
+	"github.com/charmbracelet/crush/internal/ui/common"
+	"github.com/charmbracelet/crush/internal/ui/dialog"
+)
+
+func newCompletionBackspaceUI() *UI {
+	com := common.DefaultCommon(&slashCommandWorkspace{ready: true})
+	return &UI{
+		com:      com,
+		dialog:   dialog.NewOverlay(),
+		status:   NewStatus(com, nil),
+		chat:     NewChat(com, config.ScrollbarDefault),
+		textarea: textarea.New(),
+		attachments: attachments.New(
+			attachments.NewRenderer(
+				lipgloss.NewStyle(), lipgloss.NewStyle(),
+				lipgloss.NewStyle(), lipgloss.NewStyle(),
+				lipgloss.NewStyle(), lipgloss.NewStyle(),
+			),
+			attachments.Keymap{},
+		),
+		state:  uiChat,
+		focus:  uiFocusEditor,
+		width:  140,
+		height: 45,
+	}
+}
+
+// TestAtomicBackspaceDeletesEntireCompletion verifies that pressing
+// backspace immediately after a completion insertion deletes the entire
+// inserted text at once rather than one character at a time.
+func TestAtomicBackspaceDeletesEntireCompletion(t *testing.T) {
+	t.Parallel()
+
+	m := newCompletionBackspaceUI()
+
+	// Simulate what insertCompletionText does: set the text and record
+	// the range.
+	m.textarea.SetValue("hello @path/to/file.go ")
+	m.lastCompletionStart = 6 // index of '@'
+	m.lastCompletionEnd = 23  // end of inserted text + trailing space
+
+	// Press backspace — should delete the entire completion.
+	m.Update(tea.KeyPressMsg{Code: tea.KeyBackspace})
+
+	got := m.textarea.Value()
+	if got != "hello " {
+		t.Fatalf("expected %q after atomic backspace, got %q", "hello ", got)
+	}
+	if m.lastCompletionEnd != 0 {
+		t.Fatal("expected lastCompletionEnd to be cleared after atomic delete")
+	}
+}
+
+// TestAtomicBackspaceInvalidatedByTyping verifies that typing any
+// character after completion clears the atomic-delete range so
+// subsequent backspaces behave normally.
+func TestAtomicBackspaceInvalidatedByTyping(t *testing.T) {
+	t.Parallel()
+
+	m := newCompletionBackspaceUI()
+
+	m.textarea.SetValue("hello @path/to/file.go ")
+	m.lastCompletionStart = 6
+	m.lastCompletionEnd = 23
+
+	// Type a character — should invalidate the range.
+	m.Update(tea.KeyPressMsg{Code: 'x'})
+
+	if m.lastCompletionEnd != 0 {
+		t.Fatal("expected lastCompletionEnd to be cleared after typing")
+	}
+}
+
+// TestAtomicBackspaceInvalidatedByTextChange verifies that if the
+// textarea value changes between insertion and backspace (e.g. user
+// clicked elsewhere and edited), the atomic delete is skipped.
+func TestAtomicBackspaceInvalidatedByTextChange(t *testing.T) {
+	t.Parallel()
+
+	m := newCompletionBackspaceUI()
+
+	m.textarea.SetValue("hello @path/to/file.go ")
+	m.lastCompletionStart = 6
+	m.lastCompletionEnd = 23
+
+	// Simulate text changing (e.g. user pasted or deleted something).
+	m.textarea.SetValue("hello @path/to/file.go extra")
+
+	// Press backspace — should NOT do atomic delete since length changed.
+	m.Update(tea.KeyPressMsg{Code: tea.KeyBackspace})
+
+	got := m.textarea.Value()
+	// The textarea's normal backspace should have deleted the last char.
+	if got == "hello " {
+		t.Fatal("atomic backspace should not have fired after text change")
+	}
+	if m.lastCompletionEnd != 0 {
+		t.Fatal("expected lastCompletionEnd to be cleared after invalidated backspace")
+	}
+}

--- a/internal/ui/model/completion_backspace_test.go
+++ b/internal/ui/model/completion_backspace_test.go
@@ -15,12 +15,14 @@ import (
 
 func newCompletionBackspaceUI() *UI {
 	com := common.DefaultCommon(&slashCommandWorkspace{ready: true})
+	ta := textarea.New()
+	ta.Focus()
 	return &UI{
 		com:      com,
 		dialog:   dialog.NewOverlay(),
 		status:   NewStatus(com, nil),
 		chat:     NewChat(com, config.ScrollbarDefault),
-		textarea: textarea.New(),
+		textarea: ta,
 		attachments: attachments.New(
 			attachments.NewRenderer(
 				lipgloss.NewStyle(), lipgloss.NewStyle(),
@@ -44,11 +46,9 @@ func TestAtomicBackspaceDeletesEntireCompletion(t *testing.T) {
 
 	m := newCompletionBackspaceUI()
 
-	// Simulate what insertCompletionText does: set the text and record
-	// the range.
-	m.textarea.SetValue("hello @path/to/file.go ")
-	m.lastCompletionStart = 6 // index of '@'
-	m.lastCompletionEnd = 23  // end of inserted text + trailing space
+	// Go through the real insertion path so the recorded range and text
+	// cannot drift from what the implementation actually writes.
+	insertTestCompletion(t, m, "hello ", "@path/to/file.go")
 
 	// Press backspace — should delete the entire completion.
 	m.Update(tea.KeyPressMsg{Code: tea.KeyBackspace})
@@ -70,9 +70,7 @@ func TestAtomicBackspaceInvalidatedByTyping(t *testing.T) {
 
 	m := newCompletionBackspaceUI()
 
-	m.textarea.SetValue("hello @path/to/file.go ")
-	m.lastCompletionStart = 6
-	m.lastCompletionEnd = 23
+	insertTestCompletion(t, m, "hello ", "@path/to/file.go")
 
 	// Type a character — should invalidate the range.
 	m.Update(tea.KeyPressMsg{Code: 'x'})
@@ -90,9 +88,7 @@ func TestAtomicBackspaceInvalidatedByTextChange(t *testing.T) {
 
 	m := newCompletionBackspaceUI()
 
-	m.textarea.SetValue("hello @path/to/file.go ")
-	m.lastCompletionStart = 6
-	m.lastCompletionEnd = 23
+	insertTestCompletion(t, m, "hello ", "@path/to/file.go")
 
 	// Simulate text changing (e.g. user pasted or deleted something).
 	m.textarea.SetValue("hello @path/to/file.go extra")
@@ -107,5 +103,49 @@ func TestAtomicBackspaceInvalidatedByTextChange(t *testing.T) {
 	}
 	if m.lastCompletionEnd != 0 {
 		t.Fatal("expected lastCompletionEnd to be cleared after invalidated backspace")
+	}
+}
+
+// insertTestCompletion drives the real completion-insert path: it seeds
+// the prompt with prefix, points the completion machinery at the end of
+// it, and inserts text exactly as selecting from the popup would.
+func insertTestCompletion(t *testing.T, m *UI, prefix, text string) {
+	t.Helper()
+	m.textarea.SetValue(prefix)
+	m.completionsStartIndex = len(prefix)
+	if !m.insertCompletionText(text) {
+		t.Fatalf("insertCompletionText(%q) failed", text)
+	}
+	if got, want := m.textarea.Value(), prefix+text+" "; got != want {
+		t.Fatalf("setup produced %q, want %q", got, want)
+	}
+}
+
+// TestAtomicBackspaceIgnoresStaleRangeOfEqualLength is the regression
+// test for the range being trusted on length alone. Recalling a history
+// entry replaces the whole value; if it happens to be the same length as
+// the completion that preceded it, a backspace would have cut an
+// unrelated span out of the middle of it.
+func TestAtomicBackspaceIgnoresStaleRangeOfEqualLength(t *testing.T) {
+	t.Parallel()
+
+	m := newCompletionBackspaceUI()
+	insertTestCompletion(t, m, "hello ", "@path/to/file.go")
+
+	// Same length, entirely different content — as a history recall would be.
+	stale := "totally different promp"
+	if len(stale) != len(m.textarea.Value()) {
+		t.Fatalf("test needs an equal-length replacement: %d vs %d", len(stale), len(m.textarea.Value()))
+	}
+	m.textarea.SetValue(stale)
+	m.textarea.MoveToEnd() // history recall leaves the cursor at the end
+
+	m.Update(tea.KeyPressMsg{Code: tea.KeyBackspace})
+
+	if got := m.textarea.Value(); got != "totally different prom" {
+		t.Fatalf("expected a normal single-character backspace, got %q", got)
+	}
+	if m.lastCompletionEnd != 0 {
+		t.Fatal("expected the stale range to be cleared")
 	}
 }

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -284,8 +284,13 @@ type UI struct {
 	// lastCompletionEnd tracks the end index of the most recently
 	// inserted completion text so that a single backspace can delete
 	// the entire inserted path/name at once instead of one character.
+	// lastCompletionText is the exact run that was inserted; the range
+	// is only honoured while the textarea still holds it, so a whole-value
+	// replacement (history recall, paste) cannot make a stale range point
+	// at unrelated text that happens to be the same length.
 	lastCompletionStart int
 	lastCompletionEnd   int
+	lastCompletionText  string
 
 	// Chat components
 	chat *Chat
@@ -2627,23 +2632,38 @@ func (m *UI) handleKeyPressMsg(msg tea.KeyPressMsg) tea.Cmd {
 				// no intervening edits.
 				if msg.Code == tea.KeyBackspace && m.lastCompletionEnd > 0 {
 					val := m.textarea.Value()
-					if len(val) == m.lastCompletionEnd {
-						newVal := val[:m.lastCompletionStart] + val[m.lastCompletionEnd:]
-						m.textarea.SetValue(newVal)
+					// Require the recorded run to still be sitting where it
+					// was inserted. Length alone would let a same-length
+					// value from history recall or a paste be treated as the
+					// completion and get its middle cut out.
+					if len(val) == m.lastCompletionEnd &&
+						val[m.lastCompletionStart:m.lastCompletionEnd] == m.lastCompletionText {
+						prevHeight := m.textarea.Height()
+						m.textarea.SetValue(val[:m.lastCompletionStart])
 						m.textarea.MoveToEnd()
-						m.lastCompletionStart = 0
-						m.lastCompletionEnd = 0
-						break
+						m.clearCompletionRange()
+						// Deleting a wrapped completion changes the editor's
+						// height, and the deletion is a draft edit like any
+						// other; skipping either left the layout stale until
+						// the next keystroke.
+						if cmd := m.handleTextareaHeightChange(prevHeight); cmd != nil {
+							cmds = append(cmds, cmd)
+						}
+						m.updateHistoryDraft(val)
+						// A keep-open insert (up/down-insert) leaves the popup
+						// up; its query no longer matches anything now.
+						if m.completionsOpen {
+							m.closeCompletions()
+						}
+						return tea.Batch(cmds...)
 					}
 					// Text changed since insertion; invalidate.
-					m.lastCompletionStart = 0
-					m.lastCompletionEnd = 0
+					m.clearCompletionRange()
 				}
 
 				// Any non-backspace key clears the atomic-delete range.
 				if msg.Code != tea.KeyBackspace {
-					m.lastCompletionStart = 0
-					m.lastCompletionEnd = 0
+					m.clearCompletionRange()
 				}
 
 				// Check for @ trigger before passing to textarea.
@@ -3828,9 +3848,20 @@ func (m *UI) insertCompletionText(text string) bool {
 	m.textarea.InsertRune(' ')
 
 	// Record the inserted range so backspace can delete it atomically.
+	// The trailing space is part of the run: deleting the completion
+	// should not leave a stray separator behind.
+	m.lastCompletionText = text + " "
 	m.lastCompletionStart = m.completionsStartIndex
-	m.lastCompletionEnd = m.completionsStartIndex + len(text) + 1 // +1 for trailing space
+	m.lastCompletionEnd = m.completionsStartIndex + len(m.lastCompletionText)
 	return true
+}
+
+// clearCompletionRange forgets the last inserted completion, so a later
+// backspace deletes one character like any other.
+func (m *UI) clearCompletionRange() {
+	m.lastCompletionStart = 0
+	m.lastCompletionEnd = 0
+	m.lastCompletionText = ""
 }
 
 // insertFileCompletion inserts the selected file path into the textarea,

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -281,6 +281,12 @@ type UI struct {
 	completionsQuery         string
 	completionsPositionStart image.Point // x,y where user typed '@'
 
+	// lastCompletionEnd tracks the end index of the most recently
+	// inserted completion text so that a single backspace can delete
+	// the entire inserted path/name at once instead of one character.
+	lastCompletionStart int
+	lastCompletionEnd   int
+
 	// Chat components
 	chat *Chat
 
@@ -2614,6 +2620,32 @@ func (m *UI) handleKeyPressMsg(msg tea.KeyPressMsg) tea.Cmd {
 					break
 				}
 
+				// Atomic backspace: delete the entire last-inserted
+				// completion text (file path, resource name) in one go
+				// instead of character by character. Only fires when
+				// backspace is pressed immediately after insertion with
+				// no intervening edits.
+				if msg.Code == tea.KeyBackspace && m.lastCompletionEnd > 0 {
+					val := m.textarea.Value()
+					if len(val) == m.lastCompletionEnd {
+						newVal := val[:m.lastCompletionStart] + val[m.lastCompletionEnd:]
+						m.textarea.SetValue(newVal)
+						m.textarea.MoveToEnd()
+						m.lastCompletionStart = 0
+						m.lastCompletionEnd = 0
+						break
+					}
+					// Text changed since insertion; invalidate.
+					m.lastCompletionStart = 0
+					m.lastCompletionEnd = 0
+				}
+
+				// Any non-backspace key clears the atomic-delete range.
+				if msg.Code != tea.KeyBackspace {
+					m.lastCompletionStart = 0
+					m.lastCompletionEnd = 0
+				}
+
 				// Check for @ trigger before passing to textarea.
 				curValue := m.textarea.Value()
 				curIdx := len(curValue)
@@ -3794,6 +3826,10 @@ func (m *UI) insertCompletionText(text string) bool {
 	m.textarea.SetValue(newValue)
 	m.textarea.MoveToEnd()
 	m.textarea.InsertRune(' ')
+
+	// Record the inserted range so backspace can delete it atomically.
+	m.lastCompletionStart = m.completionsStartIndex
+	m.lastCompletionEnd = m.completionsStartIndex + len(text) + 1 // +1 for trailing space
 	return true
 }
 


### PR DESCRIPTION
Two UX fixes for the editor input:

1. **Atomic backspace for completions** — Backspace after @-completion now deletes the entire inserted file path or resource name at once instead of one character at a time. The range is tracked on insertion and invalidated by any intervening keystroke or text change.

2. **Dismiss commands dialog on /** — Typing `/` while the commands dialog filter is empty now closes the dialog, so users can dismiss it without reaching for Escape.


💘 Generated with Crush