### PR TITLE
feat(ui): add inline /skill completions and token highlighting

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -41,6 +41,11 @@ linters:
         text: "SA1019.*interp.ExecHandler"
         linters:
           - staticcheck
+      # Vendored upstream code (bubbles textarea) is kept byte-close to
+      # upstream on purpose; don't restyle it.
+      - path: internal/ui/textarea/
+        linters:
+          - staticcheck
 issues:
   max-issues-per-linter: 0
   max-same-issues: 0

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/PuerkitoBio/goquery v1.12.0
 	github.com/a2aproject/a2a-go/v2 v2.3.1
 	github.com/alecthomas/chroma/v2 v2.27.0
+	github.com/atotto/clipboard v0.1.4
 	github.com/aymanbagabas/go-udiff v0.4.1
 	github.com/bmatcuk/doublestar/v4 v4.10.0
 	github.com/charlievieth/fastwalk v1.0.14
@@ -48,6 +49,7 @@ require (
 	github.com/jordanella/go-ansi-paintbrush v0.0.0-20240728195301-b7ad996ecf3d
 	github.com/lucasb-eyer/go-colorful v1.4.0
 	github.com/mattn/go-isatty v0.0.24
+	github.com/mattn/go-runewidth v0.0.24
 	github.com/modelcontextprotocol/go-sdk v1.7.0-pre.3.0.20260724080706-e761950d9795
 	github.com/ncruces/go-sqlite3 v0.35.2
 	github.com/nxadm/tail v1.4.11
@@ -93,7 +95,6 @@ require (
 	github.com/KyleBanks/depth v1.2.1 // indirect
 	github.com/andybalholm/brotli v1.2.2 // indirect
 	github.com/andybalholm/cascadia v1.3.3 // indirect
-	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aws/aws-sdk-go-v2 v1.42.1 // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.14 // indirect
 	github.com/aws/aws-sdk-go-v2/config v1.32.30 // indirect
@@ -158,7 +159,6 @@ require (
 	github.com/klauspost/cpuid/v2 v2.3.0 // indirect
 	github.com/klauspost/pgzip v1.2.6 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
-	github.com/mattn/go-runewidth v0.0.24 // indirect
 	github.com/mfridman/interpolate v0.0.2 // indirect
 	github.com/microcosm-cc/bluemonday v1.0.27 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -43,7 +43,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/invopop/jsonschema v0.14.0
 	github.com/itchyny/gojq v0.12.19
-	github.com/joestump-agent/a2tea v0.0.0-20260718201420-b797da386eaf
+	github.com/joestump-agent/a2tea v0.1.0
 	github.com/joho/godotenv v1.5.1
 	github.com/jordanella/go-ansi-paintbrush v0.0.0-20240728195301-b7ad996ecf3d
 	github.com/lucasb-eyer/go-colorful v1.4.0
@@ -223,5 +223,3 @@ require (
 	modernc.org/mathutil v1.7.1 // indirect
 	modernc.org/memory v1.11.0 // indirect
 )
-
-replace github.com/joestump-agent/a2tea => /Users/joestump/src/a2tea

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/PuerkitoBio/goquery v1.12.0
 	github.com/a2aproject/a2a-go/v2 v2.3.1
 	github.com/alecthomas/chroma/v2 v2.27.0
+	github.com/atotto/clipboard v0.1.4
 	github.com/aymanbagabas/go-udiff v0.4.1
 	github.com/bmatcuk/doublestar/v4 v4.10.0
 	github.com/charlievieth/fastwalk v1.0.14
@@ -43,11 +44,12 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/invopop/jsonschema v0.14.0
 	github.com/itchyny/gojq v0.12.19
-	github.com/joestump-agent/a2tea v0.0.0-20260718201420-b797da386eaf
+	github.com/joestump-agent/a2tea v0.1.0
 	github.com/joho/godotenv v1.5.1
 	github.com/jordanella/go-ansi-paintbrush v0.0.0-20240728195301-b7ad996ecf3d
 	github.com/lucasb-eyer/go-colorful v1.4.0
 	github.com/mattn/go-isatty v0.0.24
+	github.com/mattn/go-runewidth v0.0.24
 	github.com/modelcontextprotocol/go-sdk v1.7.0-pre.3.0.20260724080706-e761950d9795
 	github.com/nxadm/tail v1.4.11
 	github.com/odvcencio/gotreesitter v0.48.0
@@ -93,7 +95,6 @@ require (
 	github.com/KyleBanks/depth v1.2.1 // indirect
 	github.com/andybalholm/brotli v1.2.2 // indirect
 	github.com/andybalholm/cascadia v1.3.3 // indirect
-	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aws/aws-sdk-go-v2 v1.42.1 // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.14 // indirect
 	github.com/aws/aws-sdk-go-v2/config v1.32.30 // indirect
@@ -158,7 +159,6 @@ require (
 	github.com/klauspost/cpuid/v2 v2.3.0 // indirect
 	github.com/klauspost/pgzip v1.2.6 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
-	github.com/mattn/go-runewidth v0.0.24 // indirect
 	github.com/mfridman/interpolate v0.0.2 // indirect
 	github.com/microcosm-cc/bluemonday v1.0.27 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -223,3 +223,5 @@ require (
 	modernc.org/mathutil v1.7.1 // indirect
 	modernc.org/memory v1.11.0 // indirect
 )
+
+replace github.com/joestump-agent/a2tea => /Users/joestump/src/a2tea

--- a/go.sum
+++ b/go.sum
@@ -256,8 +256,8 @@ github.com/jackmordaunt/icns/v3 v3.0.1 h1:xxot6aNuGrU+lNgxz5I5H0qSeCjNKp8uTXB1j8
 github.com/jackmordaunt/icns/v3 v3.0.1/go.mod h1:5sHL59nqTd2ynTnowxB/MDQFhKNqkK8X687uKNygaSQ=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
-github.com/joestump-agent/a2tea v0.0.0-20260718201420-b797da386eaf h1:Yw8XzyZXewOiewpHLd4SQPhu7CeWlFeqjpz7uE7f5as=
-github.com/joestump-agent/a2tea v0.0.0-20260718201420-b797da386eaf/go.mod h1:pg6ATa4oTrJfhPmfQ9a/Y/5xU9DTXZ8rGVvLj3NpEaE=
+github.com/joestump-agent/a2tea v0.1.0 h1:pIlPNDSB3HV4Tz8KqoAVlwwF0YSdaX5S8Rta/ISEdNI=
+github.com/joestump-agent/a2tea v0.1.0/go.mod h1:pg6ATa4oTrJfhPmfQ9a/Y/5xU9DTXZ8rGVvLj3NpEaE=
 github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
 github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/jordanella/go-ansi-paintbrush v0.0.0-20240728195301-b7ad996ecf3d h1:on25kP+Sx7sxUMRQiA8gdcToAGet4DK/EIA30mXre+4=

--- a/go.sum
+++ b/go.sum
@@ -256,6 +256,8 @@ github.com/jackmordaunt/icns/v3 v3.0.1 h1:xxot6aNuGrU+lNgxz5I5H0qSeCjNKp8uTXB1j8
 github.com/jackmordaunt/icns/v3 v3.0.1/go.mod h1:5sHL59nqTd2ynTnowxB/MDQFhKNqkK8X687uKNygaSQ=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
+github.com/joestump-agent/a2tea v0.1.0 h1:pIlPNDSB3HV4Tz8KqoAVlwwF0YSdaX5S8Rta/ISEdNI=
+github.com/joestump-agent/a2tea v0.1.0/go.mod h1:pg6ATa4oTrJfhPmfQ9a/Y/5xU9DTXZ8rGVvLj3NpEaE=
 github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
 github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/jordanella/go-ansi-paintbrush v0.0.0-20240728195301-b7ad996ecf3d h1:on25kP+Sx7sxUMRQiA8gdcToAGet4DK/EIA30mXre+4=

--- a/go.sum
+++ b/go.sum
@@ -256,8 +256,6 @@ github.com/jackmordaunt/icns/v3 v3.0.1 h1:xxot6aNuGrU+lNgxz5I5H0qSeCjNKp8uTXB1j8
 github.com/jackmordaunt/icns/v3 v3.0.1/go.mod h1:5sHL59nqTd2ynTnowxB/MDQFhKNqkK8X687uKNygaSQ=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
-github.com/joestump-agent/a2tea v0.0.0-20260718201420-b797da386eaf h1:Yw8XzyZXewOiewpHLd4SQPhu7CeWlFeqjpz7uE7f5as=
-github.com/joestump-agent/a2tea v0.0.0-20260718201420-b797da386eaf/go.mod h1:pg6ATa4oTrJfhPmfQ9a/Y/5xU9DTXZ8rGVvLj3NpEaE=
 github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
 github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/jordanella/go-ansi-paintbrush v0.0.0-20240728195301-b7ad996ecf3d h1:on25kP+Sx7sxUMRQiA8gdcToAGet4DK/EIA30mXre+4=

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -83,8 +83,13 @@ type SessionAgentCall struct {
 	// reliable completion contract (e.g. `crush run` against a
 	// session that may be busy) MUST set it; SessionID alone is
 	// ambiguous when concurrent turns share the same session.
-	RunID            string
-	Channel          string
+	RunID   string
+	Channel string
+	// ContentWidth is the UI's chat content width hint in cells (0 when
+	// the turn has no interactive UI). Tools rendering width-sensitive
+	// remote content (e.g. A2UI surfaces with pre-sized bar geometry)
+	// use it to ask the server for exactly the right size.
+	ContentWidth     int
 	Prompt           string
 	ProviderOptions  fantasy.ProviderOptions
 	Attachments      []message.Attachment
@@ -914,6 +919,7 @@ func (a *sessionAgent) Run(ctx context.Context, call SessionAgentCall) (result *
 			callContext = context.WithValue(callContext, tools.ChannelContextKey, call.Channel)
 			callContext = context.WithValue(callContext, tools.SupportsImagesContextKey, largeModel.CatwalkCfg.SupportsImages)
 			callContext = context.WithValue(callContext, tools.ModelNameContextKey, largeModel.CatwalkCfg.Name)
+			callContext = context.WithValue(callContext, tools.ContentWidthContextKey, call.ContentWidth)
 			currentAssistant = &assistantMsg
 			return callContext, prepared, err
 		},

--- a/internal/agent/content_width.go
+++ b/internal/agent/content_width.go
@@ -1,0 +1,23 @@
+package agent
+
+import "context"
+
+type contentWidthContextKey struct{}
+
+// WithContentWidth returns ctx tagged with the UI's current chat content
+// width in cells. Tools that read width-sensitive remote content (e.g. an
+// A2UI resource whose server pre-renders bar geometry) use it to ask the
+// server for exactly the right size. Zero means "no hint".
+func WithContentWidth(ctx context.Context, width int) context.Context {
+	return context.WithValue(ctx, contentWidthContextKey{}, width)
+}
+
+// ContentWidthFromContext returns the UI content width in cells, or 0 when
+// the turn did not originate from an interactive UI (remote clients, headless
+// runs, channels).
+func ContentWidthFromContext(ctx context.Context) int {
+	if w, ok := ctx.Value(contentWidthContextKey{}).(int); ok {
+		return w
+	}
+	return 0
+}

--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -335,6 +335,7 @@ func (c *coordinator) run(ctx context.Context, accept *AcceptedRun, sessionID st
 			SessionID:        sessionID,
 			RunID:            runID,
 			Channel:          ChannelFromContext(ctx),
+			ContentWidth:     ContentWidthFromContext(ctx),
 			Prompt:           prompt,
 			Attachments:      attachments,
 			MaxOutputTokens:  maxTokens,
@@ -1499,7 +1500,12 @@ func (c *coordinator) runSubAgent(ctx context.Context, params subAgentParams) (f
 	// Run the agent
 	run := func() (*fantasy.AgentResult, error) {
 		return params.Agent.Run(ctx, SessionAgentCall{
-			SessionID:        session.ID,
+			SessionID: session.ID,
+			// Inherit the parent turn's UI width hint: the sub-agent's
+			// PrepareStep stamps call.ContentWidth over the tool-call
+			// context unconditionally, so leaving this zero would clobber
+			// the value the parent already carries.
+			ContentWidth:     tools.GetContentWidthFromContext(ctx),
 			Prompt:           params.Prompt,
 			MaxOutputTokens:  maxTokens,
 			ProviderOptions:  getProviderOptions(model, providerCfg),

--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -335,6 +335,7 @@ func (c *coordinator) run(ctx context.Context, accept *AcceptedRun, sessionID st
 			SessionID:        sessionID,
 			RunID:            runID,
 			Channel:          ChannelFromContext(ctx),
+			ContentWidth:     ContentWidthFromContext(ctx),
 			Prompt:           prompt,
 			Attachments:      attachments,
 			MaxOutputTokens:  maxTokens,

--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -1500,7 +1500,12 @@ func (c *coordinator) runSubAgent(ctx context.Context, params subAgentParams) (f
 	// Run the agent
 	run := func() (*fantasy.AgentResult, error) {
 		return params.Agent.Run(ctx, SessionAgentCall{
-			SessionID:        session.ID,
+			SessionID: session.ID,
+			// Inherit the parent turn's UI width hint: the sub-agent's
+			// PrepareStep stamps call.ContentWidth over the tool-call
+			// context unconditionally, so leaving this zero would clobber
+			// the value the parent already carries.
+			ContentWidth:     tools.GetContentWidthFromContext(ctx),
 			Prompt:           params.Prompt,
 			MaxOutputTokens:  maxTokens,
 			ProviderOptions:  getProviderOptions(model, providerCfg),

--- a/internal/agent/tools/list_mcp_resources.go
+++ b/internal/agent/tools/list_mcp_resources.go
@@ -63,15 +63,16 @@ func NewListMCPResourcesTool(cfg *config.ConfigStore, permissions permission.Ser
 				return NewPermissionDeniedResponse(), nil
 			}
 
-			resources, err := mcp.ListResources(ctx, cfg, params.MCPName)
+			resources, templates, err := mcp.ListResources(ctx, cfg, params.MCPName)
 			if err != nil {
 				return fantasy.NewTextErrorResponse(err.Error()), nil
 			}
-			if len(resources) == 0 {
+			if len(resources) == 0 && len(templates) == 0 {
 				return fantasy.NewTextResponse("No resources found"), nil
 			}
 
-			lines := make([]string, 0, len(resources))
+			lines := make([]string, 0, len(resources)+len(templates))
+
 			for _, resource := range resources {
 				if resource == nil {
 					continue
@@ -89,6 +90,24 @@ func NewListMCPResourcesTool(cfg *config.ConfigStore, permissions permission.Ser
 				}
 				if resource.Size > 0 {
 					line = fmt.Sprintf("%s [size: %d]", line, resource.Size)
+				}
+				lines = append(lines, line)
+			}
+
+			for _, template := range templates {
+				if template == nil {
+					continue
+				}
+				title := cmp.Or(template.Title, template.Name, template.URITemplate)
+				line := fmt.Sprintf("- [template] %s", title)
+				if template.URITemplate != "" {
+					line = fmt.Sprintf("%s (%s)", line, template.URITemplate)
+				}
+				if template.Description != "" {
+					line = fmt.Sprintf("%s: %s", line, template.Description)
+				}
+				if template.MIMEType != "" {
+					line = fmt.Sprintf("%s [mime: %s]", line, template.MIMEType)
 				}
 				lines = append(lines, line)
 			}

--- a/internal/agent/tools/list_mcp_resources.md
+++ b/internal/agent/tools/list_mcp_resources.md
@@ -1,1 +1,4 @@
-List available resource URIs from an MCP server by name; use before read_mcp_resource.
+List available resource URIs and resource templates from an MCP server by name; use before read_mcp_resource.
+
+Resource templates have URI templates (e.g. `cairn://run/{id}/a2ui`) that can be expanded to concrete URIs.
+To read a template resource, substitute the `{id}` parameter and pass the resulting URI to read_mcp_resource.

--- a/internal/agent/tools/mcp-tools.go
+++ b/internal/agent/tools/mcp-tools.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"slices"
+	"strings"
 
 	"charm.land/fantasy"
 	"github.com/charmbracelet/crush/internal/agent/tools/mcp"
@@ -133,6 +134,17 @@ func (m *Tool) Run(ctx context.Context, params fantasy.ToolCall) (fantasy.ToolRe
 		return fantasy.NewTextErrorResponse(err.Error()), nil
 	}
 
+	// Divert A2UI surface payloads to UI-only metadata only when a chat UI
+	// will actually render them: on channel-originated turns the reply
+	// travels back over the channel and the model needs the payload to
+	// relay it, disable_a2ui deployments opted out of surfaces entirely,
+	// and a zero content width means no interactive UI tagged this turn.
+	// Mirrors the diversion rule in read_mcp_resource.go.
+	divert := GetChannelFromContext(ctx) == "" &&
+		!m.cfg.Config().Options.DisableA2UI &&
+		GetContentWidthFromContext(ctx) > 0
+	content, metadata := splitMCPToolResult(result, m.mcpName, divert)
+
 	switch result.Type {
 	case "image", "media":
 		if !GetSupportsImagesFromContext(ctx) {
@@ -146,9 +158,51 @@ func (m *Tool) Run(ctx context.Context, params fantasy.ToolCall) (fantasy.ToolRe
 		} else {
 			response = fantasy.NewMediaResponse(result.Data, result.MediaType)
 		}
-		response.Content = result.Content
+		response.Content = content
+		if len(metadata.A2UISurfaces) > 0 {
+			response = fantasy.WithResponseMetadata(response, metadata)
+		}
 		return response, nil
 	default:
-		return fantasy.NewTextResponse(result.Content), nil
+		resp := fantasy.NewTextResponse(content)
+		if len(metadata.A2UISurfaces) > 0 {
+			resp = fantasy.WithResponseMetadata(resp, metadata)
+		}
+		return resp, nil
 	}
+}
+
+// splitMCPToolResult partitions an MCP tool result into model-facing text
+// and, when divert is set, UI-only A2UI surface payloads carried in response
+// metadata. The surfaces travel exactly like read_mcp_resource's: wrapped in
+// <a2ui-json> tags on ReadMCPResourceResponseMetadata, with a single-line
+// placeholder left for the model so it cannot echo the JSON back and
+// double-render the surface. When divert is false the raw payload is folded
+// back into the model-facing content (except payloads the server annotated
+// for the user only — hiding those from the model is the annotation's whole
+// point), so the model can still relay or summarize the data.
+func splitMCPToolResult(result mcp.ToolResult, mcpName string, divert bool) (string, ReadMCPResourceResponseMetadata) {
+	var metadata ReadMCPResourceResponseMetadata
+	content := result.Content
+	for _, surface := range result.Surfaces {
+		if divert {
+			metadata.A2UISurfaces = append(metadata.A2UISurfaces, "<a2ui-json>"+surface.Payload+"</a2ui-json>")
+			metadata.MCPSurfaceProvenance = append(metadata.MCPSurfaceProvenance, mcpName)
+			uri := strings.NewReplacer("\n", " ", "\r", " ").Replace(surface.URI)
+			placeholder := A2UISurfacePlaceholderPrefix + uri + " from MCP server " + mcpName + " — the user can already see it; do not repeat or echo its JSON payload]"
+			if content != "" {
+				content += "\n"
+			}
+			content += placeholder
+			continue
+		}
+		if !surface.AssistantVisible {
+			continue
+		}
+		if content != "" {
+			content += "\n"
+		}
+		content += surface.Payload
+	}
+	return content, metadata
 }

--- a/internal/agent/tools/mcp-tools.go
+++ b/internal/agent/tools/mcp-tools.go
@@ -181,28 +181,37 @@ func (m *Tool) Run(ctx context.Context, params fantasy.ToolCall) (fantasy.ToolRe
 // back into the model-facing content (except payloads the server annotated
 // for the user only — hiding those from the model is the annotation's whole
 // point), so the model can still relay or summarize the data.
+//
+// The audience annotation decides each surface's path (see a2uiAudience):
+// a ["user"]-only payload renders but never reaches the model; an
+// ["assistant"]-only payload reaches the model but is never rendered; an
+// empty audience does both (renders, and folds back to the model when no
+// chat UI is consuming it) — the established default.
 func splitMCPToolResult(result mcp.ToolResult, mcpName string, divert bool) (string, ReadMCPResourceResponseMetadata) {
 	var metadata ReadMCPResourceResponseMetadata
 	content := result.Content
-	for _, surface := range result.Surfaces {
-		if divert {
-			metadata.A2UISurfaces = append(metadata.A2UISurfaces, "<a2ui-json>"+surface.Payload+"</a2ui-json>")
-			metadata.MCPSurfaceProvenance = append(metadata.MCPSurfaceProvenance, mcpName)
-			uri := strings.NewReplacer("\n", " ", "\r", " ").Replace(surface.URI)
-			placeholder := A2UISurfacePlaceholderPrefix + uri + " from MCP server " + mcpName + " — the user can already see it; do not repeat or echo its JSON payload]"
-			if content != "" {
-				content += "\n"
-			}
-			content += placeholder
-			continue
-		}
-		if !surface.AssistantVisible {
-			continue
-		}
+	appendToContent := func(s string) {
 		if content != "" {
 			content += "\n"
 		}
-		content += surface.Payload
+		content += s
+	}
+	for _, surface := range result.Surfaces {
+		if divert && surface.RenderForUser {
+			// Render for the user via metadata; the model gets a
+			// placeholder so it cannot echo the JSON back and double-render.
+			metadata.A2UISurfaces = append(metadata.A2UISurfaces, "<a2ui-json>"+surface.Payload+"</a2ui-json>")
+			metadata.MCPSurfaceProvenance = append(metadata.MCPSurfaceProvenance, mcpName)
+			uri := strings.NewReplacer("\n", " ", "\r", " ").Replace(surface.URI)
+			appendToContent(A2UISurfacePlaceholderPrefix + uri + " from MCP server " + mcpName + " — the user can already see it; do not repeat or echo its JSON payload]")
+			continue
+		}
+		// Not rendered: either divert is off (no chat UI) or the surface is
+		// ["assistant"]-only. It reaches the model only when assistant-visible.
+		if !surface.AssistantVisible {
+			continue
+		}
+		appendToContent(surface.Payload)
 	}
 	return content, metadata
 }

--- a/internal/agent/tools/mcp-tools.go
+++ b/internal/agent/tools/mcp-tools.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"slices"
+	"strings"
 
 	"charm.land/fantasy"
 	"github.com/charmbracelet/crush/internal/agent/tools/mcp"
@@ -133,6 +134,17 @@ func (m *Tool) Run(ctx context.Context, params fantasy.ToolCall) (fantasy.ToolRe
 		return fantasy.NewTextErrorResponse(err.Error()), nil
 	}
 
+	// Divert A2UI surface payloads to UI-only metadata only when a chat UI
+	// will actually render them: on channel-originated turns the reply
+	// travels back over the channel and the model needs the payload to
+	// relay it, disable_a2ui deployments opted out of surfaces entirely,
+	// and a zero content width means no interactive UI tagged this turn.
+	// Mirrors the diversion rule in read_mcp_resource.go.
+	divert := GetChannelFromContext(ctx) == "" &&
+		!m.cfg.Config().Options.DisableA2UI &&
+		GetContentWidthFromContext(ctx) > 0
+	content, metadata := splitMCPToolResult(result, m.mcpName, divert)
+
 	switch result.Type {
 	case "image", "media":
 		if !GetSupportsImagesFromContext(ctx) {
@@ -146,9 +158,60 @@ func (m *Tool) Run(ctx context.Context, params fantasy.ToolCall) (fantasy.ToolRe
 		} else {
 			response = fantasy.NewMediaResponse(result.Data, result.MediaType)
 		}
-		response.Content = result.Content
+		response.Content = content
+		if len(metadata.A2UISurfaces) > 0 {
+			response = fantasy.WithResponseMetadata(response, metadata)
+		}
 		return response, nil
 	default:
-		return fantasy.NewTextResponse(result.Content), nil
+		resp := fantasy.NewTextResponse(content)
+		if len(metadata.A2UISurfaces) > 0 {
+			resp = fantasy.WithResponseMetadata(resp, metadata)
+		}
+		return resp, nil
 	}
+}
+
+// splitMCPToolResult partitions an MCP tool result into model-facing text
+// and, when divert is set, UI-only A2UI surface payloads carried in response
+// metadata. The surfaces travel exactly like read_mcp_resource's: wrapped in
+// <a2ui-json> tags on ReadMCPResourceResponseMetadata, with a single-line
+// placeholder left for the model so it cannot echo the JSON back and
+// double-render the surface. When divert is false the raw payload is folded
+// back into the model-facing content (except payloads the server annotated
+// for the user only — hiding those from the model is the annotation's whole
+// point), so the model can still relay or summarize the data.
+//
+// The audience annotation decides each surface's path (see a2uiAudience):
+// a ["user"]-only payload renders but never reaches the model; an
+// ["assistant"]-only payload reaches the model but is never rendered; an
+// empty audience does both (renders, and folds back to the model when no
+// chat UI is consuming it) — the established default.
+func splitMCPToolResult(result mcp.ToolResult, mcpName string, divert bool) (string, ReadMCPResourceResponseMetadata) {
+	var metadata ReadMCPResourceResponseMetadata
+	content := result.Content
+	appendToContent := func(s string) {
+		if content != "" {
+			content += "\n"
+		}
+		content += s
+	}
+	for _, surface := range result.Surfaces {
+		if divert && surface.RenderForUser {
+			// Render for the user via metadata; the model gets a
+			// placeholder so it cannot echo the JSON back and double-render.
+			metadata.A2UISurfaces = append(metadata.A2UISurfaces, "<a2ui-json>"+surface.Payload+"</a2ui-json>")
+			metadata.MCPSurfaceProvenance = append(metadata.MCPSurfaceProvenance, mcpName)
+			uri := strings.NewReplacer("\n", " ", "\r", " ").Replace(surface.URI)
+			appendToContent(A2UISurfacePlaceholderPrefix + uri + " from MCP server " + mcpName + " — the user can already see it; do not repeat or echo its JSON payload]")
+			continue
+		}
+		// Not rendered: either divert is off (no chat UI) or the surface is
+		// ["assistant"]-only. It reaches the model only when assistant-visible.
+		if !surface.AssistantVisible {
+			continue
+		}
+		appendToContent(surface.Payload)
+	}
+	return content, metadata
 }

--- a/internal/agent/tools/mcp/init.go
+++ b/internal/agent/tools/mcp/init.go
@@ -501,6 +501,19 @@ func connectAndRegister(ctx context.Context, cfg *config.ConfigStore, name strin
 
 	updatePrompts(name, prompts)
 
+	// Fetch resources and templates eagerly so the status display reflects
+	// the real count from the first connection, not a stale zero.  Both
+	// helpers are no-ops when the server doesn't advertise the resources
+	// capability, and gracefully handle "method not found". Bound the
+	// listing with the same per-server timeout createSession enforces:
+	// initClient runs on the startup critical path under the per-name
+	// lock, and a server that connects but then hangs on resources/list
+	// would otherwise stall WaitForInit indefinitely — with the bound it
+	// degrades to a warn and a zero count.
+	listCtx, cancelList := context.WithTimeout(ctx, mcpTimeout(m))
+	resourceCount := refreshSessionResources(listCtx, name, session)
+	cancelList()
+
 	// A repeated init must not overwrite a live session without closing it —
 	// that leaks the child process and pipes.
 	if old, ok := sessions.Take(name); ok && old != session {
@@ -509,8 +522,9 @@ func connectAndRegister(ctx context.Context, cfg *config.ConfigStore, name strin
 	sessions.Set(name, session)
 
 	updateState(name, StateConnected, nil, session, Counts{
-		Tools:   toolCount,
-		Prompts: len(prompts),
+		Tools:     toolCount,
+		Prompts:   len(prompts),
+		Resources: resourceCount,
 	})
 
 	return session, nil
@@ -522,7 +536,7 @@ func DisableSingle(cfg *config.ConfigStore, name string) error {
 		closeSession(name, session)
 	}
 
-	// Clear tools, prompts, resources, and auth state for this MCP.
+	// Clear tools, prompts, resources, templates, and auth state for this MCP.
 	clearMCPData(name)
 
 	// Update state to disabled.
@@ -591,12 +605,12 @@ func getOrRenewClient(ctx context.Context, cfg *config.ConfigStore, name string)
 		return nil, err
 	}
 
-	// StateError cleared this server's tools, prompts, and resources from the
-	// registry. Re-list and re-register them all on the fresh session and
-	// recompute the counts from what actually registered; otherwise the agent
-	// reconnects but the registries stay empty (the next tool call fails with
-	// "tool not found") while the reported counts still advertise capabilities
-	// that are no longer there.
+	// StateError cleared this server's tools, prompts, resources, and resource
+	// templates from the registry. Re-list and re-register them all on the
+	// fresh session and recompute the counts from what actually registered;
+	// otherwise the agent reconnects but the registries stay empty (the next
+	// tool call fails with "tool not found") while the reported counts still
+	// advertise capabilities that are no longer there.
 	var counts Counts
 	counts.Tools, err = registerSessionTools(ctx, cfg, name, newSess)
 	if err != nil {
@@ -614,13 +628,12 @@ func getOrRenewClient(ctx context.Context, cfg *config.ConfigStore, name string)
 	updatePrompts(name, prompts)
 	counts.Prompts = len(prompts)
 
-	resources, err := getResources(ctx, newSess)
-	if err != nil {
-		updateState(name, StateError, err, nil, Counts{})
-		closeSession(name, newSess)
-		return nil, err
-	}
-	counts.Resources = updateResources(name, resources)
+	// The StateError transition also purged this server's resources and
+	// resource templates, but counts still carries the pre-error value.
+	// Re-fetch both on the fresh session so the registries and the status
+	// count agree with what the reconnected server actually serves,
+	// instead of advertising N resources over an empty registry.
+	counts.Resources = refreshSessionResources(ctx, name, newSess)
 
 	sessions.Set(name, newSess)
 	updateState(name, StateConnected, nil, newSess, counts)
@@ -672,13 +685,14 @@ func updateState(name string, state State, err error, client *ClientSession, cou
 		if old, ok := sessions.Take(name); ok {
 			closeSession(name, old)
 		}
-		// Drop every registry entry for the dead server. Leaving prompts or
-		// resources behind lets a disconnected server keep advertising
-		// capabilities the agent can no longer fulfil, the same divergence the
-		// tool clear prevents.
+		// Drop every registry entry for the dead server. Leaving prompts,
+		// resources, or resource templates behind lets a disconnected server
+		// keep advertising capabilities the agent can no longer fulfil, the
+		// same divergence the tool clear prevents.
 		allTools.Del(name)
 		allPrompts.Del(name)
 		allResources.Del(name)
+		allResourceTemplates.Del(name)
 	}
 	states.Set(name, info)
 
@@ -1085,12 +1099,13 @@ func clearOAuthToken(cfg *config.ConfigStore, name string) {
 }
 
 // clearMCPData removes a stale MCP server's tools, prompts,
-// resources, and auth handlers from global state so they are not
-// served to the agent.
+// resources, resource templates, and auth handlers from global state so they
+// are not served to the agent.
 func clearMCPData(name string) {
 	allTools.Del(name)
 	allPrompts.Del(name)
 	allResources.Del(name)
+	allResourceTemplates.Del(name)
 	if h, ok := authURLs.Get(name); ok {
 		h.Close()
 		authURLs.Del(name)

--- a/internal/agent/tools/mcp/init.go
+++ b/internal/agent/tools/mcp/init.go
@@ -501,6 +501,22 @@ func connectAndRegister(ctx context.Context, cfg *config.ConfigStore, name strin
 
 	updatePrompts(name, prompts)
 
+	// Fetch resources and templates eagerly so the status display reflects
+	// the real count from the first connection, not a stale zero.  Both
+	// helpers are no-ops when the server doesn't advertise the resources
+	// capability, and gracefully handle "method not found".
+	resources, err := getResources(ctx, session)
+	if err != nil {
+		slog.Warn("Error listing resources", "name", name, "error", err)
+	}
+	templates, err := getResourceTemplates(ctx, session)
+	if err != nil {
+		slog.Warn("MCP server does not support resources/templates/list", "name", name, "error", err)
+		templates = nil
+	}
+	resourceCount := updateResources(name, resources)
+	templateCount := updateResourceTemplates(name, templates)
+
 	// A repeated init must not overwrite a live session without closing it —
 	// that leaks the child process and pipes.
 	if old, ok := sessions.Take(name); ok && old != session {
@@ -509,8 +525,9 @@ func connectAndRegister(ctx context.Context, cfg *config.ConfigStore, name strin
 	sessions.Set(name, session)
 
 	updateState(name, StateConnected, nil, session, Counts{
-		Tools:   toolCount,
-		Prompts: len(prompts),
+		Tools:     toolCount,
+		Prompts:   len(prompts),
+		Resources: resourceCount + templateCount,
 	})
 
 	return session, nil

--- a/internal/agent/tools/mcp/init.go
+++ b/internal/agent/tools/mcp/init.go
@@ -504,18 +504,15 @@ func connectAndRegister(ctx context.Context, cfg *config.ConfigStore, name strin
 	// Fetch resources and templates eagerly so the status display reflects
 	// the real count from the first connection, not a stale zero.  Both
 	// helpers are no-ops when the server doesn't advertise the resources
-	// capability, and gracefully handle "method not found".
-	resources, err := getResources(ctx, session)
-	if err != nil {
-		slog.Warn("Error listing resources", "name", name, "error", err)
-	}
-	templates, err := getResourceTemplates(ctx, session)
-	if err != nil {
-		slog.Warn("MCP server does not support resources/templates/list", "name", name, "error", err)
-		templates = nil
-	}
-	resourceCount := updateResources(name, resources)
-	templateCount := updateResourceTemplates(name, templates)
+	// capability, and gracefully handle "method not found". Bound the
+	// listing with the same per-server timeout createSession enforces:
+	// initClient runs on the startup critical path under the per-name
+	// lock, and a server that connects but then hangs on resources/list
+	// would otherwise stall WaitForInit indefinitely — with the bound it
+	// degrades to a warn and a zero count.
+	listCtx, cancelList := context.WithTimeout(ctx, mcpTimeout(m))
+	resourceCount := refreshSessionResources(listCtx, name, session)
+	cancelList()
 
 	// A repeated init must not overwrite a live session without closing it —
 	// that leaks the child process and pipes.
@@ -527,7 +524,7 @@ func connectAndRegister(ctx context.Context, cfg *config.ConfigStore, name strin
 	updateState(name, StateConnected, nil, session, Counts{
 		Tools:     toolCount,
 		Prompts:   len(prompts),
-		Resources: resourceCount + templateCount,
+		Resources: resourceCount,
 	})
 
 	return session, nil
@@ -539,7 +536,7 @@ func DisableSingle(cfg *config.ConfigStore, name string) error {
 		closeSession(name, session)
 	}
 
-	// Clear tools, prompts, resources, and auth state for this MCP.
+	// Clear tools, prompts, resources, templates, and auth state for this MCP.
 	clearMCPData(name)
 
 	// Update state to disabled.
@@ -608,12 +605,12 @@ func getOrRenewClient(ctx context.Context, cfg *config.ConfigStore, name string)
 		return nil, err
 	}
 
-	// StateError cleared this server's tools, prompts, and resources from the
-	// registry. Re-list and re-register them all on the fresh session and
-	// recompute the counts from what actually registered; otherwise the agent
-	// reconnects but the registries stay empty (the next tool call fails with
-	// "tool not found") while the reported counts still advertise capabilities
-	// that are no longer there.
+	// StateError cleared this server's tools, prompts, resources, and resource
+	// templates from the registry. Re-list and re-register them all on the
+	// fresh session and recompute the counts from what actually registered;
+	// otherwise the agent reconnects but the registries stay empty (the next
+	// tool call fails with "tool not found") while the reported counts still
+	// advertise capabilities that are no longer there.
 	var counts Counts
 	counts.Tools, err = registerSessionTools(ctx, cfg, name, newSess)
 	if err != nil {
@@ -631,13 +628,12 @@ func getOrRenewClient(ctx context.Context, cfg *config.ConfigStore, name string)
 	updatePrompts(name, prompts)
 	counts.Prompts = len(prompts)
 
-	resources, err := getResources(ctx, newSess)
-	if err != nil {
-		updateState(name, StateError, err, nil, Counts{})
-		closeSession(name, newSess)
-		return nil, err
-	}
-	counts.Resources = updateResources(name, resources)
+	// The StateError transition also purged this server's resources and
+	// resource templates, but counts still carries the pre-error value.
+	// Re-fetch both on the fresh session so the registries and the status
+	// count agree with what the reconnected server actually serves,
+	// instead of advertising N resources over an empty registry.
+	counts.Resources = refreshSessionResources(ctx, name, newSess)
 
 	sessions.Set(name, newSess)
 	updateState(name, StateConnected, nil, newSess, counts)
@@ -689,13 +685,14 @@ func updateState(name string, state State, err error, client *ClientSession, cou
 		if old, ok := sessions.Take(name); ok {
 			closeSession(name, old)
 		}
-		// Drop every registry entry for the dead server. Leaving prompts or
-		// resources behind lets a disconnected server keep advertising
-		// capabilities the agent can no longer fulfil, the same divergence the
-		// tool clear prevents.
+		// Drop every registry entry for the dead server. Leaving prompts,
+		// resources, or resource templates behind lets a disconnected server
+		// keep advertising capabilities the agent can no longer fulfil, the
+		// same divergence the tool clear prevents.
 		allTools.Del(name)
 		allPrompts.Del(name)
 		allResources.Del(name)
+		allResourceTemplates.Del(name)
 	}
 	states.Set(name, info)
 
@@ -1102,12 +1099,13 @@ func clearOAuthToken(cfg *config.ConfigStore, name string) {
 }
 
 // clearMCPData removes a stale MCP server's tools, prompts,
-// resources, and auth handlers from global state so they are not
-// served to the agent.
+// resources, resource templates, and auth handlers from global state so they
+// are not served to the agent.
 func clearMCPData(name string) {
 	allTools.Del(name)
 	allPrompts.Del(name)
 	allResources.Del(name)
+	allResourceTemplates.Del(name)
 	if h, ok := authURLs.Get(name); ok {
 		h.Close()
 		authURLs.Del(name)

--- a/internal/agent/tools/mcp/lifecycle_test.go
+++ b/internal/agent/tools/mcp/lifecycle_test.go
@@ -373,3 +373,75 @@ func TestMaybeStdioErr_UnwrapsChannelTransport(t *testing.T) {
 	require.Contains(t, got.Error(), "startup failed: bad config",
 		"the re-executed child's stderr must surface in the error")
 }
+
+// TestUpdateState_ErrorClearsResources pins that StateError teardown clears the
+// resources and resource-template registries alongside tools and prompts — a
+// dead server must not keep advertising resources (or templates) it can no
+// longer serve. Both entry shapes are covered: the registered session itself
+// erroring, and an error with no session at all (connect failed).
+func TestUpdateState_ErrorClearsResources(t *testing.T) {
+	const name = "test-error-clears-resources"
+	t.Cleanup(func() {
+		sessions.Del(name)
+		allTools.Del(name)
+		allResources.Del(name)
+		allResourceTemplates.Del(name)
+		states.Del(name)
+	})
+
+	sess, _ := liveSession(t, "res_tool")
+	sessions.Set(name, sess)
+	allResources.Set(name, []*Resource{{Name: "doc"}})
+	allResourceTemplates.Set(name, []*ResourceTemplate{{Name: "tmpl"}})
+
+	updateState(name, StateError, errors.New("listing broke"), sess, Counts{})
+	_, ok := allResources.Get(name)
+	require.False(t, ok, "current-session error must clear the resources registry")
+	_, ok = allResourceTemplates.Get(name)
+	require.False(t, ok, "current-session error must clear the resource-template registry")
+
+	sess2, _ := liveSession(t, "res_tool2")
+	sessions.Set(name, sess2)
+	allResources.Set(name, []*Resource{{Name: "doc2"}})
+	allResourceTemplates.Set(name, []*ResourceTemplate{{Name: "tmpl2"}})
+
+	updateState(name, StateError, errors.New("connect broke"), nil, Counts{})
+	_, ok = allResources.Get(name)
+	require.False(t, ok, "no-session error must clear the resources registry")
+	_, ok = allResourceTemplates.Get(name)
+	require.False(t, ok, "no-session error must clear the resource-template registry")
+}
+
+// TestDisableSingle_ClearsResourceTemplates pins that disabling a server
+// removes its resource templates (alongside tools, prompts, and resources)
+// from the registries — a disabled server's templates must stop appearing
+// as @-completions.
+func TestDisableSingle_ClearsResourceTemplates(t *testing.T) {
+	const name = "test-disable-clears-templates"
+	t.Cleanup(func() {
+		sessions.Del(name)
+		allTools.Del(name)
+		allResources.Del(name)
+		allResourceTemplates.Del(name)
+		states.Del(name)
+	})
+
+	cfg := config.NewTestStore(&config.Config{MCP: config.MCPs{name: {Type: config.MCPStdio}}})
+
+	sess, sessCtx := liveSession(t, "tmpl_tool")
+	sessions.Set(name, sess)
+	allResources.Set(name, []*Resource{{Name: "doc"}})
+	allResourceTemplates.Set(name, []*ResourceTemplate{{Name: "tmpl", URITemplate: "x://{id}"}})
+
+	require.NoError(t, DisableSingle(cfg, name))
+
+	require.ErrorIs(t, sessCtx.Err(), context.Canceled, "disable must close the session")
+	_, ok := allResources.Get(name)
+	require.False(t, ok, "disable must clear the resources registry")
+	_, ok = allResourceTemplates.Get(name)
+	require.False(t, ok, "disable must clear the resource-template registry")
+
+	info, ok := GetState(name)
+	require.True(t, ok)
+	require.Equal(t, StateDisabled, info.State)
+}

--- a/internal/agent/tools/mcp/resources.go
+++ b/internal/agent/tools/mcp/resources.go
@@ -14,32 +14,50 @@ import (
 
 type Resource = mcp.Resource
 
+type ResourceTemplate = mcp.ResourceTemplate
+
 type ResourceContents = mcp.ResourceContents
 
-var allResources = csync.NewMap[string, []*Resource]()
+var (
+	allResources         = csync.NewMap[string, []*Resource]()
+	allResourceTemplates = csync.NewMap[string, []*ResourceTemplate]()
+)
 
 // Resources returns all available MCP resources.
 func Resources() iter.Seq2[string, []*Resource] {
 	return allResources.Seq2()
 }
 
-// ListResources returns the current resources for an MCP server.
-func ListResources(ctx context.Context, cfg *config.ConfigStore, name string) ([]*Resource, error) {
+// ResourceTemplates returns all available MCP resource templates.
+func ResourceTemplates() iter.Seq2[string, []*ResourceTemplate] {
+	return allResourceTemplates.Seq2()
+}
+
+// ListResources returns the current resources (including resource templates) for an MCP server.
+func ListResources(ctx context.Context, cfg *config.ConfigStore, name string) ([]*Resource, []*ResourceTemplate, error) {
 	session, err := getOrRenewClient(ctx, cfg, name)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	resources, err := getResources(ctx, session)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
+	}
+
+	templates, err := getResourceTemplates(ctx, session)
+	if err != nil {
+		// Templates are best-effort; some servers may not support resources/templates/list.
+		slog.Warn("MCP server does not support resources/templates/list", "error", err)
+		templates = nil
 	}
 
 	resourceCount := updateResources(name, resources)
+	templateCount := updateResourceTemplates(name, templates)
 	prev, _ := states.Get(name)
-	prev.Counts.Resources = resourceCount
+	prev.Counts.Resources = resourceCount + templateCount
 	updateState(name, StateConnected, nil, session, prev.Counts)
-	return resources, nil
+	return resources, templates, nil
 }
 
 // ReadResource reads the contents of a resource from an MCP server.
@@ -55,7 +73,7 @@ func ReadResource(ctx context.Context, cfg *config.ConfigStore, name, uri string
 	return result.Contents, nil
 }
 
-// RefreshResources gets the updated list of resources from the MCP and updates the
+// RefreshResources gets the updated list of resources and resource templates from the MCP and updates the
 // global state.
 func RefreshResources(ctx context.Context, name string) {
 	// Runs under the per-name lifecycle lock so a concurrent renewal can't
@@ -76,10 +94,17 @@ func RefreshResources(ctx context.Context, name string) {
 		return
 	}
 
+	templates, err := getResourceTemplates(ctx, session)
+	if err != nil {
+		slog.Warn("MCP server does not support resources/templates/list", "error", err)
+		templates = nil
+	}
+
 	resourceCount := updateResources(name, resources)
+	templateCount := updateResourceTemplates(name, templates)
 
 	prev, _ := states.Get(name)
-	prev.Counts.Resources = resourceCount
+	prev.Counts.Resources = resourceCount + templateCount
 	updateState(name, StateConnected, nil, session, prev.Counts)
 }
 
@@ -99,6 +124,20 @@ func getResources(ctx context.Context, c *ClientSession) ([]*Resource, error) {
 	return result.Resources, nil
 }
 
+func getResourceTemplates(ctx context.Context, c *ClientSession) ([]*ResourceTemplate, error) {
+	if c.InitializeResult().Capabilities.Resources == nil {
+		return nil, nil
+	}
+	result, err := c.ListResourceTemplates(ctx, &mcp.ListResourceTemplatesParams{})
+	if err != nil {
+		if isMethodNotFoundError(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return result.ResourceTemplates, nil
+}
+
 // isMethodNotFoundError checks if the error is a JSON-RPC "Method not found" error.
 func isMethodNotFoundError(err error) bool {
 	var rpcErr *jsonrpc.Error
@@ -112,4 +151,13 @@ func updateResources(name string, resources []*Resource) int {
 	}
 	allResources.Set(name, resources)
 	return len(resources)
+}
+
+func updateResourceTemplates(name string, templates []*ResourceTemplate) int {
+	if len(templates) == 0 {
+		allResourceTemplates.Del(name)
+		return 0
+	}
+	allResourceTemplates.Set(name, templates)
+	return len(templates)
 }

--- a/internal/agent/tools/mcp/resources.go
+++ b/internal/agent/tools/mcp/resources.go
@@ -14,32 +14,45 @@ import (
 
 type Resource = mcp.Resource
 
+type ResourceTemplate = mcp.ResourceTemplate
+
 type ResourceContents = mcp.ResourceContents
 
-var allResources = csync.NewMap[string, []*Resource]()
+var (
+	allResources         = csync.NewMap[string, []*Resource]()
+	allResourceTemplates = csync.NewMap[string, []*ResourceTemplate]()
+)
 
 // Resources returns all available MCP resources.
 func Resources() iter.Seq2[string, []*Resource] {
 	return allResources.Seq2()
 }
 
-// ListResources returns the current resources for an MCP server.
-func ListResources(ctx context.Context, cfg *config.ConfigStore, name string) ([]*Resource, error) {
+// ResourceTemplates returns all available MCP resource templates.
+func ResourceTemplates() iter.Seq2[string, []*ResourceTemplate] {
+	return allResourceTemplates.Seq2()
+}
+
+// ListResources returns the current resources (including resource templates) for an MCP server.
+func ListResources(ctx context.Context, cfg *config.ConfigStore, name string) ([]*Resource, []*ResourceTemplate, error) {
 	session, err := getOrRenewClient(ctx, cfg, name)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	resources, err := getResources(ctx, session)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
+	templates := listTemplatesBestEffort(ctx, session, name)
+
 	resourceCount := updateResources(name, resources)
+	templateCount := updateResourceTemplates(name, templates)
 	prev, _ := states.Get(name)
-	prev.Counts.Resources = resourceCount
+	prev.Counts.Resources = resourceCount + templateCount
 	updateState(name, StateConnected, nil, session, prev.Counts)
-	return resources, nil
+	return resources, templates, nil
 }
 
 // ReadResource reads the contents of a resource from an MCP server.
@@ -55,7 +68,7 @@ func ReadResource(ctx context.Context, cfg *config.ConfigStore, name, uri string
 	return result.Contents, nil
 }
 
-// RefreshResources gets the updated list of resources from the MCP and updates the
+// RefreshResources gets the updated list of resources and resource templates from the MCP and updates the
 // global state.
 func RefreshResources(ctx context.Context, name string) {
 	// Runs under the per-name lifecycle lock so a concurrent renewal can't
@@ -76,10 +89,13 @@ func RefreshResources(ctx context.Context, name string) {
 		return
 	}
 
+	templates := listTemplatesBestEffort(ctx, session, name)
+
 	resourceCount := updateResources(name, resources)
+	templateCount := updateResourceTemplates(name, templates)
 
 	prev, _ := states.Get(name)
-	prev.Counts.Resources = resourceCount
+	prev.Counts.Resources = resourceCount + templateCount
 	updateState(name, StateConnected, nil, session, prev.Counts)
 }
 
@@ -99,6 +115,50 @@ func getResources(ctx context.Context, c *ClientSession) ([]*Resource, error) {
 	return result.Resources, nil
 }
 
+// refreshSessionResources re-fetches a session's resources and resource
+// templates (best-effort: a listing failure degrades to an empty registry
+// and a warn, never an error) and installs them in the registries. It
+// returns the combined count for ClientInfo.Counts.Resources, so callers
+// publishing a StateConnected transition report exactly what the
+// registries hold.
+func refreshSessionResources(ctx context.Context, name string, session *ClientSession) int {
+	resources, err := getResources(ctx, session)
+	if err != nil {
+		slog.Warn("Error listing MCP resources", "name", name, "error", err)
+		resources = nil
+	}
+	templates := listTemplatesBestEffort(ctx, session, name)
+	return updateResources(name, resources) + updateResourceTemplates(name, templates)
+}
+
+// listTemplatesBestEffort lists a session's resource templates, treating any
+// failure as "no templates". getResourceTemplates already swallows
+// method-not-found, so an error reaching here is a timeout, transport
+// failure, or server bug — never lack of support — and is logged as such,
+// with the server name so a multi-server config stays debuggable.
+func listTemplatesBestEffort(ctx context.Context, session *ClientSession, name string) []*ResourceTemplate {
+	templates, err := getResourceTemplates(ctx, session)
+	if err != nil {
+		slog.Warn("Error listing MCP resource templates", "name", name, "error", err)
+		return nil
+	}
+	return templates
+}
+
+func getResourceTemplates(ctx context.Context, c *ClientSession) ([]*ResourceTemplate, error) {
+	if c.InitializeResult().Capabilities.Resources == nil {
+		return nil, nil
+	}
+	result, err := c.ListResourceTemplates(ctx, &mcp.ListResourceTemplatesParams{})
+	if err != nil {
+		if isMethodNotFoundError(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return result.ResourceTemplates, nil
+}
+
 // isMethodNotFoundError checks if the error is a JSON-RPC "Method not found" error.
 func isMethodNotFoundError(err error) bool {
 	var rpcErr *jsonrpc.Error
@@ -112,4 +172,13 @@ func updateResources(name string, resources []*Resource) int {
 	}
 	allResources.Set(name, resources)
 	return len(resources)
+}
+
+func updateResourceTemplates(name string, templates []*ResourceTemplate) int {
+	if len(templates) == 0 {
+		allResourceTemplates.Del(name)
+		return 0
+	}
+	allResourceTemplates.Set(name, templates)
+	return len(templates)
 }

--- a/internal/agent/tools/mcp/resources.go
+++ b/internal/agent/tools/mcp/resources.go
@@ -45,12 +45,7 @@ func ListResources(ctx context.Context, cfg *config.ConfigStore, name string) ([
 		return nil, nil, err
 	}
 
-	templates, err := getResourceTemplates(ctx, session)
-	if err != nil {
-		// Templates are best-effort; some servers may not support resources/templates/list.
-		slog.Warn("MCP server does not support resources/templates/list", "error", err)
-		templates = nil
-	}
+	templates := listTemplatesBestEffort(ctx, session, name)
 
 	resourceCount := updateResources(name, resources)
 	templateCount := updateResourceTemplates(name, templates)
@@ -94,11 +89,7 @@ func RefreshResources(ctx context.Context, name string) {
 		return
 	}
 
-	templates, err := getResourceTemplates(ctx, session)
-	if err != nil {
-		slog.Warn("MCP server does not support resources/templates/list", "error", err)
-		templates = nil
-	}
+	templates := listTemplatesBestEffort(ctx, session, name)
 
 	resourceCount := updateResources(name, resources)
 	templateCount := updateResourceTemplates(name, templates)
@@ -122,6 +113,36 @@ func getResources(ctx context.Context, c *ClientSession) ([]*Resource, error) {
 		return nil, err
 	}
 	return result.Resources, nil
+}
+
+// refreshSessionResources re-fetches a session's resources and resource
+// templates (best-effort: a listing failure degrades to an empty registry
+// and a warn, never an error) and installs them in the registries. It
+// returns the combined count for ClientInfo.Counts.Resources, so callers
+// publishing a StateConnected transition report exactly what the
+// registries hold.
+func refreshSessionResources(ctx context.Context, name string, session *ClientSession) int {
+	resources, err := getResources(ctx, session)
+	if err != nil {
+		slog.Warn("Error listing MCP resources", "name", name, "error", err)
+		resources = nil
+	}
+	templates := listTemplatesBestEffort(ctx, session, name)
+	return updateResources(name, resources) + updateResourceTemplates(name, templates)
+}
+
+// listTemplatesBestEffort lists a session's resource templates, treating any
+// failure as "no templates". getResourceTemplates already swallows
+// method-not-found, so an error reaching here is a timeout, transport
+// failure, or server bug — never lack of support — and is logged as such,
+// with the server name so a multi-server config stays debuggable.
+func listTemplatesBestEffort(ctx context.Context, session *ClientSession, name string) []*ResourceTemplate {
+	templates, err := getResourceTemplates(ctx, session)
+	if err != nil {
+		slog.Warn("Error listing MCP resource templates", "name", name, "error", err)
+		return nil
+	}
+	return templates
 }
 
 func getResourceTemplates(ctx context.Context, c *ClientSession) ([]*ResourceTemplate, error) {

--- a/internal/agent/tools/mcp/resources_test.go
+++ b/internal/agent/tools/mcp/resources_test.go
@@ -1,0 +1,154 @@
+package mcp
+
+import (
+	"context"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/require"
+)
+
+// liveResourceSession spins up a real in-memory MCP server advertising the
+// given resources and resource templates and returns a connected client
+// session, mirroring liveSession for the resources side of the protocol.
+func liveResourceSession(t *testing.T, resources []*mcp.Resource, templates []*mcp.ResourceTemplate) *ClientSession {
+	t.Helper()
+
+	serverTransport, clientTransport := mcp.NewInMemoryTransports()
+	server := mcp.NewServer(&mcp.Implementation{Name: "srv"}, nil)
+	handler := func(context.Context, *mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
+		return &mcp.ReadResourceResult{}, nil
+	}
+	for _, r := range resources {
+		server.AddResource(r, handler)
+	}
+	for _, tmpl := range templates {
+		server.AddResourceTemplate(tmpl, handler)
+	}
+	serverSession, err := server.Connect(context.Background(), serverTransport, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = serverSession.Close() })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	client := mcp.NewClient(&mcp.Implementation{Name: "crush-test"}, nil)
+	clientSession, err := client.Connect(ctx, clientTransport, nil)
+	require.NoError(t, err)
+
+	sess := &ClientSession{ClientSession: clientSession, cancel: cancel}
+	t.Cleanup(func() { _ = sess.Close() })
+	return sess
+}
+
+// TestUpdateResourceTemplates_SetAndDelOnEmpty pins the registry-write
+// semantics updateResourceTemplates shares with updateResources: a non-empty
+// list is installed and counted, an empty (or nil) list deletes the entry
+// outright — so a server that stops advertising templates does not linger
+// with an empty-but-present registry row.
+func TestUpdateResourceTemplates_SetAndDelOnEmpty(t *testing.T) {
+	const name = "test-update-resource-templates"
+	t.Cleanup(func() { allResourceTemplates.Del(name) })
+
+	count := updateResourceTemplates(name, []*ResourceTemplate{
+		{Name: "run", URITemplate: "cairn://run/{id}"},
+		{Name: "bundle", URITemplate: "cairn://bundle/{id}"},
+	})
+	require.Equal(t, 2, count)
+	got, ok := allResourceTemplates.Get(name)
+	require.True(t, ok)
+	require.Len(t, got, 2)
+
+	count = updateResourceTemplates(name, nil)
+	require.Equal(t, 0, count)
+	_, ok = allResourceTemplates.Get(name)
+	require.False(t, ok, "an empty template list must delete the registry entry")
+}
+
+// TestGetResourceTemplates_NoResourcesCapability pins the capability gate: a
+// server that does not advertise the resources capability yields (nil, nil)
+// without a wire call, so servers with no resources at all never produce
+// warns or errors from the template fetch.
+func TestGetResourceTemplates_NoResourcesCapability(t *testing.T) {
+	sess, _ := liveSession(t, "no_resources_tool")
+	t.Cleanup(func() { _ = sess.Close() })
+
+	templates, err := getResourceTemplates(context.Background(), sess)
+	require.NoError(t, err)
+	require.Nil(t, templates)
+}
+
+// TestGetResourceTemplates_ListsTemplates pins the happy path over a real
+// in-memory server: the declared templates come back with their URI
+// templates intact.
+func TestGetResourceTemplates_ListsTemplates(t *testing.T) {
+	sess := liveResourceSession(t, nil, []*mcp.ResourceTemplate{
+		{Name: "run", URITemplate: "cairn://run/{id}/a2ui"},
+	})
+
+	templates, err := getResourceTemplates(context.Background(), sess)
+	require.NoError(t, err)
+	require.Len(t, templates, 1)
+	require.Equal(t, "cairn://run/{id}/a2ui", templates[0].URITemplate)
+}
+
+// TestRefreshSessionResources_CountsSumResourcesAndTemplates pins the seam
+// initClient and the renewal path share: both registries are populated from
+// the session and the returned count — what Counts.Resources reports — is
+// the sum of concrete resources and templates.
+func TestRefreshSessionResources_CountsSumResourcesAndTemplates(t *testing.T) {
+	const name = "test-refresh-session-resources"
+	t.Cleanup(func() {
+		allResources.Del(name)
+		allResourceTemplates.Del(name)
+	})
+
+	sess := liveResourceSession(t,
+		[]*mcp.Resource{
+			{Name: "doc-a", URI: "test://doc-a"},
+			{Name: "doc-b", URI: "test://doc-b"},
+		},
+		[]*mcp.ResourceTemplate{
+			{Name: "run", URITemplate: "test://run/{id}"},
+		},
+	)
+
+	count := refreshSessionResources(context.Background(), name, sess)
+	require.Equal(t, 3, count, "count must sum resources and templates")
+
+	resources, ok := allResources.Get(name)
+	require.True(t, ok)
+	require.Len(t, resources, 2)
+	templates, ok := allResourceTemplates.Get(name)
+	require.True(t, ok)
+	require.Len(t, templates, 1)
+}
+
+// TestRefreshResources_UpdatesRegistriesAndCount pins the notification-driven
+// refresh path end to end: RefreshResources lists both resources and
+// templates from the live session and publishes their sum on the state.
+func TestRefreshResources_UpdatesRegistriesAndCount(t *testing.T) {
+	const name = "test-refresh-resources"
+	t.Cleanup(func() {
+		sessions.Del(name)
+		allResources.Del(name)
+		allResourceTemplates.Del(name)
+		states.Del(name)
+	})
+
+	sess := liveResourceSession(t,
+		[]*mcp.Resource{{Name: "doc", URI: "test://doc"}},
+		[]*mcp.ResourceTemplate{{Name: "run", URITemplate: "test://run/{id}"}},
+	)
+	sessions.Set(name, sess)
+
+	RefreshResources(context.Background(), name)
+
+	_, ok := allResources.Get(name)
+	require.True(t, ok, "refresh must install the listed resources")
+	_, ok = allResourceTemplates.Get(name)
+	require.True(t, ok, "refresh must install the listed templates")
+
+	info, ok := GetState(name)
+	require.True(t, ok)
+	require.Equal(t, StateConnected, info.State)
+	require.Equal(t, 2, info.Counts.Resources, "state count must sum resources and templates")
+}

--- a/internal/agent/tools/mcp/tools.go
+++ b/internal/agent/tools/mcp/tools.go
@@ -65,6 +65,31 @@ func Tools() iter.Seq2[string, []*Tool] {
 	return allTools.Seq2()
 }
 
+// HasTool reports whether the named MCP server currently exposes a tool with
+// the given name. It backs the A2UI action round-trip: a server that serves
+// interactive surfaces may also expose the a2ui_action / a2ui_error tools
+// the client round-trips interactions through, and the client needs to know
+// before it commits to that path.
+func HasTool(name, toolName string) bool {
+	tools, ok := allTools.Get(name)
+	if !ok {
+		return false
+	}
+	return slices.ContainsFunc(tools, func(t *Tool) bool { return t.Name == toolName })
+}
+
+// SetToolsForTest installs the given tool names for an MCP server in the
+// shared registry and returns a cleanup that removes them. It exists for
+// tests outside this package that need HasTool to observe a server's tools.
+func SetToolsForTest(name string, toolNames ...string) func() {
+	tools := make([]*Tool, len(toolNames))
+	for i, n := range toolNames {
+		tools[i] = &Tool{Name: n}
+	}
+	allTools.Set(name, tools)
+	return func() { allTools.Del(name) }
+}
+
 // RunTool runs an MCP tool with the given input parameters.
 func RunTool(ctx context.Context, cfg *config.ConfigStore, name, toolName string, input string) (ToolResult, error) {
 	var args map[string]any

--- a/internal/agent/tools/mcp/tools.go
+++ b/internal/agent/tools/mcp/tools.go
@@ -17,12 +17,45 @@ import (
 
 type Tool = mcp.Tool
 
+// A2UIJSONMIMEType is the canonical MIME type identifying an A2UI surface
+// payload, per the A2UI-over-MCP contract. A2UILegacyMIMEType is the legacy
+// spelling reference clients also accept.
+const (
+	A2UIJSONMIMEType   = "application/a2ui+json"
+	A2UILegacyMIMEType = "application/json+a2ui"
+)
+
+// IsA2UIMIMEType reports whether mime identifies an A2UI surface payload,
+// accepting both the canonical and legacy spellings.
+func IsA2UIMIMEType(mime string) bool {
+	return mime == A2UIJSONMIMEType || mime == A2UILegacyMIMEType
+}
+
+// A2UISurface is a UI-only A2UI surface payload extracted from a tool
+// result's EmbeddedResource content. The chat UI renders it as a live
+// surface; the model never sees the raw JSON.
+type A2UISurface struct {
+	// Payload is the raw A2UI JSON.
+	Payload string
+	// URI is the embedded resource's URI, for display/diagnostics.
+	URI string
+	// AssistantVisible reports whether the server annotated the payload
+	// for the LLM as well as the user (empty audience or one containing
+	// "assistant"). An audience of ["user"] alone hides the raw JSON from
+	// the model.
+	AssistantVisible bool
+}
+
 // ToolResult represents the result of running an MCP tool.
 type ToolResult struct {
 	Type      string
 	Content   string
 	Data      []byte
 	MediaType string
+	// Surfaces carries any A2UI surface payloads found in the result's
+	// EmbeddedResource content. They are kept out of Content: the chat UI
+	// draws them, and the model only ever echoed the JSON back.
+	Surfaces []A2UISurface
 }
 
 var allTools = csync.NewMap[string, []*Tool]()
@@ -55,7 +88,15 @@ func RunTool(ctx context.Context, cfg *config.ConfigStore, name, toolName string
 		return ToolResult{Type: "text", Content: ""}, nil
 	}
 
+	return extractToolResult(result), nil
+}
+
+// extractToolResult partitions a CallToolResult's content into model-facing
+// text, binary media, and UI-only A2UI surfaces — the extraction half of
+// RunTool, split out so tests can drive it through a live in-memory server.
+func extractToolResult(result *mcp.CallToolResult) ToolResult {
 	var textParts []string
+	var surfaces []A2UISurface
 	var imageData []byte
 	var imageMimeType string
 	var audioData []byte
@@ -75,6 +116,25 @@ func RunTool(ctx context.Context, cfg *config.ConfigStore, name, toolName string
 				audioData = content.Data
 				audioMimeType = content.MIMEType
 			}
+		case *mcp.EmbeddedResource:
+			// A2UI surfaces arrive as embedded resources — pull them
+			// aside for the UI instead of stringifying them into the
+			// model-facing text.
+			if content.Resource != nil && IsA2UIMIMEType(content.Resource.MIMEType) {
+				payload := content.Resource.Text
+				if payload == "" && len(content.Resource.Blob) > 0 {
+					payload = string(content.Resource.Blob)
+				}
+				if payload != "" {
+					surfaces = append(surfaces, A2UISurface{
+						Payload:          payload,
+						URI:              content.Resource.URI,
+						AssistantVisible: a2uiAssistantVisible(content.Annotations),
+					})
+				}
+				continue
+			}
+			textParts = append(textParts, fmt.Sprintf("%v", v))
 		default:
 			textParts = append(textParts, fmt.Sprintf("%v", v))
 		}
@@ -90,7 +150,8 @@ func RunTool(ctx context.Context, cfg *config.ConfigStore, name, toolName string
 			Content:   textContent,
 			Data:      ensureRawBytes(imageData),
 			MediaType: imageMimeType,
-		}, nil
+			Surfaces:  surfaces,
+		}
 	}
 
 	if audioData != nil {
@@ -99,13 +160,27 @@ func RunTool(ctx context.Context, cfg *config.ConfigStore, name, toolName string
 			Content:   textContent,
 			Data:      ensureRawBytes(audioData),
 			MediaType: audioMimeType,
-		}, nil
+			Surfaces:  surfaces,
+		}
 	}
 
 	return ToolResult{
-		Type:    "text",
-		Content: textContent,
-	}, nil
+		Type:     "text",
+		Content:  textContent,
+		Surfaces: surfaces,
+	}
+}
+
+// a2uiAssistantVisible reports whether an A2UI embedded resource's audience
+// annotations leave the payload visible to the LLM. Per the A2UI-over-MCP
+// verbalization contract: an empty audience is visible to both user and
+// assistant; an audience of ["user"] alone renders for the user but hides
+// the raw JSON from the model.
+func a2uiAssistantVisible(annotations *mcp.Annotations) bool {
+	if annotations == nil || len(annotations.Audience) == 0 {
+		return true
+	}
+	return slices.Contains(annotations.Audience, mcp.Role("assistant"))
 }
 
 // RefreshTools gets the updated list of tools from the MCP and updates the

--- a/internal/agent/tools/mcp/tools.go
+++ b/internal/agent/tools/mcp/tools.go
@@ -39,6 +39,10 @@ type A2UISurface struct {
 	Payload string
 	// URI is the embedded resource's URI, for display/diagnostics.
 	URI string
+	// RenderForUser reports whether the payload should be rendered for the
+	// user. False only when the audience is ["assistant"] alone: the spec's
+	// verbalization contract renders for every audience except that one.
+	RenderForUser bool
 	// AssistantVisible reports whether the server annotated the payload
 	// for the LLM as well as the user (empty audience or one containing
 	// "assistant"). An audience of ["user"] alone hides the raw JSON from
@@ -151,10 +155,12 @@ func extractToolResult(result *mcp.CallToolResult) ToolResult {
 					payload = string(content.Resource.Blob)
 				}
 				if payload != "" {
+					render, assistantVisible := a2uiAudience(content.Annotations)
 					surfaces = append(surfaces, A2UISurface{
 						Payload:          payload,
 						URI:              content.Resource.URI,
-						AssistantVisible: a2uiAssistantVisible(content.Annotations),
+						RenderForUser:    render,
+						AssistantVisible: assistantVisible,
 					})
 				}
 				continue
@@ -196,16 +202,22 @@ func extractToolResult(result *mcp.CallToolResult) ToolResult {
 	}
 }
 
-// a2uiAssistantVisible reports whether an A2UI embedded resource's audience
-// annotations leave the payload visible to the LLM. Per the A2UI-over-MCP
-// verbalization contract: an empty audience is visible to both user and
-// assistant; an audience of ["user"] alone renders for the user but hides
-// the raw JSON from the model.
-func a2uiAssistantVisible(annotations *mcp.Annotations) bool {
+// a2uiAudience resolves an A2UI embedded resource's audience annotations
+// into the spec's verbalization contract:
+//
+//	audience (empty)      → render for the user, visible to the model
+//	["user"]              → render for the user, hidden from the model
+//	["assistant"]         → visible to the model, NOT rendered
+//	["user","assistant"]  → both
+//
+// It returns (renderForUser, assistantVisible).
+func a2uiAudience(annotations *mcp.Annotations) (bool, bool) {
 	if annotations == nil || len(annotations.Audience) == 0 {
-		return true
+		return true, true
 	}
-	return slices.Contains(annotations.Audience, mcp.Role("assistant"))
+	forUser := slices.Contains(annotations.Audience, mcp.Role("user"))
+	forAssistant := slices.Contains(annotations.Audience, mcp.Role("assistant"))
+	return forUser, forAssistant
 }
 
 // RefreshTools gets the updated list of tools from the MCP and updates the

--- a/internal/agent/tools/mcp/tools.go
+++ b/internal/agent/tools/mcp/tools.go
@@ -17,12 +17,49 @@ import (
 
 type Tool = mcp.Tool
 
+// A2UIJSONMIMEType is the canonical MIME type identifying an A2UI surface
+// payload, per the A2UI-over-MCP contract. A2UILegacyMIMEType is the legacy
+// spelling reference clients also accept.
+const (
+	A2UIJSONMIMEType   = "application/a2ui+json"
+	A2UILegacyMIMEType = "application/json+a2ui"
+)
+
+// IsA2UIMIMEType reports whether mime identifies an A2UI surface payload,
+// accepting both the canonical and legacy spellings.
+func IsA2UIMIMEType(mime string) bool {
+	return mime == A2UIJSONMIMEType || mime == A2UILegacyMIMEType
+}
+
+// A2UISurface is a UI-only A2UI surface payload extracted from a tool
+// result's EmbeddedResource content. The chat UI renders it as a live
+// surface; the model never sees the raw JSON.
+type A2UISurface struct {
+	// Payload is the raw A2UI JSON.
+	Payload string
+	// URI is the embedded resource's URI, for display/diagnostics.
+	URI string
+	// RenderForUser reports whether the payload should be rendered for the
+	// user. False only when the audience is ["assistant"] alone: the spec's
+	// verbalization contract renders for every audience except that one.
+	RenderForUser bool
+	// AssistantVisible reports whether the server annotated the payload
+	// for the LLM as well as the user (empty audience or one containing
+	// "assistant"). An audience of ["user"] alone hides the raw JSON from
+	// the model.
+	AssistantVisible bool
+}
+
 // ToolResult represents the result of running an MCP tool.
 type ToolResult struct {
 	Type      string
 	Content   string
 	Data      []byte
 	MediaType string
+	// Surfaces carries any A2UI surface payloads found in the result's
+	// EmbeddedResource content. They are kept out of Content: the chat UI
+	// draws them, and the model only ever echoed the JSON back.
+	Surfaces []A2UISurface
 }
 
 var allTools = csync.NewMap[string, []*Tool]()
@@ -30,6 +67,31 @@ var allTools = csync.NewMap[string, []*Tool]()
 // Tools returns all available MCP tools.
 func Tools() iter.Seq2[string, []*Tool] {
 	return allTools.Seq2()
+}
+
+// HasTool reports whether the named MCP server currently exposes a tool with
+// the given name. It backs the A2UI action round-trip: a server that serves
+// interactive surfaces may also expose the a2ui_action / a2ui_error tools
+// the client round-trips interactions through, and the client needs to know
+// before it commits to that path.
+func HasTool(name, toolName string) bool {
+	tools, ok := allTools.Get(name)
+	if !ok {
+		return false
+	}
+	return slices.ContainsFunc(tools, func(t *Tool) bool { return t.Name == toolName })
+}
+
+// SetToolsForTest installs the given tool names for an MCP server in the
+// shared registry and returns a cleanup that removes them. It exists for
+// tests outside this package that need HasTool to observe a server's tools.
+func SetToolsForTest(name string, toolNames ...string) func() {
+	tools := make([]*Tool, len(toolNames))
+	for i, n := range toolNames {
+		tools[i] = &Tool{Name: n}
+	}
+	allTools.Set(name, tools)
+	return func() { allTools.Del(name) }
 }
 
 // RunTool runs an MCP tool with the given input parameters.
@@ -55,7 +117,15 @@ func RunTool(ctx context.Context, cfg *config.ConfigStore, name, toolName string
 		return ToolResult{Type: "text", Content: ""}, nil
 	}
 
+	return extractToolResult(result), nil
+}
+
+// extractToolResult partitions a CallToolResult's content into model-facing
+// text, binary media, and UI-only A2UI surfaces — the extraction half of
+// RunTool, split out so tests can drive it through a live in-memory server.
+func extractToolResult(result *mcp.CallToolResult) ToolResult {
 	var textParts []string
+	var surfaces []A2UISurface
 	var imageData []byte
 	var imageMimeType string
 	var audioData []byte
@@ -75,6 +145,27 @@ func RunTool(ctx context.Context, cfg *config.ConfigStore, name, toolName string
 				audioData = content.Data
 				audioMimeType = content.MIMEType
 			}
+		case *mcp.EmbeddedResource:
+			// A2UI surfaces arrive as embedded resources — pull them
+			// aside for the UI instead of stringifying them into the
+			// model-facing text.
+			if content.Resource != nil && IsA2UIMIMEType(content.Resource.MIMEType) {
+				payload := content.Resource.Text
+				if payload == "" && len(content.Resource.Blob) > 0 {
+					payload = string(content.Resource.Blob)
+				}
+				if payload != "" {
+					render, assistantVisible := a2uiAudience(content.Annotations)
+					surfaces = append(surfaces, A2UISurface{
+						Payload:          payload,
+						URI:              content.Resource.URI,
+						RenderForUser:    render,
+						AssistantVisible: assistantVisible,
+					})
+				}
+				continue
+			}
+			textParts = append(textParts, fmt.Sprintf("%v", v))
 		default:
 			textParts = append(textParts, fmt.Sprintf("%v", v))
 		}
@@ -90,7 +181,8 @@ func RunTool(ctx context.Context, cfg *config.ConfigStore, name, toolName string
 			Content:   textContent,
 			Data:      ensureRawBytes(imageData),
 			MediaType: imageMimeType,
-		}, nil
+			Surfaces:  surfaces,
+		}
 	}
 
 	if audioData != nil {
@@ -99,13 +191,33 @@ func RunTool(ctx context.Context, cfg *config.ConfigStore, name, toolName string
 			Content:   textContent,
 			Data:      ensureRawBytes(audioData),
 			MediaType: audioMimeType,
-		}, nil
+			Surfaces:  surfaces,
+		}
 	}
 
 	return ToolResult{
-		Type:    "text",
-		Content: textContent,
-	}, nil
+		Type:     "text",
+		Content:  textContent,
+		Surfaces: surfaces,
+	}
+}
+
+// a2uiAudience resolves an A2UI embedded resource's audience annotations
+// into the spec's verbalization contract:
+//
+//	audience (empty)      → render for the user, visible to the model
+//	["user"]              → render for the user, hidden from the model
+//	["assistant"]         → visible to the model, NOT rendered
+//	["user","assistant"]  → both
+//
+// It returns (renderForUser, assistantVisible).
+func a2uiAudience(annotations *mcp.Annotations) (bool, bool) {
+	if annotations == nil || len(annotations.Audience) == 0 {
+		return true, true
+	}
+	forUser := slices.Contains(annotations.Audience, mcp.Role("user"))
+	forAssistant := slices.Contains(annotations.Audience, mcp.Role("assistant"))
+	return forUser, forAssistant
 }
 
 // RefreshTools gets the updated list of tools from the MCP and updates the

--- a/internal/agent/tools/mcp/tools_a2ui_test.go
+++ b/internal/agent/tools/mcp/tools_a2ui_test.go
@@ -1,0 +1,145 @@
+package mcp
+
+import (
+	"context"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/require"
+)
+
+const testA2UIToolPayload = `{"version":"v0.9","updateComponents":{"surfaceId":"card","components":[` +
+	`{"component":"Text","id":"t","text":"Recipe"}]}}`
+
+// liveA2UIToolSession spins up an in-memory MCP server whose single tool
+// returns the given content items, and returns a connected client session.
+func liveA2UIToolSession(t *testing.T, toolName string, content []mcp.Content) *ClientSession {
+	t.Helper()
+
+	serverTransport, clientTransport := mcp.NewInMemoryTransports()
+	server := mcp.NewServer(&mcp.Implementation{Name: "srv"}, nil)
+	mcp.AddTool(
+		server,
+		&mcp.Tool{Name: toolName, Description: "test tool"},
+		func(context.Context, *mcp.CallToolRequest, struct{}) (*mcp.CallToolResult, any, error) {
+			return &mcp.CallToolResult{Content: content}, nil, nil
+		},
+	)
+	serverSession, err := server.Connect(context.Background(), serverTransport, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = serverSession.Close() })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	client := mcp.NewClient(&mcp.Implementation{Name: "crush-test"}, nil)
+	clientSession, err := client.Connect(ctx, clientTransport, nil)
+	require.NoError(t, err)
+
+	sess := &ClientSession{ClientSession: clientSession, cancel: cancel}
+	t.Cleanup(func() { _ = sess.Close() })
+	return sess
+}
+
+// runToolWithSession calls the tool through the same extraction path RunTool
+// uses, without needing a registered config client.
+func runToolWithSession(t *testing.T, sess *ClientSession, toolName string) ToolResult {
+	t.Helper()
+	result, err := sess.CallTool(context.Background(), &mcp.CallToolParams{
+		Name:      toolName,
+		Arguments: map[string]any{},
+	})
+	require.NoError(t, err)
+	return extractToolResult(result)
+}
+
+func TestRunTool_A2UISurfaceExtraction(t *testing.T) {
+	t.Parallel()
+
+	t.Run("embedded A2UI resource becomes a surface, not text", func(t *testing.T) {
+		sess := liveA2UIToolSession(t, "get_card", []mcp.Content{
+			&mcp.TextContent{Text: "Your recipe card"},
+			&mcp.EmbeddedResource{
+				Resource: &mcp.ResourceContents{
+					URI:      "a2ui://recipe-card",
+					MIMEType: A2UIJSONMIMEType,
+					Text:     testA2UIToolPayload,
+				},
+			},
+		})
+		res := runToolWithSession(t, sess, "get_card")
+
+		require.Equal(t, "Your recipe card", res.Content)
+		require.Len(t, res.Surfaces, 1)
+		require.Equal(t, testA2UIToolPayload, res.Surfaces[0].Payload)
+		require.Equal(t, "a2ui://recipe-card", res.Surfaces[0].URI)
+		require.True(t, res.Surfaces[0].AssistantVisible, "no audience annotation means visible to both")
+		require.NotContains(t, res.Content, "updateComponents")
+	})
+
+	t.Run("legacy MIME spelling is recognized", func(t *testing.T) {
+		sess := liveA2UIToolSession(t, "get_card", []mcp.Content{
+			&mcp.EmbeddedResource{
+				Resource: &mcp.ResourceContents{
+					URI:      "a2ui://form",
+					MIMEType: A2UILegacyMIMEType,
+					Text:     testA2UIToolPayload,
+				},
+			},
+		})
+		res := runToolWithSession(t, sess, "get_card")
+		require.Len(t, res.Surfaces, 1)
+	})
+
+	t.Run("user-only audience hides the payload from the model", func(t *testing.T) {
+		sess := liveA2UIToolSession(t, "get_card", []mcp.Content{
+			&mcp.EmbeddedResource{
+				Resource: &mcp.ResourceContents{
+					URI:      "a2ui://card",
+					MIMEType: A2UIJSONMIMEType,
+					Text:     testA2UIToolPayload,
+				},
+				Annotations: &mcp.Annotations{Audience: []mcp.Role{"user"}},
+			},
+		})
+		res := runToolWithSession(t, sess, "get_card")
+		require.Len(t, res.Surfaces, 1)
+		require.False(t, res.Surfaces[0].AssistantVisible)
+	})
+
+	t.Run("blob-delivered surface is normalized to text", func(t *testing.T) {
+		sess := liveA2UIToolSession(t, "get_card", []mcp.Content{
+			&mcp.EmbeddedResource{
+				Resource: &mcp.ResourceContents{
+					URI:      "a2ui://card",
+					MIMEType: A2UIJSONMIMEType,
+					Blob:     []byte(testA2UIToolPayload),
+				},
+			},
+		})
+		res := runToolWithSession(t, sess, "get_card")
+		require.Len(t, res.Surfaces, 1)
+		require.Equal(t, testA2UIToolPayload, res.Surfaces[0].Payload)
+	})
+
+	t.Run("non-A2UI embedded resource stays in the text", func(t *testing.T) {
+		sess := liveA2UIToolSession(t, "get_doc", []mcp.Content{
+			&mcp.EmbeddedResource{
+				Resource: &mcp.ResourceContents{
+					URI:      "file:///doc.md",
+					MIMEType: "text/markdown",
+					Text:     "# hello",
+				},
+			},
+		})
+		res := runToolWithSession(t, sess, "get_doc")
+		require.Empty(t, res.Surfaces)
+		require.NotEmpty(t, res.Content)
+	})
+}
+
+func TestIsA2UIMIMEType(t *testing.T) {
+	t.Parallel()
+	require.True(t, IsA2UIMIMEType("application/a2ui+json"))
+	require.True(t, IsA2UIMIMEType("application/json+a2ui"))
+	require.False(t, IsA2UIMIMEType("application/json"))
+	require.False(t, IsA2UIMIMEType("text/plain"))
+}

--- a/internal/agent/tools/mcp/tools_a2ui_test.go
+++ b/internal/agent/tools/mcp/tools_a2ui_test.go
@@ -109,6 +109,24 @@ func TestRunTool_A2UISurfaceExtraction(t *testing.T) {
 		res := runToolWithSession(t, sess, "get_card")
 		require.Len(t, res.Surfaces, 1)
 		require.False(t, res.Surfaces[0].AssistantVisible)
+		require.True(t, res.Surfaces[0].RenderForUser, "user audience still renders")
+	})
+
+	t.Run("assistant-only audience is visible to the model but not rendered", func(t *testing.T) {
+		sess := liveA2UIToolSession(t, "get_card", []mcp.Content{
+			&mcp.EmbeddedResource{
+				Resource: &mcp.ResourceContents{
+					URI:      "a2ui://card",
+					MIMEType: A2UIJSONMIMEType,
+					Text:     testA2UIToolPayload,
+				},
+				Annotations: &mcp.Annotations{Audience: []mcp.Role{"assistant"}},
+			},
+		})
+		res := runToolWithSession(t, sess, "get_card")
+		require.Len(t, res.Surfaces, 1)
+		require.True(t, res.Surfaces[0].AssistantVisible)
+		require.False(t, res.Surfaces[0].RenderForUser, "assistant-only audience must not render")
 	})
 
 	t.Run("blob-delivered surface is normalized to text", func(t *testing.T) {

--- a/internal/agent/tools/mcp/tools_a2ui_test.go
+++ b/internal/agent/tools/mcp/tools_a2ui_test.go
@@ -1,0 +1,173 @@
+package mcp
+
+import (
+	"context"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/require"
+)
+
+const testA2UIToolPayload = `{"version":"v0.9","updateComponents":{"surfaceId":"card","components":[` +
+	`{"component":"Text","id":"t","text":"Recipe"}]}}`
+
+// liveA2UIToolSession spins up an in-memory MCP server whose single tool
+// returns the given content items, and returns a connected client session.
+func liveA2UIToolSession(t *testing.T, toolName string, content []mcp.Content) *ClientSession {
+	t.Helper()
+
+	serverTransport, clientTransport := mcp.NewInMemoryTransports()
+	server := mcp.NewServer(&mcp.Implementation{Name: "srv"}, nil)
+	mcp.AddTool(
+		server,
+		&mcp.Tool{Name: toolName, Description: "test tool"},
+		func(context.Context, *mcp.CallToolRequest, struct{}) (*mcp.CallToolResult, any, error) {
+			return &mcp.CallToolResult{Content: content}, nil, nil
+		},
+	)
+	serverSession, err := server.Connect(context.Background(), serverTransport, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = serverSession.Close() })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	client := mcp.NewClient(&mcp.Implementation{Name: "crush-test"}, nil)
+	clientSession, err := client.Connect(ctx, clientTransport, nil)
+	require.NoError(t, err)
+
+	sess := &ClientSession{ClientSession: clientSession, cancel: cancel}
+	t.Cleanup(func() { _ = sess.Close() })
+	return sess
+}
+
+// runToolWithSession calls the tool through the same extraction path RunTool
+// uses, without needing a registered config client.
+func runToolWithSession(t *testing.T, sess *ClientSession, toolName string) ToolResult {
+	t.Helper()
+	result, err := sess.CallTool(context.Background(), &mcp.CallToolParams{
+		Name:      toolName,
+		Arguments: map[string]any{},
+	})
+	require.NoError(t, err)
+	return extractToolResult(result)
+}
+
+func TestRunTool_A2UISurfaceExtraction(t *testing.T) {
+	t.Parallel()
+
+	t.Run("embedded A2UI resource becomes a surface, not text", func(t *testing.T) {
+		t.Parallel()
+
+		sess := liveA2UIToolSession(t, "get_card", []mcp.Content{
+			&mcp.TextContent{Text: "Your recipe card"},
+			&mcp.EmbeddedResource{
+				Resource: &mcp.ResourceContents{
+					URI:      "a2ui://recipe-card",
+					MIMEType: A2UIJSONMIMEType,
+					Text:     testA2UIToolPayload,
+				},
+			},
+		})
+		res := runToolWithSession(t, sess, "get_card")
+
+		require.Equal(t, "Your recipe card", res.Content)
+		require.Len(t, res.Surfaces, 1)
+		require.Equal(t, testA2UIToolPayload, res.Surfaces[0].Payload)
+		require.Equal(t, "a2ui://recipe-card", res.Surfaces[0].URI)
+		require.True(t, res.Surfaces[0].AssistantVisible, "no audience annotation means visible to both")
+		require.NotContains(t, res.Content, "updateComponents")
+	})
+
+	t.Run("legacy MIME spelling is recognized", func(t *testing.T) {
+		t.Parallel()
+
+		sess := liveA2UIToolSession(t, "get_card", []mcp.Content{
+			&mcp.EmbeddedResource{
+				Resource: &mcp.ResourceContents{
+					URI:      "a2ui://form",
+					MIMEType: A2UILegacyMIMEType,
+					Text:     testA2UIToolPayload,
+				},
+			},
+		})
+		res := runToolWithSession(t, sess, "get_card")
+		require.Len(t, res.Surfaces, 1)
+	})
+
+	t.Run("user-only audience hides the payload from the model", func(t *testing.T) {
+		t.Parallel()
+
+		sess := liveA2UIToolSession(t, "get_card", []mcp.Content{
+			&mcp.EmbeddedResource{
+				Resource: &mcp.ResourceContents{
+					URI:      "a2ui://card",
+					MIMEType: A2UIJSONMIMEType,
+					Text:     testA2UIToolPayload,
+				},
+				Annotations: &mcp.Annotations{Audience: []mcp.Role{"user"}},
+			},
+		})
+		res := runToolWithSession(t, sess, "get_card")
+		require.Len(t, res.Surfaces, 1)
+		require.False(t, res.Surfaces[0].AssistantVisible)
+		require.True(t, res.Surfaces[0].RenderForUser, "user audience still renders")
+	})
+
+	t.Run("assistant-only audience is visible to the model but not rendered", func(t *testing.T) {
+		sess := liveA2UIToolSession(t, "get_card", []mcp.Content{
+			&mcp.EmbeddedResource{
+				Resource: &mcp.ResourceContents{
+					URI:      "a2ui://card",
+					MIMEType: A2UIJSONMIMEType,
+					Text:     testA2UIToolPayload,
+				},
+				Annotations: &mcp.Annotations{Audience: []mcp.Role{"assistant"}},
+			},
+		})
+		res := runToolWithSession(t, sess, "get_card")
+		require.Len(t, res.Surfaces, 1)
+		require.True(t, res.Surfaces[0].AssistantVisible)
+		require.False(t, res.Surfaces[0].RenderForUser, "assistant-only audience must not render")
+	})
+
+	t.Run("blob-delivered surface is normalized to text", func(t *testing.T) {
+		t.Parallel()
+
+		sess := liveA2UIToolSession(t, "get_card", []mcp.Content{
+			&mcp.EmbeddedResource{
+				Resource: &mcp.ResourceContents{
+					URI:      "a2ui://card",
+					MIMEType: A2UIJSONMIMEType,
+					Blob:     []byte(testA2UIToolPayload),
+				},
+			},
+		})
+		res := runToolWithSession(t, sess, "get_card")
+		require.Len(t, res.Surfaces, 1)
+		require.Equal(t, testA2UIToolPayload, res.Surfaces[0].Payload)
+	})
+
+	t.Run("non-A2UI embedded resource stays in the text", func(t *testing.T) {
+		t.Parallel()
+
+		sess := liveA2UIToolSession(t, "get_doc", []mcp.Content{
+			&mcp.EmbeddedResource{
+				Resource: &mcp.ResourceContents{
+					URI:      "file:///doc.md",
+					MIMEType: "text/markdown",
+					Text:     "# hello",
+				},
+			},
+		})
+		res := runToolWithSession(t, sess, "get_doc")
+		require.Empty(t, res.Surfaces)
+		require.NotEmpty(t, res.Content)
+	})
+}
+
+func TestIsA2UIMIMEType(t *testing.T) {
+	t.Parallel()
+	require.True(t, IsA2UIMIMEType("application/a2ui+json"))
+	require.True(t, IsA2UIMIMEType("application/json+a2ui"))
+	require.False(t, IsA2UIMIMEType("application/json"))
+	require.False(t, IsA2UIMIMEType("text/plain"))
+}

--- a/internal/agent/tools/mcp/tools_a2ui_test.go
+++ b/internal/agent/tools/mcp/tools_a2ui_test.go
@@ -55,6 +55,8 @@ func TestRunTool_A2UISurfaceExtraction(t *testing.T) {
 	t.Parallel()
 
 	t.Run("embedded A2UI resource becomes a surface, not text", func(t *testing.T) {
+		t.Parallel()
+
 		sess := liveA2UIToolSession(t, "get_card", []mcp.Content{
 			&mcp.TextContent{Text: "Your recipe card"},
 			&mcp.EmbeddedResource{
@@ -76,6 +78,8 @@ func TestRunTool_A2UISurfaceExtraction(t *testing.T) {
 	})
 
 	t.Run("legacy MIME spelling is recognized", func(t *testing.T) {
+		t.Parallel()
+
 		sess := liveA2UIToolSession(t, "get_card", []mcp.Content{
 			&mcp.EmbeddedResource{
 				Resource: &mcp.ResourceContents{
@@ -90,6 +94,8 @@ func TestRunTool_A2UISurfaceExtraction(t *testing.T) {
 	})
 
 	t.Run("user-only audience hides the payload from the model", func(t *testing.T) {
+		t.Parallel()
+
 		sess := liveA2UIToolSession(t, "get_card", []mcp.Content{
 			&mcp.EmbeddedResource{
 				Resource: &mcp.ResourceContents{
@@ -106,6 +112,8 @@ func TestRunTool_A2UISurfaceExtraction(t *testing.T) {
 	})
 
 	t.Run("blob-delivered surface is normalized to text", func(t *testing.T) {
+		t.Parallel()
+
 		sess := liveA2UIToolSession(t, "get_card", []mcp.Content{
 			&mcp.EmbeddedResource{
 				Resource: &mcp.ResourceContents{
@@ -121,6 +129,8 @@ func TestRunTool_A2UISurfaceExtraction(t *testing.T) {
 	})
 
 	t.Run("non-A2UI embedded resource stays in the text", func(t *testing.T) {
+		t.Parallel()
+
 		sess := liveA2UIToolSession(t, "get_doc", []mcp.Content{
 			&mcp.EmbeddedResource{
 				Resource: &mcp.ResourceContents{

--- a/internal/agent/tools/mcp_tools_a2ui_test.go
+++ b/internal/agent/tools/mcp_tools_a2ui_test.go
@@ -1,0 +1,75 @@
+package tools
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/crush/internal/agent/tools/mcp"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSplitMCPToolResult(t *testing.T) {
+	t.Parallel()
+
+	surface := mcp.A2UISurface{
+		Payload:          testA2UIPayload,
+		URI:              "a2ui://recipe-card",
+		AssistantVisible: true,
+	}
+
+	t.Run("surfaces divert to metadata with provenance", func(t *testing.T) {
+		t.Parallel()
+		content, meta := splitMCPToolResult(mcp.ToolResult{
+			Type:     "text",
+			Content:  "Your recipe card",
+			Surfaces: []mcp.A2UISurface{surface},
+		}, "recipe", true)
+
+		require.Len(t, meta.A2UISurfaces, 1)
+		require.Equal(t, "<a2ui-json>"+testA2UIPayload+"</a2ui-json>", meta.A2UISurfaces[0])
+		require.Equal(t, []string{"recipe"}, meta.MCPSurfaceProvenance)
+		require.Contains(t, content, "Your recipe card")
+		require.True(t, strings.Contains(content, A2UISurfacePlaceholderPrefix))
+		require.NotContains(t, content, "updateComponents")
+	})
+
+	t.Run("no diversion folds the payload back for the model", func(t *testing.T) {
+		t.Parallel()
+		// Channel-originated turns keep the payload so the model can relay it.
+		content, meta := splitMCPToolResult(mcp.ToolResult{
+			Type:     "text",
+			Content:  "fallback text",
+			Surfaces: []mcp.A2UISurface{surface},
+		}, "recipe", false)
+
+		require.Empty(t, meta.A2UISurfaces)
+		require.Contains(t, content, "fallback text")
+		require.Contains(t, content, testA2UIPayload)
+	})
+
+	t.Run("user-only payload stays hidden when not diverting", func(t *testing.T) {
+		t.Parallel()
+		userOnly := surface
+		userOnly.AssistantVisible = false
+		content, meta := splitMCPToolResult(mcp.ToolResult{
+			Type:     "text",
+			Content:  "fallback text",
+			Surfaces: []mcp.A2UISurface{userOnly},
+		}, "recipe", false)
+
+		require.Empty(t, meta.A2UISurfaces)
+		require.Equal(t, "fallback text", content)
+	})
+
+	t.Run("surface without fallback text still gets a placeholder", func(t *testing.T) {
+		t.Parallel()
+		content, meta := splitMCPToolResult(mcp.ToolResult{
+			Type:     "text",
+			Content:  "",
+			Surfaces: []mcp.A2UISurface{surface},
+		}, "recipe", true)
+
+		require.Len(t, meta.A2UISurfaces, 1)
+		require.True(t, strings.HasPrefix(content, A2UISurfacePlaceholderPrefix))
+	})
+}

--- a/internal/agent/tools/mcp_tools_a2ui_test.go
+++ b/internal/agent/tools/mcp_tools_a2ui_test.go
@@ -14,6 +14,7 @@ func TestSplitMCPToolResult(t *testing.T) {
 	surface := mcp.A2UISurface{
 		Payload:          testA2UIPayload,
 		URI:              "a2ui://recipe-card",
+		RenderForUser:    true,
 		AssistantVisible: true,
 	}
 
@@ -71,5 +72,59 @@ func TestSplitMCPToolResult(t *testing.T) {
 
 		require.Len(t, meta.A2UISurfaces, 1)
 		require.True(t, strings.HasPrefix(content, A2UISurfacePlaceholderPrefix))
+	})
+
+	t.Run("user-only surface renders but stays hidden from the model", func(t *testing.T) {
+		t.Parallel()
+		userOnly := surface
+		userOnly.RenderForUser = true
+		userOnly.AssistantVisible = false
+		content, meta := splitMCPToolResult(mcp.ToolResult{
+			Type:     "text",
+			Content:  "",
+			Surfaces: []mcp.A2UISurface{userOnly},
+		}, "recipe", true)
+
+		// Renders for the user via metadata, but the model sees a
+		// placeholder, not the JSON.
+		require.Len(t, meta.A2UISurfaces, 1)
+		require.True(t, strings.HasPrefix(content, A2UISurfacePlaceholderPrefix))
+		require.NotContains(t, content, "updateComponents")
+
+		// The model-facing content — what the next agent request's history
+		// carries — holds the placeholder and none of the raw payload.
+		require.NotContains(t, content, testA2UIPayload)
+		require.NotContains(t, content, `"surfaceId"`)
+	})
+
+	t.Run("assistant-only surface reaches the model but never renders", func(t *testing.T) {
+		t.Parallel()
+		assistantOnly := surface
+		assistantOnly.RenderForUser = false
+		assistantOnly.AssistantVisible = true
+		content, meta := splitMCPToolResult(mcp.ToolResult{
+			Type:     "text",
+			Content:  "",
+			Surfaces: []mcp.A2UISurface{assistantOnly},
+		}, "recipe", true)
+
+		// No surface for the UI; the JSON goes to the model for reasoning.
+		require.Empty(t, meta.A2UISurfaces)
+		require.Contains(t, content, testA2UIPayload)
+	})
+
+	t.Run("assistant-only surface reaches the model when not diverting too", func(t *testing.T) {
+		t.Parallel()
+		assistantOnly := surface
+		assistantOnly.RenderForUser = false
+		assistantOnly.AssistantVisible = true
+		content, meta := splitMCPToolResult(mcp.ToolResult{
+			Type:     "text",
+			Content:  "",
+			Surfaces: []mcp.A2UISurface{assistantOnly},
+		}, "recipe", false)
+
+		require.Empty(t, meta.A2UISurfaces)
+		require.Contains(t, content, testA2UIPayload)
 	})
 }

--- a/internal/agent/tools/mcp_tools_a2ui_test.go
+++ b/internal/agent/tools/mcp_tools_a2ui_test.go
@@ -1,0 +1,130 @@
+package tools
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/crush/internal/agent/tools/mcp"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSplitMCPToolResult(t *testing.T) {
+	t.Parallel()
+
+	surface := mcp.A2UISurface{
+		Payload:          testA2UIPayload,
+		URI:              "a2ui://recipe-card",
+		RenderForUser:    true,
+		AssistantVisible: true,
+	}
+
+	t.Run("surfaces divert to metadata with provenance", func(t *testing.T) {
+		t.Parallel()
+		content, meta := splitMCPToolResult(mcp.ToolResult{
+			Type:     "text",
+			Content:  "Your recipe card",
+			Surfaces: []mcp.A2UISurface{surface},
+		}, "recipe", true)
+
+		require.Len(t, meta.A2UISurfaces, 1)
+		require.Equal(t, "<a2ui-json>"+testA2UIPayload+"</a2ui-json>", meta.A2UISurfaces[0])
+		require.Equal(t, []string{"recipe"}, meta.MCPSurfaceProvenance)
+		require.Contains(t, content, "Your recipe card")
+		require.True(t, strings.Contains(content, A2UISurfacePlaceholderPrefix))
+		require.NotContains(t, content, "updateComponents")
+	})
+
+	t.Run("no diversion folds the payload back for the model", func(t *testing.T) {
+		t.Parallel()
+		// Channel-originated turns keep the payload so the model can relay it.
+		content, meta := splitMCPToolResult(mcp.ToolResult{
+			Type:     "text",
+			Content:  "fallback text",
+			Surfaces: []mcp.A2UISurface{surface},
+		}, "recipe", false)
+
+		require.Empty(t, meta.A2UISurfaces)
+		require.Contains(t, content, "fallback text")
+		require.Contains(t, content, testA2UIPayload)
+	})
+
+	t.Run("user-only payload stays hidden when not diverting", func(t *testing.T) {
+		t.Parallel()
+		userOnly := surface
+		userOnly.AssistantVisible = false
+		content, meta := splitMCPToolResult(mcp.ToolResult{
+			Type:     "text",
+			Content:  "fallback text",
+			Surfaces: []mcp.A2UISurface{userOnly},
+		}, "recipe", false)
+
+		require.Empty(t, meta.A2UISurfaces)
+		require.Equal(t, "fallback text", content)
+	})
+
+	t.Run("surface without fallback text still gets a placeholder", func(t *testing.T) {
+		t.Parallel()
+		content, meta := splitMCPToolResult(mcp.ToolResult{
+			Type:     "text",
+			Content:  "",
+			Surfaces: []mcp.A2UISurface{surface},
+		}, "recipe", true)
+
+		require.Len(t, meta.A2UISurfaces, 1)
+		require.True(t, strings.HasPrefix(content, A2UISurfacePlaceholderPrefix))
+	})
+
+	t.Run("user-only surface renders but stays hidden from the model", func(t *testing.T) {
+		t.Parallel()
+		userOnly := surface
+		userOnly.RenderForUser = true
+		userOnly.AssistantVisible = false
+		content, meta := splitMCPToolResult(mcp.ToolResult{
+			Type:     "text",
+			Content:  "",
+			Surfaces: []mcp.A2UISurface{userOnly},
+		}, "recipe", true)
+
+		// Renders for the user via metadata, but the model sees a
+		// placeholder, not the JSON.
+		require.Len(t, meta.A2UISurfaces, 1)
+		require.True(t, strings.HasPrefix(content, A2UISurfacePlaceholderPrefix))
+		require.NotContains(t, content, "updateComponents")
+
+		// The model-facing content — what the next agent request's history
+		// carries — holds the placeholder and none of the raw payload.
+		require.NotContains(t, content, testA2UIPayload)
+		require.NotContains(t, content, `"surfaceId"`)
+	})
+
+	t.Run("assistant-only surface reaches the model but never renders", func(t *testing.T) {
+		t.Parallel()
+		assistantOnly := surface
+		assistantOnly.RenderForUser = false
+		assistantOnly.AssistantVisible = true
+		content, meta := splitMCPToolResult(mcp.ToolResult{
+			Type:     "text",
+			Content:  "",
+			Surfaces: []mcp.A2UISurface{assistantOnly},
+		}, "recipe", true)
+
+		// No surface for the UI; the JSON goes to the model for reasoning.
+		require.Empty(t, meta.A2UISurfaces)
+		require.Contains(t, content, testA2UIPayload)
+	})
+
+	t.Run("assistant-only surface reaches the model when not diverting too", func(t *testing.T) {
+		t.Parallel()
+		assistantOnly := surface
+		assistantOnly.RenderForUser = false
+		assistantOnly.AssistantVisible = true
+		content, meta := splitMCPToolResult(mcp.ToolResult{
+			Type:     "text",
+			Content:  "",
+			Surfaces: []mcp.A2UISurface{assistantOnly},
+		}, "recipe", false)
+
+		require.Empty(t, meta.A2UISurfaces)
+		require.Contains(t, content, testA2UIPayload)
+	})
+}

--- a/internal/agent/tools/read_mcp_resource.go
+++ b/internal/agent/tools/read_mcp_resource.go
@@ -77,8 +77,13 @@ func splitMCPResourceContents(contents []*mcp.ResourceContents, divert bool) ([]
 			metadata.A2UISurfaces = append(metadata.A2UISurfaces, "<a2ui-json>"+text+"</a2ui-json>")
 			// The placeholder is a single-line protocol the chat renderer
 			// strips line-wise — a server-controlled URI must not be able
-			// to break out of it with embedded newlines.
+			// to break out of it with embedded newlines. The injected
+			// width hint is stripped too: servers echo the request URI
+			// verbatim, and a model that re-reads the echoed ?w=N URI
+			// after a terminal resize would freeze the surface at the old
+			// width (a2uiWidthHint respects an existing w=).
 			uri := strings.NewReplacer("\n", " ", "\r", " ").Replace(content.URI)
+			uri = stripA2UIWidthParam(uri)
 			textParts = append(textParts, A2UISurfacePlaceholderPrefix+uri+" — the user can already see it; do not repeat or echo its JSON payload]")
 			continue
 		}
@@ -115,6 +120,23 @@ func a2uiWidthHint(uri string, width int) string {
 		sep = "&"
 	}
 	return fmt.Sprintf("%s%sw=%d", uri, sep, width)
+}
+
+// stripA2UIWidthParam removes the w= query parameter from a URI for display
+// in the model-facing placeholder. This URI is informational (never
+// fetched), so re-encoding any remaining query parameters is harmless.
+func stripA2UIWidthParam(uri string) string {
+	u, err := url.Parse(uri)
+	if err != nil || !u.Query().Has("w") {
+		return uri
+	}
+	q := u.Query()
+	q.Del("w")
+	base, _, _ := strings.Cut(uri, "?")
+	if enc := q.Encode(); enc != "" {
+		return base + "?" + enc
+	}
+	return base
 }
 
 func NewReadMCPResourceTool(cfg *config.ConfigStore, permissions permission.Service) fantasy.AgentTool {
@@ -177,9 +199,13 @@ func NewReadMCPResourceTool(cfg *config.ConfigStore, permissions permission.Serv
 			// Divert A2UI payloads to UI-only metadata only when a chat UI
 			// will actually render them: on channel-originated turns the
 			// reply travels back over the channel and the model needs the
-			// payload to relay it, and disable_a2ui deployments opted out
-			// of surfaces entirely.
-			divert := GetChannelFromContext(ctx) == "" && !cfg.Config().Options.DisableA2UI
+			// payload to relay it, disable_a2ui deployments opted out of
+			// surfaces entirely, and a zero content width means no
+			// interactive UI tagged this turn (headless crush run, remote
+			// clients that predate the wire field).
+			divert := GetChannelFromContext(ctx) == "" &&
+				!cfg.Config().Options.DisableA2UI &&
+				GetContentWidthFromContext(ctx) > 0
 			textParts, metadata := splitMCPResourceContents(contents, divert)
 
 			if len(textParts) == 0 {

--- a/internal/agent/tools/read_mcp_resource.go
+++ b/internal/agent/tools/read_mcp_resource.go
@@ -39,6 +39,49 @@ type ReadMCPResourceResponseMetadata struct {
 	A2UISurfaces []string `json:"a2ui_surfaces,omitempty"`
 }
 
+// A2UISurfacePlaceholderPrefix starts every model-facing placeholder that
+// stands in for a diverted A2UI surface. The chat renderer uses it to strip
+// placeholder lines from the tool content it shows the user.
+const A2UISurfacePlaceholderPrefix = "[A2UI surface rendered in the chat UI from "
+
+// splitMCPResourceContents partitions resource contents into model-facing
+// text parts and, when divert is set, UI-only A2UI surface payloads carried
+// in response metadata. divert is false when no chat UI will render the
+// metadata (channel-originated turns, disable_a2ui deployments): the raw
+// payload then stays in the model-facing content so the model can still
+// relay or summarize the data.
+func splitMCPResourceContents(contents []*mcp.ResourceContents, divert bool) ([]string, ReadMCPResourceResponseMetadata) {
+	var textParts []string
+	var metadata ReadMCPResourceResponseMetadata
+	for _, content := range contents {
+		if content == nil {
+			continue
+		}
+		text := content.Text
+		if text == "" && len(content.Blob) > 0 {
+			// Blob is a legal delivery for any MIME type, including
+			// application/a2ui+json — normalize it to text here so a
+			// blob-delivered surface cannot slip past the diversion below.
+			text = string(content.Blob)
+		}
+		if text == "" {
+			slog.Debug("MCP resource content missing text/blob", "uri", content.URI)
+			continue
+		}
+		// A2UI surfaces go to the UI via metadata, not the model-facing
+		// content: the chat renderer draws the surface itself, and the
+		// model only ever echoed the raw JSON back, double-rendering the
+		// surface.
+		if divert && content.MIMEType == a2uiMIMEType {
+			metadata.A2UISurfaces = append(metadata.A2UISurfaces, "<a2ui-json>"+text+"</a2ui-json>")
+			textParts = append(textParts, A2UISurfacePlaceholderPrefix+content.URI+" — the user can already see it; do not repeat or echo its JSON payload]")
+			continue
+		}
+		textParts = append(textParts, text)
+	}
+	return textParts, metadata
+}
+
 //go:embed read_mcp_resource.md
 var readMCPResourceDescription string
 
@@ -89,32 +132,13 @@ func NewReadMCPResourceTool(cfg *config.ConfigStore, permissions permission.Serv
 				return fantasy.NewTextResponse(""), nil
 			}
 
-			var textParts []string
-			var metadata ReadMCPResourceResponseMetadata
-			for _, content := range contents {
-				if content == nil {
-					continue
-				}
-				if content.Text != "" {
-					// A2UI surfaces go to the UI via metadata, not the
-					// model-facing content: the chat renderer renders
-					// the surface itself, and the raw JSON is
-					// unreadable to the model anyway — it only ever
-					// echoed it back, double-rendering the surface.
-					if content.MIMEType == a2uiMIMEType {
-						metadata.A2UISurfaces = append(metadata.A2UISurfaces, "<a2ui-json>"+content.Text+"</a2ui-json>")
-						textParts = append(textParts, "[A2UI surface rendered in the chat UI from "+content.URI+" — the user can already see it; do not repeat or echo its JSON payload]")
-						continue
-					}
-					textParts = append(textParts, content.Text)
-					continue
-				}
-				if len(content.Blob) > 0 {
-					textParts = append(textParts, string(content.Blob))
-					continue
-				}
-				slog.Debug("MCP resource content missing text/blob", "uri", content.URI)
-			}
+			// Divert A2UI payloads to UI-only metadata only when a chat UI
+			// will actually render them: on channel-originated turns the
+			// reply travels back over the channel and the model needs the
+			// payload to relay it, and disable_a2ui deployments opted out
+			// of surfaces entirely.
+			divert := GetChannelFromContext(ctx) == "" && !cfg.Config().Options.DisableA2UI
+			textParts, metadata := splitMCPResourceContents(contents, divert)
 
 			if len(textParts) == 0 {
 				return fantasy.NewTextResponse(""), nil

--- a/internal/agent/tools/read_mcp_resource.go
+++ b/internal/agent/tools/read_mcp_resource.go
@@ -6,6 +6,7 @@ import (
 	_ "embed"
 	"fmt"
 	"log/slog"
+	"net/url"
 	"strings"
 
 	"charm.land/fantasy"
@@ -89,17 +90,31 @@ func splitMCPResourceContents(contents []*mcp.ResourceContents, divert bool) ([]
 //go:embed read_mcp_resource.md
 var readMCPResourceDescription string
 
-// a2uiWidthHint appends ?w=N to an A2UI surface URI so the server sizes its
+// a2uiWidthHint appends w=N to an A2UI surface URI so the server sizes its
 // pre-rendered geometry to the host's content width. It is a no-op for
-// non-A2UI URIs and for URIs that already carry a width hint.
+// non-A2UI URIs and for URIs that already carry a width hint (an explicit
+// w= is respected wherever it came from). The /a2ui path suffix is the
+// convention the in-house A2UI resource templates share (cairn,
+// switchboard); the template registry's MIME types would be the
+// protocol-level signal, but templates can legitimately fail to list, so
+// the convention stays the trigger.
+//
+// The URI is parsed only to decide — the hint is appended to the original
+// string, never re-serialized, because MCP servers match URIs textually
+// against their templates.
 func a2uiWidthHint(uri string, width int) string {
-	if !strings.HasSuffix(uri, "/a2ui") && !strings.Contains(uri, "/a2ui?") {
+	u, err := url.Parse(uri)
+	if err != nil || !strings.HasSuffix(u.Path, "/a2ui") {
 		return uri
 	}
-	if strings.Contains(uri, "?") {
+	if u.Query().Has("w") {
 		return uri
 	}
-	return fmt.Sprintf("%s?w=%d", uri, width)
+	sep := "?"
+	if u.RawQuery != "" {
+		sep = "&"
+	}
+	return fmt.Sprintf("%s%sw=%d", uri, sep, width)
 }
 
 func NewReadMCPResourceTool(cfg *config.ConfigStore, permissions permission.Service) fantasy.AgentTool {

--- a/internal/agent/tools/read_mcp_resource.go
+++ b/internal/agent/tools/read_mcp_resource.go
@@ -89,6 +89,19 @@ func splitMCPResourceContents(contents []*mcp.ResourceContents, divert bool) ([]
 //go:embed read_mcp_resource.md
 var readMCPResourceDescription string
 
+// a2uiWidthHint appends ?w=N to an A2UI surface URI so the server sizes its
+// pre-rendered geometry to the host's content width. It is a no-op for
+// non-A2UI URIs and for URIs that already carry a width hint.
+func a2uiWidthHint(uri string, width int) string {
+	if !strings.HasSuffix(uri, "/a2ui") && !strings.Contains(uri, "/a2ui?") {
+		return uri
+	}
+	if strings.Contains(uri, "?") {
+		return uri
+	}
+	return fmt.Sprintf("%s?w=%d", uri, width)
+}
+
 func NewReadMCPResourceTool(cfg *config.ConfigStore, permissions permission.Service) fantasy.AgentTool {
 	return fantasy.NewParallelAgentTool(
 		ReadMCPResourceToolName,
@@ -126,6 +139,16 @@ func NewReadMCPResourceTool(cfg *config.ConfigStore, permissions permission.Serv
 			}
 			if !p {
 				return NewPermissionDeniedResponse(), nil
+			}
+
+			// A2UI surface templates (…/a2ui) pre-render their bar
+			// geometry server-side, so pass the UI's content width as
+			// the ?w= hint — the surface then fills the chat card
+			// instead of a fixed default budget. Only when the URI
+			// carries no width of its own and the turn has a UI width
+			// (0 = headless/remote turn).
+			if w := GetContentWidthFromContext(ctx); w > 0 {
+				params.URI = a2uiWidthHint(params.URI, w)
 			}
 
 			contents, err := mcp.ReadResource(ctx, cfg, params.MCPName, params.URI)

--- a/internal/agent/tools/read_mcp_resource.go
+++ b/internal/agent/tools/read_mcp_resource.go
@@ -74,7 +74,11 @@ func splitMCPResourceContents(contents []*mcp.ResourceContents, divert bool) ([]
 		// surface.
 		if divert && content.MIMEType == a2uiMIMEType {
 			metadata.A2UISurfaces = append(metadata.A2UISurfaces, "<a2ui-json>"+text+"</a2ui-json>")
-			textParts = append(textParts, A2UISurfacePlaceholderPrefix+content.URI+" — the user can already see it; do not repeat or echo its JSON payload]")
+			// The placeholder is a single-line protocol the chat renderer
+			// strips line-wise — a server-controlled URI must not be able
+			// to break out of it with embedded newlines.
+			uri := strings.NewReplacer("\n", " ", "\r", " ").Replace(content.URI)
+			textParts = append(textParts, A2UISurfacePlaceholderPrefix+uri+" — the user can already see it; do not repeat or echo its JSON payload]")
 			continue
 		}
 		textParts = append(textParts, text)

--- a/internal/agent/tools/read_mcp_resource.go
+++ b/internal/agent/tools/read_mcp_resource.go
@@ -27,6 +27,11 @@ type ReadMCPResourcePermissionsParams struct {
 
 const ReadMCPResourceToolName = "read_mcp_resource"
 
+// a2uiMIMEType is the MIME type MCP resource templates use for A2UI surfaces.
+// When a resource read returns this type, the payload is wrapped in inline
+// <a2ui-json> tags so the chat renderer renders it as a live surface.
+const a2uiMIMEType = "application/a2ui+json"
+
 //go:embed read_mcp_resource.md
 var readMCPResourceDescription string
 
@@ -83,6 +88,15 @@ func NewReadMCPResourceTool(cfg *config.ConfigStore, permissions permission.Serv
 					continue
 				}
 				if content.Text != "" {
+					// If the resource is an A2UI surface, wrap it in
+					// the inline tags so the chat renderer picks it up
+					// as a live surface instead of raw JSON. The model
+					// never needs to copy/paste the payload — the tool
+					// result itself renders as an interactive surface.
+					if content.MIMEType == a2uiMIMEType {
+						textParts = append(textParts, "<a2ui-json>"+content.Text+"</a2ui-json>")
+						continue
+					}
 					textParts = append(textParts, content.Text)
 					continue
 				}

--- a/internal/agent/tools/read_mcp_resource.go
+++ b/internal/agent/tools/read_mcp_resource.go
@@ -28,9 +28,16 @@ type ReadMCPResourcePermissionsParams struct {
 const ReadMCPResourceToolName = "read_mcp_resource"
 
 // a2uiMIMEType is the MIME type MCP resource templates use for A2UI surfaces.
-// When a resource read returns this type, the payload is wrapped in inline
-// <a2ui-json> tags so the chat renderer renders it as a live surface.
+// A2UI payloads are delivered to the UI through response metadata (never to
+// the model): the model gets a compact placeholder instead of the raw JSON,
+// so it cannot echo the payload back and double-render the surface.
 const a2uiMIMEType = "application/a2ui+json"
+
+// ReadMCPResourceResponseMetadata carries the UI-only A2UI surface payload
+// for a resource whose MIME type is application/a2ui+json.
+type ReadMCPResourceResponseMetadata struct {
+	A2UISurfaces []string `json:"a2ui_surfaces,omitempty"`
+}
 
 //go:embed read_mcp_resource.md
 var readMCPResourceDescription string
@@ -83,18 +90,20 @@ func NewReadMCPResourceTool(cfg *config.ConfigStore, permissions permission.Serv
 			}
 
 			var textParts []string
+			var metadata ReadMCPResourceResponseMetadata
 			for _, content := range contents {
 				if content == nil {
 					continue
 				}
 				if content.Text != "" {
-					// If the resource is an A2UI surface, wrap it in
-					// the inline tags so the chat renderer picks it up
-					// as a live surface instead of raw JSON. The model
-					// never needs to copy/paste the payload — the tool
-					// result itself renders as an interactive surface.
+					// A2UI surfaces go to the UI via metadata, not the
+					// model-facing content: the chat renderer renders
+					// the surface itself, and the raw JSON is
+					// unreadable to the model anyway — it only ever
+					// echoed it back, double-rendering the surface.
 					if content.MIMEType == a2uiMIMEType {
-						textParts = append(textParts, "<a2ui-json>"+content.Text+"</a2ui-json>")
+						metadata.A2UISurfaces = append(metadata.A2UISurfaces, "<a2ui-json>"+content.Text+"</a2ui-json>")
+						textParts = append(textParts, "[A2UI surface rendered in the chat UI from "+content.URI+" — the user can already see it; do not repeat or echo its JSON payload]")
 						continue
 					}
 					textParts = append(textParts, content.Text)
@@ -111,7 +120,11 @@ func NewReadMCPResourceTool(cfg *config.ConfigStore, permissions permission.Serv
 				return fantasy.NewTextResponse(""), nil
 			}
 
-			return fantasy.NewTextResponse(strings.Join(textParts, "\n")), nil
+			resp := fantasy.NewTextResponse(strings.Join(textParts, "\n"))
+			if len(metadata.A2UISurfaces) > 0 {
+				resp = fantasy.WithResponseMetadata(resp, metadata)
+			}
+			return resp, nil
 		},
 	)
 }

--- a/internal/agent/tools/read_mcp_resource.go
+++ b/internal/agent/tools/read_mcp_resource.go
@@ -6,6 +6,7 @@ import (
 	_ "embed"
 	"fmt"
 	"log/slog"
+	"net/url"
 	"strings"
 
 	"charm.land/fantasy"
@@ -27,8 +28,121 @@ type ReadMCPResourcePermissionsParams struct {
 
 const ReadMCPResourceToolName = "read_mcp_resource"
 
+// a2uiMIMEType is the MIME type MCP resource templates use for A2UI surfaces.
+// A2UI payloads are delivered to the UI through response metadata (never to
+// the model): the model gets a compact placeholder instead of the raw JSON,
+// so it cannot echo the payload back and double-render the surface.
+const a2uiMIMEType = mcp.A2UIJSONMIMEType
+
+// ReadMCPResourceResponseMetadata carries the UI-only A2UI surface payload
+// for a resource whose MIME type is application/a2ui+json (or a tool result
+// that embedded one). MCPSurfaceProvenance records which MCP server each
+// surface came from — by slice position — so a later interaction event can
+// route back to the owning server.
+type ReadMCPResourceResponseMetadata struct {
+	A2UISurfaces         []string `json:"a2ui_surfaces,omitempty"`
+	MCPSurfaceProvenance []string `json:"mcp_surface_provenance,omitempty"`
+}
+
+// A2UISurfacePlaceholderPrefix starts every model-facing placeholder that
+// stands in for a diverted A2UI surface. The chat renderer uses it to strip
+// placeholder lines from the tool content it shows the user.
+const A2UISurfacePlaceholderPrefix = "[A2UI surface rendered in the chat UI from "
+
+// splitMCPResourceContents partitions resource contents into model-facing
+// text parts and, when divert is set, UI-only A2UI surface payloads carried
+// in response metadata. divert is false when no chat UI will render the
+// metadata (channel-originated turns, disable_a2ui deployments): the raw
+// payload then stays in the model-facing content so the model can still
+// relay or summarize the data.
+func splitMCPResourceContents(contents []*mcp.ResourceContents, divert bool, provenance string) ([]string, ReadMCPResourceResponseMetadata) {
+	var textParts []string
+	var metadata ReadMCPResourceResponseMetadata
+	for _, content := range contents {
+		if content == nil {
+			continue
+		}
+		text := content.Text
+		if text == "" && len(content.Blob) > 0 {
+			// Blob is a legal delivery for any MIME type, including
+			// application/a2ui+json — normalize it to text here so a
+			// blob-delivered surface cannot slip past the diversion below.
+			text = string(content.Blob)
+		}
+		if text == "" {
+			slog.Debug("MCP resource content missing text/blob", "uri", content.URI)
+			continue
+		}
+		// A2UI surfaces go to the UI via metadata, not the model-facing
+		// content: the chat renderer draws the surface itself, and the
+		// model only ever echoed the raw JSON back, double-rendering the
+		// surface. Both the canonical and legacy MIME spellings match.
+		if divert && mcp.IsA2UIMIMEType(content.MIMEType) {
+			metadata.A2UISurfaces = append(metadata.A2UISurfaces, "<a2ui-json>"+text+"</a2ui-json>")
+			metadata.MCPSurfaceProvenance = append(metadata.MCPSurfaceProvenance, provenance)
+			// The placeholder is a single-line protocol the chat renderer
+			// strips line-wise — a server-controlled URI must not be able
+			// to break out of it with embedded newlines. The injected
+			// width hint is stripped too: servers echo the request URI
+			// verbatim, and a model that re-reads the echoed ?w=N URI
+			// after a terminal resize would freeze the surface at the old
+			// width (a2uiWidthHint respects an existing w=).
+			uri := strings.NewReplacer("\n", " ", "\r", " ").Replace(content.URI)
+			uri = stripA2UIWidthParam(uri)
+			textParts = append(textParts, A2UISurfacePlaceholderPrefix+uri+" — the user can already see it; do not repeat or echo its JSON payload]")
+			continue
+		}
+		textParts = append(textParts, text)
+	}
+	return textParts, metadata
+}
+
 //go:embed read_mcp_resource.md
 var readMCPResourceDescription string
+
+// a2uiWidthHint appends w=N to an A2UI surface URI so the server sizes its
+// pre-rendered geometry to the host's content width. It is a no-op for
+// non-A2UI URIs and for URIs that already carry a width hint (an explicit
+// w= is respected wherever it came from). The /a2ui path suffix is the
+// convention the in-house A2UI resource templates share (cairn,
+// switchboard); the template registry's MIME types would be the
+// protocol-level signal, but templates can legitimately fail to list, so
+// the convention stays the trigger.
+//
+// The URI is parsed only to decide — the hint is appended to the original
+// string, never re-serialized, because MCP servers match URIs textually
+// against their templates.
+func a2uiWidthHint(uri string, width int) string {
+	u, err := url.Parse(uri)
+	if err != nil || !strings.HasSuffix(u.Path, "/a2ui") {
+		return uri
+	}
+	if u.Query().Has("w") {
+		return uri
+	}
+	sep := "?"
+	if u.RawQuery != "" {
+		sep = "&"
+	}
+	return fmt.Sprintf("%s%sw=%d", uri, sep, width)
+}
+
+// stripA2UIWidthParam removes the w= query parameter from a URI for display
+// in the model-facing placeholder. This URI is informational (never
+// fetched), so re-encoding any remaining query parameters is harmless.
+func stripA2UIWidthParam(uri string) string {
+	u, err := url.Parse(uri)
+	if err != nil || !u.Query().Has("w") {
+		return uri
+	}
+	q := u.Query()
+	q.Del("w")
+	base, _, _ := strings.Cut(uri, "?")
+	if enc := q.Encode(); enc != "" {
+		return base + "?" + enc
+	}
+	return base
+}
 
 func NewReadMCPResourceTool(cfg *config.ConfigStore, permissions permission.Service) fantasy.AgentTool {
 	return fantasy.NewParallelAgentTool(
@@ -69,6 +183,16 @@ func NewReadMCPResourceTool(cfg *config.ConfigStore, permissions permission.Serv
 				return NewPermissionDeniedResponse(), nil
 			}
 
+			// A2UI surface templates (…/a2ui) pre-render their bar
+			// geometry server-side, so pass the UI's content width as
+			// the ?w= hint — the surface then fills the chat card
+			// instead of a fixed default budget. Only when the URI
+			// carries no width of its own and the turn has a UI width
+			// (0 = headless/remote turn).
+			if w := GetContentWidthFromContext(ctx); w > 0 {
+				params.URI = a2uiWidthHint(params.URI, w)
+			}
+
 			contents, err := mcp.ReadResource(ctx, cfg, params.MCPName, params.URI)
 			if err != nil {
 				return fantasy.NewTextErrorResponse(err.Error()), nil
@@ -77,27 +201,27 @@ func NewReadMCPResourceTool(cfg *config.ConfigStore, permissions permission.Serv
 				return fantasy.NewTextResponse(""), nil
 			}
 
-			var textParts []string
-			for _, content := range contents {
-				if content == nil {
-					continue
-				}
-				if content.Text != "" {
-					textParts = append(textParts, content.Text)
-					continue
-				}
-				if len(content.Blob) > 0 {
-					textParts = append(textParts, string(content.Blob))
-					continue
-				}
-				slog.Debug("MCP resource content missing text/blob", "uri", content.URI)
-			}
+			// Divert A2UI payloads to UI-only metadata only when a chat UI
+			// will actually render them: on channel-originated turns the
+			// reply travels back over the channel and the model needs the
+			// payload to relay it, disable_a2ui deployments opted out of
+			// surfaces entirely, and a zero content width means no
+			// interactive UI tagged this turn (headless crush run, remote
+			// clients that predate the wire field).
+			divert := GetChannelFromContext(ctx) == "" &&
+				!cfg.Config().Options.DisableA2UI &&
+				GetContentWidthFromContext(ctx) > 0
+			textParts, metadata := splitMCPResourceContents(contents, divert, params.MCPName)
 
 			if len(textParts) == 0 {
 				return fantasy.NewTextResponse(""), nil
 			}
 
-			return fantasy.NewTextResponse(strings.Join(textParts, "\n")), nil
+			resp := fantasy.NewTextResponse(strings.Join(textParts, "\n"))
+			if len(metadata.A2UISurfaces) > 0 {
+				resp = fantasy.WithResponseMetadata(resp, metadata)
+			}
+			return resp, nil
 		},
 	)
 }

--- a/internal/agent/tools/read_mcp_resource.go
+++ b/internal/agent/tools/read_mcp_resource.go
@@ -32,12 +32,16 @@ const ReadMCPResourceToolName = "read_mcp_resource"
 // A2UI payloads are delivered to the UI through response metadata (never to
 // the model): the model gets a compact placeholder instead of the raw JSON,
 // so it cannot echo the payload back and double-render the surface.
-const a2uiMIMEType = "application/a2ui+json"
+const a2uiMIMEType = mcp.A2UIJSONMIMEType
 
 // ReadMCPResourceResponseMetadata carries the UI-only A2UI surface payload
-// for a resource whose MIME type is application/a2ui+json.
+// for a resource whose MIME type is application/a2ui+json (or a tool result
+// that embedded one). MCPSurfaceProvenance records which MCP server each
+// surface came from — by slice position — so a later interaction event can
+// route back to the owning server.
 type ReadMCPResourceResponseMetadata struct {
-	A2UISurfaces []string `json:"a2ui_surfaces,omitempty"`
+	A2UISurfaces         []string `json:"a2ui_surfaces,omitempty"`
+	MCPSurfaceProvenance []string `json:"mcp_surface_provenance,omitempty"`
 }
 
 // A2UISurfacePlaceholderPrefix starts every model-facing placeholder that
@@ -51,7 +55,7 @@ const A2UISurfacePlaceholderPrefix = "[A2UI surface rendered in the chat UI from
 // metadata (channel-originated turns, disable_a2ui deployments): the raw
 // payload then stays in the model-facing content so the model can still
 // relay or summarize the data.
-func splitMCPResourceContents(contents []*mcp.ResourceContents, divert bool) ([]string, ReadMCPResourceResponseMetadata) {
+func splitMCPResourceContents(contents []*mcp.ResourceContents, divert bool, provenance string) ([]string, ReadMCPResourceResponseMetadata) {
 	var textParts []string
 	var metadata ReadMCPResourceResponseMetadata
 	for _, content := range contents {
@@ -72,9 +76,10 @@ func splitMCPResourceContents(contents []*mcp.ResourceContents, divert bool) ([]
 		// A2UI surfaces go to the UI via metadata, not the model-facing
 		// content: the chat renderer draws the surface itself, and the
 		// model only ever echoed the raw JSON back, double-rendering the
-		// surface.
-		if divert && content.MIMEType == a2uiMIMEType {
+		// surface. Both the canonical and legacy MIME spellings match.
+		if divert && mcp.IsA2UIMIMEType(content.MIMEType) {
 			metadata.A2UISurfaces = append(metadata.A2UISurfaces, "<a2ui-json>"+text+"</a2ui-json>")
+			metadata.MCPSurfaceProvenance = append(metadata.MCPSurfaceProvenance, provenance)
 			// The placeholder is a single-line protocol the chat renderer
 			// strips line-wise — a server-controlled URI must not be able
 			// to break out of it with embedded newlines. The injected
@@ -206,7 +211,7 @@ func NewReadMCPResourceTool(cfg *config.ConfigStore, permissions permission.Serv
 			divert := GetChannelFromContext(ctx) == "" &&
 				!cfg.Config().Options.DisableA2UI &&
 				GetContentWidthFromContext(ctx) > 0
-			textParts, metadata := splitMCPResourceContents(contents, divert)
+			textParts, metadata := splitMCPResourceContents(contents, divert, params.MCPName)
 
 			if len(textParts) == 0 {
 				return fantasy.NewTextResponse(""), nil

--- a/internal/agent/tools/read_mcp_resource_contents_test.go
+++ b/internal/agent/tools/read_mcp_resource_contents_test.go
@@ -71,6 +71,18 @@ func TestSplitMCPResourceContents(t *testing.T) {
 		require.True(t, strings.HasPrefix(textParts[1], A2UISurfacePlaceholderPrefix))
 	})
 
+	t.Run("placeholder hides the injected width hint", func(t *testing.T) {
+		t.Parallel()
+		// Servers echo the request URI verbatim, ?w=N included; the model
+		// must not learn a width-frozen URI it could reuse after a resize.
+		textParts, _ := splitMCPResourceContents([]*mcp.ResourceContents{
+			{URI: "cairn://run/x/a2ui?w=114", MIMEType: a2uiMIMEType, Text: testA2UIPayload},
+		}, true)
+		require.Len(t, textParts, 1)
+		require.Contains(t, textParts[0], "cairn://run/x/a2ui ")
+		require.NotContains(t, textParts[0], "w=114")
+	})
+
 	t.Run("nil and empty entries are skipped", func(t *testing.T) {
 		t.Parallel()
 		textParts, meta := splitMCPResourceContents([]*mcp.ResourceContents{

--- a/internal/agent/tools/read_mcp_resource_contents_test.go
+++ b/internal/agent/tools/read_mcp_resource_contents_test.go
@@ -18,12 +18,22 @@ func TestSplitMCPResourceContents(t *testing.T) {
 		t.Parallel()
 		textParts, meta := splitMCPResourceContents([]*mcp.ResourceContents{
 			{URI: "cairn://run/x/a2ui", MIMEType: a2uiMIMEType, Text: testA2UIPayload},
-		}, true)
+		}, true, "test-mcp")
 		require.Len(t, meta.A2UISurfaces, 1)
 		require.Equal(t, "<a2ui-json>"+testA2UIPayload+"</a2ui-json>", meta.A2UISurfaces[0])
+		require.Equal(t, []string{"test-mcp"}, meta.MCPSurfaceProvenance)
 		require.Len(t, textParts, 1)
 		require.True(t, strings.HasPrefix(textParts[0], A2UISurfacePlaceholderPrefix))
 		require.NotContains(t, textParts[0], "updateComponents")
+	})
+
+	t.Run("legacy MIME spelling is diverted too", func(t *testing.T) {
+		t.Parallel()
+		_, meta := splitMCPResourceContents([]*mcp.ResourceContents{
+			{URI: "a2ui://form", MIMEType: mcp.A2UILegacyMIMEType, Text: testA2UIPayload},
+		}, true, "test-mcp")
+		require.Len(t, meta.A2UISurfaces, 1)
+		require.Equal(t, []string{"test-mcp"}, meta.MCPSurfaceProvenance)
 	})
 
 	t.Run("a2ui blob content is diverted too", func(t *testing.T) {
@@ -32,7 +42,7 @@ func TestSplitMCPResourceContents(t *testing.T) {
 		// surface must not leak raw JSON into the model-facing content.
 		textParts, meta := splitMCPResourceContents([]*mcp.ResourceContents{
 			{URI: "cairn://run/x/a2ui", MIMEType: a2uiMIMEType, Blob: []byte(testA2UIPayload)},
-		}, true)
+		}, true, "test-mcp")
 		require.Len(t, meta.A2UISurfaces, 1)
 		require.Len(t, textParts, 1)
 		require.True(t, strings.HasPrefix(textParts[0], A2UISurfacePlaceholderPrefix))
@@ -45,7 +55,7 @@ func TestSplitMCPResourceContents(t *testing.T) {
 		// the model can relay or summarize the data.
 		textParts, meta := splitMCPResourceContents([]*mcp.ResourceContents{
 			{URI: "cairn://run/x/a2ui", MIMEType: a2uiMIMEType, Text: testA2UIPayload},
-		}, false)
+		}, false, "test-mcp")
 		require.Empty(t, meta.A2UISurfaces)
 		require.Equal(t, []string{testA2UIPayload}, textParts)
 	})
@@ -54,7 +64,7 @@ func TestSplitMCPResourceContents(t *testing.T) {
 		t.Parallel()
 		textParts, meta := splitMCPResourceContents([]*mcp.ResourceContents{
 			{URI: "cairn://artifact/x", MIMEType: "text/markdown", Text: "# hello"},
-		}, true)
+		}, true, "test-mcp")
 		require.Empty(t, meta.A2UISurfaces)
 		require.Equal(t, []string{"# hello"}, textParts)
 	})
@@ -64,7 +74,7 @@ func TestSplitMCPResourceContents(t *testing.T) {
 		textParts, meta := splitMCPResourceContents([]*mcp.ResourceContents{
 			{URI: "cairn://artifact/x", MIMEType: "text/markdown", Text: "summary"},
 			{URI: "cairn://artifact/x/a2ui", MIMEType: a2uiMIMEType, Text: testA2UIPayload},
-		}, true)
+		}, true, "test-mcp")
 		require.Len(t, meta.A2UISurfaces, 1)
 		require.Len(t, textParts, 2)
 		require.Equal(t, "summary", textParts[0])
@@ -77,7 +87,7 @@ func TestSplitMCPResourceContents(t *testing.T) {
 		// must not learn a width-frozen URI it could reuse after a resize.
 		textParts, _ := splitMCPResourceContents([]*mcp.ResourceContents{
 			{URI: "cairn://run/x/a2ui?w=114", MIMEType: a2uiMIMEType, Text: testA2UIPayload},
-		}, true)
+		}, true, "test-mcp")
 		require.Len(t, textParts, 1)
 		require.Contains(t, textParts[0], "cairn://run/x/a2ui ")
 		require.NotContains(t, textParts[0], "w=114")
@@ -88,7 +98,7 @@ func TestSplitMCPResourceContents(t *testing.T) {
 		textParts, meta := splitMCPResourceContents([]*mcp.ResourceContents{
 			nil,
 			{URI: "cairn://artifact/empty"},
-		}, true)
+		}, true, "test-mcp")
 		require.Empty(t, meta.A2UISurfaces)
 		require.Empty(t, textParts)
 	})

--- a/internal/agent/tools/read_mcp_resource_contents_test.go
+++ b/internal/agent/tools/read_mcp_resource_contents_test.go
@@ -1,0 +1,105 @@
+package tools
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/crush/internal/agent/tools/mcp"
+	"github.com/stretchr/testify/require"
+)
+
+const testA2UIPayload = `{"version":"v0.9","updateComponents":{"surfaceId":"s","components":[` +
+	`{"component":"Text","id":"t","text":"hi"}]}}`
+
+func TestSplitMCPResourceContents(t *testing.T) {
+	t.Parallel()
+
+	t.Run("a2ui text content is diverted to metadata", func(t *testing.T) {
+		t.Parallel()
+		textParts, meta := splitMCPResourceContents([]*mcp.ResourceContents{
+			{URI: "cairn://run/x/a2ui", MIMEType: a2uiMIMEType, Text: testA2UIPayload},
+		}, true, "test-mcp")
+		require.Len(t, meta.A2UISurfaces, 1)
+		require.Equal(t, "<a2ui-json>"+testA2UIPayload+"</a2ui-json>", meta.A2UISurfaces[0])
+		require.Equal(t, []string{"test-mcp"}, meta.MCPSurfaceProvenance)
+		require.Len(t, textParts, 1)
+		require.True(t, strings.HasPrefix(textParts[0], A2UISurfacePlaceholderPrefix))
+		require.NotContains(t, textParts[0], "updateComponents")
+	})
+
+	t.Run("legacy MIME spelling is diverted too", func(t *testing.T) {
+		t.Parallel()
+		_, meta := splitMCPResourceContents([]*mcp.ResourceContents{
+			{URI: "a2ui://form", MIMEType: mcp.A2UILegacyMIMEType, Text: testA2UIPayload},
+		}, true, "test-mcp")
+		require.Len(t, meta.A2UISurfaces, 1)
+		require.Equal(t, []string{"test-mcp"}, meta.MCPSurfaceProvenance)
+	})
+
+	t.Run("a2ui blob content is diverted too", func(t *testing.T) {
+		t.Parallel()
+		// Blob is a legal delivery for any MIME type — a blob-delivered
+		// surface must not leak raw JSON into the model-facing content.
+		textParts, meta := splitMCPResourceContents([]*mcp.ResourceContents{
+			{URI: "cairn://run/x/a2ui", MIMEType: a2uiMIMEType, Blob: []byte(testA2UIPayload)},
+		}, true, "test-mcp")
+		require.Len(t, meta.A2UISurfaces, 1)
+		require.Len(t, textParts, 1)
+		require.True(t, strings.HasPrefix(textParts[0], A2UISurfacePlaceholderPrefix))
+		require.NotContains(t, textParts[0], "updateComponents")
+	})
+
+	t.Run("no diversion when no UI renders metadata", func(t *testing.T) {
+		t.Parallel()
+		// Channel-originated and disable_a2ui turns keep the raw payload so
+		// the model can relay or summarize the data.
+		textParts, meta := splitMCPResourceContents([]*mcp.ResourceContents{
+			{URI: "cairn://run/x/a2ui", MIMEType: a2uiMIMEType, Text: testA2UIPayload},
+		}, false, "test-mcp")
+		require.Empty(t, meta.A2UISurfaces)
+		require.Equal(t, []string{testA2UIPayload}, textParts)
+	})
+
+	t.Run("plain text passes through", func(t *testing.T) {
+		t.Parallel()
+		textParts, meta := splitMCPResourceContents([]*mcp.ResourceContents{
+			{URI: "cairn://artifact/x", MIMEType: "text/markdown", Text: "# hello"},
+		}, true, "test-mcp")
+		require.Empty(t, meta.A2UISurfaces)
+		require.Equal(t, []string{"# hello"}, textParts)
+	})
+
+	t.Run("mixed text and a2ui keeps both", func(t *testing.T) {
+		t.Parallel()
+		textParts, meta := splitMCPResourceContents([]*mcp.ResourceContents{
+			{URI: "cairn://artifact/x", MIMEType: "text/markdown", Text: "summary"},
+			{URI: "cairn://artifact/x/a2ui", MIMEType: a2uiMIMEType, Text: testA2UIPayload},
+		}, true, "test-mcp")
+		require.Len(t, meta.A2UISurfaces, 1)
+		require.Len(t, textParts, 2)
+		require.Equal(t, "summary", textParts[0])
+		require.True(t, strings.HasPrefix(textParts[1], A2UISurfacePlaceholderPrefix))
+	})
+
+	t.Run("placeholder hides the injected width hint", func(t *testing.T) {
+		t.Parallel()
+		// Servers echo the request URI verbatim, ?w=N included; the model
+		// must not learn a width-frozen URI it could reuse after a resize.
+		textParts, _ := splitMCPResourceContents([]*mcp.ResourceContents{
+			{URI: "cairn://run/x/a2ui?w=114", MIMEType: a2uiMIMEType, Text: testA2UIPayload},
+		}, true, "test-mcp")
+		require.Len(t, textParts, 1)
+		require.Contains(t, textParts[0], "cairn://run/x/a2ui ")
+		require.NotContains(t, textParts[0], "w=114")
+	})
+
+	t.Run("nil and empty entries are skipped", func(t *testing.T) {
+		t.Parallel()
+		textParts, meta := splitMCPResourceContents([]*mcp.ResourceContents{
+			nil,
+			{URI: "cairn://artifact/empty"},
+		}, true, "test-mcp")
+		require.Empty(t, meta.A2UISurfaces)
+		require.Empty(t, textParts)
+	})
+}

--- a/internal/agent/tools/read_mcp_resource_contents_test.go
+++ b/internal/agent/tools/read_mcp_resource_contents_test.go
@@ -1,0 +1,83 @@
+package tools
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/crush/internal/agent/tools/mcp"
+	"github.com/stretchr/testify/require"
+)
+
+const testA2UIPayload = `{"version":"v0.9","updateComponents":{"surfaceId":"s","components":[` +
+	`{"component":"Text","id":"t","text":"hi"}]}}`
+
+func TestSplitMCPResourceContents(t *testing.T) {
+	t.Parallel()
+
+	t.Run("a2ui text content is diverted to metadata", func(t *testing.T) {
+		t.Parallel()
+		textParts, meta := splitMCPResourceContents([]*mcp.ResourceContents{
+			{URI: "cairn://run/x/a2ui", MIMEType: a2uiMIMEType, Text: testA2UIPayload},
+		}, true)
+		require.Len(t, meta.A2UISurfaces, 1)
+		require.Equal(t, "<a2ui-json>"+testA2UIPayload+"</a2ui-json>", meta.A2UISurfaces[0])
+		require.Len(t, textParts, 1)
+		require.True(t, strings.HasPrefix(textParts[0], A2UISurfacePlaceholderPrefix))
+		require.NotContains(t, textParts[0], "updateComponents")
+	})
+
+	t.Run("a2ui blob content is diverted too", func(t *testing.T) {
+		t.Parallel()
+		// Blob is a legal delivery for any MIME type — a blob-delivered
+		// surface must not leak raw JSON into the model-facing content.
+		textParts, meta := splitMCPResourceContents([]*mcp.ResourceContents{
+			{URI: "cairn://run/x/a2ui", MIMEType: a2uiMIMEType, Blob: []byte(testA2UIPayload)},
+		}, true)
+		require.Len(t, meta.A2UISurfaces, 1)
+		require.Len(t, textParts, 1)
+		require.True(t, strings.HasPrefix(textParts[0], A2UISurfacePlaceholderPrefix))
+		require.NotContains(t, textParts[0], "updateComponents")
+	})
+
+	t.Run("no diversion when no UI renders metadata", func(t *testing.T) {
+		t.Parallel()
+		// Channel-originated and disable_a2ui turns keep the raw payload so
+		// the model can relay or summarize the data.
+		textParts, meta := splitMCPResourceContents([]*mcp.ResourceContents{
+			{URI: "cairn://run/x/a2ui", MIMEType: a2uiMIMEType, Text: testA2UIPayload},
+		}, false)
+		require.Empty(t, meta.A2UISurfaces)
+		require.Equal(t, []string{testA2UIPayload}, textParts)
+	})
+
+	t.Run("plain text passes through", func(t *testing.T) {
+		t.Parallel()
+		textParts, meta := splitMCPResourceContents([]*mcp.ResourceContents{
+			{URI: "cairn://artifact/x", MIMEType: "text/markdown", Text: "# hello"},
+		}, true)
+		require.Empty(t, meta.A2UISurfaces)
+		require.Equal(t, []string{"# hello"}, textParts)
+	})
+
+	t.Run("mixed text and a2ui keeps both", func(t *testing.T) {
+		t.Parallel()
+		textParts, meta := splitMCPResourceContents([]*mcp.ResourceContents{
+			{URI: "cairn://artifact/x", MIMEType: "text/markdown", Text: "summary"},
+			{URI: "cairn://artifact/x/a2ui", MIMEType: a2uiMIMEType, Text: testA2UIPayload},
+		}, true)
+		require.Len(t, meta.A2UISurfaces, 1)
+		require.Len(t, textParts, 2)
+		require.Equal(t, "summary", textParts[0])
+		require.True(t, strings.HasPrefix(textParts[1], A2UISurfacePlaceholderPrefix))
+	})
+
+	t.Run("nil and empty entries are skipped", func(t *testing.T) {
+		t.Parallel()
+		textParts, meta := splitMCPResourceContents([]*mcp.ResourceContents{
+			nil,
+			{URI: "cairn://artifact/empty"},
+		}, true)
+		require.Empty(t, meta.A2UISurfaces)
+		require.Empty(t, textParts)
+	})
+}

--- a/internal/agent/tools/read_mcp_resource_test.go
+++ b/internal/agent/tools/read_mcp_resource_test.go
@@ -1,0 +1,85 @@
+package tools
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestA2UIWidthHint(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name  string
+		uri   string
+		width int
+		want  string
+	}{
+		{
+			name:  "a2ui run template gets the width",
+			uri:   "mcp://cairn/run/vitkuUpp/a2ui",
+			width: 114,
+			want:  "mcp://cairn/run/vitkuUpp/a2ui?w=114",
+		},
+		{
+			name:  "cairn-scheme alias gets the width",
+			uri:   "cairn://run/abc123/a2ui",
+			width: 90,
+			want:  "cairn://run/abc123/a2ui?w=90",
+		},
+		{
+			name:  "artifact and bundle templates get the width",
+			uri:   "mcp://cairn/artifact/PIMfMan7/a2ui",
+			width: 80,
+			want:  "mcp://cairn/artifact/PIMfMan7/a2ui?w=80",
+		},
+		{
+			name:  "an existing width hint is left alone",
+			uri:   "mcp://cairn/run/vitkuUpp/a2ui?w=60",
+			width: 114,
+			want:  "mcp://cairn/run/vitkuUpp/a2ui?w=60",
+		},
+		{
+			name:  "a non-width query still gets the width appended",
+			uri:   "mcp://cairn/run/vitkuUpp/a2ui?theme=dark",
+			width: 114,
+			want:  "mcp://cairn/run/vitkuUpp/a2ui?theme=dark&w=114",
+		},
+		{
+			name:  "non-a2ui resources are untouched",
+			uri:   "mcp://cairn/run/vitkuUpp",
+			width: 114,
+			want:  "mcp://cairn/run/vitkuUpp",
+		},
+		{
+			name:  "a2ui-looking substring outside the suffix is untouched",
+			uri:   "mcp://cairn/artifact/a2ui-notes",
+			width: 114,
+			want:  "mcp://cairn/artifact/a2ui-notes",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.want, a2uiWidthHint(tc.uri, tc.width))
+		})
+	}
+}
+
+func TestStripA2UIWidthParam(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, "cairn://run/x/a2ui", stripA2UIWidthParam("cairn://run/x/a2ui?w=114"))
+	require.Equal(t, "cairn://run/x/a2ui?theme=dark", stripA2UIWidthParam("cairn://run/x/a2ui?theme=dark&w=114"))
+	require.Equal(t, "cairn://run/x/a2ui", stripA2UIWidthParam("cairn://run/x/a2ui"))
+	require.Equal(t, "mcp://cairn/artifact/y", stripA2UIWidthParam("mcp://cairn/artifact/y"))
+}
+
+func TestGetContentWidthFromContext(t *testing.T) {
+	t.Parallel()
+
+	require.Zero(t, GetContentWidthFromContext(context.Background()))
+	ctx := context.WithValue(context.Background(), ContentWidthContextKey, 114)
+	require.Equal(t, 114, GetContentWidthFromContext(ctx))
+}

--- a/internal/agent/tools/read_mcp_resource_test.go
+++ b/internal/agent/tools/read_mcp_resource_test.go
@@ -1,0 +1,70 @@
+package tools
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestA2UIWidthHint(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name  string
+		uri   string
+		width int
+		want  string
+	}{
+		{
+			name:  "a2ui run template gets the width",
+			uri:   "mcp://cairn/run/vitkuUpp/a2ui",
+			width: 114,
+			want:  "mcp://cairn/run/vitkuUpp/a2ui?w=114",
+		},
+		{
+			name:  "cairn-scheme alias gets the width",
+			uri:   "cairn://run/abc123/a2ui",
+			width: 90,
+			want:  "cairn://run/abc123/a2ui?w=90",
+		},
+		{
+			name:  "artifact and bundle templates get the width",
+			uri:   "mcp://cairn/artifact/PIMfMan7/a2ui",
+			width: 80,
+			want:  "mcp://cairn/artifact/PIMfMan7/a2ui?w=80",
+		},
+		{
+			name:  "an existing width hint is left alone",
+			uri:   "mcp://cairn/run/vitkuUpp/a2ui?w=60",
+			width: 114,
+			want:  "mcp://cairn/run/vitkuUpp/a2ui?w=60",
+		},
+		{
+			name:  "non-a2ui resources are untouched",
+			uri:   "mcp://cairn/run/vitkuUpp",
+			width: 114,
+			want:  "mcp://cairn/run/vitkuUpp",
+		},
+		{
+			name:  "a2ui-looking substring outside the suffix is untouched",
+			uri:   "mcp://cairn/artifact/a2ui-notes",
+			width: 114,
+			want:  "mcp://cairn/artifact/a2ui-notes",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.want, a2uiWidthHint(tc.uri, tc.width))
+		})
+	}
+}
+
+func TestGetContentWidthFromContext(t *testing.T) {
+	t.Parallel()
+
+	require.Zero(t, GetContentWidthFromContext(context.Background()))
+	ctx := context.WithValue(context.Background(), ContentWidthContextKey, 114)
+	require.Equal(t, 114, GetContentWidthFromContext(ctx))
+}

--- a/internal/agent/tools/read_mcp_resource_test.go
+++ b/internal/agent/tools/read_mcp_resource_test.go
@@ -41,6 +41,12 @@ func TestA2UIWidthHint(t *testing.T) {
 			want:  "mcp://cairn/run/vitkuUpp/a2ui?w=60",
 		},
 		{
+			name:  "a non-width query still gets the width appended",
+			uri:   "mcp://cairn/run/vitkuUpp/a2ui?theme=dark",
+			width: 114,
+			want:  "mcp://cairn/run/vitkuUpp/a2ui?theme=dark&w=114",
+		},
+		{
 			name:  "non-a2ui resources are untouched",
 			uri:   "mcp://cairn/run/vitkuUpp",
 			width: 114,

--- a/internal/agent/tools/read_mcp_resource_test.go
+++ b/internal/agent/tools/read_mcp_resource_test.go
@@ -67,6 +67,15 @@ func TestA2UIWidthHint(t *testing.T) {
 	}
 }
 
+func TestStripA2UIWidthParam(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, "cairn://run/x/a2ui", stripA2UIWidthParam("cairn://run/x/a2ui?w=114"))
+	require.Equal(t, "cairn://run/x/a2ui?theme=dark", stripA2UIWidthParam("cairn://run/x/a2ui?theme=dark&w=114"))
+	require.Equal(t, "cairn://run/x/a2ui", stripA2UIWidthParam("cairn://run/x/a2ui"))
+	require.Equal(t, "mcp://cairn/artifact/y", stripA2UIWidthParam("mcp://cairn/artifact/y"))
+}
+
 func TestGetContentWidthFromContext(t *testing.T) {
 	t.Parallel()
 

--- a/internal/agent/tools/tools.go
+++ b/internal/agent/tools/tools.go
@@ -16,6 +16,7 @@ type (
 	supportsImagesKey   string
 	modelNameKey        string
 	channelContextKey   string
+	contentWidthKey     string
 )
 
 const (
@@ -29,6 +30,8 @@ const (
 	ModelNameContextKey modelNameKey = "model_name"
 	// ChannelContextKey is the key for the channel that originated the turn.
 	ChannelContextKey channelContextKey = "channel"
+	// ContentWidthContextKey is the key for the UI content width hint in cells.
+	ContentWidthContextKey contentWidthKey = "content_width"
 )
 
 // getContextValue is a generic helper that retrieves a typed value from context.
@@ -67,6 +70,12 @@ func GetSupportsImagesFromContext(ctx context.Context) bool {
 // GetModelNameFromContext retrieves the model name from the context.
 func GetModelNameFromContext(ctx context.Context) string {
 	return getContextValue(ctx, ModelNameContextKey, "")
+}
+
+// GetContentWidthFromContext retrieves the UI content width hint in cells,
+// or 0 when no hint was provided for this turn.
+func GetContentWidthFromContext(ctx context.Context) int {
+	return getContextValue(ctx, ContentWidthContextKey, 0)
 }
 
 // NewPermissionDeniedResponse returns a tool response indicating the user

--- a/internal/backend/agent.go
+++ b/internal/backend/agent.go
@@ -97,6 +97,9 @@ func (b *Backend) runAgent(ws *Workspace, msg proto.AgentMessage, accept *agent.
 	if msg.Channel != "" {
 		ctx = agent.WithChannel(ctx, msg.Channel)
 	}
+	if msg.ContentWidth > 0 {
+		ctx = agent.WithContentWidth(ctx, msg.ContentWidth)
+	}
 	_, err := ws.AgentCoordinator.RunAccepted(ctx, accept, msg.SessionID, msg.Prompt, proto.AttachmentsToMessage(msg.Attachments)...)
 	if err == nil || errors.Is(err, context.Canceled) {
 		return

--- a/internal/backend/config.go
+++ b/internal/backend/config.go
@@ -2,6 +2,7 @@ package backend
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -36,6 +37,19 @@ type MCPResourceContents struct {
 	MIMEType string `json:"mime_type,omitempty"`
 	Text     string `json:"text,omitempty"`
 	Blob     []byte `json:"blob,omitempty"`
+}
+
+// MCPToolCallResult holds the model-facing text and any A2UI surface
+// payloads from an MCP tool call.
+type MCPToolCallResult struct {
+	Content  string               `json:"content"`
+	Surfaces []MCPToolCallSurface `json:"surfaces,omitempty"`
+}
+
+// MCPToolCallSurface is a single A2UI surface payload from a tool call.
+type MCPToolCallSurface struct {
+	Payload string `json:"payload"`
+	URI     string `json:"uri"`
 }
 
 // SetConfigField sets a key/value pair in the config file for the
@@ -321,6 +335,28 @@ func (b *Backend) ReadMCPResource(ctx context.Context, workspaceID, name, uri st
 		}
 	}
 	return result, nil
+}
+
+// CallMCPTool invokes a tool on a named MCP server and returns its text
+// content plus any A2UI surface payload it embedded.
+func (b *Backend) CallMCPTool(ctx context.Context, workspaceID, name, toolName string, args map[string]any) (MCPToolCallResult, error) {
+	ws, err := b.GetWorkspace(workspaceID)
+	if err != nil {
+		return MCPToolCallResult{}, err
+	}
+	input, err := json.Marshal(args)
+	if err != nil {
+		return MCPToolCallResult{}, fmt.Errorf("failed to encode tool arguments: %w", err)
+	}
+	res, err := mcptools.RunTool(ctx, ws.Cfg, name, toolName, string(input))
+	if err != nil {
+		return MCPToolCallResult{}, err
+	}
+	out := MCPToolCallResult{Content: res.Content}
+	for _, s := range res.Surfaces {
+		out.Surfaces = append(out.Surfaces, MCPToolCallSurface{Payload: s.Payload, URI: s.URI})
+	}
+	return out, nil
 }
 
 // GetMCPPrompt retrieves a prompt from a named MCP server.

--- a/internal/client/config.go
+++ b/internal/client/config.go
@@ -291,6 +291,19 @@ type MCPResourceContents struct {
 	Blob     []byte `json:"blob,omitempty"`
 }
 
+// MCPToolCallResult holds the model-facing text and any A2UI surface
+// payloads from an MCP tool call.
+type MCPToolCallResult struct {
+	Content  string               `json:"content"`
+	Surfaces []MCPToolCallSurface `json:"surfaces,omitempty"`
+}
+
+// MCPToolCallSurface is a single A2UI surface payload from a tool call.
+type MCPToolCallSurface struct {
+	Payload string `json:"payload"`
+	URI     string `json:"uri"`
+}
+
 // EnableDockerMCP enables the Docker MCP server on the workspace.
 func (c *Client) EnableDockerMCP(ctx context.Context, id string) error {
 	rsp, err := c.post(ctx, fmt.Sprintf("/workspaces/%s/mcp/docker/enable", id), nil, nil, nil)
@@ -381,6 +394,27 @@ func (c *Client) ListMCPPrompts(ctx context.Context, id string) ([]proto.MCPProm
 		return nil, fmt.Errorf("failed to decode MCP prompts: %w", err)
 	}
 	return prompts, nil
+}
+
+// CallMCPTool calls a tool on a named MCP server.
+func (c *Client) CallMCPTool(ctx context.Context, id, name, toolName string, args map[string]any) (MCPToolCallResult, error) {
+	rsp, err := c.post(ctx, fmt.Sprintf("/workspaces/%s/mcp/call-tool", id), nil, jsonBody(struct {
+		Name     string         `json:"name"`
+		ToolName string         `json:"tool_name"`
+		Args     map[string]any `json:"args"`
+	}{Name: name, ToolName: toolName, Args: args}), http.Header{"Content-Type": []string{"application/json"}})
+	if err != nil {
+		return MCPToolCallResult{}, fmt.Errorf("failed to call MCP tool: %w", err)
+	}
+	defer rsp.Body.Close()
+	if rsp.StatusCode != http.StatusOK {
+		return MCPToolCallResult{}, fmt.Errorf("failed to call MCP tool: status code %d", rsp.StatusCode)
+	}
+	var result MCPToolCallResult
+	if err := json.NewDecoder(rsp.Body).Decode(&result); err != nil {
+		return MCPToolCallResult{}, fmt.Errorf("failed to decode MCP tool result: %w", err)
+	}
+	return result, nil
 }
 
 // GetMCPPrompt retrieves a prompt from a named MCP server.

--- a/internal/client/proto.go
+++ b/internal/client/proto.go
@@ -430,13 +430,14 @@ func (c *Client) UpdateAgent(ctx context.Context, id string) error {
 // for completion detection. Pass "" when the caller does not need
 // to distinguish its own turn's terminal event from any concurrent
 // turn on the same session (e.g. interactive TUI usage).
-func (c *Client) SendMessage(ctx context.Context, id string, sessionID, runID, channel, prompt string, attachments ...message.Attachment) error {
+func (c *Client) SendMessage(ctx context.Context, id string, sessionID, runID, channel string, contentWidth int, prompt string, attachments ...message.Attachment) error {
 	rsp, err := c.post(ctx, fmt.Sprintf("/workspaces/%s/agent", id), nil, jsonBody(proto.AgentMessage{
-		SessionID:   sessionID,
-		RunID:       runID,
-		Channel:     channel,
-		Prompt:      prompt,
-		Attachments: proto.AttachmentsFromMessage(attachments),
+		SessionID:    sessionID,
+		RunID:        runID,
+		Channel:      channel,
+		ContentWidth: contentWidth,
+		Prompt:       prompt,
+		Attachments:  proto.AttachmentsFromMessage(attachments),
 	}), http.Header{"Content-Type": []string{"application/json"}})
 	if err != nil {
 		return fmt.Errorf("failed to send message to agent: %w", err)

--- a/internal/client/proto_test.go
+++ b/internal/client/proto_test.go
@@ -97,7 +97,7 @@ func TestSendMessageAcceptsStatusAccepted(t *testing.T) {
 	defer srv.Close()
 
 	c := captureClient(t, srv)
-	require.NoError(t, c.SendMessage(context.Background(), "ws1", "sess1", "", "", "hello"))
+	require.NoError(t, c.SendMessage(context.Background(), "ws1", "sess1", "", "", 0, "hello"))
 }
 
 func TestSendMessageIncludesChannelOrigin(t *testing.T) {
@@ -111,8 +111,25 @@ func TestSendMessageIncludesChannelOrigin(t *testing.T) {
 	defer srv.Close()
 
 	c := captureClient(t, srv)
-	require.NoError(t, c.SendMessage(context.Background(), "ws1", "sess1", "", "signal", "hello"))
+	require.NoError(t, c.SendMessage(context.Background(), "ws1", "sess1", "", "signal", 0, "hello"))
 	require.Equal(t, "signal", got.Channel)
+}
+
+// The content-width hint must travel as a wire field: it is a context value
+// locally, and context values do not cross the HTTP boundary.
+func TestSendMessageIncludesContentWidth(t *testing.T) {
+	t.Parallel()
+
+	var got proto.AgentMessage
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&got))
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer srv.Close()
+
+	c := captureClient(t, srv)
+	require.NoError(t, c.SendMessage(context.Background(), "ws1", "sess1", "", "", 114, "hello"))
+	require.Equal(t, 114, got.ContentWidth)
 }
 
 func TestSendMessageAcceptsStatusOK(t *testing.T) {
@@ -124,7 +141,7 @@ func TestSendMessageAcceptsStatusOK(t *testing.T) {
 	defer srv.Close()
 
 	c := captureClient(t, srv)
-	require.NoError(t, c.SendMessage(context.Background(), "ws1", "sess1", "", "", "hello"))
+	require.NoError(t, c.SendMessage(context.Background(), "ws1", "sess1", "", "", 0, "hello"))
 }
 
 func TestSendMessageDecodesErrorBody(t *testing.T) {
@@ -137,7 +154,7 @@ func TestSendMessageDecodesErrorBody(t *testing.T) {
 	defer srv.Close()
 
 	c := captureClient(t, srv)
-	err := c.SendMessage(context.Background(), "ws1", "", "", "", "hello")
+	err := c.SendMessage(context.Background(), "ws1", "", "", "", 0, "hello")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "status code 400")
 	require.Contains(t, err.Error(), "session id is required")
@@ -153,7 +170,7 @@ func TestSendMessageFallsBackOnMalformedErrorBody(t *testing.T) {
 	defer srv.Close()
 
 	c := captureClient(t, srv)
-	err := c.SendMessage(context.Background(), "ws1", "sess1", "", "", "hello")
+	err := c.SendMessage(context.Background(), "ws1", "sess1", "", "", 0, "hello")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "status code 500")
 	require.NotContains(t, err.Error(), "not json")
@@ -168,7 +185,7 @@ func TestSendMessageFallsBackOnEmptyErrorBody(t *testing.T) {
 	defer srv.Close()
 
 	c := captureClient(t, srv)
-	err := c.SendMessage(context.Background(), "ws1", "sess1", "", "", "hello")
+	err := c.SendMessage(context.Background(), "ws1", "sess1", "", "", 0, "hello")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "status code 500")
 }

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -257,7 +257,7 @@ func runNonInteractive(
 	// loop would exit on whichever RunComplete arrived first for
 	// the same session and drop the queued prompt's output.
 	runID := uuid.New().String()
-	if err := c.SendMessage(ctx, ws.ID, sess.ID, runID, "", prompt); err != nil {
+	if err := c.SendMessage(ctx, ws.ID, sess.ID, runID, "", 0, prompt); err != nil {
 		return fmt.Errorf("failed to send message: %w", err)
 	}
 

--- a/internal/proto/proto.go
+++ b/internal/proto/proto.go
@@ -156,11 +156,17 @@ func (a AgentInfo) IsZero() bool {
 // remains correct only when no other turns are in flight for the
 // same session.
 type AgentMessage struct {
-	SessionID   string       `json:"session_id"`
-	RunID       string       `json:"run_id,omitempty"`
-	Channel     string       `json:"channel,omitempty"`
-	Prompt      string       `json:"prompt"`
-	Attachments []Attachment `json:"attachments,omitempty"`
+	SessionID string `json:"session_id"`
+	RunID     string `json:"run_id,omitempty"`
+	Channel   string `json:"channel,omitempty"`
+	// ContentWidth is the client UI's chat content width hint in cells
+	// (0 when the turn has no interactive UI). Like Channel it is a
+	// per-turn context value on the server side, so it must travel as an
+	// explicit wire field — context values do not cross the HTTP
+	// boundary. See ShellCommandRequest.TermWidth for the same pattern.
+	ContentWidth int          `json:"content_width,omitempty"`
+	Prompt       string       `json:"prompt"`
+	Attachments  []Attachment `json:"attachments,omitempty"`
 }
 
 // ShellCommandRequest represents a request to run a shell command directly.

--- a/internal/proto/requests.go
+++ b/internal/proto/requests.go
@@ -129,6 +129,13 @@ type MCPReadResourceRequest struct {
 	URI  string `json:"uri"`
 }
 
+// MCPCallToolRequest represents a request to call a tool on an MCP server.
+type MCPCallToolRequest struct {
+	Name     string         `json:"name"`
+	ToolName string         `json:"tool_name"`
+	Args     map[string]any `json:"args"`
+}
+
 // MCPGetPromptRequest represents a request to get an MCP prompt.
 type MCPGetPromptRequest struct {
 	ClientID string            `json:"client_id"`

--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -498,6 +498,56 @@ func (c *controllerV1) handleGetWorkspaceMCPPrompts(w http.ResponseWriter, r *ht
 	jsonEncode(w, prompts)
 }
 
+// a2uiCallableTools is the allow-list this route will invoke. The route
+// exists solely for the A2UI surface round-trip, which is not gated on the
+// agent's permission system (a button press is its own consent). Accepting an
+// arbitrary tool name here would turn it into remote execution of any tool on
+// any configured MCP server — file writes, shell-backed tools, network calls —
+// with no permission prompt at all.
+var a2uiCallableTools = map[string]bool{
+	"a2ui_action": true,
+	"a2ui_error":  true,
+}
+
+// handlePostWorkspaceMCPCallTool calls a tool on an MCP server. Only the A2UI
+// round-trip tools are callable; see [a2uiCallableTools].
+//
+//	@Summary		Call MCP tool
+//	@Tags			mcp
+//	@Accept			json
+//	@Produce		json
+//	@Param			id		path		string					true	"Workspace ID"
+//	@Param			request	body		proto.MCPCallToolRequest	true	"MCP call tool request"
+//	@Success		200		{object}	object
+//	@Failure		400		{object}	proto.Error
+//	@Failure		403		{object}	proto.Error
+//	@Failure		404		{object}	proto.Error
+//	@Failure		500		{object}	proto.Error
+//	@Router			/workspaces/{id}/mcp/call-tool [post]
+func (c *controllerV1) handlePostWorkspaceMCPCallTool(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+
+	var req proto.MCPCallToolRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		c.server.logError(r, "Failed to decode request", "error", err)
+		jsonError(w, http.StatusBadRequest, "failed to decode request")
+		return
+	}
+
+	if !a2uiCallableTools[req.ToolName] {
+		c.server.logError(r, "Rejected non-A2UI MCP tool call", "tool", req.ToolName)
+		jsonError(w, http.StatusForbidden, "only the A2UI round-trip tools may be called over this route")
+		return
+	}
+
+	result, err := c.backend.CallMCPTool(r.Context(), id, req.Name, req.ToolName, req.Args)
+	if err != nil {
+		c.handleError(w, r, err)
+		return
+	}
+	jsonEncode(w, result)
+}
+
 // handlePostWorkspaceMCPGetPrompt retrieves a prompt from an MCP server.
 //
 //	@Summary		Get MCP prompt

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -210,6 +210,7 @@ func (s *Server) installHandler() {
 	mux.HandleFunc("POST /v1/workspaces/{id}/mcp/refresh-tools", c.handlePostWorkspaceMCPRefreshTools)
 	mux.HandleFunc("POST /v1/workspaces/{id}/mcp/read-resource", c.handlePostWorkspaceMCPReadResource)
 	mux.HandleFunc("GET /v1/workspaces/{id}/mcp/prompts", c.handleGetWorkspaceMCPPrompts)
+	mux.HandleFunc("POST /v1/workspaces/{id}/mcp/call-tool", c.handlePostWorkspaceMCPCallTool)
 	mux.HandleFunc("POST /v1/workspaces/{id}/mcp/get-prompt", c.handlePostWorkspaceMCPGetPrompt)
 	mux.HandleFunc("GET /v1/workspaces/{id}/mcp/states", c.handleGetWorkspaceMCPStates)
 	mux.HandleFunc("POST /v1/workspaces/{id}/mcp/refresh-prompts", c.handlePostWorkspaceMCPRefreshPrompts)

--- a/internal/ui/chat/a2ui.go
+++ b/internal/ui/chat/a2ui.go
@@ -577,7 +577,9 @@ func (a *AssistantMessageItem) syncA2UISurfaces(src string, parts []a2tea.Part) 
 		if len(p.Messages) == 0 {
 			continue
 		}
-		model, err := a2tea.Render(p.Messages)
+		// Render compact: crush wraps the surface in its own A2UISurface
+		// frame, so a2tea must not draw a second CardBorder inside it.
+		model, err := a2tea.Render(p.Messages, render.WithCompact(true))
 		if err != nil {
 			// Valid A2UI with nothing to draw (e.g. a bare data-model
 			// update). The render loop skips nil entries; the block-stats
@@ -938,7 +940,12 @@ func (a *AssistantMessageItem) renderContentWithA2UI(content string, width int, 
 		// current focus ring and edited values, not a frozen snapshot.
 		model.SetSize(innerWidth, 0)
 		rendered := strings.TrimRight(model.View().Content, "\n")
-		writeChunk(surface.Width(max(width-surface.GetHorizontalBorderSize(), 1)).Render(rendered))
+		// The model renders in compact mode (a2tea drops its own CardBorder),
+		// so this frame is the ONLY box — no double border. lipgloss Width
+		// sets the TOTAL box width (border + padding included), so pass the
+		// full content width; the model inside was sized to innerWidth so its
+		// text wraps to the frame's inner area.
+		writeChunk(surface.Width(width).Render(rendered))
 	}
 
 	// Alert when the parser dropped a complete tagged block (#7) — checked

--- a/internal/ui/chat/a2ui.go
+++ b/internal/ui/chat/a2ui.go
@@ -12,7 +12,9 @@ import (
 	"unicode"
 
 	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
 	"github.com/charmbracelet/crush/internal/ui/common"
+	"github.com/charmbracelet/crush/internal/ui/styles"
 	"github.com/joestump-agent/a2tea"
 	"github.com/joestump-agent/a2tea/event"
 	"github.com/joestump-agent/a2tea/render"
@@ -560,6 +562,51 @@ func repairA2UIMessage(msg map[string]any) bool {
 	return true
 }
 
+// a2uiThemeStyles builds a2tea render.Styles from the active crush theme so
+// surfaces draw with the same palette as the rest of the chat. Card borders
+// pick up the same border color the old A2UISurface frame used (the theme's
+// visible background), headings and buttons use the brand colors, captions
+// use the muted foreground, and the focused button inverts to a
+// primary-background highlight — matching the dialog selected-item pattern.
+func a2uiThemeStyles(sty *styles.Styles) render.Styles {
+	st := render.DefaultStyles()
+	if sty == nil {
+		return st
+	}
+	st.CardBorder = st.CardBorder.
+		BorderForeground(sty.Messages.A2UISurface.GetBorderTopForeground())
+	st.Heading = st.Heading.Foreground(sty.WorkingGradFromColor)
+	st.Subheading = st.Subheading.Foreground(sty.WorkingGradToColor)
+	st.Caption = st.Caption.Foreground(sty.Dialog.SecondaryText.GetForeground())
+	st.Button = st.Button.Foreground(sty.WorkingGradFromColor)
+	st.ButtonFocused = st.ButtonFocused.
+		Background(sty.Dialog.SelectedItem.GetBackground()).
+		Foreground(sty.Dialog.SelectedItem.GetForeground()).
+		Reverse(false)
+	return st
+}
+
+// renderA2UILoading renders a "✨ Rendering UI…" placeholder for when an
+// assistant message is still streaming and an unclosed <a2ui-json> tag
+// indicates a surface is being composed. The raw partial JSON is replaced
+// with a styled shimmer that reads as intentional rather than broken.
+func renderA2UILoading(sty *styles.Styles, width int) string {
+	sparkle := lipgloss.NewStyle().
+		Foreground(sty.WorkingGradFromColor).
+		Bold(true).
+		Render("✨")
+	label := lipgloss.NewStyle().
+		Foreground(sty.WorkingLabelColor).
+		Render(" Rendering UI…")
+	box := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(sty.WorkingGradFromColor).
+		Padding(0, 1).
+		Width(width).
+		Render(sparkle + label)
+	return box
+}
+
 // syncA2UISurfaces builds — or reuses — the live a2tea models for the
 // scanned parts (#44). Surfaces are keyed by a hash of the scanned source:
 // streaming deltas rebuild them, while pure re-renders (width changes,
@@ -577,9 +624,10 @@ func (a *AssistantMessageItem) syncA2UISurfaces(src string, parts []a2tea.Part) 
 		if len(p.Messages) == 0 {
 			continue
 		}
-		// Render compact: crush wraps the surface in its own A2UISurface
-		// frame, so a2tea must not draw a second CardBorder inside it.
-		model, err := a2tea.Render(p.Messages, render.WithCompact(true))
+		// Render with the crush theme: a2tea's CardBorder picks up the
+		// palette, and crush no longer wraps the surface in its own frame —
+		// a2tea's box is the only one.
+		model, err := a2tea.Render(p.Messages, render.WithStyles(a2uiThemeStyles(a.sty)))
 		if err != nil {
 			// Valid A2UI with nothing to draw (e.g. a bare data-model
 			// update). The render loop skips nil entries; the block-stats
@@ -920,11 +968,9 @@ func (a *AssistantMessageItem) renderContentWithA2UI(content string, width int, 
 		b.WriteString(s)
 	}
 
-	// a2tea's chrome renders with terminal defaults (monochrome by design),
-	// so each surface is wrapped in a themed container to match the rest of
-	// the chat. The a2tea model is sized to the container's inner width.
-	surface := a.sty.Messages.A2UISurface
-	innerWidth := max(width-surface.GetHorizontalFrameSize(), 1)
+	// a2tea renders its own themed chrome (CardBorder, headings, buttons)
+	// via render.WithStyles — crush no longer wraps the surface in its own
+	// frame. The model is sized to the full content width.
 	for i, p := range parts {
 		writeChunk(renderMarkdown(p.Text))
 		if len(p.Messages) == 0 {
@@ -938,14 +984,17 @@ func (a *AssistantMessageItem) renderContentWithA2UI(content string, width int, 
 		}
 		// Render from the live model each call: its View reflects the
 		// current focus ring and edited values, not a frozen snapshot.
-		model.SetSize(innerWidth, 0)
+		model.SetSize(width, 0)
 		rendered := strings.TrimRight(model.View().Content, "\n")
-		// The model renders in compact mode (a2tea drops its own CardBorder),
-		// so this frame is the ONLY box — no double border. lipgloss Width
-		// sets the TOTAL box width (border + padding included), so pass the
-		// full content width; the model inside was sized to innerWidth so its
-		// text wraps to the frame's inner area.
-		writeChunk(surface.Width(width).Render(rendered))
+		writeChunk(rendered)
+	}
+
+	// While streaming, an unclosed <a2ui-json> tag means the model is
+	// still composing the surface — the parser consumed the raw JSON but
+	// produced no messages, so it doesn't appear in any part. Show a
+	// magical loading placeholder instead of leaving a blank gap.
+	if !finished && hasUnclosedA2UITag(masked) {
+		writeChunk(renderA2UILoading(a.sty, width))
 	}
 
 	// Alert when the parser dropped a complete tagged block (#7) — checked

--- a/internal/ui/chat/a2ui.go
+++ b/internal/ui/chat/a2ui.go
@@ -731,6 +731,57 @@ func a2uiPartSurfaceID(msgs []a2ui.ServerMessage) string {
 	return ""
 }
 
+// A2UIMessagesFromPayload converts a raw A2UI JSON payload (the body of an
+// MCP-served surface) into the server messages it encodes, so a follow-up
+// payload can be applied to a live surface. The payload is wrapped in the
+// wire tags before scanning because a2tea's scanner treats a bare JSON array
+// of messages as several separate bare objects; the tags make it one block.
+// An error means the payload could not be parsed at all.
+func A2UIMessagesFromPayload(payload string) ([]a2ui.ServerMessage, error) {
+	parts, err := a2tea.Scan(a2uiOpenTag + payload + a2uiCloseTag)
+	if err != nil {
+		return nil, err
+	}
+	var msgs []a2ui.ServerMessage
+	for _, p := range parts {
+		msgs = append(msgs, p.Messages...)
+	}
+	return msgs, nil
+}
+
+// A2UIMessagesSurfaceID reports the surface a batch of server messages
+// targets — the first surfaceId any of them names, whichever payload field
+// carries it. A response to an a2ui_action may update a sibling surface
+// rather than the clicked one, so the payload's own target wins over the
+// surface the interaction came from. Empty means the batch names none.
+func A2UIMessagesSurfaceID(msgs []a2ui.ServerMessage) string {
+	for _, m := range msgs {
+		switch {
+		case m.UpdateComponents != nil:
+			return m.UpdateComponents.SurfaceID
+		case m.CreateSurface != nil:
+			return m.CreateSurface.SurfaceID
+		case m.DeleteSurface != nil:
+			return m.DeleteSurface.SurfaceID
+		case m.UpdateDataModel != nil:
+			return m.UpdateDataModel.SurfaceID
+		}
+	}
+	return ""
+}
+
+// A2UIMessagesDeleteSurface reports whether a batch of server messages
+// deletes a surface. A delete that lands on a surface already gone is the
+// expected end of its life, not a mismatch worth reporting to the server.
+func A2UIMessagesDeleteSurface(msgs []a2ui.ServerMessage) bool {
+	for _, m := range msgs {
+		if m.DeleteSurface != nil {
+			return true
+		}
+	}
+	return false
+}
+
 // a2uiSurfaceRetired reports whether the surface at part-index i has been
 // retired after a submission (#45). Retired surfaces still render (showing
 // their final state) but no longer receive focus or keys.

--- a/internal/ui/chat/a2ui.go
+++ b/internal/ui/chat/a2ui.go
@@ -583,6 +583,21 @@ func a2uiThemeStyles(sty *styles.Styles) render.Styles {
 		Background(sty.Dialog.SelectedItem.GetBackground()).
 		Foreground(sty.Dialog.SelectedItem.GetForeground()).
 		Reverse(false)
+	// Inject Crush's glamour renderer so body-variant Text containing
+	// Markdown (tables, lists, bold, code) renders with the same styling
+	// as the rest of the chat. The renderer is created per-width inside
+	// the callback; glamour memoizes per width internally.
+	st.MarkdownRenderer = func(text string, width int) string {
+		renderer := common.MarkdownRenderer(sty, width)
+		mu := common.LockMarkdownRenderer(renderer)
+		mu.Lock()
+		defer mu.Unlock()
+		out, err := renderer.Render(text)
+		if err != nil {
+			return text
+		}
+		return strings.TrimSpace(out)
+	}
 	return st
 }
 

--- a/internal/ui/chat/a2ui.go
+++ b/internal/ui/chat/a2ui.go
@@ -9,9 +9,11 @@ import (
 	"regexp"
 	"slices"
 	"strings"
+	"sync"
 	"unicode"
 
 	tea "charm.land/bubbletea/v2"
+	"charm.land/glamour/v2"
 	"charm.land/lipgloss/v2"
 	"github.com/charmbracelet/crush/internal/ui/common"
 	"github.com/charmbracelet/crush/internal/ui/styles"
@@ -585,20 +587,61 @@ func a2uiThemeStyles(sty *styles.Styles) render.Styles {
 		Reverse(false)
 	// Inject Crush's glamour renderer so body-variant Text containing
 	// Markdown (tables, lists, bold, code) renders with the same styling
-	// as the rest of the chat. The renderer is created per-width inside
-	// the callback; glamour memoizes per width internally.
+	// as the rest of the chat. Rendered output is memoized per
+	// (renderer, text): items holding live surfaces bypass the chat render
+	// caches, so without a memo every repaint re-runs a full glamour parse
+	// per markdown body. The renderer lock is scoped to the Render call —
+	// callers must never hold the same renderer's lock while a surface
+	// View runs (see renderContentWithA2UI), or this hook would deadlock.
 	st.MarkdownRenderer = func(text string, width int) string {
 		renderer := common.MarkdownRenderer(sty, width)
+		if out, ok := a2uiMarkdownMemoGet(renderer, text); ok {
+			return out
+		}
 		mu := common.LockMarkdownRenderer(renderer)
 		mu.Lock()
-		defer mu.Unlock()
 		out, err := renderer.Render(text)
+		mu.Unlock()
 		if err != nil {
 			return text
 		}
-		return strings.TrimSpace(out)
+		out = strings.TrimSpace(out)
+		a2uiMarkdownMemoPut(renderer, text, out)
+		return out
 	}
 	return st
+}
+
+// a2uiMarkdownMemo caches glamour output for surface body Text. Keyed by the
+// memoized renderer pointer — which already encodes the width and is dropped
+// on theme change via InvalidateMarkdownRendererCache — plus the source text.
+// Bounded crudely: the map resets once it grows past a2uiMarkdownMemoMax.
+var (
+	a2uiMarkdownMemoMu sync.Mutex
+	a2uiMarkdownMemo   = map[a2uiMarkdownMemoKey]string{}
+)
+
+type a2uiMarkdownMemoKey struct {
+	renderer *glamour.TermRenderer
+	text     string
+}
+
+const a2uiMarkdownMemoMax = 512
+
+func a2uiMarkdownMemoGet(r *glamour.TermRenderer, text string) (string, bool) {
+	a2uiMarkdownMemoMu.Lock()
+	defer a2uiMarkdownMemoMu.Unlock()
+	out, ok := a2uiMarkdownMemo[a2uiMarkdownMemoKey{r, text}]
+	return out, ok
+}
+
+func a2uiMarkdownMemoPut(r *glamour.TermRenderer, text, out string) {
+	a2uiMarkdownMemoMu.Lock()
+	defer a2uiMarkdownMemoMu.Unlock()
+	if len(a2uiMarkdownMemo) >= a2uiMarkdownMemoMax {
+		clear(a2uiMarkdownMemo)
+	}
+	a2uiMarkdownMemo[a2uiMarkdownMemoKey{r, text}] = out
 }
 
 // renderA2UILoading renders a "✨ Rendering UI…" placeholder for when an
@@ -933,7 +976,10 @@ func a2uiSurfaceWantsKey(s render.Model, key tea.KeyMsg) bool {
 //
 // This deliberately bypasses the streaming-markdown prefix cache (which assumes
 // a single glamour render per item) and renders each segment directly. The
-// renderer is shared, so the whole multi-render sequence holds its lock.
+// renderer is shared, so each Render call takes its lock — scoped to the call,
+// never held across model.View(): a surface body Text re-enters the same
+// memoized renderer through the a2uiThemeStyles MarkdownRenderer hook, and
+// holding the lock across View would self-deadlock the UI goroutine.
 func (a *AssistantMessageItem) renderContentWithA2UI(content string, width int, finished bool) string {
 	masked, codeReps := maskMarkdownCode(content)
 	// Repair childless-but-labeled buttons on the raw JSON before parsing —
@@ -956,8 +1002,6 @@ func (a *AssistantMessageItem) renderContentWithA2UI(content string, width int, 
 
 	renderer := common.MarkdownRenderer(a.sty, width)
 	mu := common.LockMarkdownRenderer(renderer)
-	mu.Lock()
-	defer mu.Unlock()
 
 	renderMarkdown := func(text string) string {
 		if strings.TrimSpace(text) == "" {
@@ -965,7 +1009,9 @@ func (a *AssistantMessageItem) renderContentWithA2UI(content string, width int, 
 		}
 		// Restore masked code before markdown rendering.
 		text = unmaskMarkdownCode(text, codeReps)
+		mu.Lock()
 		out, err := renderer.Render(text)
+		mu.Unlock()
 		if err != nil {
 			return strings.TrimSpace(text)
 		}

--- a/internal/ui/chat/a2ui.go
+++ b/internal/ui/chat/a2ui.go
@@ -9,10 +9,14 @@ import (
 	"regexp"
 	"slices"
 	"strings"
+	"sync"
 	"unicode"
 
 	tea "charm.land/bubbletea/v2"
+	"charm.land/glamour/v2"
+	"charm.land/lipgloss/v2"
 	"github.com/charmbracelet/crush/internal/ui/common"
+	"github.com/charmbracelet/crush/internal/ui/styles"
 	"github.com/joestump-agent/a2tea"
 	"github.com/joestump-agent/a2tea/event"
 	"github.com/joestump-agent/a2tea/render"
@@ -560,6 +564,107 @@ func repairA2UIMessage(msg map[string]any) bool {
 	return true
 }
 
+// a2uiThemeStyles builds a2tea render.Styles from the active crush theme so
+// surfaces draw with the same palette as the rest of the chat. Card borders
+// pick up the same border color the old A2UISurface frame used (the theme's
+// visible background), headings and buttons use the brand colors, captions
+// use the muted foreground, and the focused button inverts to a
+// primary-background highlight — matching the dialog selected-item pattern.
+func a2uiThemeStyles(sty *styles.Styles) render.Styles {
+	st := render.DefaultStyles()
+	if sty == nil {
+		return st
+	}
+	st.CardBorder = st.CardBorder.
+		BorderForeground(sty.Messages.A2UISurface.GetBorderTopForeground())
+	st.Heading = st.Heading.Foreground(sty.WorkingGradFromColor)
+	st.Subheading = st.Subheading.Foreground(sty.WorkingGradToColor)
+	st.Caption = st.Caption.Foreground(sty.Dialog.SecondaryText.GetForeground())
+	st.Button = st.Button.Foreground(sty.WorkingGradFromColor)
+	st.ButtonFocused = st.ButtonFocused.
+		Background(sty.Dialog.SelectedItem.GetBackground()).
+		Foreground(sty.Dialog.SelectedItem.GetForeground()).
+		Reverse(false)
+	// Inject Crush's glamour renderer so body-variant Text containing
+	// Markdown (tables, lists, bold, code) renders with the same styling
+	// as the rest of the chat. Rendered output is memoized per
+	// (renderer, text): items holding live surfaces bypass the chat render
+	// caches, so without a memo every repaint re-runs a full glamour parse
+	// per markdown body. The renderer lock is scoped to the Render call —
+	// callers must never hold the same renderer's lock while a surface
+	// View runs (see renderContentWithA2UI), or this hook would deadlock.
+	st.MarkdownRenderer = func(text string, width int) string {
+		renderer := common.MarkdownRenderer(sty, width)
+		if out, ok := a2uiMarkdownMemoGet(renderer, text); ok {
+			return out
+		}
+		mu := common.LockMarkdownRenderer(renderer)
+		mu.Lock()
+		out, err := renderer.Render(text)
+		mu.Unlock()
+		if err != nil {
+			return text
+		}
+		out = strings.TrimSpace(out)
+		a2uiMarkdownMemoPut(renderer, text, out)
+		return out
+	}
+	return st
+}
+
+// a2uiMarkdownMemo caches glamour output for surface body Text. Keyed by the
+// memoized renderer pointer — which already encodes the width and is dropped
+// on theme change via InvalidateMarkdownRendererCache — plus the source text.
+// Bounded crudely: the map resets once it grows past a2uiMarkdownMemoMax.
+var (
+	a2uiMarkdownMemoMu sync.Mutex
+	a2uiMarkdownMemo   = map[a2uiMarkdownMemoKey]string{}
+)
+
+type a2uiMarkdownMemoKey struct {
+	renderer *glamour.TermRenderer
+	text     string
+}
+
+const a2uiMarkdownMemoMax = 512
+
+func a2uiMarkdownMemoGet(r *glamour.TermRenderer, text string) (string, bool) {
+	a2uiMarkdownMemoMu.Lock()
+	defer a2uiMarkdownMemoMu.Unlock()
+	out, ok := a2uiMarkdownMemo[a2uiMarkdownMemoKey{r, text}]
+	return out, ok
+}
+
+func a2uiMarkdownMemoPut(r *glamour.TermRenderer, text, out string) {
+	a2uiMarkdownMemoMu.Lock()
+	defer a2uiMarkdownMemoMu.Unlock()
+	if len(a2uiMarkdownMemo) >= a2uiMarkdownMemoMax {
+		clear(a2uiMarkdownMemo)
+	}
+	a2uiMarkdownMemo[a2uiMarkdownMemoKey{r, text}] = out
+}
+
+// renderA2UILoading renders a "✨ Rendering UI…" placeholder for when an
+// assistant message is still streaming and an unclosed <a2ui-json> tag
+// indicates a surface is being composed. The raw partial JSON is replaced
+// with a styled shimmer that reads as intentional rather than broken.
+func renderA2UILoading(sty *styles.Styles, width int) string {
+	sparkle := lipgloss.NewStyle().
+		Foreground(sty.WorkingGradFromColor).
+		Bold(true).
+		Render("✨")
+	label := lipgloss.NewStyle().
+		Foreground(sty.WorkingLabelColor).
+		Render(" Rendering UI…")
+	box := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(sty.WorkingGradFromColor).
+		Padding(0, 1).
+		Width(width).
+		Render(sparkle + label)
+	return box
+}
+
 // syncA2UISurfaces builds — or reuses — the live a2tea models for the
 // scanned parts (#44). Surfaces are keyed by a hash of the scanned source:
 // streaming deltas rebuild them, while pure re-renders (width changes,
@@ -577,7 +682,10 @@ func (a *AssistantMessageItem) syncA2UISurfaces(src string, parts []a2tea.Part) 
 		if len(p.Messages) == 0 {
 			continue
 		}
-		model, err := a2tea.Render(p.Messages)
+		// Render with the crush theme: a2tea's CardBorder picks up the
+		// palette, and crush no longer wraps the surface in its own frame —
+		// a2tea's box is the only one.
+		model, err := a2tea.Render(p.Messages, render.WithStyles(a2uiThemeStyles(a.sty)))
 		if err != nil {
 			// Valid A2UI with nothing to draw (e.g. a bare data-model
 			// update). The render loop skips nil entries; the block-stats
@@ -621,6 +729,57 @@ func a2uiPartSurfaceID(msgs []a2ui.ServerMessage) string {
 		}
 	}
 	return ""
+}
+
+// A2UIMessagesFromPayload converts a raw A2UI JSON payload (the body of an
+// MCP-served surface) into the server messages it encodes, so a follow-up
+// payload can be applied to a live surface. The payload is wrapped in the
+// wire tags before scanning because a2tea's scanner treats a bare JSON array
+// of messages as several separate bare objects; the tags make it one block.
+// An error means the payload could not be parsed at all.
+func A2UIMessagesFromPayload(payload string) ([]a2ui.ServerMessage, error) {
+	parts, err := a2tea.Scan(a2uiOpenTag + payload + a2uiCloseTag)
+	if err != nil {
+		return nil, err
+	}
+	var msgs []a2ui.ServerMessage
+	for _, p := range parts {
+		msgs = append(msgs, p.Messages...)
+	}
+	return msgs, nil
+}
+
+// A2UIMessagesSurfaceID reports the surface a batch of server messages
+// targets — the first surfaceId any of them names, whichever payload field
+// carries it. A response to an a2ui_action may update a sibling surface
+// rather than the clicked one, so the payload's own target wins over the
+// surface the interaction came from. Empty means the batch names none.
+func A2UIMessagesSurfaceID(msgs []a2ui.ServerMessage) string {
+	for _, m := range msgs {
+		switch {
+		case m.UpdateComponents != nil:
+			return m.UpdateComponents.SurfaceID
+		case m.CreateSurface != nil:
+			return m.CreateSurface.SurfaceID
+		case m.DeleteSurface != nil:
+			return m.DeleteSurface.SurfaceID
+		case m.UpdateDataModel != nil:
+			return m.UpdateDataModel.SurfaceID
+		}
+	}
+	return ""
+}
+
+// A2UIMessagesDeleteSurface reports whether a batch of server messages
+// deletes a surface. A delete that lands on a surface already gone is the
+// expected end of its life, not a mismatch worth reporting to the server.
+func A2UIMessagesDeleteSurface(msgs []a2ui.ServerMessage) bool {
+	for _, m := range msgs {
+		if m.DeleteSurface != nil {
+			return true
+		}
+	}
+	return false
 }
 
 // a2uiSurfaceRetired reports whether the surface at part-index i has been
@@ -868,7 +1027,10 @@ func a2uiSurfaceWantsKey(s render.Model, key tea.KeyMsg) bool {
 //
 // This deliberately bypasses the streaming-markdown prefix cache (which assumes
 // a single glamour render per item) and renders each segment directly. The
-// renderer is shared, so the whole multi-render sequence holds its lock.
+// renderer is shared, so each Render call takes its lock — scoped to the call,
+// never held across model.View(): a surface body Text re-enters the same
+// memoized renderer through the a2uiThemeStyles MarkdownRenderer hook, and
+// holding the lock across View would self-deadlock the UI goroutine.
 func (a *AssistantMessageItem) renderContentWithA2UI(content string, width int, finished bool) string {
 	masked, codeReps := maskMarkdownCode(content)
 	// Repair childless-but-labeled buttons on the raw JSON before parsing —
@@ -891,8 +1053,6 @@ func (a *AssistantMessageItem) renderContentWithA2UI(content string, width int, 
 
 	renderer := common.MarkdownRenderer(a.sty, width)
 	mu := common.LockMarkdownRenderer(renderer)
-	mu.Lock()
-	defer mu.Unlock()
 
 	renderMarkdown := func(text string) string {
 		if strings.TrimSpace(text) == "" {
@@ -900,7 +1060,9 @@ func (a *AssistantMessageItem) renderContentWithA2UI(content string, width int, 
 		}
 		// Restore masked code before markdown rendering.
 		text = unmaskMarkdownCode(text, codeReps)
+		mu.Lock()
 		out, err := renderer.Render(text)
+		mu.Unlock()
 		if err != nil {
 			return strings.TrimSpace(text)
 		}
@@ -918,11 +1080,9 @@ func (a *AssistantMessageItem) renderContentWithA2UI(content string, width int, 
 		b.WriteString(s)
 	}
 
-	// a2tea's chrome renders with terminal defaults (monochrome by design),
-	// so each surface is wrapped in a themed container to match the rest of
-	// the chat. The a2tea model is sized to the container's inner width.
-	surface := a.sty.Messages.A2UISurface
-	innerWidth := max(width-surface.GetHorizontalFrameSize(), 1)
+	// a2tea renders its own themed chrome (CardBorder, headings, buttons)
+	// via render.WithStyles — crush no longer wraps the surface in its own
+	// frame. The model is sized to the full content width.
 	for i, p := range parts {
 		writeChunk(renderMarkdown(p.Text))
 		if len(p.Messages) == 0 {
@@ -936,9 +1096,17 @@ func (a *AssistantMessageItem) renderContentWithA2UI(content string, width int, 
 		}
 		// Render from the live model each call: its View reflects the
 		// current focus ring and edited values, not a frozen snapshot.
-		model.SetSize(innerWidth, 0)
+		model.SetSize(width, 0)
 		rendered := strings.TrimRight(model.View().Content, "\n")
-		writeChunk(surface.Width(max(width-surface.GetHorizontalBorderSize(), 1)).Render(rendered))
+		writeChunk(rendered)
+	}
+
+	// While streaming, an unclosed <a2ui-json> tag means the model is
+	// still composing the surface — the parser consumed the raw JSON but
+	// produced no messages, so it doesn't appear in any part. Show a
+	// magical loading placeholder instead of leaving a blank gap.
+	if !finished && hasUnclosedA2UITag(masked) {
+		writeChunk(renderA2UILoading(a.sty, width))
 	}
 
 	// Alert when the parser dropped a complete tagged block (#7) — checked

--- a/internal/ui/chat/a2ui_surface_host.go
+++ b/internal/ui/chat/a2ui_surface_host.go
@@ -1,0 +1,175 @@
+package chat
+
+import (
+	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/crush/internal/csync"
+	"github.com/charmbracelet/crush/internal/ui/styles"
+	"github.com/joestump-agent/a2tea"
+	"github.com/joestump-agent/a2tea/render"
+)
+
+// a2uiSurfaceHost holds the live a2tea surface models for one message item —
+// an assistant message whose content scanned as A2UI (#44), or a tool result
+// that delivered an MCP A2UI surface (#219). The slice is indexed by
+// scan-part (assistant) or surface (tool result); entries without a
+// renderable surface hold nil.
+//
+// Assistant surfaces stream and rebuild as deltas arrive, so the assistant
+// item keys its models by source hash and retires them on first submission
+// (#45). MCP tool-result surfaces are long-lived app UIs: they build once
+// from a fixed payload, are never retired on interaction, and feed a button
+// back to the owning server (#221). The host carries the shared state and
+// behavior both kinds need; the items own their lifecycle.
+type a2uiSurfaceHost struct {
+	// surfaces holds the live a2tea models so they can receive focus and
+	// key input instead of being frozen to a rendered string.
+	surfaces []render.Model
+	// surfaceIDs holds the A2UI surface ID for each entry (empty where the
+	// part has no renderable surface), so a ButtonClicked event's
+	// SurfaceID can be routed back to the model that emitted it.
+	surfaceIDs []string
+	// sty themes the surfaces with the crush palette.
+	sty *styles.Styles
+}
+
+// buildSurfaces renders each part's messages into a live a2tea model,
+// returning the surfaces and their IDs. Parts with no messages or nothing
+// to draw (e.g. a bare data-model update) leave nil/empty entries.
+func buildA2UISurfaces(sty *styles.Styles, parts []a2tea.Part) ([]render.Model, []string) {
+	surfaces := make([]render.Model, len(parts))
+	ids := make([]string, len(parts))
+	for i, p := range parts {
+		if len(p.Messages) == 0 {
+			continue
+		}
+		model, err := a2tea.Render(p.Messages, render.WithStyles(a2uiThemeStyles(sty)))
+		if err != nil {
+			continue
+		}
+		if rm, ok := model.(render.Model); ok {
+			surfaces[i] = rm
+			ids[i] = a2uiPartSurfaceID(p.Messages)
+		}
+	}
+	return surfaces, ids
+}
+
+// hasLive reports whether the host holds at least one live surface model.
+// While true, the item's content-hash render caches are bypassed so surface
+// interaction is never served a frozen frame.
+func (h *a2uiSurfaceHost) hasLive() bool {
+	for _, s := range h.surfaces {
+		if s != nil {
+			return true
+		}
+	}
+	return false
+}
+
+// surfaceAt returns the live surface at index i, or nil.
+func (h *a2uiSurfaceHost) surfaceAt(i int) render.Model {
+	if i < 0 || i >= len(h.surfaces) {
+		return nil
+	}
+	return h.surfaces[i]
+}
+
+// focusedIndex returns the index of the surface currently holding keyboard
+// focus, or -1 when none does.
+func (h *a2uiSurfaceHost) focusedIndex() int {
+	for i, s := range h.surfaces {
+		if s != nil && s.Focused() {
+			return i
+		}
+	}
+	return -1
+}
+
+// update forwards msg into surface i's Update and stores the returned model.
+func (h *a2uiSurfaceHost) update(i int, msg tea.Msg) tea.Cmd {
+	model, cmd := h.surfaces[i].Update(msg)
+	if rm, ok := model.(render.Model); ok {
+		h.surfaces[i] = rm
+	}
+	return cmd
+}
+
+// fieldValues reads the surface's current values, if it supports them.
+func (h *a2uiSurfaceHost) fieldValues(i int) map[string]any {
+	s := h.surfaceAt(i)
+	if s == nil {
+		return nil
+	}
+	if fv, ok := s.(interface{ FieldValues() map[string]any }); ok {
+		return fv.FieldValues()
+	}
+	return nil
+}
+
+// surfaceIDFor returns the A2UI surface ID at index i.
+func (h *a2uiSurfaceHost) surfaceIDFor(i int) string {
+	if i < 0 || i >= len(h.surfaceIDs) {
+		return ""
+	}
+	return h.surfaceIDs[i]
+}
+
+// findByID returns the index of the surface with the given A2UI surface ID,
+// or -1.
+func (h *a2uiSurfaceHost) findByID(surfaceID string) int {
+	for i, id := range h.surfaceIDs {
+		if id == surfaceID && h.surfaceAt(i) != nil {
+			return i
+		}
+	}
+	return -1
+}
+
+// focus grants keyboard focus to the surface at index i and blurs the rest,
+// honoring the a2tea composition contract of at most one focused child.
+func (h *a2uiSurfaceHost) focus(i int) {
+	for j, s := range h.surfaces {
+		if s == nil {
+			continue
+		}
+		if j == i {
+			_ = s.Focus()
+		} else {
+			s.Blur()
+		}
+	}
+}
+
+// blurAll revokes keyboard focus from every live surface.
+func (h *a2uiSurfaceHost) blurAll() {
+	for _, s := range h.surfaces {
+		if s != nil {
+			s.Blur()
+		}
+	}
+}
+
+// --- MCP surface provenance registry (#219) ---
+
+// a2uiMCPProvenance maps a rendered A2UI surface ID to the MCP server that
+// served it, so a later interaction event (button press, render failure) can
+// route back to the owning server as an a2ui_action / a2ui_error tool call
+// (#221). Entries live for the process lifetime: surface IDs are
+// server-scoped (typically "default"), so re-rendering a surface from the
+// same server simply overwrites the same key.
+var a2uiMCPProvenance = csync.NewMap[string, string]()
+
+// registerA2UISurfaceProvenance records that surfaceID came from mcpName.
+// An empty surfaceID or mcpName is not registered.
+func registerA2UISurfaceProvenance(surfaceID, mcpName string) {
+	if surfaceID == "" || mcpName == "" {
+		return
+	}
+	a2uiMCPProvenance.Set(surfaceID, mcpName)
+}
+
+// A2UISurfaceProvenance returns the MCP server that served surfaceID, and
+// whether the surface is MCP-owned at all.
+func A2UISurfaceProvenance(surfaceID string) (string, bool) {
+	return a2uiMCPProvenance.Get(surfaceID)
+}

--- a/internal/ui/chat/a2ui_surface_host.go
+++ b/internal/ui/chat/a2ui_surface_host.go
@@ -28,8 +28,33 @@ type a2uiSurfaceHost struct {
 	// part has no renderable surface), so a ButtonClicked event's
 	// SurfaceID can be routed back to the model that emitted it.
 	surfaceIDs []string
+	// surfaceOwners holds the MCP server that served each entry (empty for
+	// chat-scanned surfaces). It is the item-scoped provenance the action
+	// round-trip resolves through, so two servers using the same surface ID
+	// cannot route each other's clicks.
+	surfaceOwners []string
 	// sty themes the surfaces with the crush palette.
 	sty *styles.Styles
+}
+
+// ownerFor returns the MCP server that served the surface at index i, and
+// whether one is known.
+func (h *a2uiSurfaceHost) ownerFor(i int) (string, bool) {
+	if i < 0 || i >= len(h.surfaceOwners) {
+		return "", false
+	}
+	name := h.surfaceOwners[i]
+	return name, name != ""
+}
+
+// drop releases the surface at index i, which the server deleted. The entry
+// is kept (indexes stay parallel to surfaceIDs) but nils out, so hasLive and
+// findByID stop reporting it and it can no longer take focus or keys.
+func (h *a2uiSurfaceHost) drop(i int) {
+	if i < 0 || i >= len(h.surfaces) {
+		return
+	}
+	h.surfaces[i] = nil
 }
 
 // buildSurfaces renders each part's messages into a live a2tea model,

--- a/internal/ui/chat/a2ui_surface_host.go
+++ b/internal/ui/chat/a2ui_surface_host.go
@@ -15,8 +15,8 @@ import (
 // renderable surface hold nil.
 //
 // Assistant surfaces stream and rebuild as deltas arrive, so the assistant
-// item keys its models by source hash and retires them on first submission
-// . MCP tool-result surfaces are long-lived app UIs: they build once
+// item keys its models by source hash and retires them on first
+// submission. MCP tool-result surfaces are long-lived app UIs: they build once
 // from a fixed payload, are never retired on interaction, and feed a button
 // back to the owning server. The host carries the shared state and
 // behavior both kinds need; the items own their lifecycle.
@@ -152,11 +152,14 @@ func (h *a2uiSurfaceHost) blurAll() {
 // --- MCP surface provenance registry ---
 
 // a2uiMCPProvenance maps a rendered A2UI surface ID to the MCP server that
-// served it, so a later interaction event (button press, render failure) can
-// route back to the owning server as an a2ui_action / a2ui_error tool call
-// . Entries live for the process lifetime: surface IDs are
+// served it, so a later interaction event (button press, render failure)
+// can route back to the owning server as an a2ui_action / a2ui_error tool
+// call. Entries live for the process lifetime: surface IDs are
 // server-scoped (typically "default"), so re-rendering a surface from the
-// same server simply overwrites the same key.
+// same server simply overwrites the same key. Two servers emitting the SAME
+// surface ID would clobber each other here — the action round-trip should
+// resolve provenance through the owning item before falling back to this
+// registry.
 var a2uiMCPProvenance = csync.NewMap[string, string]()
 
 // registerA2UISurfaceProvenance records that surfaceID came from mcpName.

--- a/internal/ui/chat/a2ui_surface_host.go
+++ b/internal/ui/chat/a2ui_surface_host.go
@@ -9,16 +9,16 @@ import (
 )
 
 // a2uiSurfaceHost holds the live a2tea surface models for one message item —
-// an assistant message whose content scanned as A2UI (#44), or a tool result
-// that delivered an MCP A2UI surface (#219). The slice is indexed by
+// an assistant message whose content scanned as A2UI, or a tool result
+// that delivered an MCP A2UI surface. The slice is indexed by
 // scan-part (assistant) or surface (tool result); entries without a
 // renderable surface hold nil.
 //
 // Assistant surfaces stream and rebuild as deltas arrive, so the assistant
 // item keys its models by source hash and retires them on first submission
-// (#45). MCP tool-result surfaces are long-lived app UIs: they build once
+// . MCP tool-result surfaces are long-lived app UIs: they build once
 // from a fixed payload, are never retired on interaction, and feed a button
-// back to the owning server (#221). The host carries the shared state and
+// back to the owning server. The host carries the shared state and
 // behavior both kinds need; the items own their lifecycle.
 type a2uiSurfaceHost struct {
 	// surfaces holds the live a2tea models so they can receive focus and
@@ -149,12 +149,12 @@ func (h *a2uiSurfaceHost) blurAll() {
 	}
 }
 
-// --- MCP surface provenance registry (#219) ---
+// --- MCP surface provenance registry ---
 
 // a2uiMCPProvenance maps a rendered A2UI surface ID to the MCP server that
 // served it, so a later interaction event (button press, render failure) can
 // route back to the owning server as an a2ui_action / a2ui_error tool call
-// (#221). Entries live for the process lifetime: surface IDs are
+// . Entries live for the process lifetime: surface IDs are
 // server-scoped (typically "default"), so re-rendering a surface from the
 // same server simply overwrites the same key.
 var a2uiMCPProvenance = csync.NewMap[string, string]()

--- a/internal/ui/chat/a2ui_surface_host.go
+++ b/internal/ui/chat/a2ui_surface_host.go
@@ -1,0 +1,203 @@
+package chat
+
+import (
+	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/crush/internal/csync"
+	"github.com/charmbracelet/crush/internal/ui/styles"
+	"github.com/joestump-agent/a2tea"
+	"github.com/joestump-agent/a2tea/render"
+)
+
+// a2uiSurfaceHost holds the live a2tea surface models for one message item —
+// an assistant message whose content scanned as A2UI, or a tool result
+// that delivered an MCP A2UI surface. The slice is indexed by
+// scan-part (assistant) or surface (tool result); entries without a
+// renderable surface hold nil.
+//
+// Assistant surfaces stream and rebuild as deltas arrive, so the assistant
+// item keys its models by source hash and retires them on first
+// submission. MCP tool-result surfaces are long-lived app UIs: they build once
+// from a fixed payload, are never retired on interaction, and feed a button
+// back to the owning server. The host carries the shared state and
+// behavior both kinds need; the items own their lifecycle.
+type a2uiSurfaceHost struct {
+	// surfaces holds the live a2tea models so they can receive focus and
+	// key input instead of being frozen to a rendered string.
+	surfaces []render.Model
+	// surfaceIDs holds the A2UI surface ID for each entry (empty where the
+	// part has no renderable surface), so a ButtonClicked event's
+	// SurfaceID can be routed back to the model that emitted it.
+	surfaceIDs []string
+	// surfaceOwners holds the MCP server that served each entry (empty for
+	// chat-scanned surfaces). It is the item-scoped provenance the action
+	// round-trip resolves through, so two servers using the same surface ID
+	// cannot route each other's clicks.
+	surfaceOwners []string
+	// sty themes the surfaces with the crush palette.
+	sty *styles.Styles
+}
+
+// ownerFor returns the MCP server that served the surface at index i, and
+// whether one is known.
+func (h *a2uiSurfaceHost) ownerFor(i int) (string, bool) {
+	if i < 0 || i >= len(h.surfaceOwners) {
+		return "", false
+	}
+	name := h.surfaceOwners[i]
+	return name, name != ""
+}
+
+// drop releases the surface at index i, which the server deleted. The entry
+// is kept (indexes stay parallel to surfaceIDs) but nils out, so hasLive and
+// findByID stop reporting it and it can no longer take focus or keys.
+func (h *a2uiSurfaceHost) drop(i int) {
+	if i < 0 || i >= len(h.surfaces) {
+		return
+	}
+	h.surfaces[i] = nil
+}
+
+// buildSurfaces renders each part's messages into a live a2tea model,
+// returning the surfaces and their IDs. Parts with no messages or nothing
+// to draw (e.g. a bare data-model update) leave nil/empty entries.
+func buildA2UISurfaces(sty *styles.Styles, parts []a2tea.Part) ([]render.Model, []string) {
+	surfaces := make([]render.Model, len(parts))
+	ids := make([]string, len(parts))
+	for i, p := range parts {
+		if len(p.Messages) == 0 {
+			continue
+		}
+		model, err := a2tea.Render(p.Messages, render.WithStyles(a2uiThemeStyles(sty)))
+		if err != nil {
+			continue
+		}
+		if rm, ok := model.(render.Model); ok {
+			surfaces[i] = rm
+			ids[i] = a2uiPartSurfaceID(p.Messages)
+		}
+	}
+	return surfaces, ids
+}
+
+// hasLive reports whether the host holds at least one live surface model.
+// While true, the item's content-hash render caches are bypassed so surface
+// interaction is never served a frozen frame.
+func (h *a2uiSurfaceHost) hasLive() bool {
+	for _, s := range h.surfaces {
+		if s != nil {
+			return true
+		}
+	}
+	return false
+}
+
+// surfaceAt returns the live surface at index i, or nil.
+func (h *a2uiSurfaceHost) surfaceAt(i int) render.Model {
+	if i < 0 || i >= len(h.surfaces) {
+		return nil
+	}
+	return h.surfaces[i]
+}
+
+// focusedIndex returns the index of the surface currently holding keyboard
+// focus, or -1 when none does.
+func (h *a2uiSurfaceHost) focusedIndex() int {
+	for i, s := range h.surfaces {
+		if s != nil && s.Focused() {
+			return i
+		}
+	}
+	return -1
+}
+
+// update forwards msg into surface i's Update and stores the returned model.
+func (h *a2uiSurfaceHost) update(i int, msg tea.Msg) tea.Cmd {
+	model, cmd := h.surfaces[i].Update(msg)
+	if rm, ok := model.(render.Model); ok {
+		h.surfaces[i] = rm
+	}
+	return cmd
+}
+
+// fieldValues reads the surface's current values, if it supports them.
+func (h *a2uiSurfaceHost) fieldValues(i int) map[string]any {
+	s := h.surfaceAt(i)
+	if s == nil {
+		return nil
+	}
+	if fv, ok := s.(interface{ FieldValues() map[string]any }); ok {
+		return fv.FieldValues()
+	}
+	return nil
+}
+
+// surfaceIDFor returns the A2UI surface ID at index i.
+func (h *a2uiSurfaceHost) surfaceIDFor(i int) string {
+	if i < 0 || i >= len(h.surfaceIDs) {
+		return ""
+	}
+	return h.surfaceIDs[i]
+}
+
+// findByID returns the index of the surface with the given A2UI surface ID,
+// or -1.
+func (h *a2uiSurfaceHost) findByID(surfaceID string) int {
+	for i, id := range h.surfaceIDs {
+		if id == surfaceID && h.surfaceAt(i) != nil {
+			return i
+		}
+	}
+	return -1
+}
+
+// focus grants keyboard focus to the surface at index i and blurs the rest,
+// honoring the a2tea composition contract of at most one focused child.
+func (h *a2uiSurfaceHost) focus(i int) {
+	for j, s := range h.surfaces {
+		if s == nil {
+			continue
+		}
+		if j == i {
+			_ = s.Focus()
+		} else {
+			s.Blur()
+		}
+	}
+}
+
+// blurAll revokes keyboard focus from every live surface.
+func (h *a2uiSurfaceHost) blurAll() {
+	for _, s := range h.surfaces {
+		if s != nil {
+			s.Blur()
+		}
+	}
+}
+
+// --- MCP surface provenance registry ---
+
+// a2uiMCPProvenance maps a rendered A2UI surface ID to the MCP server that
+// served it, so a later interaction event (button press, render failure)
+// can route back to the owning server as an a2ui_action / a2ui_error tool
+// call. Entries live for the process lifetime: surface IDs are
+// server-scoped (typically "default"), so re-rendering a surface from the
+// same server simply overwrites the same key. Two servers emitting the SAME
+// surface ID would clobber each other here — the action round-trip should
+// resolve provenance through the owning item before falling back to this
+// registry.
+var a2uiMCPProvenance = csync.NewMap[string, string]()
+
+// registerA2UISurfaceProvenance records that surfaceID came from mcpName.
+// An empty surfaceID or mcpName is not registered.
+func registerA2UISurfaceProvenance(surfaceID, mcpName string) {
+	if surfaceID == "" || mcpName == "" {
+		return
+	}
+	a2uiMCPProvenance.Set(surfaceID, mcpName)
+}
+
+// A2UISurfaceProvenance returns the MCP server that served surfaceID, and
+// whether the surface is MCP-owned at all.
+func A2UISurfaceProvenance(surfaceID string) (string, bool) {
+	return a2uiMCPProvenance.Get(surfaceID)
+}

--- a/internal/ui/chat/a2ui_test.go
+++ b/internal/ui/chat/a2ui_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
+	"time"
 
 	tea "charm.land/bubbletea/v2"
 	"github.com/charmbracelet/crush/internal/message"
@@ -769,6 +770,30 @@ func TestA2UISurfaceModelStableAcrossRenders(t *testing.T) {
 		"re-renders must reuse the live model — rebuilding would drop interaction state")
 }
 
+// TestA2UIClearCacheDropsSurfacesForRestyle pins the theme-swap path: a
+// style change reaches items as clearCache (applyTheme → refreshStyles →
+// InvalidateRenderCaches → ClearItemCaches), and the surface models baked
+// the old theme's render.Styles in at build time. clearCache must drop them
+// so the next render rebuilds the surfaces with the current theme instead
+// of drawing the previous palette next to newly-themed chat.
+func TestA2UIClearCacheDropsSurfacesForRestyle(t *testing.T) {
+	t.Parallel()
+
+	item := newA2UIFormItem(t)
+	_ = item.RawRender(80)
+	require.True(t, item.hasLiveA2UISurfaces())
+	first := firstLiveA2UISurface(t, item)
+
+	item.clearCache()
+	require.False(t, item.hasLiveA2UISurfaces(),
+		"a style change must drop surface models carrying baked-in styles")
+
+	_ = item.RawRender(80)
+	require.True(t, item.hasLiveA2UISurfaces(), "the next render must rebuild the surfaces")
+	require.NotSame(t, first, firstLiveA2UISurface(t, item),
+		"the rebuilt surface must be a fresh model, not the stale-styled one")
+}
+
 func TestA2UIContentCacheBypassedForLiveSurfaces(t *testing.T) {
 	t.Parallel()
 
@@ -939,4 +964,129 @@ func TestRetireA2UISurfaceUnknownID(t *testing.T) {
 	// The live surface is untouched: it can still be focused.
 	item.SetFocused(true)
 	require.GreaterOrEqual(t, item.focusedA2UISurfaceIndex(), 0)
+}
+
+// --- Single-border + width regression ---
+//
+// A Card surface renders inside exactly one box: a2tea's own CardBorder,
+// themed via render.WithStyles. Crush no longer wraps the surface in an
+// A2UISurface frame. The box must fill exactly `width` with no dangling
+// border fragments.
+
+// TestA2UISurfaceSingleBorder asserts exactly one box is drawn: one top
+// border line and one bottom border line, no nested inner border.
+func TestA2UISurfaceSingleBorder(t *testing.T) {
+	t.Parallel()
+
+	sty := styles.CharmtonePantera()
+	item := &AssistantMessageItem{sty: &sty}
+
+	plain := ansi.Strip(item.renderContentWithA2UI(a2uiSurface, 80, true))
+
+	top := strings.Count(plain, "╭")
+	bottom := strings.Count(plain, "╰")
+	require.Equal(t, 1, top, "expected exactly one top border (single box), got %d\n%s", top, plain)
+	require.Equal(t, 1, bottom, "expected exactly one bottom border (single box), got %d\n%s", bottom, plain)
+}
+
+// TestA2UISurfaceFillsWidth asserts the rendered box spans the full content
+// width — no line narrower than the box and, critically, no dangling border
+// fragment wrapped onto its own line (the double-border overflow symptom).
+func TestA2UISurfaceFillsWidth(t *testing.T) {
+	t.Parallel()
+
+	sty := styles.CharmtonePantera()
+	item := &AssistantMessageItem{sty: &sty}
+
+	for _, width := range []int{80, 60, 41} {
+		plain := ansi.Strip(item.renderContentWithA2UI(a2uiSurface, width, true))
+		lines := strings.Split(plain, "\n")
+
+		var maxW int
+		for _, ln := range lines {
+			if w := ansi.StringWidth(ln); w > maxW {
+				maxW = w
+			}
+		}
+		require.Equal(t, width, maxW, "width=%d: box must fill the full content width\n%s", width, plain)
+
+		// No line may be a lone border fragment (a right border that wrapped
+		// onto its own line), the visible sign of the double-border overflow.
+		for _, ln := range lines {
+			trimmed := strings.TrimSpace(ln)
+			require.NotEqual(t, "╮", trimmed, "width=%d: dangling top-right border fragment\n%s", width, plain)
+			require.NotEqual(t, "╯", trimmed, "width=%d: dangling bottom-right border fragment\n%s", width, plain)
+			require.NotEqual(t, "─╮", trimmed, "width=%d: wrapped border fragment\n%s", width, plain)
+			require.NotEqual(t, "─╯", trimmed, "width=%d: wrapped border fragment\n%s", width, plain)
+		}
+	}
+}
+
+// --- Streaming loading indicator ---
+
+// TestA2UIStreamingLoadingPlaceholder asserts that an unclosed <a2ui-json>
+// tag during streaming renders a magical "Rendering UI…" placeholder instead
+// of raw partial JSON.
+func TestA2UIStreamingLoadingPlaceholder(t *testing.T) {
+	t.Parallel()
+
+	sty := styles.CharmtonePantera()
+	item := &AssistantMessageItem{sty: &sty}
+
+	// Simulate streaming: prose followed by an unclosed <a2ui-json> tag.
+	content := "Here is the trace:\n\n<a2ui-json>{\"version\":\"v0.9\",\"updateComponents\":{\"surfaceId\":\"s\",\"components\":["
+
+	out := ansi.Strip(item.renderContentWithA2UI(content, 80, false))
+
+	require.Contains(t, out, "Here is the trace:", "prose before the unclosed tag should render")
+	require.Contains(t, out, "✨", "loading placeholder should contain the sparkle")
+	require.Contains(t, out, "Rendering UI", "loading placeholder should contain the label")
+	require.NotContains(t, out, `"version"`, "raw partial JSON should not leak into the render")
+	require.NotContains(t, out, `"updateComponents"`, "raw partial JSON should not leak into the render")
+	require.NotContains(t, out, `"surfaceId"`, "raw partial JSON should not leak into the render")
+}
+
+// TestA2UIStreamingLoadingPlaceholderComplete asserts that a complete
+// <a2ui-json> block during streaming renders the surface normally (no
+// loading placeholder).
+func TestA2UIStreamingLoadingPlaceholderComplete(t *testing.T) {
+	t.Parallel()
+
+	sty := styles.CharmtonePantera()
+	item := &AssistantMessageItem{sty: &sty}
+
+	content := "Here you go:\n\n" + a2uiSurface
+
+	out := ansi.Strip(item.renderContentWithA2UI(content, 80, false))
+
+	require.Contains(t, out, "Hello from A2UI", "complete surface should render its content")
+	require.NotContains(t, out, "Rendering UI", "complete surface should not show loading placeholder")
+}
+
+// Regression: a markdown-looking body Text rendered at the surface's
+// un-narrowed width re-enters the shared glamour renderer through the
+// a2uiThemeStyles MarkdownRenderer hook. renderContentWithA2UI used to hold
+// that renderer's lock across model.View(), so the hook's Lock() on the same
+// non-reentrant mutex froze the UI goroutine permanently.
+func TestRenderContentWithA2UIMarkdownBodyNoDeadlock(t *testing.T) {
+	t.Parallel()
+
+	sty := styles.CharmtonePantera()
+	item := &AssistantMessageItem{sty: &sty}
+	// Root-level Text (no Card): a2tea passes the full host width to the
+	// markdown hook, matching the outer renderer's width bucket.
+	content := `<a2ui-json>{"version":"v0.9","updateComponents":{"surfaceId":"s","components":[` +
+		`{"component":"Text","id":"t","text":"This is **bold** markdown"}` +
+		`]}}</a2ui-json>`
+
+	done := make(chan string, 1)
+	go func() {
+		done <- item.renderContentWithA2UI(content, 80, true)
+	}()
+	select {
+	case out := <-done:
+		require.Contains(t, ansi.Strip(out), "bold")
+	case <-time.After(15 * time.Second):
+		t.Fatal("renderContentWithA2UI deadlocked rendering a markdown body Text")
+	}
 }

--- a/internal/ui/chat/a2ui_test.go
+++ b/internal/ui/chat/a2ui_test.go
@@ -941,15 +941,12 @@ func TestRetireA2UISurfaceUnknownID(t *testing.T) {
 	require.GreaterOrEqual(t, item.focusedA2UISurfaceIndex(), 0)
 }
 
-// --- Double-bounded + width regression ---
+// --- Single-border + width regression ---
 //
-// A Card surface used to render inside two nested boxes: a2tea's own
-// CardBorder, then crush's A2UISurface frame around that. The inner border
-// wrapped and dangled its right edge, and the whole thing rendered two cells
-// short of the available width. The fix renders the a2tea model in compact
-// mode (no inner border) so crush's single frame is the only box, and sizes
-// the model to the frame's true content width so the box fills exactly
-// `width`.
+// A Card surface renders inside exactly one box: a2tea's own CardBorder,
+// themed via render.WithStyles. Crush no longer wraps the surface in an
+// A2UISurface frame. The box must fill exactly `width` with no dangling
+// border fragments.
 
 // TestA2UISurfaceSingleBorder asserts exactly one box is drawn: one top
 // border line and one bottom border line, no nested inner border.
@@ -998,4 +995,45 @@ func TestA2UISurfaceFillsWidth(t *testing.T) {
 			require.NotEqual(t, "─╯", trimmed, "width=%d: wrapped border fragment\n%s", width, plain)
 		}
 	}
+}
+
+// --- Streaming loading indicator ---
+
+// TestA2UIStreamingLoadingPlaceholder asserts that an unclosed <a2ui-json>
+// tag during streaming renders a magical "Rendering UI…" placeholder instead
+// of raw partial JSON.
+func TestA2UIStreamingLoadingPlaceholder(t *testing.T) {
+	t.Parallel()
+
+	sty := styles.CharmtonePantera()
+	item := &AssistantMessageItem{sty: &sty}
+
+	// Simulate streaming: prose followed by an unclosed <a2ui-json> tag.
+	content := "Here is the trace:\n\n<a2ui-json>{\"version\":\"v0.9\",\"updateComponents\":{\"surfaceId\":\"s\",\"components\":["
+
+	out := ansi.Strip(item.renderContentWithA2UI(content, 80, false))
+
+	require.Contains(t, out, "Here is the trace:", "prose before the unclosed tag should render")
+	require.Contains(t, out, "✨", "loading placeholder should contain the sparkle")
+	require.Contains(t, out, "Rendering UI", "loading placeholder should contain the label")
+	require.NotContains(t, out, `"version"`, "raw partial JSON should not leak into the render")
+	require.NotContains(t, out, `"updateComponents"`, "raw partial JSON should not leak into the render")
+	require.NotContains(t, out, `"surfaceId"`, "raw partial JSON should not leak into the render")
+}
+
+// TestA2UIStreamingLoadingPlaceholderComplete asserts that a complete
+// <a2ui-json> block during streaming renders the surface normally (no
+// loading placeholder).
+func TestA2UIStreamingLoadingPlaceholderComplete(t *testing.T) {
+	t.Parallel()
+
+	sty := styles.CharmtonePantera()
+	item := &AssistantMessageItem{sty: &sty}
+
+	content := "Here you go:\n\n" + a2uiSurface
+
+	out := ansi.Strip(item.renderContentWithA2UI(content, 80, false))
+
+	require.Contains(t, out, "Hello from A2UI", "complete surface should render its content")
+	require.NotContains(t, out, "Rendering UI", "complete surface should not show loading placeholder")
 }

--- a/internal/ui/chat/a2ui_test.go
+++ b/internal/ui/chat/a2ui_test.go
@@ -769,6 +769,30 @@ func TestA2UISurfaceModelStableAcrossRenders(t *testing.T) {
 		"re-renders must reuse the live model — rebuilding would drop interaction state")
 }
 
+// TestA2UIClearCacheDropsSurfacesForRestyle pins the theme-swap path: a
+// style change reaches items as clearCache (applyTheme → refreshStyles →
+// InvalidateRenderCaches → ClearItemCaches), and the surface models baked
+// the old theme's render.Styles in at build time. clearCache must drop them
+// so the next render rebuilds the surfaces with the current theme instead
+// of drawing the previous palette next to newly-themed chat.
+func TestA2UIClearCacheDropsSurfacesForRestyle(t *testing.T) {
+	t.Parallel()
+
+	item := newA2UIFormItem(t)
+	_ = item.RawRender(80)
+	require.True(t, item.hasLiveA2UISurfaces())
+	first := firstLiveA2UISurface(t, item)
+
+	item.clearCache()
+	require.False(t, item.hasLiveA2UISurfaces(),
+		"a style change must drop surface models carrying baked-in styles")
+
+	_ = item.RawRender(80)
+	require.True(t, item.hasLiveA2UISurfaces(), "the next render must rebuild the surfaces")
+	require.NotSame(t, first, firstLiveA2UISurface(t, item),
+		"the rebuilt surface must be a fresh model, not the stale-styled one")
+}
+
 func TestA2UIContentCacheBypassedForLiveSurfaces(t *testing.T) {
 	t.Parallel()
 

--- a/internal/ui/chat/a2ui_test.go
+++ b/internal/ui/chat/a2ui_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
+	"time"
 
 	tea "charm.land/bubbletea/v2"
 	"github.com/charmbracelet/crush/internal/message"
@@ -1060,4 +1061,32 @@ func TestA2UIStreamingLoadingPlaceholderComplete(t *testing.T) {
 
 	require.Contains(t, out, "Hello from A2UI", "complete surface should render its content")
 	require.NotContains(t, out, "Rendering UI", "complete surface should not show loading placeholder")
+}
+
+// Regression: a markdown-looking body Text rendered at the surface's
+// un-narrowed width re-enters the shared glamour renderer through the
+// a2uiThemeStyles MarkdownRenderer hook. renderContentWithA2UI used to hold
+// that renderer's lock across model.View(), so the hook's Lock() on the same
+// non-reentrant mutex froze the UI goroutine permanently.
+func TestRenderContentWithA2UIMarkdownBodyNoDeadlock(t *testing.T) {
+	t.Parallel()
+
+	sty := styles.CharmtonePantera()
+	item := &AssistantMessageItem{sty: &sty}
+	// Root-level Text (no Card): a2tea passes the full host width to the
+	// markdown hook, matching the outer renderer's width bucket.
+	content := `<a2ui-json>{"version":"v0.9","updateComponents":{"surfaceId":"s","components":[` +
+		`{"component":"Text","id":"t","text":"This is **bold** markdown"}` +
+		`]}}</a2ui-json>`
+
+	done := make(chan string, 1)
+	go func() {
+		done <- item.renderContentWithA2UI(content, 80, true)
+	}()
+	select {
+	case out := <-done:
+		require.Contains(t, ansi.Strip(out), "bold")
+	case <-time.After(15 * time.Second):
+		t.Fatal("renderContentWithA2UI deadlocked rendering a markdown body Text")
+	}
 }

--- a/internal/ui/chat/a2ui_test.go
+++ b/internal/ui/chat/a2ui_test.go
@@ -940,3 +940,62 @@ func TestRetireA2UISurfaceUnknownID(t *testing.T) {
 	item.SetFocused(true)
 	require.GreaterOrEqual(t, item.focusedA2UISurfaceIndex(), 0)
 }
+
+// --- Double-bounded + width regression ---
+//
+// A Card surface used to render inside two nested boxes: a2tea's own
+// CardBorder, then crush's A2UISurface frame around that. The inner border
+// wrapped and dangled its right edge, and the whole thing rendered two cells
+// short of the available width. The fix renders the a2tea model in compact
+// mode (no inner border) so crush's single frame is the only box, and sizes
+// the model to the frame's true content width so the box fills exactly
+// `width`.
+
+// TestA2UISurfaceSingleBorder asserts exactly one box is drawn: one top
+// border line and one bottom border line, no nested inner border.
+func TestA2UISurfaceSingleBorder(t *testing.T) {
+	t.Parallel()
+
+	sty := styles.CharmtonePantera()
+	item := &AssistantMessageItem{sty: &sty}
+
+	plain := ansi.Strip(item.renderContentWithA2UI(a2uiSurface, 80, true))
+
+	top := strings.Count(plain, "╭")
+	bottom := strings.Count(plain, "╰")
+	require.Equal(t, 1, top, "expected exactly one top border (single box), got %d\n%s", top, plain)
+	require.Equal(t, 1, bottom, "expected exactly one bottom border (single box), got %d\n%s", bottom, plain)
+}
+
+// TestA2UISurfaceFillsWidth asserts the rendered box spans the full content
+// width — no line narrower than the box and, critically, no dangling border
+// fragment wrapped onto its own line (the double-border overflow symptom).
+func TestA2UISurfaceFillsWidth(t *testing.T) {
+	t.Parallel()
+
+	sty := styles.CharmtonePantera()
+	item := &AssistantMessageItem{sty: &sty}
+
+	for _, width := range []int{80, 60, 41} {
+		plain := ansi.Strip(item.renderContentWithA2UI(a2uiSurface, width, true))
+		lines := strings.Split(plain, "\n")
+
+		var maxW int
+		for _, ln := range lines {
+			if w := ansi.StringWidth(ln); w > maxW {
+				maxW = w
+			}
+		}
+		require.Equal(t, width, maxW, "width=%d: box must fill the full content width\n%s", width, plain)
+
+		// No line may be a lone border fragment (a right border that wrapped
+		// onto its own line), the visible sign of the double-border overflow.
+		for _, ln := range lines {
+			trimmed := strings.TrimSpace(ln)
+			require.NotEqual(t, "╮", trimmed, "width=%d: dangling top-right border fragment\n%s", width, plain)
+			require.NotEqual(t, "╯", trimmed, "width=%d: dangling bottom-right border fragment\n%s", width, plain)
+			require.NotEqual(t, "─╮", trimmed, "width=%d: wrapped border fragment\n%s", width, plain)
+			require.NotEqual(t, "─╯", trimmed, "width=%d: wrapped border fragment\n%s", width, plain)
+		}
+	}
+}

--- a/internal/ui/chat/a2ui_width.go
+++ b/internal/ui/chat/a2ui_width.go
@@ -1,0 +1,25 @@
+package chat
+
+// a2uiCardChromeWidth is the border+padding chrome a2tea's Card renderer
+// subtracts from its budget (a2tea render/card.go: w := s.width - 4).
+const a2uiCardChromeWidth = 4
+
+// ToolA2UISurfaceWidth returns the interior width, in cells, of a generic
+// tool result's A2UI surface card for a chat viewport of the given width —
+// the number servers pre-rendering bar geometry should size rows to (the
+// ?w= hint read_mcp_resource sends).
+//
+// It mirrors the actual render chain rather than hand-summed constants:
+// the message list reserves one cell for its scrollbar, the tool item and
+// RenderTool each apply cappedMessageWidth, the body is indented by
+// toolBodyLeftPaddingTotal, and a2tea's card chrome takes the rest. Keeping
+// the computation here, next to the constants it depends on, is what stops
+// the hint drifting from the real card interior when the layout changes.
+//
+// Returns 0 (no hint) when the viewport is too small for a meaningful
+// width.
+func ToolA2UISurfaceWidth(chatWidth int) int {
+	listWidth := chatWidth - 1 // scrollbar reservation in model/chat.go SetSize
+	interior := cappedMessageWidth(cappedMessageWidth(listWidth)) - toolBodyLeftPaddingTotal - a2uiCardChromeWidth
+	return max(0, interior)
+}

--- a/internal/ui/chat/a2ui_width_test.go
+++ b/internal/ui/chat/a2ui_width_test.go
@@ -1,0 +1,22 @@
+package chat
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestToolA2UISurfaceWidth(t *testing.T) {
+	t.Parallel()
+
+	// Mirror of the real chain: listWidth = chatWidth-1 (scrollbar), two
+	// cappedMessageWidth passes (-2 each, 120/118 caps), tool body indent
+	// (-2), a2tea card chrome (-4).
+	require.Equal(t, 89, ToolA2UISurfaceWidth(100))
+	// Wide viewports saturate at maxTextWidth: min(...,120)-2-2-4 = 112.
+	require.Equal(t, 112, ToolA2UISurfaceWidth(140))
+	require.Equal(t, 112, ToolA2UISurfaceWidth(500))
+	// Degenerate viewports must yield 0 (no hint), never negative.
+	require.Equal(t, 0, ToolA2UISurfaceWidth(0))
+	require.Equal(t, 0, ToolA2UISurfaceWidth(8))
+}

--- a/internal/ui/chat/assistant.go
+++ b/internal/ui/chat/assistant.go
@@ -710,6 +710,15 @@ func (a *AssistantMessageItem) clearCache() {
 	a.errorSec.reset()
 	a.streamingContent.Reset()
 	a.streamingThinking.Reset()
+	// A2UI surface models bake the theme's render.Styles in at build time
+	// (a2uiThemeStyles), so after a theme swap a kept model would draw the
+	// old palette next to newly-themed chat. Drop them and let the next
+	// render rebuild from the message with the current theme; retirement
+	// marks are keyed by surface ID and survive the rebuild. The cost is
+	// losing in-progress field values on an explicit theme change —
+	// clearCache is only reached via ClearItemCaches (style change) — until
+	// a2tea grows a restyle-in-place.
+	a.dropA2UISurfaces()
 }
 
 // ToggleExpanded advances the F5 thinking view-mode cycle and returns

--- a/internal/ui/chat/generic.go
+++ b/internal/ui/chat/generic.go
@@ -81,7 +81,7 @@ func (g *GenericToolRenderContext) RenderTool(sty *styles.Styles, width int, opt
 	// embedded one), render it instead of raw text. The payload arrives via
 	// response metadata — the model only sees a placeholder, so it cannot
 	// echo the JSON back and double-render the surface. Live surface models
-	// (#219) render interactively; without them (older persisted results)
+	// render interactively; without them (older persisted results)
 	// fall back to the static snapshot. This is what makes
 	// cairn://artifact/{id}/a2ui and similar resource reads render inline.
 	if opts.Result.Metadata != "" {
@@ -108,7 +108,7 @@ func (g *GenericToolRenderContext) RenderTool(sty *styles.Styles, width int, opt
 
 // renderToolA2UIResultBody renders the metadata-delivered surfaces plus any
 // real text content the resource returned alongside them. When the item
-// carries live surface models (opts.LiveSurfaces, #219) they render
+// carries live surface models (opts.LiveSurfaces) they render
 // interactively; otherwise each surface falls back to a static snapshot.
 // When every surface fails to render, an alert replaces the body — the
 // model-facing placeholder claims the user can already see the surface,

--- a/internal/ui/chat/generic.go
+++ b/internal/ui/chat/generic.go
@@ -77,10 +77,12 @@ func (g *GenericToolRenderContext) RenderTool(sty *styles.Styles, width int, opt
 	widths := toolResultContentWidths{Body: bodyWidth, Diff: cappedWidth}
 
 	// If the tool result carries an A2UI surface (a read_mcp_resource that
-	// returned application/a2ui+json), render it as a surface snapshot
-	// instead of raw text. The payload arrives via response metadata — the
-	// model only sees a placeholder, so it cannot echo the JSON back and
-	// double-render the surface. This is what makes
+	// returned application/a2ui+json, or an mcp_* tool whose result
+	// embedded one), render it instead of raw text. The payload arrives via
+	// response metadata — the model only sees a placeholder, so it cannot
+	// echo the JSON back and double-render the surface. Live surface models
+	// (#219) render interactively; without them (older persisted results)
+	// fall back to the static snapshot. This is what makes
 	// cairn://artifact/{id}/a2ui and similar resource reads render inline.
 	if opts.Result.Metadata != "" {
 		var meta tools.ReadMCPResourceResponseMetadata
@@ -105,37 +107,53 @@ func (g *GenericToolRenderContext) RenderTool(sty *styles.Styles, width int, opt
 }
 
 // renderToolA2UIResultBody renders the metadata-delivered surfaces plus any
-// real text content the resource returned alongside them. When every surface
-// fails to render, an alert replaces the body — the model-facing placeholder
-// claims the user can already see the surface, which would be false here.
+// real text content the resource returned alongside them. When the item
+// carries live surface models (opts.LiveSurfaces, #219) they render
+// interactively; otherwise each surface falls back to a static snapshot.
+// When every surface fails to render, an alert replaces the body — the
+// model-facing placeholder claims the user can already see the surface,
+// which would be false here.
 func renderToolA2UIResultBody(sty *styles.Styles, surfaces []string, opts *ToolRenderOpts, widths toolResultContentWidths) string {
 	var b strings.Builder
-	failed := 0
-	for _, surf := range surfaces {
-		rendered, err := renderToolA2UI(sty, surf, widths.Body)
-		if err != nil || rendered == "" {
-			failed++
-			continue
+	if opts.LiveSurfaces != nil {
+		b.WriteString(opts.LiveSurfaces(widths.Body))
+	} else {
+		failed := 0
+		for _, surf := range surfaces {
+			rendered, err := renderToolA2UI(sty, surf, widths.Body)
+			if err != nil || rendered == "" {
+				failed++
+				continue
+			}
+			if b.Len() > 0 {
+				b.WriteString("\n")
+			}
+			b.WriteString(rendered)
 		}
+
+		var chunks []string
 		if b.Len() > 0 {
-			b.WriteString("\n")
+			chunks = append(chunks, sty.Tool.Body.Render(clampToolA2UI(sty, b.String(), widths.Body, opts.ExpandedContent)))
 		}
-		b.WriteString(rendered)
+		// Alert on ANY failed surface, not only when all fail: a sibling
+		// surface rendering fine must not hide that another one vanished —
+		// the model was told the user can see every one of them.
+		if failed > 0 {
+			chunks = append(chunks, sty.Tool.Body.Render(renderToolA2UIAlert(sty, widths.Body)))
+		}
+		// Show any real text the resource returned alongside its surfaces — the
+		// model-facing placeholder lines are stripped, the rest belongs to the
+		// user just as much as the surfaces do.
+		if text := stripA2UIPlaceholders(opts.Result.Content); text != "" {
+			chunks = append(chunks, renderToolResultTextContent(sty, text, widths, opts.ExpandedContent))
+		}
+		return strings.Join(chunks, "\n")
 	}
 
 	var chunks []string
 	if b.Len() > 0 {
 		chunks = append(chunks, sty.Tool.Body.Render(clampToolA2UI(sty, b.String(), widths.Body, opts.ExpandedContent)))
 	}
-	// Alert on ANY failed surface, not only when all fail: a sibling
-	// surface rendering fine must not hide that another one vanished —
-	// the model was told the user can see every one of them.
-	if failed > 0 {
-		chunks = append(chunks, sty.Tool.Body.Render(renderToolA2UIAlert(sty, widths.Body)))
-	}
-	// Show any real text the resource returned alongside its surfaces — the
-	// model-facing placeholder lines are stripped, the rest belongs to the
-	// user just as much as the surfaces do.
 	if text := stripA2UIPlaceholders(opts.Result.Content); text != "" {
 		chunks = append(chunks, renderToolResultTextContent(sty, text, widths, opts.ExpandedContent))
 	}

--- a/internal/ui/chat/generic.go
+++ b/internal/ui/chat/generic.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"strings"
 
+	"github.com/charmbracelet/crush/internal/agent/tools"
 	"github.com/charmbracelet/crush/internal/message"
 	"github.com/charmbracelet/crush/internal/ui/styles"
 	"github.com/joestump-agent/a2tea"
@@ -70,10 +71,29 @@ func (g *GenericToolRenderContext) RenderTool(sty *styles.Styles, width int, opt
 		return joinToolParts(header, body)
 	}
 
-	// If the tool result contains an A2UI surface (e.g. a read_mcp_resource
-	// that returned application/a2ui+json), render it as a live surface
-	// instead of raw text. This is what makes cairn://artifact/{id}/a2ui
-	// and similar resource reads render inline — no JSON barf.
+	// If the tool result carries an A2UI surface (a read_mcp_resource that
+	// returned application/a2ui+json), render it as a live surface instead
+	// of raw text. The payload arrives via response metadata — the model
+	// only sees a placeholder, so it cannot echo the JSON back and
+	// double-render the surface. This is what makes
+	// cairn://artifact/{id}/a2ui and similar resource reads render inline.
+	if opts.Result.Metadata != "" {
+		var meta tools.ReadMCPResourceResponseMetadata
+		if err := json.Unmarshal([]byte(opts.Result.Metadata), &meta); err == nil && len(meta.A2UISurfaces) > 0 {
+			var b strings.Builder
+			for _, surf := range meta.A2UISurfaces {
+				rendered, err := renderToolA2UI(sty, surf, bodyWidth)
+				if err != nil || rendered == "" {
+					continue
+				}
+				b.WriteString(rendered)
+				b.WriteString("\n")
+			}
+			if s := strings.TrimRight(b.String(), "\n"); s != "" {
+				return joinToolParts(header, s)
+			}
+		}
+	}
 	if a2tea.Contains(opts.Result.Content) {
 		surf, err := renderToolA2UI(sty, opts.Result.Content, bodyWidth)
 		if err == nil && surf != "" {

--- a/internal/ui/chat/generic.go
+++ b/internal/ui/chat/generic.go
@@ -2,6 +2,7 @@ package chat
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
 
 	"github.com/charmbracelet/crush/internal/agent/tools"
@@ -67,42 +68,111 @@ func (g *GenericToolRenderContext) RenderTool(sty *styles.Styles, width int, opt
 	bodyWidth := cappedWidth - toolBodyLeftPaddingTotal
 
 	if opts.Result.Data != "" && strings.HasPrefix(opts.Result.MIMEType, "image/") {
-		body := sty.Tool.Body.Render(toolOutputImageContent(sty, opts.Result.Data, opts.Result.MIMEType))
-		return joinToolParts(header, body)
+		// toolOutputImageContent applies sty.Tool.Body itself — wrapping it
+		// again here double-indented image results.
+		return joinToolParts(header, toolOutputImageContent(sty, opts.Result.Data, opts.Result.MIMEType))
 	}
 
+	widths := toolResultContentWidths{Body: bodyWidth, Diff: cappedWidth}
+
 	// If the tool result carries an A2UI surface (a read_mcp_resource that
-	// returned application/a2ui+json), render it as a live surface instead
-	// of raw text. The payload arrives via response metadata — the model
-	// only sees a placeholder, so it cannot echo the JSON back and
+	// returned application/a2ui+json), render it as a surface snapshot
+	// instead of raw text. The payload arrives via response metadata — the
+	// model only sees a placeholder, so it cannot echo the JSON back and
 	// double-render the surface. This is what makes
 	// cairn://artifact/{id}/a2ui and similar resource reads render inline.
 	if opts.Result.Metadata != "" {
 		var meta tools.ReadMCPResourceResponseMetadata
 		if err := json.Unmarshal([]byte(opts.Result.Metadata), &meta); err == nil && len(meta.A2UISurfaces) > 0 {
-			var b strings.Builder
-			for _, surf := range meta.A2UISurfaces {
-				rendered, err := renderToolA2UI(sty, surf, bodyWidth)
-				if err != nil || rendered == "" {
-					continue
-				}
-				b.WriteString(rendered)
-				b.WriteString("\n")
-			}
-			if s := strings.TrimRight(b.String(), "\n"); s != "" {
-				return joinToolParts(header, s)
-			}
+			return joinToolParts(header, renderToolA2UIResultBody(sty, meta.A2UISurfaces, opts, widths))
 		}
 	}
-	if a2tea.Contains(opts.Result.Content) {
+	// Pre-change read_mcp_resource results persisted the raw payload in the
+	// content itself — scan for it so old sessions still render as surfaces.
+	// Scoped to this tool (crush_logs and friends share this renderer and
+	// must keep payload-shaped text as text), and gated on contentHasA2UI so
+	// A2UI examples inside markdown code stay code (#6, #96).
+	if opts.ToolCall.Name == tools.ReadMCPResourceToolName && contentHasA2UI(opts.Result.Content) {
 		surf, err := renderToolA2UI(sty, opts.Result.Content, bodyWidth)
 		if err == nil && surf != "" {
-			return joinToolParts(header, surf)
+			return joinToolParts(header, sty.Tool.Body.Render(clampToolA2UI(sty, surf, bodyWidth, opts.ExpandedContent)))
 		}
 	}
 
-	body := renderToolResultTextContent(sty, opts.Result.Content, toolResultContentWidths{Body: bodyWidth, Diff: cappedWidth}, opts.ExpandedContent)
+	body := renderToolResultTextContent(sty, opts.Result.Content, widths, opts.ExpandedContent)
 	return joinToolParts(header, body)
+}
+
+// renderToolA2UIResultBody renders the metadata-delivered surfaces plus any
+// real text content the resource returned alongside them. When every surface
+// fails to render, an alert replaces the body — the model-facing placeholder
+// claims the user can already see the surface, which would be false here.
+func renderToolA2UIResultBody(sty *styles.Styles, surfaces []string, opts *ToolRenderOpts, widths toolResultContentWidths) string {
+	var b strings.Builder
+	for _, surf := range surfaces {
+		rendered, err := renderToolA2UI(sty, surf, widths.Body)
+		if err != nil || rendered == "" {
+			continue
+		}
+		if b.Len() > 0 {
+			b.WriteString("\n")
+		}
+		b.WriteString(rendered)
+	}
+
+	var chunks []string
+	if b.Len() > 0 {
+		chunks = append(chunks, sty.Tool.Body.Render(clampToolA2UI(sty, b.String(), widths.Body, opts.ExpandedContent)))
+	} else {
+		chunks = append(chunks, sty.Tool.Body.Render(renderToolA2UIAlert(sty, widths.Body)))
+	}
+	// Show any real text the resource returned alongside its surfaces — the
+	// model-facing placeholder lines are stripped, the rest belongs to the
+	// user just as much as the surfaces do.
+	if text := stripA2UIPlaceholders(opts.Result.Content); text != "" {
+		chunks = append(chunks, renderToolResultTextContent(sty, text, widths, opts.ExpandedContent))
+	}
+	return strings.Join(chunks, "\n")
+}
+
+// stripA2UIPlaceholders removes the model-facing surface placeholder lines
+// from tool content, leaving only text the user should see.
+func stripA2UIPlaceholders(content string) string {
+	var out []string
+	for _, ln := range strings.Split(content, "\n") {
+		if strings.HasPrefix(strings.TrimSpace(ln), tools.A2UISurfacePlaceholderPrefix) {
+			continue
+		}
+		out = append(out, ln)
+	}
+	return strings.TrimSpace(strings.Join(out, "\n"))
+}
+
+// clampToolA2UI applies the collapsed-height budget every other tool body
+// gets from responseContextHeight. The surface is pre-rendered ANSI, so the
+// clamp slices whole lines and appends the standard truncation footer;
+// expanding the tool result restores the full surface.
+func clampToolA2UI(sty *styles.Styles, body string, width int, expanded bool) string {
+	lines := strings.Split(body, "\n")
+	if expanded || len(lines) <= responseContextHeight {
+		return body
+	}
+	out := append([]string{}, lines[:responseContextHeight]...)
+	out = append(out, sty.Tool.ContentTruncation.
+		Width(width).
+		Render(fmt.Sprintf(assistantMessageTruncateFormat, len(lines)-responseContextHeight)))
+	return strings.Join(out, "\n")
+}
+
+// renderToolA2UIAlert mirrors the assistant path's renderA2UIAlert for tool
+// results: the resource advertised A2UI but a2tea could not draw a surface.
+func renderToolA2UIAlert(sty *styles.Styles, width int) string {
+	inner := max(width-2, 1)
+	tag := sty.Messages.ErrorTag.Render("A2UI")
+	title := sty.Messages.ErrorTitle.Render("couldn't render this resource's UI surface")
+	reason := sty.Messages.ErrorDetails.Width(inner).Render(
+		"The A2UI content was malformed or used unsupported components.")
+	return tag + " " + title + "\n\n" + reason
 }
 
 // renderToolA2UI renders a static (non-interactive) A2UI surface from tool
@@ -117,6 +187,13 @@ func renderToolA2UI(sty *styles.Styles, content string, width int) (string, erro
 	var b strings.Builder
 	themedStyles := a2uiThemeStyles(sty)
 	for _, p := range parts {
+		// Keep each part's prose: pre-change persisted results interleave
+		// text with surfaces, and dropping it would lose content the model
+		// (and user) saw.
+		if text := strings.TrimSpace(p.Text); text != "" {
+			b.WriteString(text)
+			b.WriteString("\n")
+		}
 		if len(p.Messages) == 0 {
 			continue
 		}

--- a/internal/ui/chat/generic.go
+++ b/internal/ui/chat/generic.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"charm.land/lipgloss/v2"
 	"github.com/charmbracelet/crush/internal/agent/tools"
 	"github.com/charmbracelet/crush/internal/message"
 	"github.com/charmbracelet/crush/internal/ui/styles"
@@ -109,9 +110,11 @@ func (g *GenericToolRenderContext) RenderTool(sty *styles.Styles, width int, opt
 // claims the user can already see the surface, which would be false here.
 func renderToolA2UIResultBody(sty *styles.Styles, surfaces []string, opts *ToolRenderOpts, widths toolResultContentWidths) string {
 	var b strings.Builder
+	failed := 0
 	for _, surf := range surfaces {
 		rendered, err := renderToolA2UI(sty, surf, widths.Body)
 		if err != nil || rendered == "" {
+			failed++
 			continue
 		}
 		if b.Len() > 0 {
@@ -123,7 +126,11 @@ func renderToolA2UIResultBody(sty *styles.Styles, surfaces []string, opts *ToolR
 	var chunks []string
 	if b.Len() > 0 {
 		chunks = append(chunks, sty.Tool.Body.Render(clampToolA2UI(sty, b.String(), widths.Body, opts.ExpandedContent)))
-	} else {
+	}
+	// Alert on ANY failed surface, not only when all fail: a sibling
+	// surface rendering fine must not hide that another one vanished —
+	// the model was told the user can see every one of them.
+	if failed > 0 {
 		chunks = append(chunks, sty.Tool.Body.Render(renderToolA2UIAlert(sty, widths.Body)))
 	}
 	// Show any real text the resource returned alongside its surfaces — the
@@ -186,12 +193,13 @@ func renderToolA2UI(sty *styles.Styles, content string, width int) (string, erro
 	}
 	var b strings.Builder
 	themedStyles := a2uiThemeStyles(sty)
+	proseStyle := lipgloss.NewStyle().Width(width)
 	for _, p := range parts {
-		// Keep each part's prose: pre-change persisted results interleave
-		// text with surfaces, and dropping it would lose content the model
-		// (and user) saw.
+		// Keep each part's prose, wrapped to the body budget: pre-change
+		// persisted results interleave text with surfaces, and dropping
+		// (or overflowing) it would corrupt content the model saw.
 		if text := strings.TrimSpace(p.Text); text != "" {
-			b.WriteString(text)
+			b.WriteString(proseStyle.Render(text))
 			b.WriteString("\n")
 		}
 		if len(p.Messages) == 0 {

--- a/internal/ui/chat/generic.go
+++ b/internal/ui/chat/generic.go
@@ -115,10 +115,12 @@ func (g *GenericToolRenderContext) RenderTool(sty *styles.Styles, width int, opt
 // which would be false here.
 func renderToolA2UIResultBody(sty *styles.Styles, surfaces []string, opts *ToolRenderOpts, widths toolResultContentWidths) string {
 	var b strings.Builder
+	failed := 0
 	if opts.LiveSurfaces != nil {
-		b.WriteString(opts.LiveSurfaces(widths.Body))
+		rendered, liveFailed := opts.LiveSurfaces(widths.Body)
+		b.WriteString(rendered)
+		failed = liveFailed
 	} else {
-		failed := 0
 		for _, surf := range surfaces {
 			rendered, err := renderToolA2UI(sty, surf, widths.Body)
 			if err != nil || rendered == "" {
@@ -130,30 +132,21 @@ func renderToolA2UIResultBody(sty *styles.Styles, surfaces []string, opts *ToolR
 			}
 			b.WriteString(rendered)
 		}
-
-		var chunks []string
-		if b.Len() > 0 {
-			chunks = append(chunks, sty.Tool.Body.Render(clampToolA2UI(sty, b.String(), widths.Body, opts.ExpandedContent)))
-		}
-		// Alert on ANY failed surface, not only when all fail: a sibling
-		// surface rendering fine must not hide that another one vanished —
-		// the model was told the user can see every one of them.
-		if failed > 0 {
-			chunks = append(chunks, sty.Tool.Body.Render(renderToolA2UIAlert(sty, widths.Body)))
-		}
-		// Show any real text the resource returned alongside its surfaces — the
-		// model-facing placeholder lines are stripped, the rest belongs to the
-		// user just as much as the surfaces do.
-		if text := stripA2UIPlaceholders(opts.Result.Content); text != "" {
-			chunks = append(chunks, renderToolResultTextContent(sty, text, widths, opts.ExpandedContent))
-		}
-		return strings.Join(chunks, "\n")
 	}
 
 	var chunks []string
 	if b.Len() > 0 {
 		chunks = append(chunks, sty.Tool.Body.Render(clampToolA2UI(sty, b.String(), widths.Body, opts.ExpandedContent)))
 	}
+	// Alert on ANY failed surface, not only when all fail: a sibling
+	// surface rendering fine must not hide that another one vanished —
+	// the model was told the user can see every one of them.
+	if failed > 0 {
+		chunks = append(chunks, sty.Tool.Body.Render(renderToolA2UIAlert(sty, widths.Body)))
+	}
+	// Show any real text the resource returned alongside its surfaces — the
+	// model-facing placeholder lines are stripped, the rest belongs to the
+	// user just as much as the surfaces do.
 	if text := stripA2UIPlaceholders(opts.Result.Content); text != "" {
 		chunks = append(chunks, renderToolResultTextContent(sty, text, widths, opts.ExpandedContent))
 	}

--- a/internal/ui/chat/generic.go
+++ b/internal/ui/chat/generic.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/charmbracelet/crush/internal/message"
 	"github.com/charmbracelet/crush/internal/ui/styles"
+	"github.com/joestump-agent/a2tea"
+	"github.com/joestump-agent/a2tea/render"
 )
 
 // GenericToolMessageItem is a message item that represents an unknown tool call.
@@ -68,6 +70,45 @@ func (g *GenericToolRenderContext) RenderTool(sty *styles.Styles, width int, opt
 		return joinToolParts(header, body)
 	}
 
+	// If the tool result contains an A2UI surface (e.g. a read_mcp_resource
+	// that returned application/a2ui+json), render it as a live surface
+	// instead of raw text. This is what makes cairn://artifact/{id}/a2ui
+	// and similar resource reads render inline — no JSON barf.
+	if a2tea.Contains(opts.Result.Content) {
+		surf, err := renderToolA2UI(sty, opts.Result.Content, bodyWidth)
+		if err == nil && surf != "" {
+			return joinToolParts(header, surf)
+		}
+	}
+
 	body := renderToolResultTextContent(sty, opts.Result.Content, toolResultContentWidths{Body: bodyWidth, Diff: cappedWidth}, opts.ExpandedContent)
 	return joinToolParts(header, body)
+}
+
+// renderToolA2UI renders a static (non-interactive) A2UI surface from tool
+// result content. Unlike the live surfaces on AssistantMessageItem, this does
+// not support focus/button interaction — it renders a snapshot of the surface
+// using the same themed styles.
+func renderToolA2UI(sty *styles.Styles, content string, width int) (string, error) {
+	parts, err := a2tea.Scan(content)
+	if err != nil {
+		return "", err
+	}
+	var b strings.Builder
+	themedStyles := a2uiThemeStyles(sty)
+	for _, p := range parts {
+		if len(p.Messages) == 0 {
+			continue
+		}
+		model, err := a2tea.Render(p.Messages, render.WithStyles(themedStyles))
+		if err != nil {
+			continue
+		}
+		if rm, ok := model.(render.Model); ok {
+			rm.SetSize(width, 0)
+			b.WriteString(strings.TrimRight(rm.View().Content, "\n"))
+			b.WriteString("\n")
+		}
+	}
+	return strings.TrimRight(b.String(), "\n"), nil
 }

--- a/internal/ui/chat/generic.go
+++ b/internal/ui/chat/generic.go
@@ -2,10 +2,15 @@ package chat
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
 
+	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/crush/internal/agent/tools"
 	"github.com/charmbracelet/crush/internal/message"
 	"github.com/charmbracelet/crush/internal/ui/styles"
+	"github.com/joestump-agent/a2tea"
+	"github.com/joestump-agent/a2tea/render"
 )
 
 // GenericToolMessageItem is a message item that represents an unknown tool call.
@@ -64,10 +69,162 @@ func (g *GenericToolRenderContext) RenderTool(sty *styles.Styles, width int, opt
 	bodyWidth := cappedWidth - toolBodyLeftPaddingTotal
 
 	if opts.Result.Data != "" && strings.HasPrefix(opts.Result.MIMEType, "image/") {
-		body := sty.Tool.Body.Render(toolOutputImageContent(sty, opts.Result.Data, opts.Result.MIMEType))
-		return joinToolParts(header, body)
+		// toolOutputImageContent applies sty.Tool.Body itself — wrapping it
+		// again here double-indented image results.
+		return joinToolParts(header, toolOutputImageContent(sty, opts.Result.Data, opts.Result.MIMEType))
 	}
 
-	body := renderToolResultTextContent(sty, opts.Result.Content, toolResultContentWidths{Body: bodyWidth, Diff: cappedWidth}, opts.ExpandedContent)
+	widths := toolResultContentWidths{Body: bodyWidth, Diff: cappedWidth}
+
+	// If the tool result carries an A2UI surface (a read_mcp_resource that
+	// returned application/a2ui+json, or an mcp_* tool whose result
+	// embedded one), render it instead of raw text. The payload arrives via
+	// response metadata — the model only sees a placeholder, so it cannot
+	// echo the JSON back and double-render the surface. Live surface models
+	// render interactively; without them (older persisted results)
+	// fall back to the static snapshot. This is what makes
+	// cairn://artifact/{id}/a2ui and similar resource reads render inline.
+	if opts.Result.Metadata != "" {
+		var meta tools.ReadMCPResourceResponseMetadata
+		if err := json.Unmarshal([]byte(opts.Result.Metadata), &meta); err == nil && len(meta.A2UISurfaces) > 0 {
+			return joinToolParts(header, renderToolA2UIResultBody(sty, meta.A2UISurfaces, opts, widths))
+		}
+	}
+	// Pre-change read_mcp_resource results persisted the raw payload in the
+	// content itself — scan for it so old sessions still render as surfaces.
+	// Scoped to this tool (crush_logs and friends share this renderer and
+	// must keep payload-shaped text as text), and gated on contentHasA2UI so
+	// A2UI examples inside markdown code stay code (#6, #96).
+	if opts.ToolCall.Name == tools.ReadMCPResourceToolName && contentHasA2UI(opts.Result.Content) {
+		surf, err := renderToolA2UI(sty, opts.Result.Content, bodyWidth)
+		if err == nil && surf != "" {
+			return joinToolParts(header, sty.Tool.Body.Render(clampToolA2UI(sty, surf, bodyWidth, opts.ExpandedContent)))
+		}
+	}
+
+	body := renderToolResultTextContent(sty, opts.Result.Content, widths, opts.ExpandedContent)
 	return joinToolParts(header, body)
+}
+
+// renderToolA2UIResultBody renders the metadata-delivered surfaces plus any
+// real text content the resource returned alongside them. When the item
+// carries live surface models (opts.LiveSurfaces) they render
+// interactively; otherwise each surface falls back to a static snapshot.
+// When every surface fails to render, an alert replaces the body — the
+// model-facing placeholder claims the user can already see the surface,
+// which would be false here.
+func renderToolA2UIResultBody(sty *styles.Styles, surfaces []string, opts *ToolRenderOpts, widths toolResultContentWidths) string {
+	var b strings.Builder
+	failed := 0
+	if opts.LiveSurfaces != nil {
+		rendered, liveFailed := opts.LiveSurfaces(widths.Body)
+		b.WriteString(rendered)
+		failed = liveFailed
+	} else {
+		for _, surf := range surfaces {
+			rendered, err := renderToolA2UI(sty, surf, widths.Body)
+			if err != nil || rendered == "" {
+				failed++
+				continue
+			}
+			if b.Len() > 0 {
+				b.WriteString("\n")
+			}
+			b.WriteString(rendered)
+		}
+	}
+
+	var chunks []string
+	if b.Len() > 0 {
+		chunks = append(chunks, sty.Tool.Body.Render(clampToolA2UI(sty, b.String(), widths.Body, opts.ExpandedContent)))
+	}
+	// Alert on ANY failed surface, not only when all fail: a sibling
+	// surface rendering fine must not hide that another one vanished —
+	// the model was told the user can see every one of them.
+	if failed > 0 {
+		chunks = append(chunks, sty.Tool.Body.Render(renderToolA2UIAlert(sty, widths.Body)))
+	}
+	// Show any real text the resource returned alongside its surfaces — the
+	// model-facing placeholder lines are stripped, the rest belongs to the
+	// user just as much as the surfaces do.
+	if text := stripA2UIPlaceholders(opts.Result.Content); text != "" {
+		chunks = append(chunks, renderToolResultTextContent(sty, text, widths, opts.ExpandedContent))
+	}
+	return strings.Join(chunks, "\n")
+}
+
+// stripA2UIPlaceholders removes the model-facing surface placeholder lines
+// from tool content, leaving only text the user should see.
+func stripA2UIPlaceholders(content string) string {
+	var out []string
+	for _, ln := range strings.Split(content, "\n") {
+		if strings.HasPrefix(strings.TrimSpace(ln), tools.A2UISurfacePlaceholderPrefix) {
+			continue
+		}
+		out = append(out, ln)
+	}
+	return strings.TrimSpace(strings.Join(out, "\n"))
+}
+
+// clampToolA2UI applies the collapsed-height budget every other tool body
+// gets from responseContextHeight. The surface is pre-rendered ANSI, so the
+// clamp slices whole lines and appends the standard truncation footer;
+// expanding the tool result restores the full surface.
+func clampToolA2UI(sty *styles.Styles, body string, width int, expanded bool) string {
+	lines := strings.Split(body, "\n")
+	if expanded || len(lines) <= responseContextHeight {
+		return body
+	}
+	out := append([]string{}, lines[:responseContextHeight]...)
+	out = append(out, sty.Tool.ContentTruncation.
+		Width(width).
+		Render(fmt.Sprintf(assistantMessageTruncateFormat, len(lines)-responseContextHeight)))
+	return strings.Join(out, "\n")
+}
+
+// renderToolA2UIAlert mirrors the assistant path's renderA2UIAlert for tool
+// results: the resource advertised A2UI but a2tea could not draw a surface.
+func renderToolA2UIAlert(sty *styles.Styles, width int) string {
+	inner := max(width-2, 1)
+	tag := sty.Messages.ErrorTag.Render("A2UI")
+	title := sty.Messages.ErrorTitle.Render("couldn't render this resource's UI surface")
+	reason := sty.Messages.ErrorDetails.Width(inner).Render(
+		"The A2UI content was malformed or used unsupported components.")
+	return tag + " " + title + "\n\n" + reason
+}
+
+// renderToolA2UI renders a static (non-interactive) A2UI surface from tool
+// result content. Unlike the live surfaces on AssistantMessageItem, this does
+// not support focus/button interaction — it renders a snapshot of the surface
+// using the same themed styles.
+func renderToolA2UI(sty *styles.Styles, content string, width int) (string, error) {
+	parts, err := a2tea.Scan(content)
+	if err != nil {
+		return "", err
+	}
+	var b strings.Builder
+	themedStyles := a2uiThemeStyles(sty)
+	proseStyle := lipgloss.NewStyle().Width(width)
+	for _, p := range parts {
+		// Keep each part's prose, wrapped to the body budget: pre-change
+		// persisted results interleave text with surfaces, and dropping
+		// (or overflowing) it would corrupt content the model saw.
+		if text := strings.TrimSpace(p.Text); text != "" {
+			b.WriteString(proseStyle.Render(text))
+			b.WriteString("\n")
+		}
+		if len(p.Messages) == 0 {
+			continue
+		}
+		model, err := a2tea.Render(p.Messages, render.WithStyles(themedStyles))
+		if err != nil {
+			continue
+		}
+		if rm, ok := model.(render.Model); ok {
+			rm.SetSize(width, 0)
+			b.WriteString(strings.TrimRight(rm.View().Content, "\n"))
+			b.WriteString("\n")
+		}
+	}
+	return strings.TrimRight(b.String(), "\n"), nil
 }

--- a/internal/ui/chat/generic_test.go
+++ b/internal/ui/chat/generic_test.go
@@ -120,6 +120,28 @@ func TestGenericToolMetadataAllFailShowsAlert(t *testing.T) {
 	require.NotContains(t, plain, "do not repeat")
 }
 
+// A failed surface next to a healthy sibling still surfaces an alert — the
+// model was told the user can see every surface.
+func TestGenericToolMetadataPartialFailShowsAlert(t *testing.T) {
+	t.Parallel()
+
+	meta, err := json.Marshal(tools.ReadMCPResourceResponseMetadata{
+		A2UISurfaces: []string{a2uiSurface, "<a2ui-json>{malformed</a2ui-json>"},
+	})
+	require.NoError(t, err)
+
+	sty := styles.CharmtonePantera()
+	ctx := &GenericToolRenderContext{}
+	out := ctx.RenderTool(&sty, 80, genericToolOpts(t, &message.ToolResult{
+		Content:  a2uiTestPlaceholder,
+		Metadata: string(meta),
+	}))
+	plain := ansi.Strip(out)
+
+	require.Contains(t, plain, "Hello from A2UI")
+	require.Contains(t, plain, "couldn't render this resource's UI surface")
+}
+
 // The content-scan fallback exists for pre-change persisted read_mcp_resource
 // results only — other tools sharing the generic renderer must keep
 // payload-shaped text as text.

--- a/internal/ui/chat/generic_test.go
+++ b/internal/ui/chat/generic_test.go
@@ -2,6 +2,7 @@ package chat
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/charmbracelet/crush/internal/agent/tools"
@@ -11,12 +12,20 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const a2uiTestPlaceholder = tools.A2UISurfacePlaceholderPrefix +
+	"mcp://cairn/run/abc123/a2ui — the user can already see it; do not repeat or echo its JSON payload]"
+
 func genericToolOpts(t *testing.T, result *message.ToolResult) *ToolRenderOpts {
+	t.Helper()
+	return genericToolOptsFor(t, tools.ReadMCPResourceToolName, result)
+}
+
+func genericToolOptsFor(t *testing.T, name string, result *message.ToolResult) *ToolRenderOpts {
 	t.Helper()
 	return &ToolRenderOpts{
 		ToolCall: message.ToolCall{
 			ID:       "call-1",
-			Name:     tools.ReadMCPResourceToolName,
+			Name:     name,
 			Input:    `{"mcp_name":"cairn","uri":"mcp://cairn/run/abc123/a2ui"}`,
 			Finished: true,
 		},
@@ -39,7 +48,7 @@ func TestGenericToolRendersA2UIFromMetadata(t *testing.T) {
 	sty := styles.CharmtonePantera()
 	ctx := &GenericToolRenderContext{}
 	out := ctx.RenderTool(&sty, 80, genericToolOpts(t, &message.ToolResult{
-		Content:  "[A2UI surface rendered in the chat UI]",
+		Content:  a2uiTestPlaceholder,
 		Metadata: string(meta),
 	}))
 	plain := ansi.Strip(out)
@@ -47,6 +56,8 @@ func TestGenericToolRendersA2UIFromMetadata(t *testing.T) {
 	require.Contains(t, plain, "Hello from A2UI")
 	require.NotContains(t, plain, "a2ui-json")
 	require.NotContains(t, plain, "updateComponents")
+	// The model-facing placeholder is not shown to the user.
+	require.NotContains(t, plain, "do not repeat")
 }
 
 // A result with no A2UI metadata renders its text content as before.
@@ -61,4 +72,151 @@ func TestGenericToolNoMetadataRendersText(t *testing.T) {
 	plain := ansi.Strip(out)
 
 	require.Contains(t, plain, "plain resource text")
+}
+
+// A mixed resource read (text/markdown alongside application/a2ui+json)
+// shows both the surface and the real text — only the model-facing
+// placeholder lines are stripped.
+func TestGenericToolMetadataMixedContentShowsText(t *testing.T) {
+	t.Parallel()
+
+	meta, err := json.Marshal(tools.ReadMCPResourceResponseMetadata{
+		A2UISurfaces: []string{a2uiSurface},
+	})
+	require.NoError(t, err)
+
+	sty := styles.CharmtonePantera()
+	ctx := &GenericToolRenderContext{}
+	out := ctx.RenderTool(&sty, 80, genericToolOpts(t, &message.ToolResult{
+		Content:  "the artifact summary text\n" + a2uiTestPlaceholder,
+		Metadata: string(meta),
+	}))
+	plain := ansi.Strip(out)
+
+	require.Contains(t, plain, "Hello from A2UI")
+	require.Contains(t, plain, "the artifact summary text")
+	require.NotContains(t, plain, "do not repeat")
+}
+
+// When every metadata surface fails to render, the user sees an alert — not
+// the model-facing placeholder claiming the surface is already visible.
+func TestGenericToolMetadataAllFailShowsAlert(t *testing.T) {
+	t.Parallel()
+
+	meta, err := json.Marshal(tools.ReadMCPResourceResponseMetadata{
+		A2UISurfaces: []string{"<a2ui-json>{malformed</a2ui-json>"},
+	})
+	require.NoError(t, err)
+
+	sty := styles.CharmtonePantera()
+	ctx := &GenericToolRenderContext{}
+	out := ctx.RenderTool(&sty, 80, genericToolOpts(t, &message.ToolResult{
+		Content:  a2uiTestPlaceholder,
+		Metadata: string(meta),
+	}))
+	plain := ansi.Strip(out)
+
+	require.Contains(t, plain, "couldn't render this resource's UI surface")
+	require.NotContains(t, plain, "do not repeat")
+}
+
+// The content-scan fallback exists for pre-change persisted read_mcp_resource
+// results only — other tools sharing the generic renderer must keep
+// payload-shaped text as text.
+func TestGenericToolFallbackScopedToReadMCPResource(t *testing.T) {
+	t.Parallel()
+
+	sty := styles.CharmtonePantera()
+	ctx := &GenericToolRenderContext{}
+	out := ctx.RenderTool(&sty, 80, genericToolOptsFor(t, "crush_logs", &message.ToolResult{
+		Content: "log line before\n" + a2uiSurface + "\nlog line after",
+	}))
+	plain := ansi.Strip(out)
+
+	// Rendered as text (the raw payload stays visible), not as a surface.
+	require.Contains(t, plain, "log line before")
+	require.NotContains(t, plain, "Hello from A2UI")
+}
+
+// A fenced A2UI example inside a read_mcp_resource result is documentation,
+// not live UI (#6, #96) — the masked scan must not extract it.
+func TestGenericToolFallbackIgnoresFencedExample(t *testing.T) {
+	t.Parallel()
+
+	sty := styles.CharmtonePantera()
+	ctx := &GenericToolRenderContext{}
+	out := ctx.RenderTool(&sty, 80, genericToolOpts(t, &message.ToolResult{
+		Content: "Example:\n\n```json\n" + a2uiSurface + "\n```\n\nDone.",
+	}))
+	plain := ansi.Strip(out)
+
+	require.Contains(t, plain, "Example:")
+	require.NotContains(t, plain, "Hello from A2UI")
+}
+
+// Pre-change persisted results interleave prose with tagged surfaces — the
+// fallback render keeps the prose.
+func TestGenericToolFallbackPreservesProse(t *testing.T) {
+	t.Parallel()
+
+	sty := styles.CharmtonePantera()
+	ctx := &GenericToolRenderContext{}
+	out := ctx.RenderTool(&sty, 80, genericToolOpts(t, &message.ToolResult{
+		Content: "intro prose\n" + a2uiSurface + "\nfooter prose",
+	}))
+	plain := ansi.Strip(out)
+
+	require.Contains(t, plain, "Hello from A2UI")
+	require.Contains(t, plain, "intro prose")
+	require.Contains(t, plain, "footer prose")
+}
+
+// tallA2UISurface builds a surface whose rendered height exceeds the
+// collapsed tool-body budget.
+func tallA2UISurface(t *testing.T) string {
+	t.Helper()
+	var comps []string
+	var children []string
+	for i := 0; i < 20; i++ {
+		id := string(rune('a' + i%26))
+		id += string(rune('0' + i/26))
+		children = append(children, `"`+id+`"`)
+		comps = append(comps, `{"component":"Text","id":"`+id+`","text":"row `+id+`"}`)
+	}
+	comps = append([]string{
+		`{"component":"Card","id":"root","child":"col"}`,
+		`{"component":"Column","id":"col","children":[` + strings.Join(children, ",") + `]}`,
+	}, comps...)
+	return `<a2ui-json>{"version":"v0.9","updateComponents":{"surfaceId":"s","components":[` +
+		strings.Join(comps, ",") + `]}}</a2ui-json>`
+}
+
+// A tall surface honors the same collapsed-height budget as every other tool
+// body, and expanding restores the full surface.
+func TestGenericToolA2UICollapse(t *testing.T) {
+	t.Parallel()
+
+	meta, err := json.Marshal(tools.ReadMCPResourceResponseMetadata{
+		A2UISurfaces: []string{tallA2UISurface(t)},
+	})
+	require.NoError(t, err)
+
+	sty := styles.CharmtonePantera()
+	ctx := &GenericToolRenderContext{}
+
+	collapsed := genericToolOpts(t, &message.ToolResult{
+		Content:  a2uiTestPlaceholder,
+		Metadata: string(meta),
+	})
+	out := ansi.Strip(ctx.RenderTool(&sty, 80, collapsed))
+	require.Contains(t, out, "lines hidden")
+
+	expanded := genericToolOpts(t, &message.ToolResult{
+		Content:  a2uiTestPlaceholder,
+		Metadata: string(meta),
+	})
+	expanded.ExpandedContent = true
+	outExpanded := ansi.Strip(ctx.RenderTool(&sty, 80, expanded))
+	require.NotContains(t, outExpanded, "lines hidden")
+	require.Contains(t, outExpanded, "row a0")
 }

--- a/internal/ui/chat/generic_test.go
+++ b/internal/ui/chat/generic_test.go
@@ -1,0 +1,64 @@
+package chat
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/charmbracelet/crush/internal/agent/tools"
+	"github.com/charmbracelet/crush/internal/message"
+	"github.com/charmbracelet/crush/internal/ui/styles"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/stretchr/testify/require"
+)
+
+func genericToolOpts(t *testing.T, result *message.ToolResult) *ToolRenderOpts {
+	t.Helper()
+	return &ToolRenderOpts{
+		ToolCall: message.ToolCall{
+			ID:       "call-1",
+			Name:     tools.ReadMCPResourceToolName,
+			Input:    `{"mcp_name":"cairn","uri":"mcp://cairn/run/abc123/a2ui"}`,
+			Finished: true,
+		},
+		Result: result,
+		Status: ToolStatusSuccess,
+	}
+}
+
+// The A2UI payload lives in result metadata (UI-only), not in the content
+// the model sees — the model only gets a placeholder, so it cannot echo the
+// JSON back and double-render the surface.
+func TestGenericToolRendersA2UIFromMetadata(t *testing.T) {
+	t.Parallel()
+
+	meta, err := json.Marshal(tools.ReadMCPResourceResponseMetadata{
+		A2UISurfaces: []string{a2uiSurface},
+	})
+	require.NoError(t, err)
+
+	sty := styles.CharmtonePantera()
+	ctx := &GenericToolRenderContext{}
+	out := ctx.RenderTool(&sty, 80, genericToolOpts(t, &message.ToolResult{
+		Content:  "[A2UI surface rendered in the chat UI]",
+		Metadata: string(meta),
+	}))
+	plain := ansi.Strip(out)
+
+	require.Contains(t, plain, "Hello from A2UI")
+	require.NotContains(t, plain, "a2ui-json")
+	require.NotContains(t, plain, "updateComponents")
+}
+
+// A result with no A2UI metadata renders its text content as before.
+func TestGenericToolNoMetadataRendersText(t *testing.T) {
+	t.Parallel()
+
+	sty := styles.CharmtonePantera()
+	ctx := &GenericToolRenderContext{}
+	out := ctx.RenderTool(&sty, 80, genericToolOpts(t, &message.ToolResult{
+		Content: "plain resource text",
+	}))
+	plain := ansi.Strip(out)
+
+	require.Contains(t, plain, "plain resource text")
+}

--- a/internal/ui/chat/generic_test.go
+++ b/internal/ui/chat/generic_test.go
@@ -1,0 +1,244 @@
+package chat
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/crush/internal/agent/tools"
+	"github.com/charmbracelet/crush/internal/message"
+	"github.com/charmbracelet/crush/internal/ui/styles"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/stretchr/testify/require"
+)
+
+const a2uiTestPlaceholder = tools.A2UISurfacePlaceholderPrefix +
+	"mcp://cairn/run/abc123/a2ui — the user can already see it; do not repeat or echo its JSON payload]"
+
+func genericToolOpts(t *testing.T, result *message.ToolResult) *ToolRenderOpts {
+	t.Helper()
+	return genericToolOptsFor(t, tools.ReadMCPResourceToolName, result)
+}
+
+func genericToolOptsFor(t *testing.T, name string, result *message.ToolResult) *ToolRenderOpts {
+	t.Helper()
+	return &ToolRenderOpts{
+		ToolCall: message.ToolCall{
+			ID:       "call-1",
+			Name:     name,
+			Input:    `{"mcp_name":"cairn","uri":"mcp://cairn/run/abc123/a2ui"}`,
+			Finished: true,
+		},
+		Result: result,
+		Status: ToolStatusSuccess,
+	}
+}
+
+// The A2UI payload lives in result metadata (UI-only), not in the content
+// the model sees — the model only gets a placeholder, so it cannot echo the
+// JSON back and double-render the surface.
+func TestGenericToolRendersA2UIFromMetadata(t *testing.T) {
+	t.Parallel()
+
+	meta, err := json.Marshal(tools.ReadMCPResourceResponseMetadata{
+		A2UISurfaces: []string{a2uiSurface},
+	})
+	require.NoError(t, err)
+
+	sty := styles.CharmtonePantera()
+	ctx := &GenericToolRenderContext{}
+	out := ctx.RenderTool(&sty, 80, genericToolOpts(t, &message.ToolResult{
+		Content:  a2uiTestPlaceholder,
+		Metadata: string(meta),
+	}))
+	plain := ansi.Strip(out)
+
+	require.Contains(t, plain, "Hello from A2UI")
+	require.NotContains(t, plain, "a2ui-json")
+	require.NotContains(t, plain, "updateComponents")
+	// The model-facing placeholder is not shown to the user.
+	require.NotContains(t, plain, "do not repeat")
+}
+
+// A result with no A2UI metadata renders its text content as before.
+func TestGenericToolNoMetadataRendersText(t *testing.T) {
+	t.Parallel()
+
+	sty := styles.CharmtonePantera()
+	ctx := &GenericToolRenderContext{}
+	out := ctx.RenderTool(&sty, 80, genericToolOpts(t, &message.ToolResult{
+		Content: "plain resource text",
+	}))
+	plain := ansi.Strip(out)
+
+	require.Contains(t, plain, "plain resource text")
+}
+
+// A mixed resource read (text/markdown alongside application/a2ui+json)
+// shows both the surface and the real text — only the model-facing
+// placeholder lines are stripped.
+func TestGenericToolMetadataMixedContentShowsText(t *testing.T) {
+	t.Parallel()
+
+	meta, err := json.Marshal(tools.ReadMCPResourceResponseMetadata{
+		A2UISurfaces: []string{a2uiSurface},
+	})
+	require.NoError(t, err)
+
+	sty := styles.CharmtonePantera()
+	ctx := &GenericToolRenderContext{}
+	out := ctx.RenderTool(&sty, 80, genericToolOpts(t, &message.ToolResult{
+		Content:  "the artifact summary text\n" + a2uiTestPlaceholder,
+		Metadata: string(meta),
+	}))
+	plain := ansi.Strip(out)
+
+	require.Contains(t, plain, "Hello from A2UI")
+	require.Contains(t, plain, "the artifact summary text")
+	require.NotContains(t, plain, "do not repeat")
+}
+
+// When every metadata surface fails to render, the user sees an alert — not
+// the model-facing placeholder claiming the surface is already visible.
+func TestGenericToolMetadataAllFailShowsAlert(t *testing.T) {
+	t.Parallel()
+
+	meta, err := json.Marshal(tools.ReadMCPResourceResponseMetadata{
+		A2UISurfaces: []string{"<a2ui-json>{malformed</a2ui-json>"},
+	})
+	require.NoError(t, err)
+
+	sty := styles.CharmtonePantera()
+	ctx := &GenericToolRenderContext{}
+	out := ctx.RenderTool(&sty, 80, genericToolOpts(t, &message.ToolResult{
+		Content:  a2uiTestPlaceholder,
+		Metadata: string(meta),
+	}))
+	plain := ansi.Strip(out)
+
+	require.Contains(t, plain, "couldn't render this resource's UI surface")
+	require.NotContains(t, plain, "do not repeat")
+}
+
+// A failed surface next to a healthy sibling still surfaces an alert — the
+// model was told the user can see every surface.
+func TestGenericToolMetadataPartialFailShowsAlert(t *testing.T) {
+	t.Parallel()
+
+	meta, err := json.Marshal(tools.ReadMCPResourceResponseMetadata{
+		A2UISurfaces: []string{a2uiSurface, "<a2ui-json>{malformed</a2ui-json>"},
+	})
+	require.NoError(t, err)
+
+	sty := styles.CharmtonePantera()
+	ctx := &GenericToolRenderContext{}
+	out := ctx.RenderTool(&sty, 80, genericToolOpts(t, &message.ToolResult{
+		Content:  a2uiTestPlaceholder,
+		Metadata: string(meta),
+	}))
+	plain := ansi.Strip(out)
+
+	require.Contains(t, plain, "Hello from A2UI")
+	require.Contains(t, plain, "couldn't render this resource's UI surface")
+}
+
+// The content-scan fallback exists for pre-change persisted read_mcp_resource
+// results only — other tools sharing the generic renderer must keep
+// payload-shaped text as text.
+func TestGenericToolFallbackScopedToReadMCPResource(t *testing.T) {
+	t.Parallel()
+
+	sty := styles.CharmtonePantera()
+	ctx := &GenericToolRenderContext{}
+	out := ctx.RenderTool(&sty, 80, genericToolOptsFor(t, "crush_logs", &message.ToolResult{
+		Content: "log line before\n" + a2uiSurface + "\nlog line after",
+	}))
+	plain := ansi.Strip(out)
+
+	// Rendered as text (the raw payload stays visible), not as a surface.
+	require.Contains(t, plain, "log line before")
+	require.NotContains(t, plain, "Hello from A2UI")
+}
+
+// A fenced A2UI example inside a read_mcp_resource result is documentation,
+// not live UI (#6, #96) — the masked scan must not extract it.
+func TestGenericToolFallbackIgnoresFencedExample(t *testing.T) {
+	t.Parallel()
+
+	sty := styles.CharmtonePantera()
+	ctx := &GenericToolRenderContext{}
+	out := ctx.RenderTool(&sty, 80, genericToolOpts(t, &message.ToolResult{
+		Content: "Example:\n\n```json\n" + a2uiSurface + "\n```\n\nDone.",
+	}))
+	plain := ansi.Strip(out)
+
+	require.Contains(t, plain, "Example:")
+	require.NotContains(t, plain, "Hello from A2UI")
+}
+
+// Pre-change persisted results interleave prose with tagged surfaces — the
+// fallback render keeps the prose.
+func TestGenericToolFallbackPreservesProse(t *testing.T) {
+	t.Parallel()
+
+	sty := styles.CharmtonePantera()
+	ctx := &GenericToolRenderContext{}
+	out := ctx.RenderTool(&sty, 80, genericToolOpts(t, &message.ToolResult{
+		Content: "intro prose\n" + a2uiSurface + "\nfooter prose",
+	}))
+	plain := ansi.Strip(out)
+
+	require.Contains(t, plain, "Hello from A2UI")
+	require.Contains(t, plain, "intro prose")
+	require.Contains(t, plain, "footer prose")
+}
+
+// tallA2UISurface builds a surface whose rendered height exceeds the
+// collapsed tool-body budget.
+func tallA2UISurface(t *testing.T) string {
+	t.Helper()
+	var comps []string
+	var children []string
+	for i := 0; i < 20; i++ {
+		id := string(rune('a' + i%26))
+		id += string(rune('0' + i/26))
+		children = append(children, `"`+id+`"`)
+		comps = append(comps, `{"component":"Text","id":"`+id+`","text":"row `+id+`"}`)
+	}
+	comps = append([]string{
+		`{"component":"Card","id":"root","child":"col"}`,
+		`{"component":"Column","id":"col","children":[` + strings.Join(children, ",") + `]}`,
+	}, comps...)
+	return `<a2ui-json>{"version":"v0.9","updateComponents":{"surfaceId":"s","components":[` +
+		strings.Join(comps, ",") + `]}}</a2ui-json>`
+}
+
+// A tall surface honors the same collapsed-height budget as every other tool
+// body, and expanding restores the full surface.
+func TestGenericToolA2UICollapse(t *testing.T) {
+	t.Parallel()
+
+	meta, err := json.Marshal(tools.ReadMCPResourceResponseMetadata{
+		A2UISurfaces: []string{tallA2UISurface(t)},
+	})
+	require.NoError(t, err)
+
+	sty := styles.CharmtonePantera()
+	ctx := &GenericToolRenderContext{}
+
+	collapsed := genericToolOpts(t, &message.ToolResult{
+		Content:  a2uiTestPlaceholder,
+		Metadata: string(meta),
+	})
+	out := ansi.Strip(ctx.RenderTool(&sty, 80, collapsed))
+	require.Contains(t, out, "lines hidden")
+
+	expanded := genericToolOpts(t, &message.ToolResult{
+		Content:  a2uiTestPlaceholder,
+		Metadata: string(meta),
+	})
+	expanded.ExpandedContent = true
+	outExpanded := ansi.Strip(ctx.RenderTool(&sty, 80, expanded))
+	require.NotContains(t, outExpanded, "lines hidden")
+	require.Contains(t, outExpanded, "row a0")
+}

--- a/internal/ui/chat/mcp.go
+++ b/internal/ui/chat/mcp.go
@@ -77,7 +77,7 @@ func (b *MCPToolRenderContext) RenderTool(sty *styles.Styles, width int, opts *T
 	widths := toolResultContentWidths{Body: bodyWidth, Diff: cappedWidth}
 
 	// An MCP tool result can carry an A2UI surface in its metadata
-	// (#219): the server returned an application/a2ui+json
+	//: the server returned an application/a2ui+json
 	// EmbeddedResource, diverted so the model only sees a placeholder.
 	// Render the live surface (or static fallback) instead of raw text.
 	if opts.Result.Metadata != "" {

--- a/internal/ui/chat/mcp.go
+++ b/internal/ui/chat/mcp.go
@@ -76,10 +76,10 @@ func (b *MCPToolRenderContext) RenderTool(sty *styles.Styles, width int, opts *T
 	bodyWidth := cappedWidth - toolBodyLeftPaddingTotal
 	widths := toolResultContentWidths{Body: bodyWidth, Diff: cappedWidth}
 
-	// An MCP tool result can carry an A2UI surface in its metadata
-	//: the server returned an application/a2ui+json
-	// EmbeddedResource, diverted so the model only sees a placeholder.
-	// Render the live surface (or static fallback) instead of raw text.
+	// An MCP tool result can carry an A2UI surface in its metadata: the
+	// server returned an application/a2ui+json EmbeddedResource, diverted
+	// so the model only sees a placeholder. Render the live surface (or
+	// static fallback) instead of raw text.
 	if opts.Result.Metadata != "" {
 		var meta tools.ReadMCPResourceResponseMetadata
 		if err := json.Unmarshal([]byte(opts.Result.Metadata), &meta); err == nil && len(meta.A2UISurfaces) > 0 {

--- a/internal/ui/chat/mcp.go
+++ b/internal/ui/chat/mcp.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/charmbracelet/crush/internal/agent/tools"
 	"github.com/charmbracelet/crush/internal/message"
 	"github.com/charmbracelet/crush/internal/ui/styles"
 )
@@ -73,6 +74,19 @@ func (b *MCPToolRenderContext) RenderTool(sty *styles.Styles, width int, opts *T
 	}
 
 	bodyWidth := cappedWidth - toolBodyLeftPaddingTotal
-	body := renderToolResultTextContent(sty, opts.Result.Content, toolResultContentWidths{Body: bodyWidth, Diff: cappedWidth}, opts.ExpandedContent)
+	widths := toolResultContentWidths{Body: bodyWidth, Diff: cappedWidth}
+
+	// An MCP tool result can carry an A2UI surface in its metadata
+	// (#219): the server returned an application/a2ui+json
+	// EmbeddedResource, diverted so the model only sees a placeholder.
+	// Render the live surface (or static fallback) instead of raw text.
+	if opts.Result.Metadata != "" {
+		var meta tools.ReadMCPResourceResponseMetadata
+		if err := json.Unmarshal([]byte(opts.Result.Metadata), &meta); err == nil && len(meta.A2UISurfaces) > 0 {
+			return joinToolParts(header, renderToolA2UIResultBody(sty, meta.A2UISurfaces, opts, widths))
+		}
+	}
+
+	body := renderToolResultTextContent(sty, opts.Result.Content, widths, opts.ExpandedContent)
 	return joinToolParts(header, body)
 }

--- a/internal/ui/chat/mcp.go
+++ b/internal/ui/chat/mcp.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/charmbracelet/crush/internal/agent/tools"
 	"github.com/charmbracelet/crush/internal/message"
 	"github.com/charmbracelet/crush/internal/ui/styles"
 )
@@ -73,6 +74,19 @@ func (b *MCPToolRenderContext) RenderTool(sty *styles.Styles, width int, opts *T
 	}
 
 	bodyWidth := cappedWidth - toolBodyLeftPaddingTotal
-	body := renderToolResultTextContent(sty, opts.Result.Content, toolResultContentWidths{Body: bodyWidth, Diff: cappedWidth}, opts.ExpandedContent)
+	widths := toolResultContentWidths{Body: bodyWidth, Diff: cappedWidth}
+
+	// An MCP tool result can carry an A2UI surface in its metadata: the
+	// server returned an application/a2ui+json EmbeddedResource, diverted
+	// so the model only sees a placeholder. Render the live surface (or
+	// static fallback) instead of raw text.
+	if opts.Result.Metadata != "" {
+		var meta tools.ReadMCPResourceResponseMetadata
+		if err := json.Unmarshal([]byte(opts.Result.Metadata), &meta); err == nil && len(meta.A2UISurfaces) > 0 {
+			return joinToolParts(header, renderToolA2UIResultBody(sty, meta.A2UISurfaces, opts, widths))
+		}
+	}
+
+	body := renderToolResultTextContent(sty, opts.Result.Content, widths, opts.ExpandedContent)
 	return joinToolParts(header, body)
 }

--- a/internal/ui/chat/prompt_tokens.go
+++ b/internal/ui/chat/prompt_tokens.go
@@ -1,0 +1,56 @@
+package chat
+
+import (
+	"strings"
+
+	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/crush/internal/ui/common"
+	"github.com/charmbracelet/crush/internal/ui/styles"
+	"github.com/charmbracelet/x/ansi"
+)
+
+// highlightPromptTokens restyles the @file and /skill tokens in an
+// already-rendered user message so a token keeps the colour it had in the
+// prompt editor after the message is posted.
+//
+// It runs over the rendered output rather than the Markdown source because
+// that output is what the reader sees: Glamour has already wrapped, padded
+// and coloured the text, and re-deriving offsets from the source would not
+// survive any of that. Each line is scanned in its ANSI-stripped form and
+// the token spans are converted to display cells, which is exactly what
+// lipgloss.StyleRanges wants. A token split across a soft wrap highlights
+// on the segment it starts in, which is the same thing the textarea does.
+func highlightPromptTokens(content string, sty *styles.Styles) string {
+	if content == "" {
+		return content
+	}
+
+	lines := strings.Split(content, "\n")
+	changed := false
+	for i, line := range lines {
+		plain := []rune(ansi.Strip(line))
+		tokens := common.ScanPromptTokens(plain)
+		if len(tokens) == 0 {
+			continue
+		}
+
+		ranges := make([]lipgloss.Range, 0, len(tokens))
+		for _, tok := range tokens {
+			// Rune offsets are not cell offsets once wide runes or combining
+			// marks are in play, and StyleRanges counts cells.
+			start := ansi.StringWidth(string(plain[:tok.Start]))
+			end := start + ansi.StringWidth(string(plain[tok.Start:tok.End]))
+			style := sty.Editor.TokenFile
+			if tok.Kind == common.PromptTokenSkill {
+				style = sty.Editor.TokenSkill
+			}
+			ranges = append(ranges, lipgloss.NewRange(start, end, style))
+		}
+		lines[i] = lipgloss.StyleRanges(line, ranges...)
+		changed = true
+	}
+	if !changed {
+		return content
+	}
+	return strings.Join(lines, "\n")
+}

--- a/internal/ui/chat/prompt_tokens_test.go
+++ b/internal/ui/chat/prompt_tokens_test.go
@@ -1,0 +1,102 @@
+package chat
+
+import (
+	"strings"
+	"testing"
+
+	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/crush/internal/ui/common"
+	"github.com/charmbracelet/crush/internal/ui/styles"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/stretchr/testify/require"
+)
+
+// tokenTestStyles returns styles with unmistakable token colours so a test
+// can assert which span picked which one up.
+func tokenTestStyles() *styles.Styles {
+	sty := styles.CharmtonePantera()
+	sty.Editor.TokenFile = lipgloss.NewStyle().Foreground(lipgloss.Color("1"))
+	sty.Editor.TokenSkill = lipgloss.NewStyle().Foreground(lipgloss.Color("2"))
+	return &sty
+}
+
+// styledSpans returns the substrings of an ANSI string rendered under the
+// given SGR foreground parameter.
+func styledSpans(s, sgr string) []string {
+	var out []string
+	for _, part := range strings.Split(s, "\x1b["+sgr+"m")[1:] {
+		if idx := strings.Index(part, "\x1b["); idx >= 0 {
+			part = part[:idx]
+		}
+		out = append(out, part)
+	}
+	return out
+}
+
+func withKnownSkills(t *testing.T, names ...string) {
+	t.Helper()
+	common.SetPromptSkillNames(names)
+	t.Cleanup(func() { common.SetPromptSkillNames(nil) })
+}
+
+func TestHighlightPromptTokensStylesFileAndSkill(t *testing.T) {
+	withKnownSkills(t, "code-review")
+	sty := tokenTestStyles()
+
+	got := highlightPromptTokens("please /code-review @main.go now", sty)
+
+	require.Equal(t, "please /code-review @main.go now", ansi.Strip(got))
+	require.Equal(t, []string{"@main.go"}, styledSpans(got, "31"))
+	require.Equal(t, []string{"/code-review"}, styledSpans(got, "32"))
+}
+
+func TestHighlightPromptTokensLeavesProseAlone(t *testing.T) {
+	withKnownSkills(t, "commit")
+	sty := tokenTestStyles()
+
+	// No word-boundary trigger anywhere: an email-like run, an inline
+	// slash, and an unknown slash-word.
+	const in = "mail me@foo.com or a/b or /bogus"
+	require.Equal(t, in, highlightPromptTokens(in, sty))
+}
+
+func TestHighlightPromptTokensPreservesSurroundingAnsi(t *testing.T) {
+	withKnownSkills(t)
+	sty := tokenTestStyles()
+
+	// Glamour hands us pre-styled text; restyling a token must not eat the
+	// styling around it or change the visible characters.
+	in := lipgloss.NewStyle().Bold(true).Render("see @main.go here")
+	got := highlightPromptTokens(in, sty)
+
+	require.Equal(t, "see @main.go here", ansi.Strip(got))
+	require.Equal(t, []string{"@main.go"}, styledSpans(got, "31"))
+}
+
+func TestHighlightPromptTokensMultiline(t *testing.T) {
+	withKnownSkills(t, "commit")
+	sty := tokenTestStyles()
+
+	got := highlightPromptTokens("@one.go\nplain\n/commit", sty)
+
+	lines := strings.Split(got, "\n")
+	require.Len(t, lines, 3)
+	require.Equal(t, []string{"@one.go"}, styledSpans(lines[0], "31"))
+	require.Equal(t, "plain", lines[1], "untouched lines are returned verbatim")
+	require.Equal(t, []string{"/commit"}, styledSpans(lines[2], "32"))
+}
+
+// TestUserMessageRendersPromptTokens is the end-to-end check: the same
+// colours the prompt editor uses survive into the posted message.
+func TestUserMessageRendersPromptTokens(t *testing.T) {
+	withKnownSkills(t, "code-review")
+
+	item := newTestUserItem("please /code-review @main.go", 0)
+	item.sty = tokenTestStyles()
+
+	out := item.RawRender(80)
+
+	require.Contains(t, ansi.Strip(out), "/code-review")
+	require.Contains(t, styledSpans(out, "31"), "@main.go")
+	require.Contains(t, styledSpans(out, "32"), "/code-review")
+}

--- a/internal/ui/chat/tool_a2ui.go
+++ b/internal/ui/chat/tool_a2ui.go
@@ -36,16 +36,20 @@ func (t *baseToolMessageItem) syncToolA2UISurfaces() {
 	}
 	var surfaces []render.Model
 	var ids []string
+	failed := 0
 	for i, surfJSON := range meta.A2UISurfaces {
 		parts, err := a2tea.Scan(surfJSON)
 		if err != nil {
+			failed++
 			continue
 		}
 		built, builtIDs := buildA2UISurfaces(t.sty, parts)
+		payloadLive := 0
 		for j, m := range built {
 			if m == nil {
 				continue
 			}
+			payloadLive++
 			surfaces = append(surfaces, m)
 			id := builtIDs[j]
 			ids = append(ids, id)
@@ -55,9 +59,16 @@ func (t *baseToolMessageItem) syncToolA2UISurfaces() {
 				registerA2UISurfaceProvenance(id, meta.MCPSurfaceProvenance[i])
 			}
 		}
+		// A payload that scanned but drew nothing (unsupported components,
+		// bare data-model update) failed just like a scan error: the model
+		// was told the user can see it.
+		if payloadLive == 0 {
+			failed++
+		}
 	}
 	t.a2ui.surfaces = surfaces
 	t.a2ui.surfaceIDs = ids
+	t.surfaceBuildFailed = failed
 	t.surfaceSrcHash = h
 	t.surfaceScanned = true
 	if t.focusableMessageItem.isFocused() {
@@ -89,11 +100,13 @@ func (t *baseToolMessageItem) blurToolA2UISurfaces() {
 }
 
 // renderToolA2UISurfaces renders each live surface from its model at the
-// given width, joined by blank lines. Surfaces that fail to produce output
-// are skipped; the alert path in generic.go/mcp.go covers payloads that
-// produced no renderable model at all.
-func (t *baseToolMessageItem) renderToolA2UISurfaces(width int) string {
+// given width, joined by blank lines. It also reports how many surfaces
+// failed — payloads that never built a model (surfaceBuildFailed) plus live
+// models that drew nothing — so the renderer can show the same alert the
+// static path shows: the model was told the user can see every surface.
+func (t *baseToolMessageItem) renderToolA2UISurfaces(width int) (string, int) {
 	var b strings.Builder
+	failed := t.surfaceBuildFailed
 	for _, s := range t.a2ui.surfaces {
 		if s == nil {
 			continue
@@ -101,6 +114,7 @@ func (t *baseToolMessageItem) renderToolA2UISurfaces(width int) string {
 		s.SetSize(width, 0)
 		rendered := strings.TrimRight(s.View().Content, "\n")
 		if rendered == "" {
+			failed++
 			continue
 		}
 		if b.Len() > 0 {
@@ -108,7 +122,7 @@ func (t *baseToolMessageItem) renderToolA2UISurfaces(width int) string {
 		}
 		b.WriteString(rendered)
 	}
-	return b.String()
+	return b.String(), failed
 }
 
 // HandleKeyEvent routes keys to the focused live MCP surface first

--- a/internal/ui/chat/tool_a2ui.go
+++ b/internal/ui/chat/tool_a2ui.go
@@ -1,0 +1,126 @@
+package chat
+
+import (
+	"encoding/json"
+	"strings"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/crush/internal/agent/tools"
+	"github.com/joestump-agent/a2tea"
+	"github.com/joestump-agent/a2tea/render"
+)
+
+// syncToolA2UISurfaces builds — or reuses — the live a2tea models for the
+// surfaces carried in the tool result's metadata (#219). Models are keyed by
+// a hash of the metadata: a re-render with the same result reuses the live
+// models (preserving focus and edited field values), while a result swap
+// (SetResult) rebuilds them. Each surface's provenance is registered so a
+// later interaction routes back to the owning MCP server (#221).
+func (t *baseToolMessageItem) syncToolA2UISurfaces() {
+	if t.result == nil || t.result.Metadata == "" {
+		t.a2ui.surfaces = nil
+		t.a2ui.surfaceIDs = nil
+		t.surfaceScanned = false
+		return
+	}
+	var meta tools.ReadMCPResourceResponseMetadata
+	if err := json.Unmarshal([]byte(t.result.Metadata), &meta); err != nil || len(meta.A2UISurfaces) == 0 {
+		t.a2ui.surfaces = nil
+		t.a2ui.surfaceIDs = nil
+		t.surfaceScanned = false
+		return
+	}
+	h := fnv64(t.result.Metadata)
+	if t.surfaceScanned && t.surfaceSrcHash == h {
+		return
+	}
+	var surfaces []render.Model
+	var ids []string
+	for i, surfJSON := range meta.A2UISurfaces {
+		parts, err := a2tea.Scan(surfJSON)
+		if err != nil {
+			continue
+		}
+		built, builtIDs := buildA2UISurfaces(t.sty, parts)
+		for j, m := range built {
+			if m == nil {
+				continue
+			}
+			surfaces = append(surfaces, m)
+			id := builtIDs[j]
+			ids = append(ids, id)
+			// Provenance is parallel to A2UISurfaces; a missing or short
+			// slice (older persisted results) means unknown origin.
+			if i < len(meta.MCPSurfaceProvenance) {
+				registerA2UISurfaceProvenance(id, meta.MCPSurfaceProvenance[i])
+			}
+		}
+	}
+	t.a2ui.surfaces = surfaces
+	t.a2ui.surfaceIDs = ids
+	t.surfaceSrcHash = h
+	t.surfaceScanned = true
+	if t.focusableMessageItem.isFocused() {
+		t.focusToolA2UISurfaces()
+	}
+}
+
+// hasToolA2UISurfaces reports whether this item carries live MCP surfaces.
+func (t *baseToolMessageItem) hasToolA2UISurfaces() bool {
+	return t.a2ui.hasLive()
+}
+
+// focusToolA2UISurfaces grants focus to the first live surface and blurs the
+// rest. MCP surfaces are long-lived app UIs (#219) — unlike chat-scanned
+// forms they are never retired on submission, so every live surface is
+// focusable.
+func (t *baseToolMessageItem) focusToolA2UISurfaces() {
+	for i, s := range t.a2ui.surfaces {
+		if s != nil {
+			t.a2ui.focus(i)
+			return
+		}
+	}
+}
+
+// blurToolA2UISurfaces revokes keyboard focus from every live surface.
+func (t *baseToolMessageItem) blurToolA2UISurfaces() {
+	t.a2ui.blurAll()
+}
+
+// renderToolA2UISurfaces renders each live surface from its model at the
+// given width, joined by blank lines. Surfaces that fail to produce output
+// are skipped; the alert path in generic.go/mcp.go covers payloads that
+// produced no renderable model at all.
+func (t *baseToolMessageItem) renderToolA2UISurfaces(width int) string {
+	var b strings.Builder
+	for _, s := range t.a2ui.surfaces {
+		if s == nil {
+			continue
+		}
+		s.SetSize(width, 0)
+		rendered := strings.TrimRight(s.View().Content, "\n")
+		if rendered == "" {
+			continue
+		}
+		if b.Len() > 0 {
+			b.WriteString("\n\n")
+		}
+		b.WriteString(rendered)
+	}
+	return b.String()
+}
+
+// HandleKeyEvent routes keys to the focused live MCP surface first
+// (#219) — Tab/Shift+Tab cycle its focus ring, Enter activates a button,
+// printable keys edit a focused field (see a2uiSurfaceWantsKey) — then falls
+// through to the copy shortcut. A button activation surfaces as an
+// a2uievent.ButtonClicked tea.Cmd, which the UI model routes per the
+// surface's provenance (#221).
+func (t *baseToolMessageItem) handleA2UIKeyEvent(key tea.KeyMsg) (bool, tea.Cmd) {
+	if idx := t.a2ui.focusedIndex(); idx >= 0 && a2uiSurfaceWantsKey(t.a2ui.surfaces[idx], key) {
+		t.Bump()
+		return true, t.a2ui.update(idx, key)
+	}
+	return false, nil
+}

--- a/internal/ui/chat/tool_a2ui.go
+++ b/internal/ui/chat/tool_a2ui.go
@@ -11,11 +11,11 @@ import (
 )
 
 // syncToolA2UISurfaces builds — or reuses — the live a2tea models for the
-// surfaces carried in the tool result's metadata (#219). Models are keyed by
+// surfaces carried in the tool result's metadata. Models are keyed by
 // a hash of the metadata: a re-render with the same result reuses the live
 // models (preserving focus and edited field values), while a result swap
 // (SetResult) rebuilds them. Each surface's provenance is registered so a
-// later interaction routes back to the owning MCP server (#221).
+// later interaction routes back to the owning MCP server.
 func (t *baseToolMessageItem) syncToolA2UISurfaces() {
 	if t.result == nil || t.result.Metadata == "" {
 		t.a2ui.surfaces = nil
@@ -71,7 +71,7 @@ func (t *baseToolMessageItem) hasToolA2UISurfaces() bool {
 }
 
 // focusToolA2UISurfaces grants focus to the first live surface and blurs the
-// rest. MCP surfaces are long-lived app UIs (#219) — unlike chat-scanned
+// rest. MCP surfaces are long-lived app UIs — unlike chat-scanned
 // forms they are never retired on submission, so every live surface is
 // focusable.
 func (t *baseToolMessageItem) focusToolA2UISurfaces() {
@@ -112,11 +112,11 @@ func (t *baseToolMessageItem) renderToolA2UISurfaces(width int) string {
 }
 
 // HandleKeyEvent routes keys to the focused live MCP surface first
-// (#219) — Tab/Shift+Tab cycle its focus ring, Enter activates a button,
+// — Tab/Shift+Tab cycle its focus ring, Enter activates a button,
 // printable keys edit a focused field (see a2uiSurfaceWantsKey) — then falls
 // through to the copy shortcut. A button activation surfaces as an
 // a2uievent.ButtonClicked tea.Cmd, which the UI model routes per the
-// surface's provenance (#221).
+// surface's provenance.
 func (t *baseToolMessageItem) handleA2UIKeyEvent(key tea.KeyMsg) (bool, tea.Cmd) {
 	if idx := t.a2ui.focusedIndex(); idx >= 0 && a2uiSurfaceWantsKey(t.a2ui.surfaces[idx], key) {
 		t.Bump()

--- a/internal/ui/chat/tool_a2ui.go
+++ b/internal/ui/chat/tool_a2ui.go
@@ -8,6 +8,7 @@ import (
 	"github.com/charmbracelet/crush/internal/agent/tools"
 	"github.com/joestump-agent/a2tea"
 	"github.com/joestump-agent/a2tea/render"
+	a2ui "github.com/tmc/a2ui"
 )
 
 // syncToolA2UISurfaces builds — or reuses — the live a2tea models for the
@@ -20,6 +21,7 @@ func (t *baseToolMessageItem) syncToolA2UISurfaces() {
 	if t.result == nil || t.result.Metadata == "" {
 		t.a2ui.surfaces = nil
 		t.a2ui.surfaceIDs = nil
+		t.a2ui.surfaceOwners = nil
 		t.surfaceScanned = false
 		return
 	}
@@ -27,6 +29,7 @@ func (t *baseToolMessageItem) syncToolA2UISurfaces() {
 	if err := json.Unmarshal([]byte(t.result.Metadata), &meta); err != nil || len(meta.A2UISurfaces) == 0 {
 		t.a2ui.surfaces = nil
 		t.a2ui.surfaceIDs = nil
+		t.a2ui.surfaceOwners = nil
 		t.surfaceScanned = false
 		return
 	}
@@ -36,6 +39,7 @@ func (t *baseToolMessageItem) syncToolA2UISurfaces() {
 	}
 	var surfaces []render.Model
 	var ids []string
+	var owners []string
 	failed := 0
 	for i, surfJSON := range meta.A2UISurfaces {
 		parts, err := a2tea.Scan(surfJSON)
@@ -54,10 +58,17 @@ func (t *baseToolMessageItem) syncToolA2UISurfaces() {
 			id := builtIDs[j]
 			ids = append(ids, id)
 			// Provenance is parallel to A2UISurfaces; a missing or short
-			// slice (older persisted results) means unknown origin.
+			// slice (older persisted results) means unknown origin. It is
+			// recorded per surface on the item — the round-trip resolves
+			// through that, so two servers sharing a surface ID stay
+			// distinct — and mirrored into the global registry for callers
+			// that only hold an ID.
+			owner := ""
 			if i < len(meta.MCPSurfaceProvenance) {
-				registerA2UISurfaceProvenance(id, meta.MCPSurfaceProvenance[i])
+				owner = meta.MCPSurfaceProvenance[i]
+				registerA2UISurfaceProvenance(id, owner)
 			}
+			owners = append(owners, owner)
 		}
 		// A payload that scanned but drew nothing (unsupported components,
 		// bare data-model update) failed just like a scan error: the model
@@ -68,6 +79,7 @@ func (t *baseToolMessageItem) syncToolA2UISurfaces() {
 	}
 	t.a2ui.surfaces = surfaces
 	t.a2ui.surfaceIDs = ids
+	t.a2ui.surfaceOwners = owners
 	t.surfaceBuildFailed = failed
 	t.surfaceSrcHash = h
 	t.surfaceScanned = true
@@ -76,9 +88,86 @@ func (t *baseToolMessageItem) syncToolA2UISurfaces() {
 	}
 }
 
+// A2UISurfaceItem is implemented by message items that hold live MCP A2UI
+// surfaces (tool message items carrying an MCP-served payload). It lets the
+// UI model locate a surface by ID, read its input values for an a2ui_action
+// context, and feed a server's response back into the surface.
+type A2UISurfaceItem interface {
+	// HasA2UISurface reports whether the item holds the named surface.
+	HasA2UISurface(surfaceID string) bool
+	// A2UISurfaceIsFocused reports whether the item holds the named surface
+	// AND that surface currently has keyboard focus. Surface IDs are only
+	// unique within a server, so two items can hold the same ID; the
+	// focused one is the one the user is actually interacting with.
+	A2UISurfaceIsFocused(surfaceID string) bool
+	// A2UISurfaceOwner returns the MCP server that served the named
+	// surface, and whether one is known.
+	A2UISurfaceOwner(surfaceID string) (string, bool)
+	// ToolA2UIFieldValues reads the named surface's current input values.
+	ToolA2UIFieldValues(surfaceID string) map[string]any
+	// ApplyToolA2UIUpdate feeds server messages back into the named
+	// surface, reporting whether it still has renderable state.
+	ApplyToolA2UIUpdate(surfaceID string, msgs []a2ui.ServerMessage) bool
+}
+
 // hasToolA2UISurfaces reports whether this item carries live MCP surfaces.
 func (t *baseToolMessageItem) hasToolA2UISurfaces() bool {
 	return t.a2ui.hasLive()
+}
+
+// HasA2UISurface reports whether this item holds the named surface.
+func (t *baseToolMessageItem) HasA2UISurface(surfaceID string) bool {
+	return t.a2ui.findByID(surfaceID) >= 0
+}
+
+// A2UISurfaceIsFocused reports whether this item holds the named surface and
+// that surface currently has keyboard focus.
+func (t *baseToolMessageItem) A2UISurfaceIsFocused(surfaceID string) bool {
+	idx := t.a2ui.findByID(surfaceID)
+	return idx >= 0 && idx == t.a2ui.focusedIndex()
+}
+
+// A2UISurfaceOwner returns the MCP server that served the named surface.
+func (t *baseToolMessageItem) A2UISurfaceOwner(surfaceID string) (string, bool) {
+	return t.a2ui.ownerFor(t.a2ui.findByID(surfaceID))
+}
+
+// ToolA2UIFieldValues reads the named surface's current input values, for
+// building an a2ui_action context.
+func (t *baseToolMessageItem) ToolA2UIFieldValues(surfaceID string) map[string]any {
+	idx := t.a2ui.findByID(surfaceID)
+	return t.a2ui.fieldValues(idx)
+}
+
+// ApplyToolA2UIUpdate feeds a batch of A2UI server messages back into the
+// named surface (the response to an a2ui_action round-trip): the surface
+// updates in place rather than being replaced, preserving focus and edited
+// state the server did not touch. It reports whether the surface still has
+// renderable state afterward (false means the server deleted it).
+func (t *baseToolMessageItem) ApplyToolA2UIUpdate(surfaceID string, msgs []a2ui.ServerMessage) bool {
+	idx := t.a2ui.findByID(surfaceID)
+	s := t.a2ui.surfaceAt(idx)
+	if s == nil {
+		return false
+	}
+	applier, ok := s.(interface {
+		Apply([]a2ui.ServerMessage) bool
+	})
+	if !ok {
+		return false
+	}
+	alive := applier.Apply(msgs)
+	if !alive {
+		// The server deleted the surface. Release the model so it stops
+		// claiming focus and swallowing keys for something that draws
+		// nothing, and re-focus whatever is left.
+		t.a2ui.drop(idx)
+		if t.isFocused() {
+			t.focusToolA2UISurfaces()
+		}
+	}
+	t.Bump()
+	return alive
 }
 
 // focusToolA2UISurfaces grants focus to the first live surface and blurs the

--- a/internal/ui/chat/tool_a2ui.go
+++ b/internal/ui/chat/tool_a2ui.go
@@ -83,7 +83,7 @@ func (t *baseToolMessageItem) syncToolA2UISurfaces() {
 	t.surfaceBuildFailed = failed
 	t.surfaceSrcHash = h
 	t.surfaceScanned = true
-	if t.focusableMessageItem.isFocused() {
+	if t.isFocused() {
 		t.focusToolA2UISurfaces()
 	}
 }

--- a/internal/ui/chat/tool_a2ui.go
+++ b/internal/ui/chat/tool_a2ui.go
@@ -1,0 +1,229 @@
+package chat
+
+import (
+	"encoding/json"
+	"strings"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/crush/internal/agent/tools"
+	"github.com/joestump-agent/a2tea"
+	"github.com/joestump-agent/a2tea/render"
+	a2ui "github.com/tmc/a2ui"
+)
+
+// syncToolA2UISurfaces builds — or reuses — the live a2tea models for the
+// surfaces carried in the tool result's metadata. Models are keyed by
+// a hash of the metadata: a re-render with the same result reuses the live
+// models (preserving focus and edited field values), while a result swap
+// (SetResult) rebuilds them. Each surface's provenance is registered so a
+// later interaction routes back to the owning MCP server.
+func (t *baseToolMessageItem) syncToolA2UISurfaces() {
+	if t.result == nil || t.result.Metadata == "" {
+		t.a2ui.surfaces = nil
+		t.a2ui.surfaceIDs = nil
+		t.a2ui.surfaceOwners = nil
+		t.surfaceScanned = false
+		return
+	}
+	var meta tools.ReadMCPResourceResponseMetadata
+	if err := json.Unmarshal([]byte(t.result.Metadata), &meta); err != nil || len(meta.A2UISurfaces) == 0 {
+		t.a2ui.surfaces = nil
+		t.a2ui.surfaceIDs = nil
+		t.a2ui.surfaceOwners = nil
+		t.surfaceScanned = false
+		return
+	}
+	h := fnv64(t.result.Metadata)
+	if t.surfaceScanned && t.surfaceSrcHash == h {
+		return
+	}
+	var surfaces []render.Model
+	var ids []string
+	var owners []string
+	failed := 0
+	for i, surfJSON := range meta.A2UISurfaces {
+		parts, err := a2tea.Scan(surfJSON)
+		if err != nil {
+			failed++
+			continue
+		}
+		built, builtIDs := buildA2UISurfaces(t.sty, parts)
+		payloadLive := 0
+		for j, m := range built {
+			if m == nil {
+				continue
+			}
+			payloadLive++
+			surfaces = append(surfaces, m)
+			id := builtIDs[j]
+			ids = append(ids, id)
+			// Provenance is parallel to A2UISurfaces; a missing or short
+			// slice (older persisted results) means unknown origin. It is
+			// recorded per surface on the item — the round-trip resolves
+			// through that, so two servers sharing a surface ID stay
+			// distinct — and mirrored into the global registry for callers
+			// that only hold an ID.
+			owner := ""
+			if i < len(meta.MCPSurfaceProvenance) {
+				owner = meta.MCPSurfaceProvenance[i]
+				registerA2UISurfaceProvenance(id, owner)
+			}
+			owners = append(owners, owner)
+		}
+		// A payload that scanned but drew nothing (unsupported components,
+		// bare data-model update) failed just like a scan error: the model
+		// was told the user can see it.
+		if payloadLive == 0 {
+			failed++
+		}
+	}
+	t.a2ui.surfaces = surfaces
+	t.a2ui.surfaceIDs = ids
+	t.a2ui.surfaceOwners = owners
+	t.surfaceBuildFailed = failed
+	t.surfaceSrcHash = h
+	t.surfaceScanned = true
+	if t.isFocused() {
+		t.focusToolA2UISurfaces()
+	}
+}
+
+// A2UISurfaceItem is implemented by message items that hold live MCP A2UI
+// surfaces (tool message items carrying an MCP-served payload). It lets the
+// UI model locate a surface by ID, read its input values for an a2ui_action
+// context, and feed a server's response back into the surface.
+type A2UISurfaceItem interface {
+	// HasA2UISurface reports whether the item holds the named surface.
+	HasA2UISurface(surfaceID string) bool
+	// A2UISurfaceIsFocused reports whether the item holds the named surface
+	// AND that surface currently has keyboard focus. Surface IDs are only
+	// unique within a server, so two items can hold the same ID; the
+	// focused one is the one the user is actually interacting with.
+	A2UISurfaceIsFocused(surfaceID string) bool
+	// A2UISurfaceOwner returns the MCP server that served the named
+	// surface, and whether one is known.
+	A2UISurfaceOwner(surfaceID string) (string, bool)
+	// ToolA2UIFieldValues reads the named surface's current input values.
+	ToolA2UIFieldValues(surfaceID string) map[string]any
+	// ApplyToolA2UIUpdate feeds server messages back into the named
+	// surface, reporting whether it still has renderable state.
+	ApplyToolA2UIUpdate(surfaceID string, msgs []a2ui.ServerMessage) bool
+}
+
+// hasToolA2UISurfaces reports whether this item carries live MCP surfaces.
+func (t *baseToolMessageItem) hasToolA2UISurfaces() bool {
+	return t.a2ui.hasLive()
+}
+
+// HasA2UISurface reports whether this item holds the named surface.
+func (t *baseToolMessageItem) HasA2UISurface(surfaceID string) bool {
+	return t.a2ui.findByID(surfaceID) >= 0
+}
+
+// A2UISurfaceIsFocused reports whether this item holds the named surface and
+// that surface currently has keyboard focus.
+func (t *baseToolMessageItem) A2UISurfaceIsFocused(surfaceID string) bool {
+	idx := t.a2ui.findByID(surfaceID)
+	return idx >= 0 && idx == t.a2ui.focusedIndex()
+}
+
+// A2UISurfaceOwner returns the MCP server that served the named surface.
+func (t *baseToolMessageItem) A2UISurfaceOwner(surfaceID string) (string, bool) {
+	return t.a2ui.ownerFor(t.a2ui.findByID(surfaceID))
+}
+
+// ToolA2UIFieldValues reads the named surface's current input values, for
+// building an a2ui_action context.
+func (t *baseToolMessageItem) ToolA2UIFieldValues(surfaceID string) map[string]any {
+	idx := t.a2ui.findByID(surfaceID)
+	return t.a2ui.fieldValues(idx)
+}
+
+// ApplyToolA2UIUpdate feeds a batch of A2UI server messages back into the
+// named surface (the response to an a2ui_action round-trip): the surface
+// updates in place rather than being replaced, preserving focus and edited
+// state the server did not touch. It reports whether the surface still has
+// renderable state afterward (false means the server deleted it).
+func (t *baseToolMessageItem) ApplyToolA2UIUpdate(surfaceID string, msgs []a2ui.ServerMessage) bool {
+	idx := t.a2ui.findByID(surfaceID)
+	s := t.a2ui.surfaceAt(idx)
+	if s == nil {
+		return false
+	}
+	applier, ok := s.(interface {
+		Apply([]a2ui.ServerMessage) bool
+	})
+	if !ok {
+		return false
+	}
+	alive := applier.Apply(msgs)
+	if !alive {
+		// The server deleted the surface. Release the model so it stops
+		// claiming focus and swallowing keys for something that draws
+		// nothing, and re-focus whatever is left.
+		t.a2ui.drop(idx)
+		if t.isFocused() {
+			t.focusToolA2UISurfaces()
+		}
+	}
+	t.Bump()
+	return alive
+}
+
+// focusToolA2UISurfaces grants focus to the first live surface and blurs the
+// rest. MCP surfaces are long-lived app UIs — unlike chat-scanned
+// forms they are never retired on submission, so every live surface is
+// focusable.
+func (t *baseToolMessageItem) focusToolA2UISurfaces() {
+	for i, s := range t.a2ui.surfaces {
+		if s != nil {
+			t.a2ui.focus(i)
+			return
+		}
+	}
+}
+
+// blurToolA2UISurfaces revokes keyboard focus from every live surface.
+func (t *baseToolMessageItem) blurToolA2UISurfaces() {
+	t.a2ui.blurAll()
+}
+
+// renderToolA2UISurfaces renders each live surface from its model at the
+// given width, joined by blank lines. It also reports how many surfaces
+// failed — payloads that never built a model (surfaceBuildFailed) plus live
+// models that drew nothing — so the renderer can show the same alert the
+// static path shows: the model was told the user can see every surface.
+func (t *baseToolMessageItem) renderToolA2UISurfaces(width int) (string, int) {
+	var b strings.Builder
+	failed := t.surfaceBuildFailed
+	for _, s := range t.a2ui.surfaces {
+		if s == nil {
+			continue
+		}
+		s.SetSize(width, 0)
+		rendered := strings.TrimRight(s.View().Content, "\n")
+		if rendered == "" {
+			failed++
+			continue
+		}
+		if b.Len() > 0 {
+			b.WriteString("\n\n")
+		}
+		b.WriteString(rendered)
+	}
+	return b.String(), failed
+}
+
+// HandleKeyEvent routes keys to the focused live MCP surface first
+// — Tab/Shift+Tab cycle its focus ring, Enter activates a button,
+// printable keys edit a focused field (see a2uiSurfaceWantsKey) — then falls
+// through to the copy shortcut. A button activation surfaces as an
+// a2uievent.ButtonClicked tea.Cmd, which the UI model routes per the
+// surface's provenance.
+func (t *baseToolMessageItem) handleA2UIKeyEvent(key tea.KeyMsg) (bool, tea.Cmd) {
+	if idx := t.a2ui.focusedIndex(); idx >= 0 && a2uiSurfaceWantsKey(t.a2ui.surfaces[idx], key) {
+		t.Bump()
+		return true, t.a2ui.update(idx, key)
+	}
+	return false, nil
+}

--- a/internal/ui/chat/tool_a2ui_test.go
+++ b/internal/ui/chat/tool_a2ui_test.go
@@ -1,0 +1,131 @@
+package chat
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/charmbracelet/crush/internal/agent/tools"
+	"github.com/charmbracelet/crush/internal/message"
+	"github.com/charmbracelet/crush/internal/ui/styles"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/stretchr/testify/require"
+)
+
+const a2uiToolSurface = `<a2ui-json>{"version":"v0.9","updateComponents":{"surfaceId":"card","components":[` +
+	`{"component":"Card","id":"root","child":"col"},` +
+	`{"component":"Column","id":"col","children":["title"]},` +
+	`{"component":"Text","id":"title","variant":"h2","text":"Recipe Card"}]}}` + `</a2ui-json>`
+
+// newA2UIToolItem builds a base tool item whose result metadata carries the
+// given surfaces and provenance — the shape read_mcp_resource and mcp_* tool
+// results produce.
+func newA2UIToolItem(t *testing.T, surfaces, provenance []string, toolName string) *baseToolMessageItem {
+	t.Helper()
+	meta, err := json.Marshal(tools.ReadMCPResourceResponseMetadata{
+		A2UISurfaces:         surfaces,
+		MCPSurfaceProvenance: provenance,
+	})
+	require.NoError(t, err)
+
+	sty := styles.CharmtonePantera()
+	return newBaseToolMessageItem(&sty, message.ToolCall{
+		ID:       "call-1",
+		Name:     toolName,
+		Input:    `{}`,
+		Finished: true,
+	}, &message.ToolResult{
+		ToolCallID: "call-1",
+		Content:    a2uiTestPlaceholder,
+		Metadata:   string(meta),
+	}, &GenericToolRenderContext{}, false)
+}
+
+func TestToolA2UISurfaces(t *testing.T) {
+	t.Parallel()
+
+	t.Run("metadata surfaces build live models", func(t *testing.T) {
+		t.Parallel()
+		item := newA2UIToolItem(t, []string{a2uiToolSurface}, []string{"cairn"}, tools.ReadMCPResourceToolName)
+		item.syncToolA2UISurfaces()
+
+		require.True(t, item.hasToolA2UISurfaces())
+		require.Len(t, item.a2ui.surfaces, 1)
+		require.Equal(t, "card", item.a2ui.surfaceIDs[0])
+	})
+
+	t.Run("provenance is registered per surface", func(t *testing.T) {
+		t.Parallel()
+		item := newA2UIToolItem(t, []string{a2uiToolSurface}, []string{"cairn"}, tools.ReadMCPResourceToolName)
+		item.syncToolA2UISurfaces()
+
+		server, ok := A2UISurfaceProvenance("card")
+		require.True(t, ok)
+		require.Equal(t, "cairn", server)
+	})
+
+	t.Run("missing provenance means unknown origin", func(t *testing.T) {
+		t.Parallel()
+		item := newA2UIToolItem(t, []string{a2uiToolSurface}, nil, tools.ReadMCPResourceToolName)
+		item.syncToolA2UISurfaces()
+		require.True(t, item.hasToolA2UISurfaces())
+	})
+
+	t.Run("same metadata reuses live models", func(t *testing.T) {
+		t.Parallel()
+		item := newA2UIToolItem(t, []string{a2uiToolSurface}, []string{"cairn"}, tools.ReadMCPResourceToolName)
+		item.syncToolA2UISurfaces()
+		first := item.a2ui.surfaces[0]
+
+		// A re-render with the same result must reuse the model so focus
+		// and edited field values survive.
+		item.syncToolA2UISurfaces()
+		require.Same(t, first, item.a2ui.surfaces[0])
+	})
+
+	t.Run("malformed payload yields no live surface", func(t *testing.T) {
+		t.Parallel()
+		item := newA2UIToolItem(t, []string{"<a2ui-json>{malformed</a2ui-json>"}, []string{"cairn"}, tools.ReadMCPResourceToolName)
+		item.syncToolA2UISurfaces()
+		require.False(t, item.hasToolA2UISurfaces())
+	})
+
+	t.Run("rendering a live surface draws its content", func(t *testing.T) {
+		t.Parallel()
+		item := newA2UIToolItem(t, []string{a2uiToolSurface}, []string{"cairn"}, tools.ReadMCPResourceToolName)
+		item.syncToolA2UISurfaces()
+		out := item.renderToolA2UISurfaces(80)
+		plain := ansi.Strip(out)
+		require.Contains(t, plain, "Recipe Card")
+		require.NotContains(t, plain, "updateComponents")
+	})
+
+	t.Run("RawRender renders the surface instead of the placeholder", func(t *testing.T) {
+		t.Parallel()
+		item := newA2UIToolItem(t, []string{a2uiToolSurface}, []string{"cairn"}, tools.ReadMCPResourceToolName)
+		out := ansi.Strip(item.RawRender(100))
+		require.Contains(t, out, "Recipe Card")
+		require.NotContains(t, out, "do not repeat")
+	})
+}
+
+// The MCP tool renderer (mcp_* tools) renders metadata surfaces too, not
+// just read_mcp_resource.
+func TestMCPToolRendersA2UIFromMetadata(t *testing.T) {
+	t.Parallel()
+
+	meta, err := json.Marshal(tools.ReadMCPResourceResponseMetadata{
+		A2UISurfaces: []string{a2uiToolSurface},
+	})
+	require.NoError(t, err)
+
+	sty := styles.CharmtonePantera()
+	ctx := &MCPToolRenderContext{}
+	out := ctx.RenderTool(&sty, 80, genericToolOptsFor(t, "mcp_recipe_get_recipe_a2ui", &message.ToolResult{
+		Content:  a2uiTestPlaceholder,
+		Metadata: string(meta),
+	}))
+	plain := ansi.Strip(out)
+
+	require.Contains(t, plain, "Recipe Card")
+	require.NotContains(t, plain, "do not repeat")
+}

--- a/internal/ui/chat/tool_a2ui_test.go
+++ b/internal/ui/chat/tool_a2ui_test.go
@@ -93,10 +93,29 @@ func TestToolA2UISurfaces(t *testing.T) {
 		t.Parallel()
 		item := newA2UIToolItem(t, []string{a2uiToolSurface}, []string{"cairn"}, tools.ReadMCPResourceToolName)
 		item.syncToolA2UISurfaces()
-		out := item.renderToolA2UISurfaces(80)
+		out, failed := item.renderToolA2UISurfaces(80)
 		plain := ansi.Strip(out)
 		require.Contains(t, plain, "Recipe Card")
 		require.NotContains(t, plain, "updateComponents")
+		require.Zero(t, failed)
+	})
+
+	t.Run("a failed sibling payload still alerts next to a live surface", func(t *testing.T) {
+		t.Parallel()
+		// One payload renders, one is malformed: the live path must show
+		// the rendered surface AND the alert — the model was told the
+		// user can see both.
+		item := newA2UIToolItem(t,
+			[]string{a2uiToolSurface, "<a2ui-json>{malformed</a2ui-json>"},
+			[]string{"cairn", "cairn"}, tools.ReadMCPResourceToolName)
+		item.syncToolA2UISurfaces()
+		require.True(t, item.hasToolA2UISurfaces())
+		_, failed := item.renderToolA2UISurfaces(80)
+		require.Equal(t, 1, failed)
+
+		out := ansi.Strip(item.RawRender(100))
+		require.Contains(t, out, "Recipe Card")
+		require.Contains(t, out, "couldn't render this resource's UI surface")
 	})
 
 	t.Run("RawRender renders the surface instead of the placeholder", func(t *testing.T) {

--- a/internal/ui/chat/tool_a2ui_test.go
+++ b/internal/ui/chat/tool_a2ui_test.go
@@ -1,0 +1,150 @@
+package chat
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/charmbracelet/crush/internal/agent/tools"
+	"github.com/charmbracelet/crush/internal/message"
+	"github.com/charmbracelet/crush/internal/ui/styles"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/stretchr/testify/require"
+)
+
+const a2uiToolSurface = `<a2ui-json>{"version":"v0.9","updateComponents":{"surfaceId":"card","components":[` +
+	`{"component":"Card","id":"root","child":"col"},` +
+	`{"component":"Column","id":"col","children":["title"]},` +
+	`{"component":"Text","id":"title","variant":"h2","text":"Recipe Card"}]}}` + `</a2ui-json>`
+
+// newA2UIToolItem builds a base tool item whose result metadata carries the
+// given surfaces and provenance — the shape read_mcp_resource and mcp_* tool
+// results produce.
+func newA2UIToolItem(t *testing.T, surfaces, provenance []string, toolName string) *baseToolMessageItem {
+	t.Helper()
+	meta, err := json.Marshal(tools.ReadMCPResourceResponseMetadata{
+		A2UISurfaces:         surfaces,
+		MCPSurfaceProvenance: provenance,
+	})
+	require.NoError(t, err)
+
+	sty := styles.CharmtonePantera()
+	return newBaseToolMessageItem(&sty, message.ToolCall{
+		ID:       "call-1",
+		Name:     toolName,
+		Input:    `{}`,
+		Finished: true,
+	}, &message.ToolResult{
+		ToolCallID: "call-1",
+		Content:    a2uiTestPlaceholder,
+		Metadata:   string(meta),
+	}, &GenericToolRenderContext{}, false)
+}
+
+func TestToolA2UISurfaces(t *testing.T) {
+	t.Parallel()
+
+	t.Run("metadata surfaces build live models", func(t *testing.T) {
+		t.Parallel()
+		item := newA2UIToolItem(t, []string{a2uiToolSurface}, []string{"cairn"}, tools.ReadMCPResourceToolName)
+		item.syncToolA2UISurfaces()
+
+		require.True(t, item.hasToolA2UISurfaces())
+		require.Len(t, item.a2ui.surfaces, 1)
+		require.Equal(t, "card", item.a2ui.surfaceIDs[0])
+	})
+
+	t.Run("provenance is registered per surface", func(t *testing.T) {
+		t.Parallel()
+		item := newA2UIToolItem(t, []string{a2uiToolSurface}, []string{"cairn"}, tools.ReadMCPResourceToolName)
+		item.syncToolA2UISurfaces()
+
+		server, ok := A2UISurfaceProvenance("card")
+		require.True(t, ok)
+		require.Equal(t, "cairn", server)
+	})
+
+	t.Run("missing provenance means unknown origin", func(t *testing.T) {
+		t.Parallel()
+		item := newA2UIToolItem(t, []string{a2uiToolSurface}, nil, tools.ReadMCPResourceToolName)
+		item.syncToolA2UISurfaces()
+		require.True(t, item.hasToolA2UISurfaces())
+	})
+
+	t.Run("same metadata reuses live models", func(t *testing.T) {
+		t.Parallel()
+		item := newA2UIToolItem(t, []string{a2uiToolSurface}, []string{"cairn"}, tools.ReadMCPResourceToolName)
+		item.syncToolA2UISurfaces()
+		first := item.a2ui.surfaces[0]
+
+		// A re-render with the same result must reuse the model so focus
+		// and edited field values survive.
+		item.syncToolA2UISurfaces()
+		require.Same(t, first, item.a2ui.surfaces[0])
+	})
+
+	t.Run("malformed payload yields no live surface", func(t *testing.T) {
+		t.Parallel()
+		item := newA2UIToolItem(t, []string{"<a2ui-json>{malformed</a2ui-json>"}, []string{"cairn"}, tools.ReadMCPResourceToolName)
+		item.syncToolA2UISurfaces()
+		require.False(t, item.hasToolA2UISurfaces())
+	})
+
+	t.Run("rendering a live surface draws its content", func(t *testing.T) {
+		t.Parallel()
+		item := newA2UIToolItem(t, []string{a2uiToolSurface}, []string{"cairn"}, tools.ReadMCPResourceToolName)
+		item.syncToolA2UISurfaces()
+		out, failed := item.renderToolA2UISurfaces(80)
+		plain := ansi.Strip(out)
+		require.Contains(t, plain, "Recipe Card")
+		require.NotContains(t, plain, "updateComponents")
+		require.Zero(t, failed)
+	})
+
+	t.Run("a failed sibling payload still alerts next to a live surface", func(t *testing.T) {
+		t.Parallel()
+		// One payload renders, one is malformed: the live path must show
+		// the rendered surface AND the alert — the model was told the
+		// user can see both.
+		item := newA2UIToolItem(t,
+			[]string{a2uiToolSurface, "<a2ui-json>{malformed</a2ui-json>"},
+			[]string{"cairn", "cairn"}, tools.ReadMCPResourceToolName)
+		item.syncToolA2UISurfaces()
+		require.True(t, item.hasToolA2UISurfaces())
+		_, failed := item.renderToolA2UISurfaces(80)
+		require.Equal(t, 1, failed)
+
+		out := ansi.Strip(item.RawRender(100))
+		require.Contains(t, out, "Recipe Card")
+		require.Contains(t, out, "couldn't render this resource's UI surface")
+	})
+
+	t.Run("RawRender renders the surface instead of the placeholder", func(t *testing.T) {
+		t.Parallel()
+		item := newA2UIToolItem(t, []string{a2uiToolSurface}, []string{"cairn"}, tools.ReadMCPResourceToolName)
+		out := ansi.Strip(item.RawRender(100))
+		require.Contains(t, out, "Recipe Card")
+		require.NotContains(t, out, "do not repeat")
+	})
+}
+
+// The MCP tool renderer (mcp_* tools) renders metadata surfaces too, not
+// just read_mcp_resource.
+func TestMCPToolRendersA2UIFromMetadata(t *testing.T) {
+	t.Parallel()
+
+	meta, err := json.Marshal(tools.ReadMCPResourceResponseMetadata{
+		A2UISurfaces: []string{a2uiToolSurface},
+	})
+	require.NoError(t, err)
+
+	sty := styles.CharmtonePantera()
+	ctx := &MCPToolRenderContext{}
+	out := ctx.RenderTool(&sty, 80, genericToolOptsFor(t, "mcp_recipe_get_recipe_a2ui", &message.ToolResult{
+		Content:  a2uiTestPlaceholder,
+		Metadata: string(meta),
+	}))
+	plain := ansi.Strip(out)
+
+	require.Contains(t, plain, "Recipe Card")
+	require.NotContains(t, plain, "do not repeat")
+}

--- a/internal/ui/chat/tools.go
+++ b/internal/ui/chat/tools.go
@@ -99,11 +99,12 @@ type ToolRenderOpts struct {
 	IsSpinning      bool
 	Status          ToolStatus
 	// LiveSurfaces renders the item's live MCP A2UI surface models at the
-	// given width. Set only when the result metadata carried
-	// renderable surfaces; nil otherwise, in which case renderers fall
-	// back to the static/text paths. Carried on the opts because the
-	// ToolRenderer interface does not see the owning item.
-	LiveSurfaces func(width int) string
+	// given width, and reports how many of the metadata's surfaces failed
+	// to draw. Set only when the result metadata carried renderable
+	// surfaces; nil otherwise, in which case renderers fall back to the
+	// static/text paths. Carried on the opts because the ToolRenderer
+	// interface does not see the owning item.
+	LiveSurfaces func(width int) (string, int)
 }
 
 // IsPending returns true if the tool call is still pending (not finished and
@@ -170,16 +171,19 @@ type baseToolMessageItem struct {
 	// parseHyperlinkSpans for why the app must handle this itself).
 	hyperlinks []hyperlinkSpan
 
-	// a2ui holds the live surface models for an MCP-served A2UI payload
-	//: a read_mcp_resource or mcp_* tool whose result metadata
-	// carries surfaces. They render interactively and, being long-lived
-	// app UIs, are never retired on interaction. Nil for tools
-	// without surfaces. surfaceSrcHash fingerprints the metadata the
-	// models were built from so a re-render with the same metadata reuses
-	// the live models (and their edited values) instead of rebuilding.
-	a2ui           a2uiSurfaceHost
-	surfaceSrcHash uint64
-	surfaceScanned bool
+	// a2ui holds the live surface models for an MCP-served A2UI payload:
+	// a read_mcp_resource or mcp_* tool whose result metadata carries
+	// surfaces. They render interactively and, being long-lived app UIs,
+	// are never retired on interaction. Nil for tools without surfaces.
+	// surfaceSrcHash fingerprints the metadata the models were built from
+	// so a re-render with the same metadata reuses the live models (and
+	// their edited values) instead of rebuilding; surfaceBuildFailed
+	// counts payloads that never produced a drawable model, so the
+	// renderer can alert on them.
+	a2ui               a2uiSurfaceHost
+	surfaceSrcHash     uint64
+	surfaceScanned     bool
+	surfaceBuildFailed int
 }
 
 var _ Expandable = (*baseToolMessageItem)(nil)
@@ -369,7 +373,7 @@ func (t *baseToolMessageItem) RawRender(width int) string {
 	// edited values, not a frozen frame.
 	t.syncToolA2UISurfaces()
 	liveSurfaces := t.hasToolA2UISurfaces()
-	var liveRender func(width int) string
+	var liveRender func(width int) (string, int)
 	if liveSurfaces {
 		liveRender = t.renderToolA2UISurfaces
 	}

--- a/internal/ui/chat/tools.go
+++ b/internal/ui/chat/tools.go
@@ -98,6 +98,13 @@ type ToolRenderOpts struct {
 	Compact         bool
 	IsSpinning      bool
 	Status          ToolStatus
+	// LiveSurfaces renders the item's live MCP A2UI surface models at the
+	// given width, and reports how many of the metadata's surfaces failed
+	// to draw. Set only when the result metadata carried renderable
+	// surfaces; nil otherwise, in which case renderers fall back to the
+	// static/text paths. Carried on the opts because the ToolRenderer
+	// interface does not see the owning item.
+	LiveSurfaces func(width int) (string, int)
 }
 
 // IsPending returns true if the tool call is still pending (not finished and
@@ -163,6 +170,20 @@ type baseToolMessageItem struct {
 	// output so a plain click on a URL opens it in the browser (see
 	// parseHyperlinkSpans for why the app must handle this itself).
 	hyperlinks []hyperlinkSpan
+
+	// a2ui holds the live surface models for an MCP-served A2UI payload:
+	// a read_mcp_resource or mcp_* tool whose result metadata carries
+	// surfaces. They render interactively and, being long-lived app UIs,
+	// are never retired on interaction. Nil for tools without surfaces.
+	// surfaceSrcHash fingerprints the metadata the models were built from
+	// so a re-render with the same metadata reuses the live models (and
+	// their edited values) instead of rebuilding; surfaceBuildFailed
+	// counts payloads that never produced a drawable model, so the
+	// renderer can alert on them.
+	a2ui               a2uiSurfaceHost
+	surfaceSrcHash     uint64
+	surfaceScanned     bool
+	surfaceBuildFailed int
 }
 
 var _ Expandable = (*baseToolMessageItem)(nil)
@@ -196,6 +217,7 @@ func newBaseToolMessageItem(
 		status:                   status,
 		hasCappedWidth:           hasCappedWidth,
 	}
+	t.a2ui.sty = sty
 	t.anim = anim.New(anim.Settings{
 		ID:          toolCall.ID,
 		Size:        15,
@@ -345,9 +367,20 @@ func (t *baseToolMessageItem) RawRender(width int) string {
 		toolItemWidth = cappedMessageWidth(width)
 	}
 
+	// Build or refresh the live MCP surface models from the result
+	// metadata. While surfaces are live the content cache is
+	// bypassed: a surface's View reflects the current focus ring and
+	// edited values, not a frozen frame.
+	t.syncToolA2UISurfaces()
+	liveSurfaces := t.hasToolA2UISurfaces()
+	var liveRender func(width int) (string, int)
+	if liveSurfaces {
+		liveRender = t.renderToolA2UISurfaces
+	}
+
 	content, height, ok := t.getCachedRender(toolItemWidth)
 	// if we are spinning or there is no cache rerender
-	if !ok || t.isSpinning() {
+	if !ok || t.isSpinning() || liveSurfaces {
 		content = t.toolRenderer.RenderTool(t.sty, toolItemWidth, &ToolRenderOpts{
 			ToolCall:        t.toolCall,
 			Result:          t.result,
@@ -356,6 +389,7 @@ func (t *baseToolMessageItem) RawRender(width int) string {
 			Compact:         t.isCompact,
 			IsSpinning:      t.isSpinning(),
 			Status:          t.computeStatus(),
+			LiveSurfaces:    liveRender,
 		})
 
 		// Prepend hook indicator if hooks ran for this tool call.
@@ -366,8 +400,11 @@ func (t *baseToolMessageItem) RawRender(width int) string {
 		}
 
 		height = lipgloss.Height(content)
-		// cache the rendered content
-		t.setCachedRender(content, toolItemWidth, height)
+		// cache the rendered content — but not while surfaces are live:
+		// the next interaction changes the view.
+		if !liveSurfaces {
+			t.setCachedRender(content, toolItemWidth, height)
+		}
 	}
 
 	// Re-index hyperlink spans on every render (cheap relative to the
@@ -382,8 +419,9 @@ func (t *baseToolMessageItem) RawRender(width int) string {
 func (t *baseToolMessageItem) Render(width int) string {
 	// Cache the prefixed output keyed by (width, prefix variant).
 	// Bypass the cache while spinning (RawRender output is
-	// frame-dependent) or while a highlight range is active.
-	useCache := !t.isSpinning() && !t.isHighlighted()
+	// frame-dependent), while a highlight range is active, or while
+	// live MCP surfaces can change between frames.
+	useCache := !t.isSpinning() && !t.isHighlighted() && !t.hasToolA2UISurfaces()
 	var key uint64
 	switch {
 	case t.isCompact:
@@ -432,6 +470,9 @@ func (t *baseToolMessageItem) SetToolCall(tc message.ToolCall) {
 // SetResult sets the tool result associated with this message item.
 func (t *baseToolMessageItem) SetResult(res *message.ToolResult) {
 	t.result = res
+	// New metadata may carry different surfaces; force a rebuild on the
+	// next render while preserving focus/edits when it is unchanged.
+	t.surfaceScanned = false
 	t.clearCache()
 	t.Bump()
 }
@@ -535,13 +576,34 @@ func (t *baseToolMessageItem) HandleMouseClickCmd(btn ansi.MouseButton, x, y int
 	return true, nil
 }
 
-// HandleKeyEvent implements KeyEventHandler.
+// HandleKeyEvent implements KeyEventHandler. A focused live MCP surface
+// gets first claim on the keys it understands — Tab/Shift+Tab cycle
+// its focus ring, Enter activates a button (surfacing an
+// a2uievent.ButtonClicked the UI model routes per provenance) — and
+// every other key falls through, so the copy shortcut keeps working
+// whenever no surface consumes the key.
 func (t *baseToolMessageItem) HandleKeyEvent(key tea.KeyMsg) (bool, tea.Cmd) {
+	if handled, cmd := t.handleA2UIKeyEvent(key); handled {
+		return true, cmd
+	}
 	if k := key.String(); k == "c" || k == "y" {
 		text := t.formatToolForCopy()
 		return true, common.CopyToClipboard(text, "Tool content copied to clipboard")
 	}
 	return false, nil
+}
+
+// SetFocused implements MessageItem. Focus also drives the live MCP
+// surfaces: gaining focus grants it to the first live surface,
+// losing focus blurs them all — so the focus ring only ever lives on the
+// selected item.
+func (t *baseToolMessageItem) SetFocused(focused bool) {
+	t.focusableMessageItem.SetFocused(focused)
+	if focused {
+		t.focusToolA2UISurfaces()
+	} else {
+		t.blurToolA2UISurfaces()
+	}
 }
 
 // pendingTool renders a tool that is still in progress with an animation.

--- a/internal/ui/chat/tools.go
+++ b/internal/ui/chat/tools.go
@@ -98,6 +98,12 @@ type ToolRenderOpts struct {
 	Compact         bool
 	IsSpinning      bool
 	Status          ToolStatus
+	// LiveSurfaces renders the item's live MCP A2UI surface models at the
+	// given width (#219). Set only when the result metadata carried
+	// renderable surfaces; nil otherwise, in which case renderers fall
+	// back to the static/text paths. Carried on the opts because the
+	// ToolRenderer interface does not see the owning item.
+	LiveSurfaces func(width int) string
 }
 
 // IsPending returns true if the tool call is still pending (not finished and
@@ -163,6 +169,17 @@ type baseToolMessageItem struct {
 	// output so a plain click on a URL opens it in the browser (see
 	// parseHyperlinkSpans for why the app must handle this itself).
 	hyperlinks []hyperlinkSpan
+
+	// a2ui holds the live surface models for an MCP-served A2UI payload
+	// (#219): a read_mcp_resource or mcp_* tool whose result metadata
+	// carries surfaces. They render interactively and, being long-lived
+	// app UIs, are never retired on interaction (#221). Nil for tools
+	// without surfaces. surfaceSrcHash fingerprints the metadata the
+	// models were built from so a re-render with the same metadata reuses
+	// the live models (and their edited values) instead of rebuilding.
+	a2ui           a2uiSurfaceHost
+	surfaceSrcHash uint64
+	surfaceScanned bool
 }
 
 var _ Expandable = (*baseToolMessageItem)(nil)
@@ -196,6 +213,7 @@ func newBaseToolMessageItem(
 		status:                   status,
 		hasCappedWidth:           hasCappedWidth,
 	}
+	t.a2ui.sty = sty
 	t.anim = anim.New(anim.Settings{
 		ID:          toolCall.ID,
 		Size:        15,
@@ -345,9 +363,20 @@ func (t *baseToolMessageItem) RawRender(width int) string {
 		toolItemWidth = cappedMessageWidth(width)
 	}
 
+	// Build or refresh the live MCP surface models from the result
+	// metadata (#219). While surfaces are live the content cache is
+	// bypassed: a surface's View reflects the current focus ring and
+	// edited values, not a frozen frame.
+	t.syncToolA2UISurfaces()
+	liveSurfaces := t.hasToolA2UISurfaces()
+	var liveRender func(width int) string
+	if liveSurfaces {
+		liveRender = t.renderToolA2UISurfaces
+	}
+
 	content, height, ok := t.getCachedRender(toolItemWidth)
 	// if we are spinning or there is no cache rerender
-	if !ok || t.isSpinning() {
+	if !ok || t.isSpinning() || liveSurfaces {
 		content = t.toolRenderer.RenderTool(t.sty, toolItemWidth, &ToolRenderOpts{
 			ToolCall:        t.toolCall,
 			Result:          t.result,
@@ -356,6 +385,7 @@ func (t *baseToolMessageItem) RawRender(width int) string {
 			Compact:         t.isCompact,
 			IsSpinning:      t.isSpinning(),
 			Status:          t.computeStatus(),
+			LiveSurfaces:    liveRender,
 		})
 
 		// Prepend hook indicator if hooks ran for this tool call.
@@ -366,8 +396,11 @@ func (t *baseToolMessageItem) RawRender(width int) string {
 		}
 
 		height = lipgloss.Height(content)
-		// cache the rendered content
-		t.setCachedRender(content, toolItemWidth, height)
+		// cache the rendered content — but not while surfaces are live:
+		// the next interaction changes the view.
+		if !liveSurfaces {
+			t.setCachedRender(content, toolItemWidth, height)
+		}
 	}
 
 	// Re-index hyperlink spans on every render (cheap relative to the
@@ -382,8 +415,9 @@ func (t *baseToolMessageItem) RawRender(width int) string {
 func (t *baseToolMessageItem) Render(width int) string {
 	// Cache the prefixed output keyed by (width, prefix variant).
 	// Bypass the cache while spinning (RawRender output is
-	// frame-dependent) or while a highlight range is active.
-	useCache := !t.isSpinning() && !t.isHighlighted()
+	// frame-dependent), while a highlight range is active, or while
+	// live MCP surfaces can change between frames.
+	useCache := !t.isSpinning() && !t.isHighlighted() && !t.hasToolA2UISurfaces()
 	var key uint64
 	switch {
 	case t.isCompact:
@@ -432,6 +466,9 @@ func (t *baseToolMessageItem) SetToolCall(tc message.ToolCall) {
 // SetResult sets the tool result associated with this message item.
 func (t *baseToolMessageItem) SetResult(res *message.ToolResult) {
 	t.result = res
+	// New metadata may carry different surfaces; force a rebuild on the
+	// next render while preserving focus/edits when it is unchanged.
+	t.surfaceScanned = false
 	t.clearCache()
 	t.Bump()
 }
@@ -535,13 +572,34 @@ func (t *baseToolMessageItem) HandleMouseClickCmd(btn ansi.MouseButton, x, y int
 	return true, nil
 }
 
-// HandleKeyEvent implements KeyEventHandler.
+// HandleKeyEvent implements KeyEventHandler. A focused live MCP surface
+// gets first claim on the keys it understands (#219) — Tab/Shift+Tab cycle
+// its focus ring, Enter activates a button (surfacing an
+// a2uievent.ButtonClicked the UI model routes per provenance, #221) — and
+// every other key falls through, so the copy shortcut keeps working
+// whenever no surface consumes the key.
 func (t *baseToolMessageItem) HandleKeyEvent(key tea.KeyMsg) (bool, tea.Cmd) {
+	if handled, cmd := t.handleA2UIKeyEvent(key); handled {
+		return true, cmd
+	}
 	if k := key.String(); k == "c" || k == "y" {
 		text := t.formatToolForCopy()
 		return true, common.CopyToClipboard(text, "Tool content copied to clipboard")
 	}
 	return false, nil
+}
+
+// SetFocused implements MessageItem. Focus also drives the live MCP
+// surfaces (#219): gaining focus grants it to the first live surface,
+// losing focus blurs them all — so the focus ring only ever lives on the
+// selected item.
+func (t *baseToolMessageItem) SetFocused(focused bool) {
+	t.focusableMessageItem.SetFocused(focused)
+	if focused {
+		t.focusToolA2UISurfaces()
+	} else {
+		t.blurToolA2UISurfaces()
+	}
 }
 
 // pendingTool renders a tool that is still in progress with an animation.

--- a/internal/ui/chat/tools.go
+++ b/internal/ui/chat/tools.go
@@ -99,7 +99,7 @@ type ToolRenderOpts struct {
 	IsSpinning      bool
 	Status          ToolStatus
 	// LiveSurfaces renders the item's live MCP A2UI surface models at the
-	// given width (#219). Set only when the result metadata carried
+	// given width. Set only when the result metadata carried
 	// renderable surfaces; nil otherwise, in which case renderers fall
 	// back to the static/text paths. Carried on the opts because the
 	// ToolRenderer interface does not see the owning item.
@@ -171,9 +171,9 @@ type baseToolMessageItem struct {
 	hyperlinks []hyperlinkSpan
 
 	// a2ui holds the live surface models for an MCP-served A2UI payload
-	// (#219): a read_mcp_resource or mcp_* tool whose result metadata
+	//: a read_mcp_resource or mcp_* tool whose result metadata
 	// carries surfaces. They render interactively and, being long-lived
-	// app UIs, are never retired on interaction (#221). Nil for tools
+	// app UIs, are never retired on interaction. Nil for tools
 	// without surfaces. surfaceSrcHash fingerprints the metadata the
 	// models were built from so a re-render with the same metadata reuses
 	// the live models (and their edited values) instead of rebuilding.
@@ -364,7 +364,7 @@ func (t *baseToolMessageItem) RawRender(width int) string {
 	}
 
 	// Build or refresh the live MCP surface models from the result
-	// metadata (#219). While surfaces are live the content cache is
+	// metadata. While surfaces are live the content cache is
 	// bypassed: a surface's View reflects the current focus ring and
 	// edited values, not a frozen frame.
 	t.syncToolA2UISurfaces()
@@ -573,9 +573,9 @@ func (t *baseToolMessageItem) HandleMouseClickCmd(btn ansi.MouseButton, x, y int
 }
 
 // HandleKeyEvent implements KeyEventHandler. A focused live MCP surface
-// gets first claim on the keys it understands (#219) — Tab/Shift+Tab cycle
+// gets first claim on the keys it understands — Tab/Shift+Tab cycle
 // its focus ring, Enter activates a button (surfacing an
-// a2uievent.ButtonClicked the UI model routes per provenance, #221) — and
+// a2uievent.ButtonClicked the UI model routes per provenance) — and
 // every other key falls through, so the copy shortcut keeps working
 // whenever no surface consumes the key.
 func (t *baseToolMessageItem) HandleKeyEvent(key tea.KeyMsg) (bool, tea.Cmd) {
@@ -590,7 +590,7 @@ func (t *baseToolMessageItem) HandleKeyEvent(key tea.KeyMsg) (bool, tea.Cmd) {
 }
 
 // SetFocused implements MessageItem. Focus also drives the live MCP
-// surfaces (#219): gaining focus grants it to the first live surface,
+// surfaces: gaining focus grants it to the first live surface,
 // losing focus blurs them all — so the focus ring only ever lives on the
 // selected item.
 func (t *baseToolMessageItem) SetFocused(focused bool) {

--- a/internal/ui/chat/user.go
+++ b/internal/ui/chat/user.go
@@ -105,6 +105,11 @@ func (m *UserMessageItem) RawRender(width int) string {
 				content = strings.TrimSuffix(result, "\n")
 			}
 
+			// Carry the prompt editor's @file / /skill colours into the
+			// posted message, so a token does not lose its highlight the
+			// moment it leaves the editor.
+			content = highlightPromptTokens(content, m.sty)
+
 			if len(m.message.BinaryContent()) > 0 {
 				attachmentsStr := m.renderAttachments(cappedWidth)
 				if content == "" {

--- a/internal/ui/common/prompttokens.go
+++ b/internal/ui/common/prompttokens.go
@@ -1,0 +1,97 @@
+package common
+
+import (
+	"strings"
+	"sync"
+)
+
+// PromptTokenKind distinguishes the two things the prompt marks up.
+type PromptTokenKind int
+
+const (
+	// PromptTokenFile is an "@path" file mention.
+	PromptTokenFile PromptTokenKind = iota
+	// PromptTokenSkill is a "/name" skill reference.
+	PromptTokenSkill
+)
+
+// PromptToken is a highlighted span within a single line, expressed in rune
+// offsets: Start is inclusive, End exclusive.
+type PromptToken struct {
+	Start int
+	End   int
+	Kind  PromptTokenKind
+}
+
+// promptSkills is the set of skill names a "/token" may refer to.
+//
+// It lives here, rather than being threaded through every message-item
+// constructor, because both the prompt editor and the posted-message
+// renderer must agree on it exactly — a token that lights up while you type
+// has to stay lit after you hit enter. The UI event loop is the only
+// writer; renderers read it. This mirrors the package-level discovery-state
+// mirror in internal/skills.
+var promptSkills struct {
+	mu    sync.RWMutex
+	names []string
+}
+
+// SetPromptSkillNames replaces the known-skill set used to validate "/"
+// tokens. Called whenever the effective skill list changes.
+func SetPromptSkillNames(names []string) {
+	promptSkills.mu.Lock()
+	promptSkills.names = names
+	promptSkills.mu.Unlock()
+}
+
+// IsPromptSkillPrefix reports whether name is a prefix of some known skill
+// name. Prefix rather than exact match is deliberate: it is what gives live
+// feedback as a skill name is typed, and using the same rule after the
+// prompt is submitted keeps the highlight from flickering off mid-word.
+func IsPromptSkillPrefix(name string) bool {
+	if name == "" {
+		return false
+	}
+	promptSkills.mu.RLock()
+	defer promptSkills.mu.RUnlock()
+	for _, s := range promptSkills.names {
+		if strings.HasPrefix(s, name) {
+			return true
+		}
+	}
+	return false
+}
+
+// ScanPromptTokens finds the @file and /skill tokens in a single line.
+//
+// Tokens start at a word boundary (start of line or after whitespace) and
+// run to the next whitespace, so they never span lines. An "@" token always
+// counts — the file may not exist yet, and the completions popup is the
+// discovery path — while a "/" token counts only when it matches a known
+// skill, so ordinary prose and absolute paths are left alone.
+func ScanPromptTokens(line []rune) []PromptToken {
+	var tokens []PromptToken
+	i := 0
+	for i < len(line) {
+		atWordStart := i == 0 || isSpaceRune(line[i-1])
+		if atWordStart && (line[i] == '@' || line[i] == '/') && i+1 < len(line) && !isSpaceRune(line[i+1]) {
+			end := i + 1
+			for end < len(line) && !isSpaceRune(line[end]) {
+				end++
+			}
+			if line[i] == '@' {
+				tokens = append(tokens, PromptToken{Start: i, End: end, Kind: PromptTokenFile})
+			} else if IsPromptSkillPrefix(string(line[i+1 : end])) {
+				tokens = append(tokens, PromptToken{Start: i, End: end, Kind: PromptTokenSkill})
+			}
+			i = end
+			continue
+		}
+		i++
+	}
+	return tokens
+}
+
+func isSpaceRune(r rune) bool {
+	return r == ' ' || r == '\t'
+}

--- a/internal/ui/common/prompttokens_test.go
+++ b/internal/ui/common/prompttokens_test.go
@@ -1,0 +1,77 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// scan is a readability helper: it returns each token's literal text
+// alongside its kind, which is what the assertions below actually care
+// about. The known-skill set is process-wide, so these tests are serial.
+func scan(t *testing.T, line string, skills ...string) []string {
+	t.Helper()
+	SetPromptSkillNames(skills)
+	t.Cleanup(func() { SetPromptSkillNames(nil) })
+
+	runes := []rune(line)
+	var out []string
+	for _, tok := range ScanPromptTokens(runes) {
+		kind := "file"
+		if tok.Kind == PromptTokenSkill {
+			kind = "skill"
+		}
+		out = append(out, kind+":"+string(runes[tok.Start:tok.End]))
+	}
+	return out
+}
+
+func TestScanPromptTokensFileMentions(t *testing.T) {
+	require.Equal(t,
+		[]string{"file:@foo.go", "file:@bar.md"},
+		scan(t, "see @foo.go and @bar.md end"),
+	)
+}
+
+func TestScanPromptTokensSkillsMustBeKnown(t *testing.T) {
+	require.Equal(t, []string{"skill:/code-review"},
+		scan(t, "please /code-review this", "code-review", "commit"))
+	require.Empty(t, scan(t, "please /bogus this", "code-review"))
+}
+
+func TestScanPromptTokensSkillPrefixMatches(t *testing.T) {
+	// Prefix matching is what gives live feedback mid-word, and using the
+	// same rule after submit keeps the highlight from flickering.
+	require.Len(t, scan(t, "/cod", "code-review"), 1)
+	require.Empty(t, scan(t, "/codeX", "code-review"))
+}
+
+func TestScanPromptTokensRequireWordBoundary(t *testing.T) {
+	// An email address, a relative path, and a URL are all prose here.
+	require.Empty(t, scan(t, "mail me@foo.go or a/b or x/commit", "commit"))
+	// Tab counts as a boundary.
+	require.Len(t, scan(t, "x\t@foo.go"), 1)
+	// So does start-of-line.
+	require.Len(t, scan(t, "@foo.go trailing"), 1)
+}
+
+func TestScanPromptTokensBareTriggersIgnored(t *testing.T) {
+	require.Empty(t, scan(t, "@ / @", "commit"))
+	require.Empty(t, scan(t, "@"))
+	require.Empty(t, scan(t, ""))
+}
+
+func TestScanPromptTokensAbsolutePathIsNotASkill(t *testing.T) {
+	// "/usr/bin" starts a word but is not a skill, so it stays prose even
+	// when a skill named "usr-something" exists.
+	require.Empty(t, scan(t, "look in /usr/bin", "usr-tools"))
+}
+
+func TestIsPromptSkillPrefixEmptyName(t *testing.T) {
+	SetPromptSkillNames([]string{"commit"})
+	t.Cleanup(func() { SetPromptSkillNames(nil) })
+
+	// A bare "/" has no name to match; it must not match everything.
+	require.False(t, IsPromptSkillPrefix(""))
+	require.True(t, IsPromptSkillPrefix("com"))
+}

--- a/internal/ui/completions/completions.go
+++ b/internal/ui/completions/completions.go
@@ -44,6 +44,19 @@ type CompletionItemsLoadedMsg struct {
 	Resources []ResourceCompletionValue
 }
 
+// Trigger identifies which trigger character opened the completions popup.
+type Trigger rune
+
+const (
+	// TriggerNone means the completions popup is closed.
+	TriggerNone Trigger = 0
+	// TriggerFile is the '@' file-mention trigger.
+	TriggerFile Trigger = '@'
+	// TriggerSkill is the '/' skill trigger (mid-prompt only; at the start
+	// of an empty prompt '/' opens the commands dialog instead).
+	TriggerSkill Trigger = '/'
+)
+
 // Completions represents the completions popup component.
 type Completions struct {
 	// Popup dimensions
@@ -177,6 +190,38 @@ func (c *Completions) SetItems(files []FileCompletionValue, resources []Resource
 		item := NewCompletionItem(
 			resource.MCPName+"/"+cmp.Or(resource.Title, resource.URI),
 			resource,
+			c.normalStyle,
+			c.focusedStyle,
+			c.matchStyle,
+		)
+		items = append(items, item)
+	}
+
+	c.open = true
+	c.query = ""
+	c.allItems = items
+	c.filtered = append([]list.FilterableItem(nil), items...)
+	c.list.SetItems(c.filtered...)
+	c.list.SetFilter("")
+	c.list.Focus()
+
+	c.width = maxWidth
+	c.height = ordered.Clamp(len(items), int(minHeight), int(maxHeight))
+	c.list.SetSize(c.width, c.height)
+	c.list.SelectFirst()
+	c.list.ScrollToSelected()
+
+	c.updateSize()
+}
+
+// SetSkillItems sets skill items and opens the popup. Unlike files, skills
+// are already in memory, so no async load is needed.
+func (c *Completions) SetSkillItems(skills []SkillCompletionValue) {
+	items := make([]list.FilterableItem, 0, len(skills))
+	for _, skill := range skills {
+		item := NewCompletionItem(
+			skill.Name,
+			skill,
 			c.normalStyle,
 			c.focusedStyle,
 			c.matchStyle,
@@ -375,6 +420,11 @@ func (c *Completions) selectCurrent(keepOpen bool) tea.Msg {
 	}
 
 	switch item := item.Value().(type) {
+	case SkillCompletionValue:
+		return SelectionMsg[SkillCompletionValue]{
+			Value:    item,
+			KeepOpen: keepOpen,
+		}
 	case ResourceCompletionValue:
 		return SelectionMsg[ResourceCompletionValue]{
 			Value:    item,

--- a/internal/ui/completions/completions.go
+++ b/internal/ui/completions/completions.go
@@ -214,18 +214,49 @@ func (c *Completions) SetItems(files []FileCompletionValue, resources []Resource
 	c.updateSize()
 }
 
+// skillDetailSeparator sits between a skill's name and its description in
+// the popup row.
+const skillDetailSeparator = " - "
+
+// minSkillDetailWidth is the smallest description tail worth showing. Below
+// it the row is all ellipsis and the description only costs width, so long
+// skill names simply render bare.
+const minSkillDetailWidth = 12
+
 // SetSkillItems sets skill items and opens the popup. Unlike files, skills
 // are already in memory, so no async load is needed.
+//
+// Each row reads "/name - description", with the description truncated to
+// whatever width the name leaves behind. The description is part of the
+// item's text, so the fuzzy filter matches it too: typing "/pdf" finds a
+// skill described as "extract text from PDFs" even if it is named
+// "document-tools".
 func (c *Completions) SetSkillItems(skills []SkillCompletionValue) {
 	items := make([]list.FilterableItem, 0, len(skills))
 	for _, skill := range skills {
+		name := "/" + skill.Name
+		text := name
+		detailStart := -1
+		if desc := flattenSkillDescription(skill.Description); desc != "" {
+			// maxWidth is the popup's hard cap and renderItem reserves a
+			// cell of padding on each side, so that is the real budget the
+			// name and description share.
+			budget := maxWidth - 2 - ansi.StringWidth(name) - len(skillDetailSeparator)
+			if budget >= minSkillDetailWidth {
+				detailStart = len(name)
+				text = name + skillDetailSeparator + ansi.Truncate(desc, budget, "…")
+			}
+		}
 		item := NewCompletionItem(
-			skill.Name,
+			text,
 			skill,
 			c.normalStyle,
 			c.focusedStyle,
 			c.matchStyle,
 		)
+		if detailStart >= 0 {
+			item = item.withDetail(detailStart, name)
+		}
 		items = append(items, item)
 	}
 
@@ -288,10 +319,28 @@ func (c *Completions) applyNamePriorityFilter(query string) {
 
 	queryLower := strings.ToLower(strings.TrimSpace(query))
 	slices.SortStableFunc(filtered, func(a, b list.FilterableItem) int {
-		return namePriorityTier(a.Filter(), queryLower) - namePriorityTier(b.Filter(), queryLower)
+		return namePriorityTier(tierKey(a), queryLower) - namePriorityTier(tierKey(b), queryLower)
 	})
 	c.filtered = filtered
 	c.list.SetItems(c.filtered...)
+}
+
+// tierKey returns the string namePriorityTier should rank an item on. Items
+// whose display text carries a trailing detail (skills, which append their
+// description) expose the bare name via SortKey; everything else ranks on
+// its filter text, which is the path.
+func tierKey(item list.FilterableItem) string {
+	if s, ok := item.(interface{ SortKey() string }); ok {
+		return s.SortKey()
+	}
+	return item.Filter()
+}
+
+// flattenSkillDescription collapses a SKILL.md description onto one line.
+// Frontmatter descriptions are frequently wrapped across several lines, and
+// a popup row is exactly one.
+func flattenSkillDescription(desc string) string {
+	return strings.Join(strings.Fields(desc), " ")
 }
 
 func namePriorityTier(path, queryLower string) int {

--- a/internal/ui/completions/completions.go
+++ b/internal/ui/completions/completions.go
@@ -428,5 +428,15 @@ func loadMCPResources() []ResourceCompletionValue {
 			})
 		}
 	}
+	for mcpName, mcpTemplates := range mcp.ResourceTemplates() {
+		for _, t := range mcpTemplates {
+			resources = append(resources, ResourceCompletionValue{
+				MCPName:  mcpName,
+				URI:      t.URITemplate,
+				Title:    t.Name,
+				MIMEType: t.MIMEType,
+			})
+		}
+	}
 	return resources
 }

--- a/internal/ui/completions/completions.go
+++ b/internal/ui/completions/completions.go
@@ -44,6 +44,19 @@ type CompletionItemsLoadedMsg struct {
 	Resources []ResourceCompletionValue
 }
 
+// Trigger identifies which trigger character opened the completions popup.
+type Trigger rune
+
+const (
+	// TriggerNone means the completions popup is closed.
+	TriggerNone Trigger = 0
+	// TriggerFile is the '@' file-mention trigger.
+	TriggerFile Trigger = '@'
+	// TriggerSkill is the '/' skill trigger (mid-prompt only; at the start
+	// of an empty prompt '/' opens the commands dialog instead).
+	TriggerSkill Trigger = '/'
+)
+
 // Completions represents the completions popup component.
 type Completions struct {
 	// Popup dimensions
@@ -201,6 +214,69 @@ func (c *Completions) SetItems(files []FileCompletionValue, resources []Resource
 	c.updateSize()
 }
 
+// skillDetailSeparator sits between a skill's name and its description in
+// the popup row.
+const skillDetailSeparator = " - "
+
+// minSkillDetailWidth is the smallest description tail worth showing. Below
+// it the row is all ellipsis and the description only costs width, so long
+// skill names simply render bare.
+const minSkillDetailWidth = 12
+
+// SetSkillItems sets skill items and opens the popup. Unlike files, skills
+// are already in memory, so no async load is needed.
+//
+// Each row reads "/name - description", with the description truncated to
+// whatever width the name leaves behind. The description is part of the
+// item's text, so the fuzzy filter matches it too: typing "/pdf" finds a
+// skill described as "extract text from PDFs" even if it is named
+// "document-tools".
+func (c *Completions) SetSkillItems(skills []SkillCompletionValue) {
+	items := make([]list.FilterableItem, 0, len(skills))
+	for _, skill := range skills {
+		name := "/" + skill.Name
+		text := name
+		detailStart := -1
+		if desc := flattenSkillDescription(skill.Description); desc != "" {
+			// maxWidth is the popup's hard cap and renderItem reserves a
+			// cell of padding on each side, so that is the real budget the
+			// name and description share.
+			budget := maxWidth - 2 - ansi.StringWidth(name) - len(skillDetailSeparator)
+			if budget >= minSkillDetailWidth {
+				detailStart = len(name)
+				text = name + skillDetailSeparator + ansi.Truncate(desc, budget, "…")
+			}
+		}
+		item := NewCompletionItem(
+			text,
+			skill,
+			c.normalStyle,
+			c.focusedStyle,
+			c.matchStyle,
+		)
+		if detailStart >= 0 {
+			item = item.withDetail(detailStart, name)
+		}
+		items = append(items, item)
+	}
+
+	c.open = true
+	c.query = ""
+	c.allItems = items
+	c.filtered = append([]list.FilterableItem(nil), items...)
+	c.list.SetItems(c.filtered...)
+	c.list.SetFilter("")
+	c.list.Focus()
+
+	c.width = maxWidth
+	c.height = ordered.Clamp(len(items), int(minHeight), int(maxHeight))
+	c.list.SetSize(c.width, c.height)
+	c.list.SelectFirst()
+	c.list.ScrollToSelected()
+
+	c.updateSize()
+}
+
 // Close closes the completions popup.
 func (c *Completions) Close() {
 	c.open = false
@@ -243,10 +319,28 @@ func (c *Completions) applyNamePriorityFilter(query string) {
 
 	queryLower := strings.ToLower(strings.TrimSpace(query))
 	slices.SortStableFunc(filtered, func(a, b list.FilterableItem) int {
-		return namePriorityTier(a.Filter(), queryLower) - namePriorityTier(b.Filter(), queryLower)
+		return namePriorityTier(tierKey(a), queryLower) - namePriorityTier(tierKey(b), queryLower)
 	})
 	c.filtered = filtered
 	c.list.SetItems(c.filtered...)
+}
+
+// tierKey returns the string namePriorityTier should rank an item on. Items
+// whose display text carries a trailing detail (skills, which append their
+// description) expose the bare name via SortKey; everything else ranks on
+// its filter text, which is the path.
+func tierKey(item list.FilterableItem) string {
+	if s, ok := item.(interface{ SortKey() string }); ok {
+		return s.SortKey()
+	}
+	return item.Filter()
+}
+
+// flattenSkillDescription collapses a SKILL.md description onto one line.
+// Frontmatter descriptions are frequently wrapped across several lines, and
+// a popup row is exactly one.
+func flattenSkillDescription(desc string) string {
+	return strings.Join(strings.Fields(desc), " ")
 }
 
 func namePriorityTier(path, queryLower string) int {
@@ -375,6 +469,11 @@ func (c *Completions) selectCurrent(keepOpen bool) tea.Msg {
 	}
 
 	switch item := item.Value().(type) {
+	case SkillCompletionValue:
+		return SelectionMsg[SkillCompletionValue]{
+			Value:    item,
+			KeepOpen: keepOpen,
+		}
 	case ResourceCompletionValue:
 		return SelectionMsg[ResourceCompletionValue]{
 			Value:    item,
@@ -425,6 +524,16 @@ func loadMCPResources() []ResourceCompletionValue {
 				URI:      r.URI,
 				Title:    r.Name,
 				MIMEType: r.MIMEType,
+			})
+		}
+	}
+	for mcpName, mcpTemplates := range mcp.ResourceTemplates() {
+		for _, t := range mcpTemplates {
+			resources = append(resources, ResourceCompletionValue{
+				MCPName:  mcpName,
+				URI:      t.URITemplate,
+				Title:    t.Name,
+				MIMEType: t.MIMEType,
 			})
 		}
 	}

--- a/internal/ui/completions/item.go
+++ b/internal/ui/completions/item.go
@@ -2,6 +2,7 @@ package completions
 
 import (
 	"slices"
+	"strings"
 
 	"charm.land/lipgloss/v2"
 	"github.com/charmbracelet/crush/internal/ui/list"
@@ -21,6 +22,14 @@ type ResourceCompletionValue struct {
 	URI      string
 	Title    string
 	MIMEType string
+}
+
+// IsTemplate reports whether the completion's URI is an unexpanded RFC 6570
+// URI template (it still contains a "{expression}") rather than a concrete,
+// readable resource URI. Templates come from resources/templates/list and
+// cannot be read until their placeholders are filled in.
+func (r ResourceCompletionValue) IsTemplate() bool {
+	return strings.Contains(r.URI, "{")
 }
 
 // CompletionItem represents an item in the completions list.

--- a/internal/ui/completions/item.go
+++ b/internal/ui/completions/item.go
@@ -24,10 +24,14 @@ type ResourceCompletionValue struct {
 	MIMEType string
 }
 
-// SkillCompletionValue represents an agent skill completion value.
+// SkillCompletionValue represents an agent skill completion value. The
+// fields mirror the SKILL.md frontmatter: Description is shown after the
+// name in the popup and folded into the item's filter text, so a skill is
+// findable by what it does and not only by what it is called.
 type SkillCompletionValue struct {
-	Name string
-	Path string
+	Name        string
+	Description string
+	Path        string
 }
 
 // IsTemplate reports whether the completion's URI is an unexpanded RFC 6570
@@ -48,6 +52,16 @@ type CompletionItem struct {
 	focused bool
 	cache   map[int]string
 
+	// detailStart is the byte offset in text where the secondary detail
+	// (e.g. a skill's description) begins, or -1 when the item is all
+	// primary text. The detail renders dimmed so the name still leads.
+	detailStart int
+
+	// sortKey is what the name-priority tiering ranks on. It defaults to
+	// text, but items whose display text carries a trailing detail set it
+	// to the bare name so the description can't skew the tier.
+	sortKey string
+
 	// Styles
 	normalStyle  lipgloss.Style
 	focusedStyle lipgloss.Style
@@ -60,10 +74,25 @@ func NewCompletionItem(text string, value any, normalStyle, focusedStyle, matchS
 		Versioned:    list.NewVersioned(),
 		text:         text,
 		value:        value,
+		detailStart:  -1,
+		sortKey:      text,
 		normalStyle:  normalStyle,
 		focusedStyle: focusedStyle,
 		matchStyle:   matchStyle,
 	}
+}
+
+// withDetail marks everything from byte offset start onwards as secondary
+// detail text and ranks the item on sortKey instead of its full text.
+func (c *CompletionItem) withDetail(start int, sortKey string) *CompletionItem {
+	c.detailStart = start
+	c.sortKey = sortKey
+	return c
+}
+
+// SortKey returns the string the name-priority tiering ranks on.
+func (c *CompletionItem) SortKey() string {
+	return c.sortKey
 }
 
 // Finished implements list.Item. Completion items render purely from
@@ -129,6 +158,7 @@ func (c *CompletionItem) Render(width int) string {
 		c.focusedStyle,
 		c.matchStyle,
 		c.text,
+		c.detailStart,
 		c.focused,
 		width,
 		c.cache,
@@ -139,6 +169,7 @@ func (c *CompletionItem) Render(width int) string {
 func renderItem(
 	normalStyle, focusedStyle, matchStyle lipgloss.Style,
 	text string,
+	detailStart int,
 	focused bool,
 	width int,
 	cache map[int]string,
@@ -169,6 +200,17 @@ func renderItem(
 
 	// Render full-width text with background.
 	content := style.Padding(0, 1).Width(width).Render(text)
+
+	// Dim the trailing detail (a skill's description) so the name still
+	// leads the row. Applied before the match ranges so a fuzzy hit inside
+	// the description still reads as a match.
+	if detailStart >= 0 {
+		start, _ := bytePosToVisibleCharPos(text, [2]int{detailStart, detailStart})
+		if start+1 < width {
+			detailStyle := style.Faint(true)
+			content = lipgloss.StyleRanges(content, lipgloss.NewRange(start+1, width, detailStyle))
+		}
+	}
 
 	// Apply match highlighting using StyleRanges.
 	if len(match.MatchedIndexes) > 0 {

--- a/internal/ui/completions/item.go
+++ b/internal/ui/completions/item.go
@@ -24,6 +24,12 @@ type ResourceCompletionValue struct {
 	MIMEType string
 }
 
+// SkillCompletionValue represents an agent skill completion value.
+type SkillCompletionValue struct {
+	Name string
+	Path string
+}
+
 // IsTemplate reports whether the completion's URI is an unexpanded RFC 6570
 // URI template (it still contains a "{expression}") rather than a concrete,
 // readable resource URI. Templates come from resources/templates/list and

--- a/internal/ui/completions/item.go
+++ b/internal/ui/completions/item.go
@@ -2,6 +2,7 @@ package completions
 
 import (
 	"slices"
+	"strings"
 
 	"charm.land/lipgloss/v2"
 	"github.com/charmbracelet/crush/internal/ui/list"
@@ -23,6 +24,24 @@ type ResourceCompletionValue struct {
 	MIMEType string
 }
 
+// SkillCompletionValue represents an agent skill completion value. The
+// fields mirror the SKILL.md frontmatter: Description is shown after the
+// name in the popup and folded into the item's filter text, so a skill is
+// findable by what it does and not only by what it is called.
+type SkillCompletionValue struct {
+	Name        string
+	Description string
+	Path        string
+}
+
+// IsTemplate reports whether the completion's URI is an unexpanded RFC 6570
+// URI template (it still contains a "{expression}") rather than a concrete,
+// readable resource URI. Templates come from resources/templates/list and
+// cannot be read until their placeholders are filled in.
+func (r ResourceCompletionValue) IsTemplate() bool {
+	return strings.Contains(r.URI, "{")
+}
+
 // CompletionItem represents an item in the completions list.
 type CompletionItem struct {
 	*list.Versioned
@@ -32,6 +51,16 @@ type CompletionItem struct {
 	match   fuzzy.Match
 	focused bool
 	cache   map[int]string
+
+	// detailStart is the byte offset in text where the secondary detail
+	// (e.g. a skill's description) begins, or -1 when the item is all
+	// primary text. The detail renders dimmed so the name still leads.
+	detailStart int
+
+	// sortKey is what the name-priority tiering ranks on. It defaults to
+	// text, but items whose display text carries a trailing detail set it
+	// to the bare name so the description can't skew the tier.
+	sortKey string
 
 	// Styles
 	normalStyle  lipgloss.Style
@@ -45,10 +74,25 @@ func NewCompletionItem(text string, value any, normalStyle, focusedStyle, matchS
 		Versioned:    list.NewVersioned(),
 		text:         text,
 		value:        value,
+		detailStart:  -1,
+		sortKey:      text,
 		normalStyle:  normalStyle,
 		focusedStyle: focusedStyle,
 		matchStyle:   matchStyle,
 	}
+}
+
+// withDetail marks everything from byte offset start onwards as secondary
+// detail text and ranks the item on sortKey instead of its full text.
+func (c *CompletionItem) withDetail(start int, sortKey string) *CompletionItem {
+	c.detailStart = start
+	c.sortKey = sortKey
+	return c
+}
+
+// SortKey returns the string the name-priority tiering ranks on.
+func (c *CompletionItem) SortKey() string {
+	return c.sortKey
 }
 
 // Finished implements list.Item. Completion items render purely from
@@ -114,6 +158,7 @@ func (c *CompletionItem) Render(width int) string {
 		c.focusedStyle,
 		c.matchStyle,
 		c.text,
+		c.detailStart,
 		c.focused,
 		width,
 		c.cache,
@@ -124,6 +169,7 @@ func (c *CompletionItem) Render(width int) string {
 func renderItem(
 	normalStyle, focusedStyle, matchStyle lipgloss.Style,
 	text string,
+	detailStart int,
 	focused bool,
 	width int,
 	cache map[int]string,
@@ -154,6 +200,17 @@ func renderItem(
 
 	// Render full-width text with background.
 	content := style.Padding(0, 1).Width(width).Render(text)
+
+	// Dim the trailing detail (a skill's description) so the name still
+	// leads the row. Applied before the match ranges so a fuzzy hit inside
+	// the description still reads as a match.
+	if detailStart >= 0 {
+		start, _ := bytePosToVisibleCharPos(text, [2]int{detailStart, detailStart})
+		if start+1 < width {
+			detailStyle := style.Faint(true)
+			content = lipgloss.StyleRanges(content, lipgloss.NewRange(start+1, width, detailStyle))
+		}
+	}
 
 	// Apply match highlighting using StyleRanges.
 	if len(match.MatchedIndexes) > 0 {

--- a/internal/ui/completions/item_test.go
+++ b/internal/ui/completions/item_test.go
@@ -1,0 +1,20 @@
+package completions
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestResourceCompletionValueIsTemplate pins the concrete-vs-template
+// distinction the insertion path relies on: a URI still carrying an RFC 6570
+// placeholder must not be read eagerly (the server would see the literal
+// braces), while a concrete URI must keep the auto-attachment read.
+func TestResourceCompletionValueIsTemplate(t *testing.T) {
+	t.Parallel()
+
+	require.True(t, ResourceCompletionValue{URI: "cairn://run/{id}/a2ui"}.IsTemplate())
+	require.True(t, ResourceCompletionValue{URI: "switchboard://queue/{name}"}.IsTemplate())
+	require.False(t, ResourceCompletionValue{URI: "cairn://run/abc123/a2ui"}.IsTemplate())
+	require.False(t, ResourceCompletionValue{URI: ""}.IsTemplate())
+}

--- a/internal/ui/completions/skills_test.go
+++ b/internal/ui/completions/skills_test.go
@@ -1,9 +1,11 @@
 package completions
 
 import (
+	"strings"
 	"testing"
 
 	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/x/ansi"
 	"github.com/stretchr/testify/require"
 )
 
@@ -22,7 +24,7 @@ func TestSetSkillItemsOpensWithSkills(t *testing.T) {
 	require.Len(t, c.filtered, 2)
 	first, ok := c.filtered[0].(*CompletionItem)
 	require.True(t, ok)
-	require.Equal(t, "code-review", first.Text())
+	require.Equal(t, "/code-review", first.Text())
 }
 
 func TestSkillCompletionFilter(t *testing.T) {
@@ -41,7 +43,63 @@ func TestSkillCompletionFilter(t *testing.T) {
 	first, ok := c.filtered[0].(*CompletionItem)
 	require.True(t, ok)
 	// "coder" is an exact-stem/prefix tier winner over "code-review".
-	require.Equal(t, "coder", first.Text())
+	require.Equal(t, "/coder", first.Text())
+}
+
+func TestSkillDescriptionShownAndSearchable(t *testing.T) {
+	t.Parallel()
+
+	c := New(lipgloss.NewStyle(), lipgloss.NewStyle(), lipgloss.NewStyle())
+	c.SetSkillItems([]SkillCompletionValue{
+		{Name: "skill-creator", Description: "Use for naming skills\nand writing frontmatter."},
+		{Name: "commit", Description: "Write a conventional commit."},
+	})
+
+	first, ok := c.filtered[0].(*CompletionItem)
+	require.True(t, ok)
+	// The row reads "/name - description", with the frontmatter
+	// description flattened onto one line.
+	require.Equal(t, "/skill-creator - Use for naming skills and writing frontmatter.", first.Text())
+	// The name leads; the description renders as dimmed detail.
+	require.Equal(t, len("/skill-creator"), first.detailStart)
+	require.Equal(t, "/skill-creator", first.SortKey())
+
+	// The description is part of the filter text, so a skill is findable by
+	// what it does and not only by what it is named.
+	c.Filter("frontmatter")
+	require.Len(t, c.filtered, 1)
+	hit, ok := c.filtered[0].(*CompletionItem)
+	require.True(t, ok)
+	require.Equal(t, "skill-creator", hit.Value().(SkillCompletionValue).Name)
+}
+
+func TestSkillDescriptionTruncatedToPopupWidth(t *testing.T) {
+	t.Parallel()
+
+	c := New(lipgloss.NewStyle(), lipgloss.NewStyle(), lipgloss.NewStyle())
+	c.SetSkillItems([]SkillCompletionValue{
+		{Name: "commit", Description: strings.Repeat("long ", 200)},
+	})
+
+	first, ok := c.filtered[0].(*CompletionItem)
+	require.True(t, ok)
+	require.LessOrEqual(t, ansi.StringWidth(first.Text()), maxWidth-2)
+	require.True(t, strings.HasSuffix(first.Text(), "…"), "expected an ellipsis, got %q", first.Text())
+}
+
+func TestSkillDescriptionDroppedWhenNameEatsTheRow(t *testing.T) {
+	t.Parallel()
+
+	// A name long enough to leave no room for a useful description renders
+	// bare rather than as a row of ellipsis.
+	long := strings.Repeat("a", maxWidth)
+	c := New(lipgloss.NewStyle(), lipgloss.NewStyle(), lipgloss.NewStyle())
+	c.SetSkillItems([]SkillCompletionValue{{Name: long, Description: "does things"}})
+
+	first, ok := c.filtered[0].(*CompletionItem)
+	require.True(t, ok)
+	require.Equal(t, "/"+long, first.Text())
+	require.Equal(t, -1, first.detailStart)
 }
 
 func TestSelectCurrentReturnsSkillSelectionMsg(t *testing.T) {

--- a/internal/ui/completions/skills_test.go
+++ b/internal/ui/completions/skills_test.go
@@ -1,0 +1,158 @@
+package completions
+
+import (
+	"strings"
+	"testing"
+
+	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSetSkillItemsOpensWithSkills(t *testing.T) {
+	t.Parallel()
+
+	c := New(lipgloss.NewStyle(), lipgloss.NewStyle(), lipgloss.NewStyle())
+	require.False(t, c.IsOpen())
+
+	c.SetSkillItems([]SkillCompletionValue{
+		{Name: "code-review", Path: "/skills/code-review/SKILL.md"},
+		{Name: "commit", Path: "/skills/commit/SKILL.md"},
+	})
+
+	require.True(t, c.IsOpen())
+	require.Len(t, c.filtered, 2)
+	first, ok := c.filtered[0].(*CompletionItem)
+	require.True(t, ok)
+	require.Equal(t, "/code-review", first.Text())
+}
+
+func TestSkillCompletionFilter(t *testing.T) {
+	t.Parallel()
+
+	c := New(lipgloss.NewStyle(), lipgloss.NewStyle(), lipgloss.NewStyle())
+	c.SetSkillItems([]SkillCompletionValue{
+		{Name: "code-review"},
+		{Name: "commit"},
+		{Name: "coder"},
+	})
+
+	c.Filter("cod")
+
+	require.NotEmpty(t, c.filtered)
+	first, ok := c.filtered[0].(*CompletionItem)
+	require.True(t, ok)
+	// "coder" is an exact-stem/prefix tier winner over "code-review".
+	require.Equal(t, "/coder", first.Text())
+}
+
+func TestSkillDescriptionShownAndSearchable(t *testing.T) {
+	t.Parallel()
+
+	c := New(lipgloss.NewStyle(), lipgloss.NewStyle(), lipgloss.NewStyle())
+	c.SetSkillItems([]SkillCompletionValue{
+		{Name: "skill-creator", Description: "Use for naming skills\nand writing frontmatter."},
+		{Name: "commit", Description: "Write a conventional commit."},
+	})
+
+	first, ok := c.filtered[0].(*CompletionItem)
+	require.True(t, ok)
+	// The row reads "/name - description", with the frontmatter
+	// description flattened onto one line.
+	require.Equal(t, "/skill-creator - Use for naming skills and writing frontmatter.", first.Text())
+	// The name leads; the description renders as dimmed detail.
+	require.Equal(t, len("/skill-creator"), first.detailStart)
+	require.Equal(t, "/skill-creator", first.SortKey())
+
+	// The description is part of the filter text, so a skill is findable by
+	// what it does and not only by what it is named.
+	c.Filter("frontmatter")
+	require.Len(t, c.filtered, 1)
+	hit, ok := c.filtered[0].(*CompletionItem)
+	require.True(t, ok)
+	require.Equal(t, "skill-creator", hit.Value().(SkillCompletionValue).Name)
+}
+
+func TestSkillDescriptionTruncatedToPopupWidth(t *testing.T) {
+	t.Parallel()
+
+	c := New(lipgloss.NewStyle(), lipgloss.NewStyle(), lipgloss.NewStyle())
+	c.SetSkillItems([]SkillCompletionValue{
+		{Name: "commit", Description: strings.Repeat("long ", 200)},
+	})
+
+	first, ok := c.filtered[0].(*CompletionItem)
+	require.True(t, ok)
+	require.LessOrEqual(t, ansi.StringWidth(first.Text()), maxWidth-2)
+	require.True(t, strings.HasSuffix(first.Text(), "…"), "expected an ellipsis, got %q", first.Text())
+}
+
+func TestSkillDescriptionDroppedWhenNameEatsTheRow(t *testing.T) {
+	t.Parallel()
+
+	// A name long enough to leave no room for a useful description renders
+	// bare rather than as a row of ellipsis.
+	long := strings.Repeat("a", maxWidth)
+	c := New(lipgloss.NewStyle(), lipgloss.NewStyle(), lipgloss.NewStyle())
+	c.SetSkillItems([]SkillCompletionValue{{Name: long, Description: "does things"}})
+
+	first, ok := c.filtered[0].(*CompletionItem)
+	require.True(t, ok)
+	require.Equal(t, "/"+long, first.Text())
+	require.Equal(t, -1, first.detailStart)
+}
+
+func TestSelectCurrentReturnsSkillSelectionMsg(t *testing.T) {
+	t.Parallel()
+
+	c := New(lipgloss.NewStyle(), lipgloss.NewStyle(), lipgloss.NewStyle())
+	c.SetSkillItems([]SkillCompletionValue{
+		{Name: "commit", Path: "/skills/commit/SKILL.md"},
+	})
+
+	msg := c.selectCurrent(false)
+	sel, ok := msg.(SelectionMsg[SkillCompletionValue])
+	require.True(t, ok, "expected SelectionMsg[SkillCompletionValue], got %T", msg)
+	require.Equal(t, "commit", sel.Value.Name)
+	require.Equal(t, "/skills/commit/SKILL.md", sel.Value.Path)
+	require.False(t, sel.KeepOpen)
+	require.False(t, c.IsOpen(), "popup should close on non-keep-open select")
+}
+
+func TestSelectCurrentSkillKeepOpen(t *testing.T) {
+	t.Parallel()
+
+	c := New(lipgloss.NewStyle(), lipgloss.NewStyle(), lipgloss.NewStyle())
+	c.SetSkillItems([]SkillCompletionValue{{Name: "commit"}})
+
+	msg := c.selectCurrent(true)
+	sel, ok := msg.(SelectionMsg[SkillCompletionValue])
+	require.True(t, ok)
+	require.True(t, sel.KeepOpen)
+	require.True(t, c.IsOpen(), "popup should stay open on keep-open select")
+}
+
+func TestSetSkillItemsEmpty(t *testing.T) {
+	t.Parallel()
+
+	c := New(lipgloss.NewStyle(), lipgloss.NewStyle(), lipgloss.NewStyle())
+	c.SetSkillItems(nil)
+
+	require.True(t, c.IsOpen())
+	require.False(t, c.HasItems())
+	require.Nil(t, c.selectCurrent(false))
+}
+
+func TestSkillItemsDoNotAffectFileSelectionDispatch(t *testing.T) {
+	t.Parallel()
+
+	// Regression: file/resource values must still dispatch their own
+	// SelectionMsg types after the skill case was added.
+	c := New(lipgloss.NewStyle(), lipgloss.NewStyle(), lipgloss.NewStyle())
+	c.SetItems([]FileCompletionValue{{Path: "foo.go"}}, nil)
+
+	msg := c.selectCurrent(false)
+	sel, ok := msg.(SelectionMsg[FileCompletionValue])
+	require.True(t, ok, "expected SelectionMsg[FileCompletionValue], got %T", msg)
+	require.Equal(t, "foo.go", sel.Value.Path)
+}

--- a/internal/ui/completions/skills_test.go
+++ b/internal/ui/completions/skills_test.go
@@ -1,0 +1,100 @@
+package completions
+
+import (
+	"testing"
+
+	"charm.land/lipgloss/v2"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSetSkillItemsOpensWithSkills(t *testing.T) {
+	t.Parallel()
+
+	c := New(lipgloss.NewStyle(), lipgloss.NewStyle(), lipgloss.NewStyle())
+	require.False(t, c.IsOpen())
+
+	c.SetSkillItems([]SkillCompletionValue{
+		{Name: "code-review", Path: "/skills/code-review/SKILL.md"},
+		{Name: "commit", Path: "/skills/commit/SKILL.md"},
+	})
+
+	require.True(t, c.IsOpen())
+	require.Len(t, c.filtered, 2)
+	first, ok := c.filtered[0].(*CompletionItem)
+	require.True(t, ok)
+	require.Equal(t, "code-review", first.Text())
+}
+
+func TestSkillCompletionFilter(t *testing.T) {
+	t.Parallel()
+
+	c := New(lipgloss.NewStyle(), lipgloss.NewStyle(), lipgloss.NewStyle())
+	c.SetSkillItems([]SkillCompletionValue{
+		{Name: "code-review"},
+		{Name: "commit"},
+		{Name: "coder"},
+	})
+
+	c.Filter("cod")
+
+	require.NotEmpty(t, c.filtered)
+	first, ok := c.filtered[0].(*CompletionItem)
+	require.True(t, ok)
+	// "coder" is an exact-stem/prefix tier winner over "code-review".
+	require.Equal(t, "coder", first.Text())
+}
+
+func TestSelectCurrentReturnsSkillSelectionMsg(t *testing.T) {
+	t.Parallel()
+
+	c := New(lipgloss.NewStyle(), lipgloss.NewStyle(), lipgloss.NewStyle())
+	c.SetSkillItems([]SkillCompletionValue{
+		{Name: "commit", Path: "/skills/commit/SKILL.md"},
+	})
+
+	msg := c.selectCurrent(false)
+	sel, ok := msg.(SelectionMsg[SkillCompletionValue])
+	require.True(t, ok, "expected SelectionMsg[SkillCompletionValue], got %T", msg)
+	require.Equal(t, "commit", sel.Value.Name)
+	require.Equal(t, "/skills/commit/SKILL.md", sel.Value.Path)
+	require.False(t, sel.KeepOpen)
+	require.False(t, c.IsOpen(), "popup should close on non-keep-open select")
+}
+
+func TestSelectCurrentSkillKeepOpen(t *testing.T) {
+	t.Parallel()
+
+	c := New(lipgloss.NewStyle(), lipgloss.NewStyle(), lipgloss.NewStyle())
+	c.SetSkillItems([]SkillCompletionValue{{Name: "commit"}})
+
+	msg := c.selectCurrent(true)
+	sel, ok := msg.(SelectionMsg[SkillCompletionValue])
+	require.True(t, ok)
+	require.True(t, sel.KeepOpen)
+	require.True(t, c.IsOpen(), "popup should stay open on keep-open select")
+}
+
+func TestSetSkillItemsEmpty(t *testing.T) {
+	t.Parallel()
+
+	c := New(lipgloss.NewStyle(), lipgloss.NewStyle(), lipgloss.NewStyle())
+	c.SetSkillItems(nil)
+
+	require.True(t, c.IsOpen())
+	require.False(t, c.HasItems())
+	require.Nil(t, c.selectCurrent(false))
+}
+
+func TestSkillItemsDoNotAffectFileSelectionDispatch(t *testing.T) {
+	t.Parallel()
+
+	// Regression: file/resource values must still dispatch their own
+	// SelectionMsg types after the skill case was added.
+	c := New(lipgloss.NewStyle(), lipgloss.NewStyle(), lipgloss.NewStyle())
+	c.SetItems([]FileCompletionValue{{Path: "foo.go"}}, nil)
+
+	msg := c.selectCurrent(false)
+	sel, ok := msg.(SelectionMsg[FileCompletionValue])
+	require.True(t, ok, "expected SelectionMsg[FileCompletionValue], got %T", msg)
+	require.Equal(t, "foo.go", sel.Value.Path)
+}

--- a/internal/ui/dialog/question_editor.go
+++ b/internal/ui/dialog/question_editor.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 
 	"charm.land/bubbles/v2/key"
-	"charm.land/bubbles/v2/textarea"
+	"github.com/charmbracelet/crush/internal/ui/textarea"
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 	"github.com/charmbracelet/crush/internal/ui/styles"

--- a/internal/ui/dialog/question_editor.go
+++ b/internal/ui/dialog/question_editor.go
@@ -5,10 +5,10 @@ import (
 	"strings"
 
 	"charm.land/bubbles/v2/key"
-	"github.com/charmbracelet/crush/internal/ui/textarea"
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 	"github.com/charmbracelet/crush/internal/ui/styles"
+	"github.com/charmbracelet/crush/internal/ui/textarea"
 	uv "github.com/charmbracelet/ultraviolet"
 )
 

--- a/internal/ui/dialog/question_editor.go
+++ b/internal/ui/dialog/question_editor.go
@@ -5,10 +5,10 @@ import (
 	"strings"
 
 	"charm.land/bubbles/v2/key"
-	"charm.land/bubbles/v2/textarea"
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 	"github.com/charmbracelet/crush/internal/ui/styles"
+	"github.com/charmbracelet/crush/internal/ui/textarea"
 	uv "github.com/charmbracelet/ultraviolet"
 )
 

--- a/internal/ui/dialog/question_freetext.go
+++ b/internal/ui/dialog/question_freetext.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 
 	"charm.land/bubbles/v2/key"
-	"charm.land/bubbles/v2/textarea"
+	"github.com/charmbracelet/crush/internal/ui/textarea"
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 	"github.com/charmbracelet/crush/internal/question"

--- a/internal/ui/dialog/question_freetext.go
+++ b/internal/ui/dialog/question_freetext.go
@@ -5,12 +5,12 @@ import (
 	"strings"
 
 	"charm.land/bubbles/v2/key"
-	"charm.land/bubbles/v2/textarea"
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 	"github.com/charmbracelet/crush/internal/question"
 	"github.com/charmbracelet/crush/internal/ui/common"
 	"github.com/charmbracelet/crush/internal/ui/styles"
+	"github.com/charmbracelet/crush/internal/ui/textarea"
 	uv "github.com/charmbracelet/ultraviolet"
 	"github.com/charmbracelet/x/ansi"
 )

--- a/internal/ui/dialog/question_freetext.go
+++ b/internal/ui/dialog/question_freetext.go
@@ -5,12 +5,12 @@ import (
 	"strings"
 
 	"charm.land/bubbles/v2/key"
-	"github.com/charmbracelet/crush/internal/ui/textarea"
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 	"github.com/charmbracelet/crush/internal/question"
 	"github.com/charmbracelet/crush/internal/ui/common"
 	"github.com/charmbracelet/crush/internal/ui/styles"
+	"github.com/charmbracelet/crush/internal/ui/textarea"
 	uv "github.com/charmbracelet/ultraviolet"
 	"github.com/charmbracelet/x/ansi"
 )

--- a/internal/ui/model/a2ui_action_test.go
+++ b/internal/ui/model/a2ui_action_test.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"charm.land/bubbles/v2/textarea"
+	"github.com/charmbracelet/crush/internal/ui/textarea"
 
 	"github.com/charmbracelet/crush/internal/agent/tools"
 	mcptools "github.com/charmbracelet/crush/internal/agent/tools/mcp"

--- a/internal/ui/model/a2ui_action_test.go
+++ b/internal/ui/model/a2ui_action_test.go
@@ -1,0 +1,353 @@
+package model
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"charm.land/bubbles/v2/textarea"
+
+	"github.com/charmbracelet/crush/internal/agent/tools"
+	mcptools "github.com/charmbracelet/crush/internal/agent/tools/mcp"
+	"github.com/charmbracelet/crush/internal/config"
+	"github.com/charmbracelet/crush/internal/message"
+	"github.com/charmbracelet/crush/internal/session"
+	"github.com/charmbracelet/crush/internal/ui/chat"
+	"github.com/charmbracelet/crush/internal/ui/common"
+	"github.com/charmbracelet/crush/internal/workspace"
+	"github.com/joestump-agent/a2tea/event"
+	"github.com/stretchr/testify/require"
+	a2ui "github.com/tmc/a2ui"
+)
+
+// a2uiActionWorkspace stubs the workspace calls the A2UI action round-trip
+// touches, recording a2ui_action / a2ui_error calls and serving canned
+// responses.
+type a2uiActionWorkspace struct {
+	workspace.Workspace
+
+	// toolCalls records (name, toolName) pairs in call order.
+	toolCalls [][2]string
+	// lastArgs records the args of the most recent call.
+	lastArgs map[string]any
+	// response is the canned CallMCPTool result.
+	response workspace.MCPToolCallResult
+	// err is returned from CallMCPTool when set.
+	err error
+	// lastPrompt records the content of the most recent AgentRun, so the
+	// fallback path's submission prompt can be asserted on.
+	lastPrompt string
+}
+
+func (w *a2uiActionWorkspace) AgentIsReady() bool     { return true }
+func (w *a2uiActionWorkspace) AgentReadyErr() error   { return nil }
+func (w *a2uiActionWorkspace) Config() *config.Config { return nil }
+
+func (w *a2uiActionWorkspace) AgentRun(_ context.Context, _, content string, _ ...message.Attachment) error {
+	w.lastPrompt = content
+	return nil
+}
+
+func (w *a2uiActionWorkspace) CallMCPTool(_ context.Context, name, toolName string, args map[string]any) (workspace.MCPToolCallResult, error) {
+	w.toolCalls = append(w.toolCalls, [2]string{name, toolName})
+	w.lastArgs = args
+	return w.response, w.err
+}
+
+// a2uiActionForm is an MCP-served surface with a submit button carrying a
+// server-side action, plus a TextField whose value feeds the action context.
+const a2uiActionForm = `{"version":"v0.9","updateComponents":{"surfaceId":"booking","components":[` +
+	`{"component":"Card","id":"root","child":"col"},` +
+	`{"component":"Column","id":"col","children":["start","btn-confirm"]},` +
+	`{"component":"TextField","id":"start","label":"Start","value":"2026-03-20"},` +
+	`{"component":"Button","id":"btn-confirm","child":"btn-confirm-t","action":{"event":{"name":"confirm_booking"}}},` +
+	`{"component":"Text","id":"btn-confirm-t","text":"Confirm"}` +
+	`]}}`
+
+// newA2UIActionUI builds a UI whose chat holds a tool message item carrying
+// an MCP-served A2UI surface with provenance registered to mcpName.
+func newA2UIActionUI(t *testing.T, ws *a2uiActionWorkspace, mcpName string) *UI {
+	t.Helper()
+	m, _ := newA2UIActionUIItem(t, ws, mcpName)
+	return m
+}
+
+// newA2UIActionUIItem is newA2UIActionUI, also handing back the tool item so
+// a test can assert on what the surface actually renders.
+func newA2UIActionUIItem(t *testing.T, ws *a2uiActionWorkspace, mcpName string) (*UI, chat.ToolMessageItem) {
+	t.Helper()
+	com := common.DefaultCommon(ws)
+	m := &UI{
+		com:      com,
+		status:   NewStatus(com, nil),
+		chat:     NewChat(com, config.ScrollbarDefault),
+		textarea: textarea.New(),
+		state:    uiChat,
+		focus:    uiFocusMain,
+		width:    140,
+		height:   45,
+		session:  &session.Session{ID: "sess-1"},
+	}
+
+	meta, err := json.Marshal(tools.ReadMCPResourceResponseMetadata{
+		A2UISurfaces:         []string{"<a2ui-json>" + a2uiActionForm + "</a2ui-json>"},
+		MCPSurfaceProvenance: []string{mcpName},
+	})
+	require.NoError(t, err)
+
+	item := chat.NewMCPToolMessageItem(com.Styles, message.ToolCall{
+		ID:       "call-1",
+		Name:     "mcp_" + mcpName + "_get_form",
+		Input:    `{}`,
+		Finished: true,
+	}, &message.ToolResult{
+		ToolCallID: "call-1",
+		Content:    "form",
+		Metadata:   string(meta),
+	}, false)
+	m.chat.AppendMessages(item)
+	// Render once so the item builds its live surface models and registers
+	// provenance.
+	_ = item.RawRender(100)
+	return m, item
+}
+
+func TestHandleA2UIButtonClickedMCPSurfaceRoundTrips(t *testing.T) {
+	t.Parallel()
+
+	// The MCP tool registry is process-global; a per-test server name keeps
+	// parallel tests from overwriting each other's capabilities.
+	srv := t.Name()
+
+	ws := &a2uiActionWorkspace{
+		response: workspace.MCPToolCallResult{Content: "Booking confirmed"},
+	}
+	m := newA2UIActionUI(t, ws, srv)
+	cleanup := mcptools.SetToolsForTest(srv, "a2ui_action")
+	t.Cleanup(cleanup)
+
+	cmd := m.handleA2UIButtonClicked(event.ButtonClicked{
+		Source: event.Source{ComponentID: "btn-confirm", SurfaceID: "booking"},
+		ID:     "btn-confirm",
+		Action: &a2ui.EventAction{Name: "confirm_booking"},
+	})
+	require.NotNil(t, cmd, "an MCP surface with a2ui_action must round-trip")
+	msg := cmd()
+	result, ok := msg.(a2uiActionResultMsg)
+	require.True(t, ok, "the cmd must produce an a2uiActionResultMsg")
+	require.NoError(t, result.err)
+	require.Equal(t, "booking", result.surfaceID)
+
+	// The server got the action name and the surface's field values as the
+	// context.
+	require.Len(t, ws.toolCalls, 1)
+	require.Equal(t, [2]string{srv, "a2ui_action"}, ws.toolCalls[0])
+	require.Equal(t, "confirm_booking", ws.lastArgs["name"])
+	ctx, ok := ws.lastArgs["context"].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "2026-03-20", ctx["start"])
+
+	// The surface is NOT retired — MCP surfaces are long-lived.
+	_, found := m.chat.A2UISurfaceFieldValues("booking")
+	require.True(t, found, "the surface must stay live after the round-trip")
+}
+
+func TestHandleA2UIButtonClickedMCPSurfaceWithoutActionToolFallsBack(t *testing.T) {
+	t.Parallel()
+
+	// The MCP tool registry is process-global; a per-test server name keeps
+	// parallel tests from overwriting each other's capabilities.
+	srv := t.Name()
+
+	ws := &a2uiActionWorkspace{}
+	m := newA2UIActionUI(t, ws, srv)
+	// Server serves surfaces but NOT a2ui_action.
+	cleanup := mcptools.SetToolsForTest(srv, "some_other_tool")
+	t.Cleanup(cleanup)
+
+	cmd := m.handleA2UIButtonClicked(event.ButtonClicked{
+		Source: event.Source{ComponentID: "btn-confirm", SurfaceID: "booking"},
+		ID:     "btn-confirm",
+		Action: &a2ui.EventAction{Name: "confirm_booking"},
+	})
+	require.NotNil(t, cmd, "fallback must start an agent turn")
+	runCmdTree(cmd)
+
+	require.Empty(t, ws.toolCalls, "no a2ui_action call without the tool")
+
+	// The prompt must carry what the user typed. RetireA2UISurface only
+	// matches assistant items, so an MCP surface's values have to come from
+	// the tool item that holds them — otherwise the whole form is silently
+	// dropped before the agent ever sees it.
+	require.Contains(t, ws.lastPrompt, "2026-03-20",
+		"the fallback submission must carry the surface's field values")
+	require.Contains(t, ws.lastPrompt, "confirm_booking")
+}
+
+func TestHandleA2UIActionResultAppliesSurfacePayload(t *testing.T) {
+	t.Parallel()
+
+	// The MCP tool registry is process-global; a per-test server name keeps
+	// parallel tests from overwriting each other's capabilities.
+	srv := t.Name()
+
+	ws := &a2uiActionWorkspace{}
+	m, item := newA2UIActionUIItem(t, ws, srv)
+	cleanup := mcptools.SetToolsForTest(srv, "a2ui_action")
+	t.Cleanup(cleanup)
+
+	require.Contains(t, item.RawRender(100), "Confirm", "precondition: the original label renders")
+
+	// A response carrying an A2UI payload updates the surface in place.
+	update := `{"version":"v0.9","updateComponents":{"surfaceId":"booking","components":[` +
+		`{"component":"Text","id":"btn-confirm-t","text":"Booked!"}]}}`
+	cmd := m.handleA2UIActionResult(a2uiActionResultMsg{
+		surfaceID: "booking",
+		mcpName:   srv,
+		surfaces:  []string{update},
+	})
+	require.Nil(t, cmd)
+
+	// The update actually reached the live surface — not just "no error".
+	rendered := item.RawRender(100)
+	require.Contains(t, rendered, "Booked!", "the payload must update the surface in place")
+	require.NotContains(t, rendered, "Confirm", "the old label must be replaced")
+
+	// The surface still exists after the in-place update, and the edited
+	// field the server did not touch is preserved.
+	values, found := m.chat.A2UISurfaceFieldValues("booking")
+	require.True(t, found)
+	require.Equal(t, "2026-03-20", values["start"], "untouched field values must survive")
+}
+
+func TestHandleA2UIActionResultInvalidPayloadReportsToServer(t *testing.T) {
+	t.Parallel()
+
+	// The MCP tool registry is process-global; a per-test server name keeps
+	// parallel tests from overwriting each other's capabilities.
+	srv := t.Name()
+
+	ws := &a2uiActionWorkspace{}
+	m := newA2UIActionUI(t, ws, srv)
+	cleanup := mcptools.SetToolsForTest(srv, "a2ui_action", "a2ui_error")
+	t.Cleanup(cleanup)
+
+	// A malformed payload must round-trip an a2ui_error back to the server:
+	// the command reportA2UIError builds has to actually reach Bubble Tea.
+	cmd := m.handleA2UIActionResult(a2uiActionResultMsg{
+		surfaceID: "booking",
+		mcpName:   srv,
+		surfaces:  []string{`{"version":"v0.9","updateComponents":{`},
+	})
+	require.NotNil(t, cmd, "a malformed payload must produce an a2ui_error command")
+	runCmdTree(cmd)
+
+	require.Len(t, ws.toolCalls, 1)
+	require.Equal(t, [2]string{srv, "a2ui_error"}, ws.toolCalls[0])
+	// Truncated JSON scans as prose rather than failing outright, so it
+	// lands as INVALID_PAYLOAD (parsed, but no server messages) rather than
+	// INVALID_JSON. Either way it must not be a silent no-op.
+	require.Equal(t, "INVALID_PAYLOAD", ws.lastArgs["code"])
+	require.Equal(t, "booking", ws.lastArgs["surfaceId"])
+}
+
+func TestHandleA2UIActionResultHonorsPayloadSurfaceID(t *testing.T) {
+	t.Parallel()
+
+	// The MCP tool registry is process-global; a per-test server name keeps
+	// parallel tests from overwriting each other's capabilities.
+	srv := t.Name()
+
+	ws := &a2uiActionWorkspace{}
+	m, item := newA2UIActionUIItem(t, ws, srv)
+	cleanup := mcptools.SetToolsForTest(srv, "a2ui_action", "a2ui_error")
+	t.Cleanup(cleanup)
+
+	// The server answers the "booking" click by targeting a DIFFERENT
+	// surface. That payload must not be forced onto "booking".
+	update := `{"version":"v0.9","updateComponents":{"surfaceId":"receipt","components":[` +
+		`{"component":"Text","id":"btn-confirm-t","text":"Booked!"}]}}`
+	cmd := m.handleA2UIActionResult(a2uiActionResultMsg{
+		surfaceID: "booking",
+		mcpName:   srv,
+		surfaces:  []string{update},
+	})
+	require.NotNil(t, cmd, "a payload for an unheld surface must be reported back")
+	runCmdTree(cmd)
+
+	require.Contains(t, item.RawRender(100), "Confirm",
+		"a payload aimed at another surface must not corrupt the clicked one")
+	require.Len(t, ws.toolCalls, 1)
+	require.Equal(t, [2]string{srv, "a2ui_error"}, ws.toolCalls[0])
+	require.Equal(t, "SURFACE_NOT_FOUND", ws.lastArgs["code"])
+	require.Equal(t, "receipt", ws.lastArgs["surfaceId"])
+}
+
+func TestHandleA2UIActionResultDeletedSurfaceGoesAway(t *testing.T) {
+	t.Parallel()
+
+	// The MCP tool registry is process-global; a per-test server name keeps
+	// parallel tests from overwriting each other's capabilities.
+	srv := t.Name()
+
+	ws := &a2uiActionWorkspace{}
+	m := newA2UIActionUI(t, ws, srv)
+	cleanup := mcptools.SetToolsForTest(srv, "a2ui_action", "a2ui_error")
+	t.Cleanup(cleanup)
+
+	// The server dismisses the form. The surface must be released, not left
+	// behind as a dead widget that still takes focus and swallows keys —
+	// and a delete is not an error worth reporting back.
+	cmd := m.handleA2UIActionResult(a2uiActionResultMsg{
+		surfaceID: "booking",
+		mcpName:   srv,
+		surfaces:  []string{`{"version":"v0.9","deleteSurface":{"surfaceId":"booking"}}`},
+	})
+	runCmdTree(cmd)
+
+	_, found := m.chat.A2UISurfaceFieldValues("booking")
+	require.False(t, found, "a deleted surface must no longer be live")
+	require.Empty(t, ws.toolCalls, "deleting a surface is not an error to report")
+}
+
+func TestHandleA2UIActionResultErrorReports(t *testing.T) {
+	t.Parallel()
+
+	// The MCP tool registry is process-global; a per-test server name keeps
+	// parallel tests from overwriting each other's capabilities.
+	srv := t.Name()
+
+	ws := &a2uiActionWorkspace{}
+	m := newA2UIActionUI(t, ws, srv)
+
+	cmd := m.handleA2UIActionResult(a2uiActionResultMsg{
+		surfaceID: "booking",
+		mcpName:   srv,
+		err:       context.DeadlineExceeded,
+	})
+	require.NotNil(t, cmd, "an error must surface as a note")
+}
+
+func TestReportA2UIErrorCallsErrorTool(t *testing.T) {
+	t.Parallel()
+
+	// The MCP tool registry is process-global; a per-test server name keeps
+	// parallel tests from overwriting each other's capabilities.
+	srv := t.Name()
+
+	ws := &a2uiActionWorkspace{}
+	m := newA2UIActionUI(t, ws, srv)
+	cleanup := mcptools.SetToolsForTest(srv, "a2ui_error")
+	t.Cleanup(cleanup)
+
+	// An empty server name exercises the surface-owner resolution path.
+	cmd := m.reportA2UIError("", "booking", "INVALID_JSON", "bad payload")
+	require.NotNil(t, cmd)
+	msg := cmd()
+	require.Nil(t, msg, "a successful a2ui_error call produces no message")
+
+	require.Len(t, ws.toolCalls, 1)
+	require.Equal(t, [2]string{srv, "a2ui_error"}, ws.toolCalls[0])
+	require.Equal(t, "INVALID_JSON", ws.lastArgs["code"])
+	require.Equal(t, "booking", ws.lastArgs["surfaceId"])
+}

--- a/internal/ui/model/a2ui_action_test.go
+++ b/internal/ui/model/a2ui_action_test.go
@@ -1,0 +1,353 @@
+package model
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/charmbracelet/crush/internal/ui/textarea"
+
+	"github.com/charmbracelet/crush/internal/agent/tools"
+	mcptools "github.com/charmbracelet/crush/internal/agent/tools/mcp"
+	"github.com/charmbracelet/crush/internal/config"
+	"github.com/charmbracelet/crush/internal/message"
+	"github.com/charmbracelet/crush/internal/session"
+	"github.com/charmbracelet/crush/internal/ui/chat"
+	"github.com/charmbracelet/crush/internal/ui/common"
+	"github.com/charmbracelet/crush/internal/workspace"
+	"github.com/joestump-agent/a2tea/event"
+	"github.com/stretchr/testify/require"
+	a2ui "github.com/tmc/a2ui"
+)
+
+// a2uiActionWorkspace stubs the workspace calls the A2UI action round-trip
+// touches, recording a2ui_action / a2ui_error calls and serving canned
+// responses.
+type a2uiActionWorkspace struct {
+	workspace.Workspace
+
+	// toolCalls records (name, toolName) pairs in call order.
+	toolCalls [][2]string
+	// lastArgs records the args of the most recent call.
+	lastArgs map[string]any
+	// response is the canned CallMCPTool result.
+	response workspace.MCPToolCallResult
+	// err is returned from CallMCPTool when set.
+	err error
+	// lastPrompt records the content of the most recent AgentRun, so the
+	// fallback path's submission prompt can be asserted on.
+	lastPrompt string
+}
+
+func (w *a2uiActionWorkspace) AgentIsReady() bool     { return true }
+func (w *a2uiActionWorkspace) AgentReadyErr() error   { return nil }
+func (w *a2uiActionWorkspace) Config() *config.Config { return nil }
+
+func (w *a2uiActionWorkspace) AgentRun(_ context.Context, _, content string, _ ...message.Attachment) error {
+	w.lastPrompt = content
+	return nil
+}
+
+func (w *a2uiActionWorkspace) CallMCPTool(_ context.Context, name, toolName string, args map[string]any) (workspace.MCPToolCallResult, error) {
+	w.toolCalls = append(w.toolCalls, [2]string{name, toolName})
+	w.lastArgs = args
+	return w.response, w.err
+}
+
+// a2uiActionForm is an MCP-served surface with a submit button carrying a
+// server-side action, plus a TextField whose value feeds the action context.
+const a2uiActionForm = `{"version":"v0.9","updateComponents":{"surfaceId":"booking","components":[` +
+	`{"component":"Card","id":"root","child":"col"},` +
+	`{"component":"Column","id":"col","children":["start","btn-confirm"]},` +
+	`{"component":"TextField","id":"start","label":"Start","value":"2026-03-20"},` +
+	`{"component":"Button","id":"btn-confirm","child":"btn-confirm-t","action":{"event":{"name":"confirm_booking"}}},` +
+	`{"component":"Text","id":"btn-confirm-t","text":"Confirm"}` +
+	`]}}`
+
+// newA2UIActionUI builds a UI whose chat holds a tool message item carrying
+// an MCP-served A2UI surface with provenance registered to mcpName.
+func newA2UIActionUI(t *testing.T, ws *a2uiActionWorkspace, mcpName string) *UI {
+	t.Helper()
+	m, _ := newA2UIActionUIItem(t, ws, mcpName)
+	return m
+}
+
+// newA2UIActionUIItem is newA2UIActionUI, also handing back the tool item so
+// a test can assert on what the surface actually renders.
+func newA2UIActionUIItem(t *testing.T, ws *a2uiActionWorkspace, mcpName string) (*UI, chat.ToolMessageItem) {
+	t.Helper()
+	com := common.DefaultCommon(ws)
+	m := &UI{
+		com:      com,
+		status:   NewStatus(com, nil),
+		chat:     NewChat(com, config.ScrollbarDefault),
+		textarea: textarea.New(),
+		state:    uiChat,
+		focus:    uiFocusMain,
+		width:    140,
+		height:   45,
+		session:  &session.Session{ID: "sess-1"},
+	}
+
+	meta, err := json.Marshal(tools.ReadMCPResourceResponseMetadata{
+		A2UISurfaces:         []string{"<a2ui-json>" + a2uiActionForm + "</a2ui-json>"},
+		MCPSurfaceProvenance: []string{mcpName},
+	})
+	require.NoError(t, err)
+
+	item := chat.NewMCPToolMessageItem(com.Styles, message.ToolCall{
+		ID:       "call-1",
+		Name:     "mcp_" + mcpName + "_get_form",
+		Input:    `{}`,
+		Finished: true,
+	}, &message.ToolResult{
+		ToolCallID: "call-1",
+		Content:    "form",
+		Metadata:   string(meta),
+	}, false)
+	m.chat.AppendMessages(item)
+	// Render once so the item builds its live surface models and registers
+	// provenance.
+	_ = item.RawRender(100)
+	return m, item
+}
+
+func TestHandleA2UIButtonClickedMCPSurfaceRoundTrips(t *testing.T) {
+	t.Parallel()
+
+	// The MCP tool registry is process-global; a per-test server name keeps
+	// parallel tests from overwriting each other's capabilities.
+	srv := t.Name()
+
+	ws := &a2uiActionWorkspace{
+		response: workspace.MCPToolCallResult{Content: "Booking confirmed"},
+	}
+	m := newA2UIActionUI(t, ws, srv)
+	cleanup := mcptools.SetToolsForTest(srv, "a2ui_action")
+	t.Cleanup(cleanup)
+
+	cmd := m.handleA2UIButtonClicked(event.ButtonClicked{
+		Source: event.Source{ComponentID: "btn-confirm", SurfaceID: "booking"},
+		ID:     "btn-confirm",
+		Action: &a2ui.EventAction{Name: "confirm_booking"},
+	})
+	require.NotNil(t, cmd, "an MCP surface with a2ui_action must round-trip")
+	msg := cmd()
+	result, ok := msg.(a2uiActionResultMsg)
+	require.True(t, ok, "the cmd must produce an a2uiActionResultMsg")
+	require.NoError(t, result.err)
+	require.Equal(t, "booking", result.surfaceID)
+
+	// The server got the action name and the surface's field values as the
+	// context.
+	require.Len(t, ws.toolCalls, 1)
+	require.Equal(t, [2]string{srv, "a2ui_action"}, ws.toolCalls[0])
+	require.Equal(t, "confirm_booking", ws.lastArgs["name"])
+	ctx, ok := ws.lastArgs["context"].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "2026-03-20", ctx["start"])
+
+	// The surface is NOT retired — MCP surfaces are long-lived.
+	_, found := m.chat.A2UISurfaceFieldValues("booking")
+	require.True(t, found, "the surface must stay live after the round-trip")
+}
+
+func TestHandleA2UIButtonClickedMCPSurfaceWithoutActionToolFallsBack(t *testing.T) {
+	t.Parallel()
+
+	// The MCP tool registry is process-global; a per-test server name keeps
+	// parallel tests from overwriting each other's capabilities.
+	srv := t.Name()
+
+	ws := &a2uiActionWorkspace{}
+	m := newA2UIActionUI(t, ws, srv)
+	// Server serves surfaces but NOT a2ui_action.
+	cleanup := mcptools.SetToolsForTest(srv, "some_other_tool")
+	t.Cleanup(cleanup)
+
+	cmd := m.handleA2UIButtonClicked(event.ButtonClicked{
+		Source: event.Source{ComponentID: "btn-confirm", SurfaceID: "booking"},
+		ID:     "btn-confirm",
+		Action: &a2ui.EventAction{Name: "confirm_booking"},
+	})
+	require.NotNil(t, cmd, "fallback must start an agent turn")
+	runCmdTree(cmd)
+
+	require.Empty(t, ws.toolCalls, "no a2ui_action call without the tool")
+
+	// The prompt must carry what the user typed. RetireA2UISurface only
+	// matches assistant items, so an MCP surface's values have to come from
+	// the tool item that holds them — otherwise the whole form is silently
+	// dropped before the agent ever sees it.
+	require.Contains(t, ws.lastPrompt, "2026-03-20",
+		"the fallback submission must carry the surface's field values")
+	require.Contains(t, ws.lastPrompt, "confirm_booking")
+}
+
+func TestHandleA2UIActionResultAppliesSurfacePayload(t *testing.T) {
+	t.Parallel()
+
+	// The MCP tool registry is process-global; a per-test server name keeps
+	// parallel tests from overwriting each other's capabilities.
+	srv := t.Name()
+
+	ws := &a2uiActionWorkspace{}
+	m, item := newA2UIActionUIItem(t, ws, srv)
+	cleanup := mcptools.SetToolsForTest(srv, "a2ui_action")
+	t.Cleanup(cleanup)
+
+	require.Contains(t, item.RawRender(100), "Confirm", "precondition: the original label renders")
+
+	// A response carrying an A2UI payload updates the surface in place.
+	update := `{"version":"v0.9","updateComponents":{"surfaceId":"booking","components":[` +
+		`{"component":"Text","id":"btn-confirm-t","text":"Booked!"}]}}`
+	cmd := m.handleA2UIActionResult(a2uiActionResultMsg{
+		surfaceID: "booking",
+		mcpName:   srv,
+		surfaces:  []string{update},
+	})
+	require.Nil(t, cmd)
+
+	// The update actually reached the live surface — not just "no error".
+	rendered := item.RawRender(100)
+	require.Contains(t, rendered, "Booked!", "the payload must update the surface in place")
+	require.NotContains(t, rendered, "Confirm", "the old label must be replaced")
+
+	// The surface still exists after the in-place update, and the edited
+	// field the server did not touch is preserved.
+	values, found := m.chat.A2UISurfaceFieldValues("booking")
+	require.True(t, found)
+	require.Equal(t, "2026-03-20", values["start"], "untouched field values must survive")
+}
+
+func TestHandleA2UIActionResultInvalidPayloadReportsToServer(t *testing.T) {
+	t.Parallel()
+
+	// The MCP tool registry is process-global; a per-test server name keeps
+	// parallel tests from overwriting each other's capabilities.
+	srv := t.Name()
+
+	ws := &a2uiActionWorkspace{}
+	m := newA2UIActionUI(t, ws, srv)
+	cleanup := mcptools.SetToolsForTest(srv, "a2ui_action", "a2ui_error")
+	t.Cleanup(cleanup)
+
+	// A malformed payload must round-trip an a2ui_error back to the server:
+	// the command reportA2UIError builds has to actually reach Bubble Tea.
+	cmd := m.handleA2UIActionResult(a2uiActionResultMsg{
+		surfaceID: "booking",
+		mcpName:   srv,
+		surfaces:  []string{`{"version":"v0.9","updateComponents":{`},
+	})
+	require.NotNil(t, cmd, "a malformed payload must produce an a2ui_error command")
+	runCmdTree(cmd)
+
+	require.Len(t, ws.toolCalls, 1)
+	require.Equal(t, [2]string{srv, "a2ui_error"}, ws.toolCalls[0])
+	// Truncated JSON scans as prose rather than failing outright, so it
+	// lands as INVALID_PAYLOAD (parsed, but no server messages) rather than
+	// INVALID_JSON. Either way it must not be a silent no-op.
+	require.Equal(t, "INVALID_PAYLOAD", ws.lastArgs["code"])
+	require.Equal(t, "booking", ws.lastArgs["surfaceId"])
+}
+
+func TestHandleA2UIActionResultHonorsPayloadSurfaceID(t *testing.T) {
+	t.Parallel()
+
+	// The MCP tool registry is process-global; a per-test server name keeps
+	// parallel tests from overwriting each other's capabilities.
+	srv := t.Name()
+
+	ws := &a2uiActionWorkspace{}
+	m, item := newA2UIActionUIItem(t, ws, srv)
+	cleanup := mcptools.SetToolsForTest(srv, "a2ui_action", "a2ui_error")
+	t.Cleanup(cleanup)
+
+	// The server answers the "booking" click by targeting a DIFFERENT
+	// surface. That payload must not be forced onto "booking".
+	update := `{"version":"v0.9","updateComponents":{"surfaceId":"receipt","components":[` +
+		`{"component":"Text","id":"btn-confirm-t","text":"Booked!"}]}}`
+	cmd := m.handleA2UIActionResult(a2uiActionResultMsg{
+		surfaceID: "booking",
+		mcpName:   srv,
+		surfaces:  []string{update},
+	})
+	require.NotNil(t, cmd, "a payload for an unheld surface must be reported back")
+	runCmdTree(cmd)
+
+	require.Contains(t, item.RawRender(100), "Confirm",
+		"a payload aimed at another surface must not corrupt the clicked one")
+	require.Len(t, ws.toolCalls, 1)
+	require.Equal(t, [2]string{srv, "a2ui_error"}, ws.toolCalls[0])
+	require.Equal(t, "SURFACE_NOT_FOUND", ws.lastArgs["code"])
+	require.Equal(t, "receipt", ws.lastArgs["surfaceId"])
+}
+
+func TestHandleA2UIActionResultDeletedSurfaceGoesAway(t *testing.T) {
+	t.Parallel()
+
+	// The MCP tool registry is process-global; a per-test server name keeps
+	// parallel tests from overwriting each other's capabilities.
+	srv := t.Name()
+
+	ws := &a2uiActionWorkspace{}
+	m := newA2UIActionUI(t, ws, srv)
+	cleanup := mcptools.SetToolsForTest(srv, "a2ui_action", "a2ui_error")
+	t.Cleanup(cleanup)
+
+	// The server dismisses the form. The surface must be released, not left
+	// behind as a dead widget that still takes focus and swallows keys —
+	// and a delete is not an error worth reporting back.
+	cmd := m.handleA2UIActionResult(a2uiActionResultMsg{
+		surfaceID: "booking",
+		mcpName:   srv,
+		surfaces:  []string{`{"version":"v0.9","deleteSurface":{"surfaceId":"booking"}}`},
+	})
+	runCmdTree(cmd)
+
+	_, found := m.chat.A2UISurfaceFieldValues("booking")
+	require.False(t, found, "a deleted surface must no longer be live")
+	require.Empty(t, ws.toolCalls, "deleting a surface is not an error to report")
+}
+
+func TestHandleA2UIActionResultErrorReports(t *testing.T) {
+	t.Parallel()
+
+	// The MCP tool registry is process-global; a per-test server name keeps
+	// parallel tests from overwriting each other's capabilities.
+	srv := t.Name()
+
+	ws := &a2uiActionWorkspace{}
+	m := newA2UIActionUI(t, ws, srv)
+
+	cmd := m.handleA2UIActionResult(a2uiActionResultMsg{
+		surfaceID: "booking",
+		mcpName:   srv,
+		err:       context.DeadlineExceeded,
+	})
+	require.NotNil(t, cmd, "an error must surface as a note")
+}
+
+func TestReportA2UIErrorCallsErrorTool(t *testing.T) {
+	t.Parallel()
+
+	// The MCP tool registry is process-global; a per-test server name keeps
+	// parallel tests from overwriting each other's capabilities.
+	srv := t.Name()
+
+	ws := &a2uiActionWorkspace{}
+	m := newA2UIActionUI(t, ws, srv)
+	cleanup := mcptools.SetToolsForTest(srv, "a2ui_error")
+	t.Cleanup(cleanup)
+
+	// An empty server name exercises the surface-owner resolution path.
+	cmd := m.reportA2UIError("", "booking", "INVALID_JSON", "bad payload")
+	require.NotNil(t, cmd)
+	msg := cmd()
+	require.Nil(t, msg, "a successful a2ui_error call produces no message")
+
+	require.Len(t, ws.toolCalls, 1)
+	require.Equal(t, [2]string{srv, "a2ui_error"}, ws.toolCalls[0])
+	require.Equal(t, "INVALID_JSON", ws.lastArgs["code"])
+	require.Equal(t, "booking", ws.lastArgs["surfaceId"])
+}

--- a/internal/ui/model/a2ui_submit_test.go
+++ b/internal/ui/model/a2ui_submit_test.go
@@ -5,8 +5,8 @@ import (
 	"strings"
 	"testing"
 
-	"charm.land/bubbles/v2/textarea"
 	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/crush/internal/ui/textarea"
 
 	"github.com/charmbracelet/crush/internal/config"
 	"github.com/charmbracelet/crush/internal/message"

--- a/internal/ui/model/channel_test.go
+++ b/internal/ui/model/channel_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"charm.land/bubbles/v2/textarea"
+	"github.com/charmbracelet/crush/internal/ui/textarea"
 
 	"github.com/charmbracelet/crush/internal/agent/tools/mcp"
 	"github.com/charmbracelet/crush/internal/config"

--- a/internal/ui/model/chat.go
+++ b/internal/ui/model/chat.go
@@ -16,6 +16,7 @@ import (
 	"github.com/charmbracelet/x/ansi"
 	"github.com/clipperhouse/displaywidth"
 	"github.com/clipperhouse/uax29/v2/words"
+	a2ui "github.com/tmc/a2ui"
 )
 
 // Constants for multi-click detection.
@@ -800,6 +801,63 @@ func (m *Chat) RetireA2UISurface(surfaceID string) (map[string]any, bool) {
 		}
 	}
 	return nil, false
+}
+
+// a2uiSurfaceItem locates the chat item holding the named MCP surface.
+// Surface IDs are only unique within a server — invoking the same tool twice
+// appends two items carrying the same ID — so the focused surface wins: that
+// is the one the user is actually interacting with. Only when nothing is
+// focused does it fall back to the first match.
+func (m *Chat) a2uiSurfaceItem(surfaceID string) (chat.A2UISurfaceItem, bool) {
+	var first chat.A2UISurfaceItem
+	for i := range m.list.Len() {
+		item, ok := m.list.ItemAt(i).(chat.A2UISurfaceItem)
+		if !ok || !item.HasA2UISurface(surfaceID) {
+			continue
+		}
+		if item.A2UISurfaceIsFocused(surfaceID) {
+			return item, true
+		}
+		if first == nil {
+			first = item
+		}
+	}
+	return first, first != nil
+}
+
+// A2UISurfaceOwner returns the MCP server that served the named surface,
+// resolved through the item that owns it rather than the global
+// surfaceID-keyed registry, so two servers using the same surface ID cannot
+// route each other's interactions.
+func (m *Chat) A2UISurfaceOwner(surfaceID string) (string, bool) {
+	item, ok := m.a2uiSurfaceItem(surfaceID)
+	if !ok {
+		return "", false
+	}
+	return item.A2UISurfaceOwner(surfaceID)
+}
+
+// A2UISurfaceFieldValues reads the named MCP surface's current input values,
+// for building an a2ui_action context. It reports whether a tool item held
+// the surface.
+func (m *Chat) A2UISurfaceFieldValues(surfaceID string) (map[string]any, bool) {
+	item, ok := m.a2uiSurfaceItem(surfaceID)
+	if !ok {
+		return nil, false
+	}
+	return item.ToolA2UIFieldValues(surfaceID), true
+}
+
+// ApplyA2UISurfaceUpdate feeds a batch of A2UI server messages back into the
+// named MCP surface (the response to an a2ui_action round-trip). It reports
+// whether the surface still has renderable state afterward — false means no
+// item held it, or the server deleted it.
+func (m *Chat) ApplyA2UISurfaceUpdate(surfaceID string, msgs []a2ui.ServerMessage) bool {
+	item, ok := m.a2uiSurfaceItem(surfaceID)
+	if !ok {
+		return false
+	}
+	return item.ApplyToolA2UIUpdate(surfaceID, msgs)
 }
 
 // ToggleExpandedSelectedItem expands the selected message item if it is expandable.

--- a/internal/ui/model/completion_backspace_test.go
+++ b/internal/ui/model/completion_backspace_test.go
@@ -3,7 +3,6 @@ package model
 import (
 	"testing"
 
-	"charm.land/bubbles/v2/textarea"
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 
@@ -11,6 +10,7 @@ import (
 	"github.com/charmbracelet/crush/internal/ui/attachments"
 	"github.com/charmbracelet/crush/internal/ui/common"
 	"github.com/charmbracelet/crush/internal/ui/dialog"
+	"github.com/charmbracelet/crush/internal/ui/textarea"
 )
 
 func newCompletionBackspaceUI() *UI {

--- a/internal/ui/model/layout_test.go
+++ b/internal/ui/model/layout_test.go
@@ -5,11 +5,11 @@ import (
 	"strings"
 	"testing"
 
-	"charm.land/bubbles/v2/textarea"
 	"github.com/charmbracelet/crush/internal/config"
 	"github.com/charmbracelet/crush/internal/session"
 	"github.com/charmbracelet/crush/internal/ui/chat"
 	"github.com/charmbracelet/crush/internal/ui/common"
+	"github.com/charmbracelet/crush/internal/ui/textarea"
 )
 
 // testMessageItem is a minimal chat item used to populate the chat list

--- a/internal/ui/model/prompt_highlight_render_test.go
+++ b/internal/ui/model/prompt_highlight_render_test.go
@@ -1,0 +1,82 @@
+package model
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/crush/internal/skills"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRenderEditorViewStylesTokens is the end-to-end check: a prompt
+// containing @file and /skill tokens renders with ANSI styling once the
+// highlighter is wired, and the plain text is unchanged underneath.
+func TestRenderEditorViewStylesTokens(t *testing.T) {
+	t.Parallel()
+
+	m := newSkillCompletionUI()
+	m.promptHighlighter = newTestHighlighter("code-review")
+	m.textarea.SetHighlighter(m.promptHighlighter)
+	m.textarea.SetValue("please /code-review @main.go")
+	m.textarea.SetWidth(120)
+
+	view := m.renderEditorView(120)
+
+	stripped := ansi.Strip(view)
+	require.Contains(t, stripped, "please /code-review @main.go")
+	require.True(t, strings.Contains(view, "\x1b["), "expected styled output, got %q", view)
+}
+
+// TestRenderEditorViewUnknownSkillNotStyled verifies an arbitrary /word in
+// the prompt is left alone.
+func TestRenderEditorViewUnknownSkillNotStyled(t *testing.T) {
+	t.Parallel()
+
+	m := newSkillCompletionUI()
+	m.promptHighlighter = newTestHighlighter("code-review")
+	m.textarea.SetHighlighter(m.promptHighlighter)
+	m.textarea.SetValue("what is /bogus anyway")
+	m.textarea.SetWidth(120)
+
+	before := m.textarea.View()
+	after := func() string {
+		m.promptHighlighter.Rescan(m.textarea.Value())
+		return m.textarea.View()
+	}()
+	require.Equal(t, before, after)
+}
+
+// TestRenderEditorViewBangModeSuppressesTokens verifies shell prompts don't
+// get token styling.
+func TestRenderEditorViewBangModeSuppressesTokens(t *testing.T) {
+	t.Parallel()
+
+	m := newSkillCompletionUI()
+	m.promptHighlighter = newTestHighlighter("ls")
+	m.textarea.SetHighlighter(m.promptHighlighter)
+	m.bangMode = true
+	m.textarea.SetValue("ls /tmp")
+	m.textarea.SetWidth(120)
+
+	before := m.textarea.View()
+	_ = m.renderEditorView(120)
+	after := m.textarea.View()
+
+	require.Equal(t, before, after, "bang mode must not restyle the prompt")
+}
+
+// TestPromptHighlighterSeededFromSkillStates covers the construction-time
+// seeding: names come from skillStates so a /skill typed before the first
+// skills.Event still highlights.
+func TestPromptHighlighterSeededFromSkillStates(t *testing.T) {
+	t.Parallel()
+
+	m := newSkillCompletionUI()
+	m.skillStates = []*skills.SkillState{
+		{Name: "commit", State: skills.StateNormal},
+	}
+	h := newTestHighlighter(m.skillNames()...)
+	h.Rescan("/commit")
+	require.Len(t, h.Highlight(0, nil), 1)
+}

--- a/internal/ui/model/prompt_highlight_render_test.go
+++ b/internal/ui/model/prompt_highlight_render_test.go
@@ -13,10 +13,8 @@ import (
 // containing @file and /skill tokens renders with ANSI styling once the
 // highlighter is wired, and the plain text is unchanged underneath.
 func TestRenderEditorViewStylesTokens(t *testing.T) {
-	t.Parallel()
-
 	m := newSkillCompletionUI()
-	m.promptHighlighter = newTestHighlighter("code-review")
+	m.promptHighlighter = newTestHighlighter(t, "code-review")
 	m.textarea.SetHighlighter(m.promptHighlighter)
 	m.textarea.SetValue("please /code-review @main.go")
 	m.textarea.SetWidth(120)
@@ -31,10 +29,8 @@ func TestRenderEditorViewStylesTokens(t *testing.T) {
 // TestRenderEditorViewUnknownSkillNotStyled verifies an arbitrary /word in
 // the prompt is left alone.
 func TestRenderEditorViewUnknownSkillNotStyled(t *testing.T) {
-	t.Parallel()
-
 	m := newSkillCompletionUI()
-	m.promptHighlighter = newTestHighlighter("code-review")
+	m.promptHighlighter = newTestHighlighter(t, "code-review")
 	m.textarea.SetHighlighter(m.promptHighlighter)
 	m.textarea.SetValue("what is /bogus anyway")
 	m.textarea.SetWidth(120)
@@ -50,10 +46,8 @@ func TestRenderEditorViewUnknownSkillNotStyled(t *testing.T) {
 // TestRenderEditorViewBangModeSuppressesTokens verifies shell prompts don't
 // get token styling.
 func TestRenderEditorViewBangModeSuppressesTokens(t *testing.T) {
-	t.Parallel()
-
 	m := newSkillCompletionUI()
-	m.promptHighlighter = newTestHighlighter("ls")
+	m.promptHighlighter = newTestHighlighter(t, "ls")
 	m.textarea.SetHighlighter(m.promptHighlighter)
 	m.bangMode = true
 	m.textarea.SetValue("ls /tmp")
@@ -70,13 +64,11 @@ func TestRenderEditorViewBangModeSuppressesTokens(t *testing.T) {
 // seeding: names come from skillStates so a /skill typed before the first
 // skills.Event still highlights.
 func TestPromptHighlighterSeededFromSkillStates(t *testing.T) {
-	t.Parallel()
-
 	m := newSkillCompletionUI()
 	m.skillStates = []*skills.SkillState{
 		{Name: "commit", State: skills.StateNormal},
 	}
-	h := newTestHighlighter(m.skillNames()...)
+	h := newTestHighlighter(t, m.skillNames()...)
 	h.Rescan("/commit")
 	require.Len(t, h.Highlight(0, nil), 1)
 }

--- a/internal/ui/model/prompt_highlight_render_test.go
+++ b/internal/ui/model/prompt_highlight_render_test.go
@@ -1,0 +1,74 @@
+package model
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/crush/internal/skills"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRenderEditorViewStylesTokens is the end-to-end check: a prompt
+// containing @file and /skill tokens renders with ANSI styling once the
+// highlighter is wired, and the plain text is unchanged underneath.
+func TestRenderEditorViewStylesTokens(t *testing.T) {
+	m := newSkillCompletionUI()
+	m.promptHighlighter = newTestHighlighter(t, "code-review")
+	m.textarea.SetHighlighter(m.promptHighlighter)
+	m.textarea.SetValue("please /code-review @main.go")
+	m.textarea.SetWidth(120)
+
+	view := m.renderEditorView(120)
+
+	stripped := ansi.Strip(view)
+	require.Contains(t, stripped, "please /code-review @main.go")
+	require.True(t, strings.Contains(view, "\x1b["), "expected styled output, got %q", view)
+}
+
+// TestRenderEditorViewUnknownSkillNotStyled verifies an arbitrary /word in
+// the prompt is left alone.
+func TestRenderEditorViewUnknownSkillNotStyled(t *testing.T) {
+	m := newSkillCompletionUI()
+	m.promptHighlighter = newTestHighlighter(t, "code-review")
+	m.textarea.SetHighlighter(m.promptHighlighter)
+	m.textarea.SetValue("what is /bogus anyway")
+	m.textarea.SetWidth(120)
+
+	before := m.textarea.View()
+	after := func() string {
+		m.promptHighlighter.Rescan(m.textarea.Value())
+		return m.textarea.View()
+	}()
+	require.Equal(t, before, after)
+}
+
+// TestRenderEditorViewBangModeSuppressesTokens verifies shell prompts don't
+// get token styling.
+func TestRenderEditorViewBangModeSuppressesTokens(t *testing.T) {
+	m := newSkillCompletionUI()
+	m.promptHighlighter = newTestHighlighter(t, "ls")
+	m.textarea.SetHighlighter(m.promptHighlighter)
+	m.bangMode = true
+	m.textarea.SetValue("ls /tmp")
+	m.textarea.SetWidth(120)
+
+	before := m.textarea.View()
+	_ = m.renderEditorView(120)
+	after := m.textarea.View()
+
+	require.Equal(t, before, after, "bang mode must not restyle the prompt")
+}
+
+// TestPromptHighlighterSeededFromSkillStates covers the construction-time
+// seeding: names come from skillStates so a /skill typed before the first
+// skills.Event still highlights.
+func TestPromptHighlighterSeededFromSkillStates(t *testing.T) {
+	m := newSkillCompletionUI()
+	m.skillStates = []*skills.SkillState{
+		{Name: "commit", State: skills.StateNormal},
+	}
+	h := newTestHighlighter(t, m.skillNames()...)
+	h.Rescan("/commit")
+	require.Len(t, h.Highlight(0, nil), 1)
+}

--- a/internal/ui/model/prompt_highlighter.go
+++ b/internal/ui/model/prompt_highlighter.go
@@ -1,0 +1,128 @@
+package model
+
+import (
+	"strings"
+
+	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/crush/internal/ui/textarea"
+)
+
+// promptHighlighter implements textarea.LineHighlighter for the prompt:
+// it marks @file tokens and /skill tokens as they are typed. Tokens are
+// recognized at word boundaries (start of line or after whitespace) and run
+// to the next whitespace — they never span lines, which keeps the
+// textarea's per-line range contract trivially satisfiable.
+//
+// A @token is always highlighted (the file may not exist yet, and the
+// completion popup is the discovery path). A /token is only highlighted
+// when it is a prefix of a known skill name, so arbitrary slash-words in
+// prose don't get styled as skills.
+type promptHighlighter struct {
+	fileStyle  lipgloss.Style
+	skillStyle lipgloss.Style
+
+	// skillNames is the set of known skill names used to validate /tokens.
+	skillNames []string
+
+	// lines caches the tokenized logical lines from the last Rescan.
+	lines [][]lipgloss.Range
+}
+
+var _ textarea.LineHighlighter = (*promptHighlighter)(nil)
+
+func newPromptHighlighter(fileStyle, skillStyle lipgloss.Style, skillNames []string) *promptHighlighter {
+	return &promptHighlighter{
+		fileStyle:  fileStyle,
+		skillStyle: skillStyle,
+		skillNames: skillNames,
+	}
+}
+
+// setSkillNames updates the known skill set (e.g. after a skills reload).
+func (h *promptHighlighter) setSkillNames(names []string) {
+	h.skillNames = names
+}
+
+// Rescan retokenizes the full prompt value. Called whenever the textarea
+// value changes; cheap (linear scan) and keeps Highlight a pure lookup.
+func (h *promptHighlighter) Rescan(value string) {
+	rawLines := strings.Split(value, "\n")
+	h.lines = make([][]lipgloss.Range, len(rawLines))
+	for i, line := range rawLines {
+		h.lines[i] = h.scanLine([]rune(line))
+	}
+}
+
+// Highlight implements textarea.LineHighlighter.
+func (h *promptHighlighter) Highlight(lineIdx int, _ []rune) []lipgloss.Range {
+	if lineIdx < 0 || lineIdx >= len(h.lines) {
+		return nil
+	}
+	return h.lines[lineIdx]
+}
+
+// scanLine finds all tokens in a single logical line.
+func (h *promptHighlighter) scanLine(line []rune) []lipgloss.Range {
+	var ranges []lipgloss.Range
+	i := 0
+	for i < len(line) {
+		atWordStart := i == 0 || isSpaceRune(line[i-1])
+		if atWordStart && (line[i] == '@' || line[i] == '/') && i+1 < len(line) && !isSpaceRune(line[i+1]) {
+			end := i + 1
+			for end < len(line) && !isSpaceRune(line[end]) {
+				end++
+			}
+			if style, ok := h.tokenStyle(line[i], line[i+1:end]); ok {
+				ranges = append(ranges, lipgloss.NewRange(i, end, style))
+			}
+			i = end
+			continue
+		}
+		i++
+	}
+	return ranges
+}
+
+// tokenStyle decides whether a candidate token gets styled, and with which
+// style. trigger is '@' or '/'; word is the token body without the trigger.
+func (h *promptHighlighter) tokenStyle(trigger rune, word []rune) (lipgloss.Style, bool) {
+	if trigger == '@' {
+		return h.fileStyle, true
+	}
+	if len(word) == 0 {
+		return lipgloss.Style{}, false
+	}
+	name := string(word)
+	for _, s := range h.skillNames {
+		if strings.HasPrefix(s, name) {
+			return h.skillStyle, true
+		}
+	}
+	return lipgloss.Style{}, false
+}
+
+func isSpaceRune(r rune) bool {
+	return r == ' ' || r == '\t'
+}
+
+// skillNames returns the names of the skills a /token may refer to. It
+// shares skillCompletionValues' source of truth — the effective catalog,
+// falling back to discovery states before the first catalog load — so a
+// token highlights exactly when the popup would have offered it.
+func (m *UI) skillNames() []string {
+	values := m.skillCompletionValues()
+	names := make([]string, 0, len(values))
+	for _, v := range values {
+		names = append(names, v.Name)
+	}
+	return names
+}
+
+// refreshSkillNames re-primes the prompt highlighter's known-skill set.
+// Called from every path that can change the effective skill list.
+func (m *UI) refreshSkillNames() {
+	if m.promptHighlighter == nil {
+		return
+	}
+	m.promptHighlighter.setSkillNames(m.skillNames())
+}

--- a/internal/ui/model/prompt_highlighter.go
+++ b/internal/ui/model/prompt_highlighter.go
@@ -4,25 +4,18 @@ import (
 	"strings"
 
 	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/crush/internal/ui/common"
 	"github.com/charmbracelet/crush/internal/ui/textarea"
 )
 
-// promptHighlighter implements textarea.LineHighlighter for the prompt:
-// it marks @file tokens and /skill tokens as they are typed. Tokens are
-// recognized at word boundaries (start of line or after whitespace) and run
-// to the next whitespace — they never span lines, which keeps the
-// textarea's per-line range contract trivially satisfiable.
-//
-// A @token is always highlighted (the file may not exist yet, and the
-// completion popup is the discovery path). A /token is only highlighted
-// when it is a prefix of a known skill name, so arbitrary slash-words in
-// prose don't get styled as skills.
+// promptHighlighter implements textarea.LineHighlighter for the prompt: it
+// marks @file tokens and /skill tokens as they are typed. Tokenization
+// itself lives in common.ScanPromptTokens, shared with the posted-message
+// renderer so a token looks the same before and after you hit enter; this
+// type only maps tokens onto the editor's styles and caches the result.
 type promptHighlighter struct {
 	fileStyle  lipgloss.Style
 	skillStyle lipgloss.Style
-
-	// skillNames is the set of known skill names used to validate /tokens.
-	skillNames []string
 
 	// lines caches the tokenized logical lines from the last Rescan.
 	lines [][]lipgloss.Range
@@ -30,17 +23,11 @@ type promptHighlighter struct {
 
 var _ textarea.LineHighlighter = (*promptHighlighter)(nil)
 
-func newPromptHighlighter(fileStyle, skillStyle lipgloss.Style, skillNames []string) *promptHighlighter {
+func newPromptHighlighter(fileStyle, skillStyle lipgloss.Style) *promptHighlighter {
 	return &promptHighlighter{
 		fileStyle:  fileStyle,
 		skillStyle: skillStyle,
-		skillNames: skillNames,
 	}
-}
-
-// setSkillNames updates the known skill set (e.g. after a skills reload).
-func (h *promptHighlighter) setSkillNames(names []string) {
-	h.skillNames = names
 }
 
 // Rescan retokenizes the full prompt value. Called whenever the textarea
@@ -61,48 +48,24 @@ func (h *promptHighlighter) Highlight(lineIdx int, _ []rune) []lipgloss.Range {
 	return h.lines[lineIdx]
 }
 
-// scanLine finds all tokens in a single logical line.
+// scanLine turns one logical line's tokens into styled rune ranges.
 func (h *promptHighlighter) scanLine(line []rune) []lipgloss.Range {
-	var ranges []lipgloss.Range
-	i := 0
-	for i < len(line) {
-		atWordStart := i == 0 || isSpaceRune(line[i-1])
-		if atWordStart && (line[i] == '@' || line[i] == '/') && i+1 < len(line) && !isSpaceRune(line[i+1]) {
-			end := i + 1
-			for end < len(line) && !isSpaceRune(line[end]) {
-				end++
-			}
-			if style, ok := h.tokenStyle(line[i], line[i+1:end]); ok {
-				ranges = append(ranges, lipgloss.NewRange(i, end, style))
-			}
-			i = end
-			continue
-		}
-		i++
+	tokens := common.ScanPromptTokens(line)
+	if len(tokens) == 0 {
+		return nil
+	}
+	ranges := make([]lipgloss.Range, 0, len(tokens))
+	for _, tok := range tokens {
+		ranges = append(ranges, lipgloss.NewRange(tok.Start, tok.End, h.tokenStyle(tok.Kind)))
 	}
 	return ranges
 }
 
-// tokenStyle decides whether a candidate token gets styled, and with which
-// style. trigger is '@' or '/'; word is the token body without the trigger.
-func (h *promptHighlighter) tokenStyle(trigger rune, word []rune) (lipgloss.Style, bool) {
-	if trigger == '@' {
-		return h.fileStyle, true
+func (h *promptHighlighter) tokenStyle(kind common.PromptTokenKind) lipgloss.Style {
+	if kind == common.PromptTokenSkill {
+		return h.skillStyle
 	}
-	if len(word) == 0 {
-		return lipgloss.Style{}, false
-	}
-	name := string(word)
-	for _, s := range h.skillNames {
-		if strings.HasPrefix(s, name) {
-			return h.skillStyle, true
-		}
-	}
-	return lipgloss.Style{}, false
-}
-
-func isSpaceRune(r rune) bool {
-	return r == ' ' || r == '\t'
+	return h.fileStyle
 }
 
 // skillNames returns the names of the skills a /token may refer to. It
@@ -118,11 +81,8 @@ func (m *UI) skillNames() []string {
 	return names
 }
 
-// refreshSkillNames re-primes the prompt highlighter's known-skill set.
+// refreshSkillNames re-primes the known-skill set that validates "/" tokens.
 // Called from every path that can change the effective skill list.
 func (m *UI) refreshSkillNames() {
-	if m.promptHighlighter == nil {
-		return
-	}
-	m.promptHighlighter.setSkillNames(m.skillNames())
+	common.SetPromptSkillNames(m.skillNames())
 }

--- a/internal/ui/model/prompt_highlighter.go
+++ b/internal/ui/model/prompt_highlighter.go
@@ -1,0 +1,88 @@
+package model
+
+import (
+	"strings"
+
+	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/crush/internal/ui/common"
+	"github.com/charmbracelet/crush/internal/ui/textarea"
+)
+
+// promptHighlighter implements textarea.LineHighlighter for the prompt: it
+// marks @file tokens and /skill tokens as they are typed. Tokenization
+// itself lives in common.ScanPromptTokens, shared with the posted-message
+// renderer so a token looks the same before and after you hit enter; this
+// type only maps tokens onto the editor's styles and caches the result.
+type promptHighlighter struct {
+	fileStyle  lipgloss.Style
+	skillStyle lipgloss.Style
+
+	// lines caches the tokenized logical lines from the last Rescan.
+	lines [][]lipgloss.Range
+}
+
+var _ textarea.LineHighlighter = (*promptHighlighter)(nil)
+
+func newPromptHighlighter(fileStyle, skillStyle lipgloss.Style) *promptHighlighter {
+	return &promptHighlighter{
+		fileStyle:  fileStyle,
+		skillStyle: skillStyle,
+	}
+}
+
+// Rescan retokenizes the full prompt value. Called whenever the textarea
+// value changes; cheap (linear scan) and keeps Highlight a pure lookup.
+func (h *promptHighlighter) Rescan(value string) {
+	rawLines := strings.Split(value, "\n")
+	h.lines = make([][]lipgloss.Range, len(rawLines))
+	for i, line := range rawLines {
+		h.lines[i] = h.scanLine([]rune(line))
+	}
+}
+
+// Highlight implements textarea.LineHighlighter.
+func (h *promptHighlighter) Highlight(lineIdx int, _ []rune) []lipgloss.Range {
+	if lineIdx < 0 || lineIdx >= len(h.lines) {
+		return nil
+	}
+	return h.lines[lineIdx]
+}
+
+// scanLine turns one logical line's tokens into styled rune ranges.
+func (h *promptHighlighter) scanLine(line []rune) []lipgloss.Range {
+	tokens := common.ScanPromptTokens(line)
+	if len(tokens) == 0 {
+		return nil
+	}
+	ranges := make([]lipgloss.Range, 0, len(tokens))
+	for _, tok := range tokens {
+		ranges = append(ranges, lipgloss.NewRange(tok.Start, tok.End, h.tokenStyle(tok.Kind)))
+	}
+	return ranges
+}
+
+func (h *promptHighlighter) tokenStyle(kind common.PromptTokenKind) lipgloss.Style {
+	if kind == common.PromptTokenSkill {
+		return h.skillStyle
+	}
+	return h.fileStyle
+}
+
+// skillNames returns the names of the skills a /token may refer to. It
+// shares skillCompletionValues' source of truth — the effective catalog,
+// falling back to discovery states before the first catalog load — so a
+// token highlights exactly when the popup would have offered it.
+func (m *UI) skillNames() []string {
+	values := m.skillCompletionValues()
+	names := make([]string, 0, len(values))
+	for _, v := range values {
+		names = append(names, v.Name)
+	}
+	return names
+}
+
+// refreshSkillNames re-primes the known-skill set that validates "/" tokens.
+// Called from every path that can change the effective skill list.
+func (m *UI) refreshSkillNames() {
+	common.SetPromptSkillNames(m.skillNames())
+}

--- a/internal/ui/model/prompt_highlighter_test.go
+++ b/internal/ui/model/prompt_highlighter_test.go
@@ -1,0 +1,122 @@
+package model
+
+import (
+	"testing"
+
+	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/crush/internal/skills"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestHighlighter(skillNames ...string) *promptHighlighter {
+	return newPromptHighlighter(
+		lipgloss.NewStyle().Foreground(lipgloss.Color("1")),
+		lipgloss.NewStyle().Foreground(lipgloss.Color("2")),
+		skillNames,
+	)
+}
+
+func TestPromptHighlighterFileTokens(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHighlighter()
+	h.Rescan("see @foo.go and @bar.md end")
+
+	line := h.Highlight(0, nil)
+	require.Len(t, line, 2)
+	require.Equal(t, 4, line[0].Start)
+	require.Equal(t, 11, line[0].End) // "@foo.go"
+	require.Equal(t, 16, line[1].Start)
+	require.Equal(t, 23, line[1].End) // "@bar.md"
+}
+
+func TestPromptHighlighterSkillTokens(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHighlighter("code-review", "commit")
+
+	h.Rescan("please /code-review this")
+	line := h.Highlight(0, nil)
+	require.Len(t, line, 1)
+	require.Equal(t, 7, line[0].Start)
+	require.Equal(t, 19, line[0].End) // "/code-review"
+
+	// Unknown slash-words are not styled.
+	h.Rescan("please /bogus this")
+	require.Empty(t, h.Highlight(0, nil))
+}
+
+func TestPromptHighlighterSkillPrefixWhileTyping(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHighlighter("code-review")
+
+	// Mid-typing prefix of a known skill highlights (live feedback).
+	h.Rescan("/cod")
+	require.Len(t, h.Highlight(0, nil), 1)
+
+	// Diverged from every known skill: no highlight.
+	h.Rescan("/codeX")
+	require.Empty(t, h.Highlight(0, nil))
+}
+
+func TestPromptHighlighterWordBoundary(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHighlighter("commit")
+
+	// Triggers must start a word: email-like and path-like runs don't count.
+	h.Rescan("mail me@foo.go or a/b")
+	require.Empty(t, h.Highlight(0, nil))
+
+	// Tab counts as a boundary too.
+	h.Rescan("x\t@foo.go")
+	require.Len(t, h.Highlight(0, nil), 1)
+}
+
+func TestPromptHighlighterBareTriggerNotStyled(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHighlighter()
+	h.Rescan("@ / @")
+	require.Empty(t, h.Highlight(0, nil))
+}
+
+func TestPromptHighlighterMultiline(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHighlighter()
+	h.Rescan("first @one.go\nsecond @two.go\nthird plain")
+
+	require.Len(t, h.Highlight(0, nil), 1)
+	require.Len(t, h.Highlight(1, nil), 1)
+	require.Empty(t, h.Highlight(2, nil))
+	// Out of range is safe.
+	require.Nil(t, h.Highlight(3, nil))
+}
+
+func TestPromptHighlighterSkillNamesUpdate(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHighlighter()
+	h.Rescan("/commit")
+	require.Empty(t, h.Highlight(0, nil))
+
+	h.setSkillNames([]string{"commit"})
+	h.Rescan("/commit")
+	require.Len(t, h.Highlight(0, nil), 1)
+}
+
+// TestSkillNamesHelper verifies the UI helper filters to healthy skills.
+func TestSkillNamesHelper(t *testing.T) {
+	t.Parallel()
+
+	m := &UI{
+		skillStates: []*skills.SkillState{
+			{Name: "good", State: skills.StateNormal},
+			{Name: "bad", State: skills.StateError},
+			nil,
+		},
+	}
+	require.Equal(t, []string{"good"}, m.skillNames())
+}

--- a/internal/ui/model/prompt_highlighter_test.go
+++ b/internal/ui/model/prompt_highlighter_test.go
@@ -1,0 +1,145 @@
+package model
+
+import (
+	"testing"
+
+	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/crush/internal/skills"
+	"github.com/charmbracelet/crush/internal/ui/common"
+	"github.com/stretchr/testify/require"
+)
+
+// newTestHighlighter builds a highlighter and primes the known-skill set it
+// validates "/" tokens against. That set is process-wide (see
+// common.SetPromptSkillNames), so these tests do not run in parallel.
+func newTestHighlighter(t *testing.T, skillNames ...string) *promptHighlighter {
+	t.Helper()
+	common.SetPromptSkillNames(skillNames)
+	t.Cleanup(func() { common.SetPromptSkillNames(nil) })
+	return newPromptHighlighter(
+		lipgloss.NewStyle().Foreground(lipgloss.Color("1")),
+		lipgloss.NewStyle().Foreground(lipgloss.Color("2")),
+	)
+}
+
+func TestPromptHighlighterFileTokens(t *testing.T) {
+	h := newTestHighlighter(t)
+	h.Rescan("see @foo.go and @bar.md end")
+
+	line := h.Highlight(0, nil)
+	require.Len(t, line, 2)
+	require.Equal(t, 4, line[0].Start)
+	require.Equal(t, 11, line[0].End) // "@foo.go"
+	require.Equal(t, 16, line[1].Start)
+	require.Equal(t, 23, line[1].End) // "@bar.md"
+}
+
+func TestPromptHighlighterSkillTokens(t *testing.T) {
+	h := newTestHighlighter(t, "code-review", "commit")
+
+	h.Rescan("please /code-review this")
+	line := h.Highlight(0, nil)
+	require.Len(t, line, 1)
+	require.Equal(t, 7, line[0].Start)
+	require.Equal(t, 19, line[0].End) // "/code-review"
+
+	// Unknown slash-words are not styled.
+	h.Rescan("please /bogus this")
+	require.Empty(t, h.Highlight(0, nil))
+}
+
+// TestPromptHighlighterUsesDistinctStyles pins that the two token kinds do
+// not collapse onto one colour.
+func TestPromptHighlighterUsesDistinctStyles(t *testing.T) {
+	h := newTestHighlighter(t, "commit")
+	h.Rescan("@foo.go /commit")
+
+	line := h.Highlight(0, nil)
+	require.Len(t, line, 2)
+	require.Equal(t, h.fileStyle, line[0].Style)
+	require.Equal(t, h.skillStyle, line[1].Style)
+}
+
+func TestPromptHighlighterSkillPrefixWhileTyping(t *testing.T) {
+	h := newTestHighlighter(t, "code-review")
+
+	// Mid-typing prefix of a known skill highlights (live feedback).
+	h.Rescan("/cod")
+	require.Len(t, h.Highlight(0, nil), 1)
+
+	// Diverged from every known skill: no highlight.
+	h.Rescan("/codeX")
+	require.Empty(t, h.Highlight(0, nil))
+}
+
+func TestPromptHighlighterWordBoundary(t *testing.T) {
+	h := newTestHighlighter(t, "commit")
+
+	// Triggers must start a word: email-like and path-like runs don't count.
+	h.Rescan("mail me@foo.go or a/b")
+	require.Empty(t, h.Highlight(0, nil))
+
+	// Tab counts as a boundary too.
+	h.Rescan("x\t@foo.go")
+	require.Len(t, h.Highlight(0, nil), 1)
+}
+
+func TestPromptHighlighterBareTriggerNotStyled(t *testing.T) {
+	h := newTestHighlighter(t)
+	h.Rescan("@ / @")
+	require.Empty(t, h.Highlight(0, nil))
+}
+
+func TestPromptHighlighterMultiline(t *testing.T) {
+	h := newTestHighlighter(t)
+	h.Rescan("first @one.go\nsecond @two.go\nthird plain")
+
+	require.Len(t, h.Highlight(0, nil), 1)
+	require.Len(t, h.Highlight(1, nil), 1)
+	require.Empty(t, h.Highlight(2, nil))
+	// Out of range is safe.
+	require.Nil(t, h.Highlight(3, nil))
+}
+
+func TestPromptHighlighterSkillNamesUpdate(t *testing.T) {
+	h := newTestHighlighter(t)
+	h.Rescan("/commit")
+	require.Empty(t, h.Highlight(0, nil))
+
+	common.SetPromptSkillNames([]string{"commit"})
+	h.Rescan("/commit")
+	require.Len(t, h.Highlight(0, nil), 1)
+}
+
+// TestSkillNamesHelper verifies the UI helper filters to healthy skills.
+func TestSkillNamesHelper(t *testing.T) {
+	t.Parallel()
+
+	m := &UI{
+		skillStates: []*skills.SkillState{
+			{Name: "good", State: skills.StateNormal},
+			{Name: "bad", State: skills.StateError},
+			nil,
+		},
+	}
+	require.Equal(t, []string{"good"}, m.skillNames())
+}
+
+// TestSkillNamesFromCatalog verifies the highlighter validates "/" tokens
+// against the same effective skill set the completions popup offers, so a
+// disabled or overridden skill cannot highlight in one place and be missing
+// from the other.
+func TestSkillNamesFromCatalog(t *testing.T) {
+	t.Parallel()
+
+	m := &UI{
+		skillStates: []*skills.SkillState{
+			{Name: "stale-state-only", State: skills.StateNormal},
+		},
+		skillCatalog: []skills.CatalogEntry{
+			{Name: "commit"},
+			{Name: "alpha"},
+		},
+	}
+	require.Equal(t, []string{"alpha", "commit"}, m.skillNames())
+}

--- a/internal/ui/model/prompt_highlighter_test.go
+++ b/internal/ui/model/prompt_highlighter_test.go
@@ -5,21 +5,25 @@ import (
 
 	"charm.land/lipgloss/v2"
 	"github.com/charmbracelet/crush/internal/skills"
+	"github.com/charmbracelet/crush/internal/ui/common"
 	"github.com/stretchr/testify/require"
 )
 
-func newTestHighlighter(skillNames ...string) *promptHighlighter {
+// newTestHighlighter builds a highlighter and primes the known-skill set it
+// validates "/" tokens against. That set is process-wide (see
+// common.SetPromptSkillNames), so these tests do not run in parallel.
+func newTestHighlighter(t *testing.T, skillNames ...string) *promptHighlighter {
+	t.Helper()
+	common.SetPromptSkillNames(skillNames)
+	t.Cleanup(func() { common.SetPromptSkillNames(nil) })
 	return newPromptHighlighter(
 		lipgloss.NewStyle().Foreground(lipgloss.Color("1")),
 		lipgloss.NewStyle().Foreground(lipgloss.Color("2")),
-		skillNames,
 	)
 }
 
 func TestPromptHighlighterFileTokens(t *testing.T) {
-	t.Parallel()
-
-	h := newTestHighlighter()
+	h := newTestHighlighter(t)
 	h.Rescan("see @foo.go and @bar.md end")
 
 	line := h.Highlight(0, nil)
@@ -31,9 +35,7 @@ func TestPromptHighlighterFileTokens(t *testing.T) {
 }
 
 func TestPromptHighlighterSkillTokens(t *testing.T) {
-	t.Parallel()
-
-	h := newTestHighlighter("code-review", "commit")
+	h := newTestHighlighter(t, "code-review", "commit")
 
 	h.Rescan("please /code-review this")
 	line := h.Highlight(0, nil)
@@ -46,10 +48,20 @@ func TestPromptHighlighterSkillTokens(t *testing.T) {
 	require.Empty(t, h.Highlight(0, nil))
 }
 
-func TestPromptHighlighterSkillPrefixWhileTyping(t *testing.T) {
-	t.Parallel()
+// TestPromptHighlighterUsesDistinctStyles pins that the two token kinds do
+// not collapse onto one colour.
+func TestPromptHighlighterUsesDistinctStyles(t *testing.T) {
+	h := newTestHighlighter(t, "commit")
+	h.Rescan("@foo.go /commit")
 
-	h := newTestHighlighter("code-review")
+	line := h.Highlight(0, nil)
+	require.Len(t, line, 2)
+	require.Equal(t, h.fileStyle, line[0].Style)
+	require.Equal(t, h.skillStyle, line[1].Style)
+}
+
+func TestPromptHighlighterSkillPrefixWhileTyping(t *testing.T) {
+	h := newTestHighlighter(t, "code-review")
 
 	// Mid-typing prefix of a known skill highlights (live feedback).
 	h.Rescan("/cod")
@@ -61,9 +73,7 @@ func TestPromptHighlighterSkillPrefixWhileTyping(t *testing.T) {
 }
 
 func TestPromptHighlighterWordBoundary(t *testing.T) {
-	t.Parallel()
-
-	h := newTestHighlighter("commit")
+	h := newTestHighlighter(t, "commit")
 
 	// Triggers must start a word: email-like and path-like runs don't count.
 	h.Rescan("mail me@foo.go or a/b")
@@ -75,17 +85,13 @@ func TestPromptHighlighterWordBoundary(t *testing.T) {
 }
 
 func TestPromptHighlighterBareTriggerNotStyled(t *testing.T) {
-	t.Parallel()
-
-	h := newTestHighlighter()
+	h := newTestHighlighter(t)
 	h.Rescan("@ / @")
 	require.Empty(t, h.Highlight(0, nil))
 }
 
 func TestPromptHighlighterMultiline(t *testing.T) {
-	t.Parallel()
-
-	h := newTestHighlighter()
+	h := newTestHighlighter(t)
 	h.Rescan("first @one.go\nsecond @two.go\nthird plain")
 
 	require.Len(t, h.Highlight(0, nil), 1)
@@ -96,13 +102,11 @@ func TestPromptHighlighterMultiline(t *testing.T) {
 }
 
 func TestPromptHighlighterSkillNamesUpdate(t *testing.T) {
-	t.Parallel()
-
-	h := newTestHighlighter()
+	h := newTestHighlighter(t)
 	h.Rescan("/commit")
 	require.Empty(t, h.Highlight(0, nil))
 
-	h.setSkillNames([]string{"commit"})
+	common.SetPromptSkillNames([]string{"commit"})
 	h.Rescan("/commit")
 	require.Len(t, h.Highlight(0, nil), 1)
 }
@@ -119,4 +123,23 @@ func TestSkillNamesHelper(t *testing.T) {
 		},
 	}
 	require.Equal(t, []string{"good"}, m.skillNames())
+}
+
+// TestSkillNamesFromCatalog verifies the highlighter validates "/" tokens
+// against the same effective skill set the completions popup offers, so a
+// disabled or overridden skill cannot highlight in one place and be missing
+// from the other.
+func TestSkillNamesFromCatalog(t *testing.T) {
+	t.Parallel()
+
+	m := &UI{
+		skillStates: []*skills.SkillState{
+			{Name: "stale-state-only", State: skills.StateNormal},
+		},
+		skillCatalog: []skills.CatalogEntry{
+			{Name: "commit"},
+			{Name: "alpha"},
+		},
+	}
+	require.Equal(t, []string{"alpha", "commit"}, m.skillNames())
 }

--- a/internal/ui/model/session_busy_test.go
+++ b/internal/ui/model/session_busy_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 	"time"
 
-	"charm.land/bubbles/v2/textarea"
 	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/crush/internal/ui/textarea"
 	"github.com/charmbracelet/x/ansi"
 	"github.com/stretchr/testify/require"
 

--- a/internal/ui/model/sidebar_focus_test.go
+++ b/internal/ui/model/sidebar_focus_test.go
@@ -4,12 +4,12 @@ import (
 	"testing"
 
 	"charm.land/bubbles/v2/key"
-	"charm.land/bubbles/v2/textarea"
 	tea "charm.land/bubbletea/v2"
 	"github.com/charmbracelet/crush/internal/config"
 	"github.com/charmbracelet/crush/internal/ui/common"
 	"github.com/charmbracelet/crush/internal/ui/dialog"
 	"github.com/charmbracelet/crush/internal/ui/styles"
+	"github.com/charmbracelet/crush/internal/ui/textarea"
 	uv "github.com/charmbracelet/ultraviolet"
 	"github.com/stretchr/testify/require"
 )

--- a/internal/ui/model/skill_completion_test.go
+++ b/internal/ui/model/skill_completion_test.go
@@ -1,0 +1,170 @@
+package model
+
+import (
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"charm.land/bubbles/v2/textarea"
+
+	"github.com/charmbracelet/crush/internal/config"
+	"github.com/charmbracelet/crush/internal/skills"
+	"github.com/charmbracelet/crush/internal/ui/attachments"
+	"github.com/charmbracelet/crush/internal/ui/common"
+	"github.com/charmbracelet/crush/internal/ui/completions"
+	"github.com/stretchr/testify/require"
+)
+
+func newSkillCompletionUI() *UI {
+	com := common.DefaultCommon(&slashCommandWorkspace{ready: true})
+	m := &UI{
+		com:      com,
+		status:   NewStatus(com, nil),
+		chat:     NewChat(com, config.ScrollbarDefault),
+		textarea: textarea.New(),
+		state:    uiChat,
+		focus:    uiFocusEditor,
+		width:    140,
+		height:   45,
+	}
+	m.attachments = attachments.New(nil, attachments.Keymap{})
+	m.completions = completions.New(
+		com.Styles.Completions.Normal,
+		com.Styles.Completions.Focused,
+		com.Styles.Completions.Match,
+	)
+	return m
+}
+
+// TestOpenSkillCompletionsPopulatesFromSkillStates verifies the popup opens
+// in skill mode with items built from healthy skill states only.
+func TestOpenSkillCompletionsPopulatesFromSkillStates(t *testing.T) {
+	t.Parallel()
+
+	m := newSkillCompletionUI()
+	m.skillStates = []*skills.SkillState{
+		{Name: "commit", Path: "/skills/commit/SKILL.md", State: skills.StateNormal},
+		{Name: "code-review", Path: "/skills/code-review/SKILL.md", State: skills.StateNormal},
+		{Name: "broken", Path: "/skills/broken/SKILL.md", State: skills.StateError},
+		nil,
+	}
+
+	m.openSkillCompletions(5)
+
+	require.True(t, m.completionsOpen)
+	require.Equal(t, completions.TriggerSkill, m.completionsTrigger)
+	require.Equal(t, 5, m.completionsStartIndex)
+	require.True(t, m.completions.IsOpen())
+	require.True(t, m.completions.HasItems())
+}
+
+// TestOpenSkillCompletionsSortsByName pins alphabetical ordering of the
+// skill popup items: with no query the first selected item should be the
+// alphabetically-first skill.
+func TestOpenSkillCompletionsSortsByName(t *testing.T) {
+	t.Parallel()
+
+	m := newSkillCompletionUI()
+	m.skillStates = []*skills.SkillState{
+		{Name: "zebra", State: skills.StateNormal},
+		{Name: "alpha", State: skills.StateNormal},
+	}
+
+	m.openSkillCompletions(0)
+
+	// Select the first item without filtering: it should be "alpha".
+	msg, handled := m.completions.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	require.True(t, handled)
+	sel, ok := msg.(completions.SelectionMsg[completions.SkillCompletionValue])
+	require.True(t, ok, "expected skill selection, got %T", msg)
+	require.Equal(t, "alpha", sel.Value.Name)
+}
+
+// TestInsertSkillCompletion verifies selecting a skill replaces the /query
+// with "/skill-name" plus a trailing space.
+func TestInsertSkillCompletion(t *testing.T) {
+	t.Parallel()
+
+	m := newSkillCompletionUI()
+	m.textarea.SetValue("hello can you /cod")
+	m.completionsOpen = true
+	m.completionsTrigger = completions.TriggerSkill
+	m.completionsStartIndex = len("hello can you ")
+
+	m.insertSkillCompletion(completions.SkillCompletionValue{Name: "code-review"})
+
+	require.Equal(t, "hello can you /code-review ", m.textarea.Value())
+}
+
+// TestInsertSkillCompletionKeepsSlashRegression guards against the
+// double-slash bug: the replacement span includes the trigger '/', so the
+// inserted text must include exactly one.
+func TestInsertSkillCompletionKeepsSlashRegression(t *testing.T) {
+	t.Parallel()
+
+	m := newSkillCompletionUI()
+	m.textarea.SetValue("/com")
+	m.completionsOpen = true
+	m.completionsTrigger = completions.TriggerSkill
+	m.completionsStartIndex = 0
+
+	m.insertSkillCompletion(completions.SkillCompletionValue{Name: "commit"})
+
+	require.Equal(t, "/commit ", m.textarea.Value())
+}
+
+// TestCloseCompletionsResetsTrigger verifies closing the popup clears the
+// trigger mode so a stale async file load can't clobber a later skill popup.
+func TestCloseCompletionsResetsTrigger(t *testing.T) {
+	t.Parallel()
+
+	m := newSkillCompletionUI()
+	m.completionsOpen = true
+	m.completionsTrigger = completions.TriggerSkill
+	m.completionsQuery = "cod"
+	m.completionsStartIndex = 3
+
+	m.closeCompletions()
+
+	require.False(t, m.completionsOpen)
+	require.Equal(t, completions.TriggerNone, m.completionsTrigger)
+	require.Empty(t, m.completionsQuery)
+	require.Zero(t, m.completionsStartIndex)
+}
+
+// TestCompletionItemsLoadedIgnoredInSkillMode is the regression test for the
+// stale async load: a file-completion load that resolves while the popup is
+// in skill mode must not replace the skill items.
+func TestCompletionItemsLoadedIgnoredInSkillMode(t *testing.T) {
+	t.Parallel()
+
+	m := newSkillCompletionUI()
+	m.skillStates = []*skills.SkillState{{Name: "commit", State: skills.StateNormal}}
+	m.openSkillCompletions(0)
+	require.True(t, m.completions.HasItems())
+
+	// A stale async file load completing while in skill mode must be ignored.
+	m.Update(completions.CompletionItemsLoadedMsg{
+		Files: []completions.FileCompletionValue{{Path: "foo.go"}},
+	})
+
+	// Skill items survive: filtering by skill name still matches.
+	m.completions.Filter("commit")
+	require.True(t, m.completions.HasItems())
+}
+
+// TestCompletionItemsLoadedAppliesInFileMode is the counterpart regression:
+// the async file load must still populate the popup when in file mode.
+func TestCompletionItemsLoadedAppliesInFileMode(t *testing.T) {
+	t.Parallel()
+
+	m := newSkillCompletionUI()
+	m.completionsOpen = true
+	m.completionsTrigger = completions.TriggerFile
+
+	m.Update(completions.CompletionItemsLoadedMsg{
+		Files: []completions.FileCompletionValue{{Path: "foo.go"}},
+	})
+
+	m.completions.Filter("foo")
+	require.True(t, m.completions.HasItems())
+}

--- a/internal/ui/model/skill_completion_test.go
+++ b/internal/ui/model/skill_completion_test.go
@@ -3,8 +3,8 @@ package model
 import (
 	"testing"
 
-	"charm.land/bubbles/v2/textarea"
 	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/crush/internal/ui/textarea"
 
 	"github.com/charmbracelet/crush/internal/config"
 	"github.com/charmbracelet/crush/internal/skills"

--- a/internal/ui/model/skill_completion_test.go
+++ b/internal/ui/model/skill_completion_test.go
@@ -3,8 +3,8 @@ package model
 import (
 	"testing"
 
-	tea "charm.land/bubbletea/v2"
 	"charm.land/bubbles/v2/textarea"
+	tea "charm.land/bubbletea/v2"
 
 	"github.com/charmbracelet/crush/internal/config"
 	"github.com/charmbracelet/crush/internal/skills"
@@ -55,6 +55,70 @@ func TestOpenSkillCompletionsPopulatesFromSkillStates(t *testing.T) {
 	require.Equal(t, 5, m.completionsStartIndex)
 	require.True(t, m.completions.IsOpen())
 	require.True(t, m.completions.HasItems())
+}
+
+// TestSkillCompletionValuesPrefersCatalog verifies the popup is built from
+// the effective skill catalog once it has loaded. The catalog is what
+// carries descriptions, includes builtin skills, and has already resolved
+// user-over-builtin overrides and the disabled-skills list — the raw
+// discovery states do none of that.
+func TestSkillCompletionValuesPrefersCatalog(t *testing.T) {
+	t.Parallel()
+
+	m := newSkillCompletionUI()
+	m.skillStates = []*skills.SkillState{
+		{Name: "only-a-state", Path: "/skills/only-a-state/SKILL.md", State: skills.StateNormal},
+	}
+	m.skillCatalog = []skills.CatalogEntry{
+		{ID: "crush://skills/commit/SKILL.md", Name: "commit", Description: "Write a conventional commit."},
+		{ID: "/skills/alpha/SKILL.md", Name: "alpha", Description: "Go first."},
+		{Name: ""}, // Nameless entries are not selectable; drop them.
+	}
+
+	values := m.skillCompletionValues()
+
+	require.Equal(t, []completions.SkillCompletionValue{
+		{Name: "alpha", Description: "Go first.", Path: "/skills/alpha/SKILL.md"},
+		{Name: "commit", Description: "Write a conventional commit.", Path: "crush://skills/commit/SKILL.md"},
+	}, values)
+}
+
+// TestSkillCompletionValuesFallsBackToStates covers the window between
+// startup and the first catalog load: a name-only list still beats an empty
+// popup. Duplicate names (a user skill shadowing a builtin) collapse to one.
+func TestSkillCompletionValuesFallsBackToStates(t *testing.T) {
+	t.Parallel()
+
+	m := newSkillCompletionUI()
+	m.skillStates = []*skills.SkillState{
+		{Name: "commit", Path: "/user/skills/commit/SKILL.md", State: skills.StateNormal},
+		{Name: "commit", Path: "crush://skills/commit/SKILL.md", State: skills.StateNormal},
+		{Name: "", Path: "/skills/unnamed/SKILL.md", State: skills.StateNormal},
+		{Name: "broken", State: skills.StateError},
+		nil,
+	}
+
+	values := m.skillCompletionValues()
+
+	require.Equal(t, []completions.SkillCompletionValue{
+		{Name: "commit", Path: "/user/skills/commit/SKILL.md"},
+	}, values)
+}
+
+// TestOpenSkillCompletionsNoopWithoutSkills guards the empty-popup trap: an
+// open completions popup consumes enter and the arrow keys, so opening one
+// with nothing in it would leave a user with no skills unable to submit a
+// prompt containing a '/'.
+func TestOpenSkillCompletionsNoopWithoutSkills(t *testing.T) {
+	t.Parallel()
+
+	m := newSkillCompletionUI()
+
+	m.openSkillCompletions(3)
+
+	require.False(t, m.completionsOpen)
+	require.Equal(t, completions.TriggerNone, m.completionsTrigger)
+	require.False(t, m.completions.IsOpen())
 }
 
 // TestOpenSkillCompletionsSortsByName pins alphabetical ordering of the

--- a/internal/ui/model/skill_completion_test.go
+++ b/internal/ui/model/skill_completion_test.go
@@ -1,0 +1,234 @@
+package model
+
+import (
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/crush/internal/ui/textarea"
+
+	"github.com/charmbracelet/crush/internal/config"
+	"github.com/charmbracelet/crush/internal/skills"
+	"github.com/charmbracelet/crush/internal/ui/attachments"
+	"github.com/charmbracelet/crush/internal/ui/common"
+	"github.com/charmbracelet/crush/internal/ui/completions"
+	"github.com/stretchr/testify/require"
+)
+
+func newSkillCompletionUI() *UI {
+	com := common.DefaultCommon(&slashCommandWorkspace{ready: true})
+	m := &UI{
+		com:      com,
+		status:   NewStatus(com, nil),
+		chat:     NewChat(com, config.ScrollbarDefault),
+		textarea: textarea.New(),
+		state:    uiChat,
+		focus:    uiFocusEditor,
+		width:    140,
+		height:   45,
+	}
+	m.attachments = attachments.New(nil, attachments.Keymap{})
+	m.completions = completions.New(
+		com.Styles.Completions.Normal,
+		com.Styles.Completions.Focused,
+		com.Styles.Completions.Match,
+	)
+	return m
+}
+
+// TestOpenSkillCompletionsPopulatesFromSkillStates verifies the popup opens
+// in skill mode with items built from healthy skill states only.
+func TestOpenSkillCompletionsPopulatesFromSkillStates(t *testing.T) {
+	t.Parallel()
+
+	m := newSkillCompletionUI()
+	m.skillStates = []*skills.SkillState{
+		{Name: "commit", Path: "/skills/commit/SKILL.md", State: skills.StateNormal},
+		{Name: "code-review", Path: "/skills/code-review/SKILL.md", State: skills.StateNormal},
+		{Name: "broken", Path: "/skills/broken/SKILL.md", State: skills.StateError},
+		nil,
+	}
+
+	m.openSkillCompletions(5)
+
+	require.True(t, m.completionsOpen)
+	require.Equal(t, completions.TriggerSkill, m.completionsTrigger)
+	require.Equal(t, 5, m.completionsStartIndex)
+	require.True(t, m.completions.IsOpen())
+	require.True(t, m.completions.HasItems())
+}
+
+// TestSkillCompletionValuesPrefersCatalog verifies the popup is built from
+// the effective skill catalog once it has loaded. The catalog is what
+// carries descriptions, includes builtin skills, and has already resolved
+// user-over-builtin overrides and the disabled-skills list — the raw
+// discovery states do none of that.
+func TestSkillCompletionValuesPrefersCatalog(t *testing.T) {
+	t.Parallel()
+
+	m := newSkillCompletionUI()
+	m.skillStates = []*skills.SkillState{
+		{Name: "only-a-state", Path: "/skills/only-a-state/SKILL.md", State: skills.StateNormal},
+	}
+	m.skillCatalog = []skills.CatalogEntry{
+		{ID: "crush://skills/commit/SKILL.md", Name: "commit", Description: "Write a conventional commit."},
+		{ID: "/skills/alpha/SKILL.md", Name: "alpha", Description: "Go first."},
+		{Name: ""}, // Nameless entries are not selectable; drop them.
+	}
+
+	values := m.skillCompletionValues()
+
+	require.Equal(t, []completions.SkillCompletionValue{
+		{Name: "alpha", Description: "Go first.", Path: "/skills/alpha/SKILL.md"},
+		{Name: "commit", Description: "Write a conventional commit.", Path: "crush://skills/commit/SKILL.md"},
+	}, values)
+}
+
+// TestSkillCompletionValuesFallsBackToStates covers the window between
+// startup and the first catalog load: a name-only list still beats an empty
+// popup. Duplicate names (a user skill shadowing a builtin) collapse to one.
+func TestSkillCompletionValuesFallsBackToStates(t *testing.T) {
+	t.Parallel()
+
+	m := newSkillCompletionUI()
+	m.skillStates = []*skills.SkillState{
+		{Name: "commit", Path: "/user/skills/commit/SKILL.md", State: skills.StateNormal},
+		{Name: "commit", Path: "crush://skills/commit/SKILL.md", State: skills.StateNormal},
+		{Name: "", Path: "/skills/unnamed/SKILL.md", State: skills.StateNormal},
+		{Name: "broken", State: skills.StateError},
+		nil,
+	}
+
+	values := m.skillCompletionValues()
+
+	require.Equal(t, []completions.SkillCompletionValue{
+		{Name: "commit", Path: "/user/skills/commit/SKILL.md"},
+	}, values)
+}
+
+// TestOpenSkillCompletionsNoopWithoutSkills guards the empty-popup trap: an
+// open completions popup consumes enter and the arrow keys, so opening one
+// with nothing in it would leave a user with no skills unable to submit a
+// prompt containing a '/'.
+func TestOpenSkillCompletionsNoopWithoutSkills(t *testing.T) {
+	t.Parallel()
+
+	m := newSkillCompletionUI()
+
+	m.openSkillCompletions(3)
+
+	require.False(t, m.completionsOpen)
+	require.Equal(t, completions.TriggerNone, m.completionsTrigger)
+	require.False(t, m.completions.IsOpen())
+}
+
+// TestOpenSkillCompletionsSortsByName pins alphabetical ordering of the
+// skill popup items: with no query the first selected item should be the
+// alphabetically-first skill.
+func TestOpenSkillCompletionsSortsByName(t *testing.T) {
+	t.Parallel()
+
+	m := newSkillCompletionUI()
+	m.skillStates = []*skills.SkillState{
+		{Name: "zebra", State: skills.StateNormal},
+		{Name: "alpha", State: skills.StateNormal},
+	}
+
+	m.openSkillCompletions(0)
+
+	// Select the first item without filtering: it should be "alpha".
+	msg, handled := m.completions.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	require.True(t, handled)
+	sel, ok := msg.(completions.SelectionMsg[completions.SkillCompletionValue])
+	require.True(t, ok, "expected skill selection, got %T", msg)
+	require.Equal(t, "alpha", sel.Value.Name)
+}
+
+// TestInsertSkillCompletion verifies selecting a skill replaces the /query
+// with "/skill-name" plus a trailing space.
+func TestInsertSkillCompletion(t *testing.T) {
+	t.Parallel()
+
+	m := newSkillCompletionUI()
+	m.textarea.SetValue("hello can you /cod")
+	m.completionsOpen = true
+	m.completionsTrigger = completions.TriggerSkill
+	m.completionsStartIndex = len("hello can you ")
+
+	m.insertSkillCompletion(completions.SkillCompletionValue{Name: "code-review"})
+
+	require.Equal(t, "hello can you /code-review ", m.textarea.Value())
+}
+
+// TestInsertSkillCompletionKeepsSlashRegression guards against the
+// double-slash bug: the replacement span includes the trigger '/', so the
+// inserted text must include exactly one.
+func TestInsertSkillCompletionKeepsSlashRegression(t *testing.T) {
+	t.Parallel()
+
+	m := newSkillCompletionUI()
+	m.textarea.SetValue("/com")
+	m.completionsOpen = true
+	m.completionsTrigger = completions.TriggerSkill
+	m.completionsStartIndex = 0
+
+	m.insertSkillCompletion(completions.SkillCompletionValue{Name: "commit"})
+
+	require.Equal(t, "/commit ", m.textarea.Value())
+}
+
+// TestCloseCompletionsResetsTrigger verifies closing the popup clears the
+// trigger mode so a stale async file load can't clobber a later skill popup.
+func TestCloseCompletionsResetsTrigger(t *testing.T) {
+	t.Parallel()
+
+	m := newSkillCompletionUI()
+	m.completionsOpen = true
+	m.completionsTrigger = completions.TriggerSkill
+	m.completionsQuery = "cod"
+	m.completionsStartIndex = 3
+
+	m.closeCompletions()
+
+	require.False(t, m.completionsOpen)
+	require.Equal(t, completions.TriggerNone, m.completionsTrigger)
+	require.Empty(t, m.completionsQuery)
+	require.Zero(t, m.completionsStartIndex)
+}
+
+// TestCompletionItemsLoadedIgnoredInSkillMode is the regression test for the
+// stale async load: a file-completion load that resolves while the popup is
+// in skill mode must not replace the skill items.
+func TestCompletionItemsLoadedIgnoredInSkillMode(t *testing.T) {
+	t.Parallel()
+
+	m := newSkillCompletionUI()
+	m.skillStates = []*skills.SkillState{{Name: "commit", State: skills.StateNormal}}
+	m.openSkillCompletions(0)
+	require.True(t, m.completions.HasItems())
+
+	// A stale async file load completing while in skill mode must be ignored.
+	m.Update(completions.CompletionItemsLoadedMsg{
+		Files: []completions.FileCompletionValue{{Path: "foo.go"}},
+	})
+
+	// Skill items survive: filtering by skill name still matches.
+	m.completions.Filter("commit")
+	require.True(t, m.completions.HasItems())
+}
+
+// TestCompletionItemsLoadedAppliesInFileMode is the counterpart regression:
+// the async file load must still populate the popup when in file mode.
+func TestCompletionItemsLoadedAppliesInFileMode(t *testing.T) {
+	t.Parallel()
+
+	m := newSkillCompletionUI()
+	m.completionsOpen = true
+	m.completionsTrigger = completions.TriggerFile
+
+	m.Update(completions.CompletionItemsLoadedMsg{
+		Files: []completions.FileCompletionValue{{Path: "foo.go"}},
+	})
+
+	m.completions.Filter("foo")
+	require.True(t, m.completions.HasItems())
+}

--- a/internal/ui/model/slash_command_test.go
+++ b/internal/ui/model/slash_command_test.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"testing"
 
-	"charm.land/bubbles/v2/textarea"
 	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/crush/internal/ui/textarea"
 
 	"github.com/charmbracelet/crush/internal/config"
 	"github.com/charmbracelet/crush/internal/session"

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -23,7 +23,6 @@ import (
 	"charm.land/bubbles/v2/help"
 	"charm.land/bubbles/v2/key"
 	"charm.land/bubbles/v2/spinner"
-	"charm.land/bubbles/v2/textarea"
 	tea "charm.land/bubbletea/v2"
 	"charm.land/catwalk/pkg/catwalk"
 	"charm.land/lipgloss/v2"
@@ -58,6 +57,7 @@ import (
 	"github.com/charmbracelet/crush/internal/ui/logo"
 	"github.com/charmbracelet/crush/internal/ui/notification"
 	"github.com/charmbracelet/crush/internal/ui/styles"
+	"github.com/charmbracelet/crush/internal/ui/textarea"
 	"github.com/charmbracelet/crush/internal/ui/util"
 	"github.com/charmbracelet/crush/internal/version"
 	"github.com/charmbracelet/crush/internal/workspace"
@@ -286,6 +286,10 @@ type UI struct {
 	completionsQuery         string
 	completionsPositionStart image.Point // x,y where user typed the trigger
 
+	// promptHighlighter styles @file and /skill tokens inline as the user
+	// types. Installed on the textarea via SetHighlighter.
+	promptHighlighter *promptHighlighter
+
 	// Chat components
 	chat *Chat
 
@@ -398,6 +402,13 @@ func New(com *common.Common, initialSessionID string, continueLast bool) *UI {
 	ta.MaxHeight = TextareaMaxHeight
 	ta.Focus()
 
+	promptHL := newPromptHighlighter(
+		com.Styles.Editor.TokenFile,
+		com.Styles.Editor.TokenSkill,
+		nil, // Skill names arrive with the first skills.Event.
+	)
+	ta.SetHighlighter(promptHL)
+
 	scrollbarMode := config.ScrollbarDefault
 	if cfg := com.Config(); cfg.Options.TUI != nil && cfg.Options.TUI.Scrollbar != "" {
 		scrollbarMode = cfg.Options.TUI.Scrollbar
@@ -447,6 +458,7 @@ func New(com *common.Common, initialSessionID string, continueLast bool) *UI {
 		completions:         comp,
 		attachments:         attachments,
 		todoSpinner:         todoSpinner,
+		promptHighlighter:   promptHL,
 		lspStates:           make(map[string]workspace.LSPClientInfo),
 		mcpStates:           make(map[string]mcp.ClientInfo),
 		notifyBackend:       notification.NoopBackend{},
@@ -455,6 +467,7 @@ func New(com *common.Common, initialSessionID string, continueLast bool) *UI {
 		continueLastSession: continueLast,
 		skillStates:         skills.GetLatestStates(),
 	}
+	ui.promptHighlighter.setSkillNames(ui.skillNames())
 
 	status := NewStatus(com, ui)
 
@@ -804,6 +817,7 @@ func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case userCommandsLoadedMsg:
 		m.customCommands = msg.Commands
 		m.skillCatalog = msg.SkillEntries
+		m.refreshSkillNames()
 		dia := m.dialog.Dialog(dialog.CommandsID)
 		if dia == nil {
 			break
@@ -936,6 +950,7 @@ func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.lspStates = m.com.Workspace.LSPGetStates()
 	case pubsub.Event[skills.Event]:
 		m.skillStates = msg.Payload.States
+		m.refreshSkillNames()
 		// Discovery states carry no descriptions and no override/disable
 		// resolution, so re-read the catalog too: a ctrl+r reload in the
 		// skills dialog must move both the command palette and the '/'
@@ -4152,6 +4167,19 @@ func (m *UI) renderEditorView(width int) string {
 	var attachmentsView string
 	if len(m.attachments.List()) > 0 {
 		attachmentsView = m.attachments.Render(width)
+	}
+	// Retokenize @file and /skill tokens on every render. The scan is
+	// linear in prompt length and render happens every frame anyway, so
+	// this is the single seam that stays correct for every value-mutation
+	// path (typing, paste, history, completion inserts). Bang mode is a
+	// shell prompt — its slashes are paths, not skills — so tokens are
+	// suppressed there.
+	if m.promptHighlighter != nil {
+		if m.bangMode {
+			m.promptHighlighter.Rescan("")
+		} else {
+			m.promptHighlighter.Rescan(m.textarea.Value())
+		}
 	}
 	return strings.Join([]string{
 		attachmentsView,

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -405,7 +405,6 @@ func New(com *common.Common, initialSessionID string, continueLast bool) *UI {
 	promptHL := newPromptHighlighter(
 		com.Styles.Editor.TokenFile,
 		com.Styles.Editor.TokenSkill,
-		nil, // Skill names arrive with the first skills.Event.
 	)
 	ta.SetHighlighter(promptHL)
 
@@ -467,7 +466,7 @@ func New(com *common.Common, initialSessionID string, continueLast bool) *UI {
 		continueLastSession: continueLast,
 		skillStates:         skills.GetLatestStates(),
 	}
-	ui.promptHighlighter.setSkillNames(ui.skillNames())
+	ui.refreshSkillNames()
 
 	status := NewStatus(com, ui)
 

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -278,9 +278,10 @@ type UI struct {
 	// Completions state
 	completions              *completions.Completions
 	completionsOpen          bool
+	completionsTrigger       completions.Trigger
 	completionsStartIndex    int
 	completionsQuery         string
-	completionsPositionStart image.Point // x,y where user typed '@'
+	completionsPositionStart image.Point // x,y where user typed the trigger
 
 	// Chat components
 	chat *Chat
@@ -1352,7 +1353,9 @@ func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case util.ClearStatusMsg:
 		m.status.ClearInfoMsg()
 	case completions.CompletionItemsLoadedMsg:
-		if m.completionsOpen {
+		// Guard against a stale async file load landing after the popup
+		// switched to (or was reopened in) skill mode.
+		if m.completionsOpen && m.completionsTrigger == completions.TriggerFile {
 			m.completions.SetItems(msg.Files, msg.Resources)
 		}
 	case uv.KittyGraphicsEvent:
@@ -2474,6 +2477,11 @@ func (m *UI) handleKeyPressMsg(msg tea.KeyPressMsg) tea.Cmd {
 			if m.completionsOpen {
 				if msg, ok := m.completions.Update(msg); ok {
 					switch msg := msg.(type) {
+					case completions.SelectionMsg[completions.SkillCompletionValue]:
+						cmds = append(cmds, m.insertSkillCompletion(msg.Value))
+						if !msg.KeepOpen {
+							m.closeCompletions()
+						}
 					case completions.SelectionMsg[completions.FileCompletionValue]:
 						cmds = append(cmds, m.insertFileCompletion(msg.Value.Path))
 						if !msg.KeepOpen {
@@ -2486,6 +2494,7 @@ func (m *UI) handleKeyPressMsg(msg tea.KeyPressMsg) tea.Cmd {
 						}
 					case completions.ClosedMsg:
 						m.completionsOpen = false
+						m.completionsTrigger = completions.TriggerNone
 					}
 					return tea.Batch(cmds...)
 				}
@@ -2622,20 +2631,32 @@ func (m *UI) handleKeyPressMsg(msg tea.KeyPressMsg) tea.Cmd {
 					break
 				}
 
-				// Check for @ trigger before passing to textarea.
+				// Check for completion triggers before passing to textarea.
 				curValue := m.textarea.Value()
 				curIdx := len(curValue)
 
-				// Trigger completions on @.
+				// Trigger file completions on @.
 				if msg.String() == "@" && !m.completionsOpen {
 					// Only show if beginning of prompt or after whitespace.
 					if curIdx == 0 || (curIdx > 0 && isWhitespace(curValue[curIdx-1])) {
 						m.completionsOpen = true
+						m.completionsTrigger = completions.TriggerFile
 						m.completionsQuery = ""
 						m.completionsStartIndex = curIdx
 						m.completionsPositionStart = m.completionsPosition()
 						depth, limit := m.com.Config().Options.TUI.Completions.Limits()
 						cmds = append(cmds, m.completions.Open(depth, limit))
+					}
+				}
+
+				// Trigger skill completions on / mid-prompt. At the start of
+				// an empty prompt the commands dialog handles '/' instead
+				// (see the Editor.Commands binding above), so here we only
+				// fire when the textarea already has content and '/' begins
+				// a new word.
+				if msg.String() == "/" && !m.completionsOpen && !m.bangMode {
+					if curIdx > 0 && isWhitespace(curValue[curIdx-1]) {
+						m.openSkillCompletions(curIdx)
 					}
 				}
 
@@ -2679,8 +2700,9 @@ func (m *UI) handleKeyPressMsg(msg tea.KeyPressMsg) tea.Cmd {
 				m.updateHistoryDraft(curValue)
 
 				// After updating textarea, check if we need to filter completions.
-				// Skip filtering on the initial @ keystroke since items are loading async.
-				if m.completionsOpen && msg.String() != "@" {
+				// Skip filtering on the initial trigger keystroke since items
+				// are loading async.
+				if m.completionsOpen && msg.String() != string(m.completionsTrigger) {
 					newValue := m.textarea.Value()
 					newIdx := len(newValue)
 
@@ -2693,7 +2715,7 @@ func (m *UI) handleKeyPressMsg(msg tea.KeyPressMsg) tea.Cmd {
 					} else {
 						// Extract current word and filter.
 						word := m.textareaWord()
-						if strings.HasPrefix(word, "@") {
+						if strings.HasPrefix(word, string(m.completionsTrigger)) {
 							m.completionsQuery = word[1:]
 							m.completions.Filter(m.completionsQuery)
 						} else if m.completionsOpen {
@@ -3783,9 +3805,36 @@ func (m *UI) bangPromptFunc(info textarea.PromptInfo) string {
 // closeCompletions closes the completions popup and resets state.
 func (m *UI) closeCompletions() {
 	m.completionsOpen = false
+	m.completionsTrigger = completions.TriggerNone
 	m.completionsQuery = ""
 	m.completionsStartIndex = 0
 	m.completions.Close()
+}
+
+// openSkillCompletions opens the completions popup in skill mode at the
+// given trigger index. Skills are already in memory (m.skillStates), so no
+// async load is needed.
+func (m *UI) openSkillCompletions(startIndex int) {
+	var values []completions.SkillCompletionValue
+	for _, s := range m.skillStates {
+		if s == nil || s.State != skills.StateNormal {
+			continue
+		}
+		values = append(values, completions.SkillCompletionValue{
+			Name: s.Name,
+			Path: s.Path,
+		})
+	}
+	slices.SortFunc(values, func(a, b completions.SkillCompletionValue) int {
+		return strings.Compare(a.Name, b.Name)
+	})
+
+	m.completionsOpen = true
+	m.completionsTrigger = completions.TriggerSkill
+	m.completionsQuery = ""
+	m.completionsStartIndex = startIndex
+	m.completionsPositionStart = m.completionsPosition()
+	m.completions.SetSkillItems(values)
 }
 
 // insertCompletionText replaces the @query in the textarea with the given text.
@@ -3920,6 +3969,17 @@ func (m *UI) insertMCPResourceCompletion(item completions.ResourceCompletionValu
 		}
 	}
 	return tea.Batch(heightCmd, resourceCmd)
+}
+
+// insertSkillCompletion inserts the selected skill name into the textarea,
+// replacing the /query. Unlike files, skills are not attached — the
+// "/skill-name" text in the prompt is the signal to load the skill.
+func (m *UI) insertSkillCompletion(skill completions.SkillCompletionValue) tea.Cmd {
+	prevHeight := m.textarea.Height()
+	if !m.insertCompletionText("/" + skill.Name) {
+		return nil
+	}
+	return m.handleTextareaHeightChange(prevHeight)
 }
 
 // completionsPosition returns the X and Y position for the completions popup.

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -136,9 +136,12 @@ type shellStreamMsg struct {
 type (
 	// cancelTimerExpiredMsg is sent when the cancel timer expires.
 	cancelTimerExpiredMsg struct{}
-	// userCommandsLoadedMsg is sent when user commands are loaded.
+	// userCommandsLoadedMsg is sent when user commands are loaded. It also
+	// carries the skill catalog the command list was built from, so the
+	// '/' completions popup gets descriptions off the same single load.
 	userCommandsLoadedMsg struct {
-		Commands []commands.CustomCommand
+		Commands     []commands.CustomCommand
+		SkillEntries []skills.CatalogEntry
 	}
 	// mcpPromptsLoadedMsg is sent when mcp prompts are loaded.
 	mcpPromptsLoadedMsg struct {
@@ -299,6 +302,11 @@ type UI struct {
 
 	// skills
 	skillStates []*skills.SkillState
+
+	// skillCatalog is the effective visible skill set (post-override,
+	// post-disable) with frontmatter descriptions, refreshed alongside the
+	// custom commands. It backs the '/' completions popup.
+	skillCatalog []skills.CatalogEntry
 
 	// sidebarLogo keeps a cached version of the sidebar sidebarLogo.
 	sidebarLogo string
@@ -654,7 +662,7 @@ func (m *UI) loadCustomCommands() tea.Cmd {
 			slog.Error("Failed to load skill commands", "error", err)
 		}
 		customCommands = append(customCommands, commands.FromSkillCatalog(skillEntries)...)
-		return userCommandsLoadedMsg{Commands: customCommands}
+		return userCommandsLoadedMsg{Commands: customCommands, SkillEntries: skillEntries}
 	}
 }
 
@@ -795,6 +803,7 @@ func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case userCommandsLoadedMsg:
 		m.customCommands = msg.Commands
+		m.skillCatalog = msg.SkillEntries
 		dia := m.dialog.Dialog(dialog.CommandsID)
 		if dia == nil {
 			break
@@ -927,6 +936,11 @@ func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.lspStates = m.com.Workspace.LSPGetStates()
 	case pubsub.Event[skills.Event]:
 		m.skillStates = msg.Payload.States
+		// Discovery states carry no descriptions and no override/disable
+		// resolution, so re-read the catalog too: a ctrl+r reload in the
+		// skills dialog must move both the command palette and the '/'
+		// completions popup.
+		cmds = append(cmds, m.loadCustomCommands())
 	case pubsub.Event[mcp.Event]:
 		switch msg.Payload.Type {
 		case mcp.EventStateChanged:
@@ -3811,23 +3825,60 @@ func (m *UI) closeCompletions() {
 	m.completions.Close()
 }
 
-// openSkillCompletions opens the completions popup in skill mode at the
-// given trigger index. Skills are already in memory (m.skillStates), so no
-// async load is needed.
-func (m *UI) openSkillCompletions(startIndex int) {
+// skillCompletionValues returns the skills offered by the '/' popup.
+//
+// The catalog is the right source: it is the effective, post-dedup,
+// post-disable set, it includes the builtin skills the raw discovery states
+// omit, and it carries each skill's frontmatter description. The discovery
+// states are only a fallback for the window between startup and the first
+// catalog load, where a name-only list still beats an empty popup.
+func (m *UI) skillCompletionValues() []completions.SkillCompletionValue {
 	var values []completions.SkillCompletionValue
-	for _, s := range m.skillStates {
-		if s == nil || s.State != skills.StateNormal {
-			continue
+	if len(m.skillCatalog) > 0 {
+		for _, entry := range m.skillCatalog {
+			if entry.Name == "" {
+				continue
+			}
+			values = append(values, completions.SkillCompletionValue{
+				Name:        entry.Name,
+				Description: entry.Description,
+				Path:        entry.ID,
+			})
 		}
-		values = append(values, completions.SkillCompletionValue{
-			Name: s.Name,
-			Path: s.Path,
-		})
+	} else {
+		seen := make(map[string]struct{}, len(m.skillStates))
+		for _, s := range m.skillStates {
+			if s == nil || s.Name == "" || s.State != skills.StateNormal {
+				continue
+			}
+			if _, dup := seen[s.Name]; dup {
+				continue
+			}
+			seen[s.Name] = struct{}{}
+			values = append(values, completions.SkillCompletionValue{
+				Name: s.Name,
+				Path: s.Path,
+			})
+		}
 	}
 	slices.SortFunc(values, func(a, b completions.SkillCompletionValue) int {
 		return strings.Compare(a.Name, b.Name)
 	})
+	return values
+}
+
+// openSkillCompletions opens the completions popup in skill mode at the
+// given trigger index. Skills are already in memory, so no async load is
+// needed.
+func (m *UI) openSkillCompletions(startIndex int) {
+	values := m.skillCompletionValues()
+	if len(values) == 0 {
+		// An open-but-empty popup still consumes enter and the arrow keys,
+		// so a user with no skills configured could not submit a prompt
+		// containing a '/'. Unlike '@' there is nothing to wait on here —
+		// no skills means no popup.
+		return
+	}
 
 	m.completionsOpen = true
 	m.completionsTrigger = completions.TriggerSkill

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -3849,15 +3849,27 @@ func (m *UI) insertFileCompletion(path string) tea.Cmd {
 }
 
 // insertMCPResourceCompletion inserts the selected resource into the textarea,
-// replacing the @query, and adds the resource as an attachment.
+// replacing the @query, and adds the resource as an attachment. An unexpanded
+// resource template is only inserted as text: its URI still carries RFC 6570
+// placeholders ("cairn://run/{id}"), so reading it now would send the literal
+// braces to the server and fail — the read happens once someone (user or
+// agent) has substituted real values.
 func (m *UI) insertMCPResourceCompletion(item completions.ResourceCompletionValue) tea.Cmd {
 	displayText := cmp.Or(item.Title, item.URI)
+	if item.IsTemplate() {
+		// Insert the raw template URI, not the title: the placeholders are
+		// the point — they show what needs filling in.
+		displayText = item.URI
+	}
 
 	prevHeight := m.textarea.Height()
 	if !m.insertCompletionText(displayText) {
 		return nil
 	}
 	heightCmd := m.handleTextareaHeightChange(prevHeight)
+	if item.IsTemplate() {
+		return heightCmd
+	}
 
 	resourceCmd := func() tea.Msg {
 		contents, err := m.com.Workspace.ReadMCPResource(

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -785,6 +785,13 @@ func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			cmds = append(cmds, cmd)
 		}
 
+	case a2uiActionResultMsg:
+		// An a2ui_action round-trip returned: update the originating
+		// surface in place (or land plain text) without an agent turn.
+		if cmd := m.handleA2UIActionResult(msg); cmd != nil {
+			cmds = append(cmds, cmd)
+		}
+
 	case userCommandsLoadedMsg:
 		m.customCommands = msg.Commands
 		dia := m.dialog.Dialog(dialog.CommandsID)
@@ -4220,11 +4227,174 @@ func (m *UI) sendMessage(content string, attachments ...message.Attachment) tea.
 // the surface rebuilt without an ID — in which case the submission still
 // goes out with just the button identity rather than being dropped.
 func (m *UI) handleA2UIButtonClicked(clicked a2uievent.ButtonClicked) tea.Cmd {
-	values, _ := m.chat.RetireA2UISurface(clicked.SurfaceID)
+	// A cancel/dismiss button only ever dismisses the surface locally —
+	// it never starts an agent turn nor round-trips to an MCP server.
+	// Checked first, before any provenance branch.
 	if chat.A2UIButtonIsCancel(clicked) {
+		m.chat.RetireA2UISurface(clicked.SurfaceID)
 		return nil
 	}
+	// MCP-served surface: route the interaction back to the owning server
+	// when it speaks the action round-trip, instead of starting an agent
+	// turn. The button press is itself the consent, so the a2ui_action
+	// call is not gated on permission. The surface is long-lived — it is
+	// NOT retired, and a surface payload in the response updates it in
+	// place.
+	// Provenance resolves through the item that owns the surface, falling
+	// back to the global surfaceID-keyed registry only when no live item
+	// claims it: surface IDs are server-scoped (typically "default"), so two
+	// servers would otherwise clobber each other in that registry and route
+	// one another's clicks.
+	mcpName, isMCP := m.chat.A2UISurfaceOwner(clicked.SurfaceID)
+	if !isMCP {
+		mcpName, isMCP = chat.A2UISurfaceProvenance(clicked.SurfaceID)
+	}
+	if isMCP && clicked.Action != nil {
+		if mcp.HasTool(mcpName, "a2ui_action") {
+			return m.runA2UIAction(mcpName, clicked)
+		}
+		// The server serves surfaces but not the action round-trip: keep
+		// today's behavior so a dumb server still works.
+	}
+	// RetireA2UISurface only matches assistant items, so an MCP surface's
+	// values must be read from the tool item that holds it — otherwise the
+	// fallback submits the button identity with everything the user typed
+	// silently dropped.
+	values, ok := m.chat.RetireA2UISurface(clicked.SurfaceID)
+	if !ok {
+		values, _ = m.chat.A2UISurfaceFieldValues(clicked.SurfaceID)
+	}
 	return m.sendMessage(chat.A2UISubmissionPrompt(clicked, values))
+}
+
+// a2uiActionResultMsg carries the outcome of an a2ui_action round-trip back
+// to the UI so the surface updates in place (or a plain-text reply lands as
+// tool output) without an agent turn.
+type a2uiActionResultMsg struct {
+	surfaceID string
+	mcpName   string
+	// surfaces holds any A2UI payloads the response embedded, applied to
+	// the surface in place. content holds plain text from the response.
+	surfaces []string
+	content  string
+	err      error
+}
+
+// runA2UIAction calls the owning server's a2ui_action tool with the
+// button's action name and the surface's resolved input values as the
+// context. The call runs off the UI goroutine; the result returns as an
+// a2uiActionResultMsg.
+func (m *UI) runA2UIAction(mcpName string, clicked a2uievent.ButtonClicked) tea.Cmd {
+	values, _ := m.chat.A2UISurfaceFieldValues(clicked.SurfaceID)
+	if values == nil {
+		values = map[string]any{}
+	}
+	args := map[string]any{
+		"name":    clicked.Action.Name,
+		"context": values,
+	}
+	surfaceID := clicked.SurfaceID
+	return func() tea.Msg {
+		res, err := m.com.Workspace.CallMCPTool(context.Background(), mcpName, "a2ui_action", args)
+		if err != nil {
+			return a2uiActionResultMsg{surfaceID: surfaceID, mcpName: mcpName, err: err}
+		}
+		out := a2uiActionResultMsg{surfaceID: surfaceID, mcpName: mcpName, content: res.Content}
+		for _, s := range res.Surfaces {
+			out.surfaces = append(out.surfaces, s.Payload)
+		}
+		return out
+	}
+}
+
+// handleA2UIActionResult applies an a2ui_action response: any A2UI payload
+// updates the originating surface in place (the surface stays live), and any
+// plain text lands as an informational note. A transport/server error is
+// surfaced as an error note — the surface is left untouched.
+func (m *UI) handleA2UIActionResult(msg a2uiActionResultMsg) tea.Cmd {
+	if msg.err != nil {
+		return util.ReportError(fmt.Errorf("A2UI action failed: %w", msg.err))
+	}
+	var cmds []tea.Cmd
+	for _, payload := range msg.surfaces {
+		if cmd := m.applyA2UIPayloadToSurface(msg.mcpName, msg.surfaceID, payload); cmd != nil {
+			cmds = append(cmds, cmd)
+		}
+	}
+	if msg.content != "" {
+		cmds = append(cmds, util.ReportInfo(msg.content))
+	}
+	if len(cmds) == 0 {
+		return nil
+	}
+	return tea.Batch(cmds...)
+}
+
+// applyA2UIPayloadToSurface scans an A2UI payload and feeds its server
+// messages into the surface the payload targets, which updates in place. A
+// payload that does not scan, or that targets a surface nothing holds, is
+// reported back to the owning server as an a2ui_error when it exposes that
+// tool. clickedID is the surface the interaction came from — the fallback
+// target for a payload that declares no surface of its own — and mcpName is
+// the server that sent it, which is who any error is reported to.
+func (m *UI) applyA2UIPayloadToSurface(mcpName, clickedID, payload string) tea.Cmd {
+	msgs, err := chat.A2UIMessagesFromPayload(payload)
+	if err != nil {
+		return m.reportA2UIError(mcpName, clickedID, "INVALID_JSON",
+			"Failed to parse A2UI payload.")
+	}
+	if len(msgs) == 0 {
+		// The payload parsed but carried no server messages — it scanned
+		// as prose, not A2UI. Applying it would be a silent no-op, which
+		// looks to the user like a dead button.
+		return m.reportA2UIError(mcpName, clickedID, "INVALID_PAYLOAD",
+			"Payload carried no A2UI server messages.")
+	}
+	// Honor the surface the payload itself declares: a server may answer an
+	// action by updating a sibling surface, not the clicked one. Forcing
+	// every payload onto the clicked ID would corrupt that surface instead.
+	target := chat.A2UIMessagesSurfaceID(msgs)
+	if target == "" {
+		target = clickedID
+	}
+	if !m.chat.ApplyA2UISurfaceUpdate(target, msgs) {
+		// Either nothing holds that surface, or the server just deleted
+		// it. A delete is the expected end of a surface's life; a payload
+		// aimed at a surface we never had is a real mismatch worth
+		// reporting back.
+		if !chat.A2UIMessagesDeleteSurface(msgs) {
+			return m.reportA2UIError(mcpName, target, "SURFACE_NOT_FOUND",
+				fmt.Sprintf("No live surface %q to apply the payload to.", target))
+		}
+	}
+	return nil
+}
+
+// reportA2UIError reports a render failure to mcpName via its a2ui_error
+// tool, when it exposes one. Otherwise the failure is only shown to the user
+// (the existing render-failure alert path). mcpName may be empty when the
+// caller only holds a surface ID, in which case the owner is resolved from
+// the surface — item-scoped first, same as the action path, because the
+// global registry is keyed by surface ID alone and two servers sharing an ID
+// clobber each other there.
+func (m *UI) reportA2UIError(mcpName, surfaceID, code, message string) tea.Cmd {
+	ok := mcpName != ""
+	if !ok {
+		if mcpName, ok = m.chat.A2UISurfaceOwner(surfaceID); !ok {
+			mcpName, ok = chat.A2UISurfaceProvenance(surfaceID)
+		}
+	}
+	if !ok || !mcp.HasTool(mcpName, "a2ui_error") {
+		return nil
+	}
+	args := map[string]any{"code": code, "message": message, "surfaceId": surfaceID}
+	return func() tea.Msg {
+		_, err := m.com.Workspace.CallMCPTool(context.Background(), mcpName, "a2ui_error", args)
+		if err != nil {
+			return util.InfoMsg{Type: util.InfoTypeError, Msg: fmt.Sprintf("A2UI error report failed: %v", err)}
+		}
+		return nil
+	}
 }
 
 // handleChannelMessage injects a channel event pushed by an MCP server into a

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -27,6 +27,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"charm.land/catwalk/pkg/catwalk"
 	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/crush/internal/agent"
 	"github.com/charmbracelet/crush/internal/agent/hyper"
 	"github.com/charmbracelet/crush/internal/agent/notify"
 	agenttools "github.com/charmbracelet/crush/internal/agent/tools"
@@ -4173,6 +4174,11 @@ func (m *UI) sendMessage(content string, attachments ...message.Attachment) tea.
 
 	// Capture session ID to avoid race with main goroutine updating m.session.
 	sessionID := m.session.ID
+	// The turn's content width hint: tools that read width-sensitive remote
+	// content (A2UI surfaces with server-pre-rendered bar geometry) get the
+	// surface card's interior width so the server sizes its rows to fill the
+	// card — the message cap minus the tool-item indent and the card chrome.
+	contentWidth := min(m.layout.main.Dx()-2, 120) - 6
 	// Optimistically mark the agent busy: the prompt we are about to submit
 	// either starts a run or is enqueued behind one. This keeps esc pressed
 	// right after enter routing to cancelAgent instead of reading a stale
@@ -4188,7 +4194,7 @@ func (m *UI) sendMessage(content string, attachments ...message.Attachment) tea.
 		// been accepted (HTTP 202) or synchronously with a validation
 		// or transport error. Run failures and cancellation surface
 		// through SSE-derived events, not this return value.
-		err := m.com.Workspace.AgentRun(context.Background(), sessionID, content, attachments...)
+		err := m.com.Workspace.AgentRun(agent.WithContentWidth(context.Background(), contentWidth), sessionID, content, attachments...)
 		if err != nil && !errors.Is(err, context.Canceled) {
 			return util.InfoMsg{
 				Type: util.InfoTypeError,

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -23,10 +23,10 @@ import (
 	"charm.land/bubbles/v2/help"
 	"charm.land/bubbles/v2/key"
 	"charm.land/bubbles/v2/spinner"
-	"charm.land/bubbles/v2/textarea"
 	tea "charm.land/bubbletea/v2"
 	"charm.land/catwalk/pkg/catwalk"
 	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/crush/internal/agent"
 	"github.com/charmbracelet/crush/internal/agent/hyper"
 	"github.com/charmbracelet/crush/internal/agent/notify"
 	agenttools "github.com/charmbracelet/crush/internal/agent/tools"
@@ -57,6 +57,7 @@ import (
 	"github.com/charmbracelet/crush/internal/ui/logo"
 	"github.com/charmbracelet/crush/internal/ui/notification"
 	"github.com/charmbracelet/crush/internal/ui/styles"
+	"github.com/charmbracelet/crush/internal/ui/textarea"
 	"github.com/charmbracelet/crush/internal/ui/util"
 	"github.com/charmbracelet/crush/internal/version"
 	"github.com/charmbracelet/crush/internal/workspace"
@@ -135,9 +136,12 @@ type shellStreamMsg struct {
 type (
 	// cancelTimerExpiredMsg is sent when the cancel timer expires.
 	cancelTimerExpiredMsg struct{}
-	// userCommandsLoadedMsg is sent when user commands are loaded.
+	// userCommandsLoadedMsg is sent when user commands are loaded. It also
+	// carries the skill catalog the command list was built from, so the
+	// '/' completions popup gets descriptions off the same single load.
 	userCommandsLoadedMsg struct {
-		Commands []commands.CustomCommand
+		Commands     []commands.CustomCommand
+		SkillEntries []skills.CatalogEntry
 	}
 	// mcpPromptsLoadedMsg is sent when mcp prompts are loaded.
 	mcpPromptsLoadedMsg struct {
@@ -277,9 +281,14 @@ type UI struct {
 	// Completions state
 	completions              *completions.Completions
 	completionsOpen          bool
+	completionsTrigger       completions.Trigger
 	completionsStartIndex    int
 	completionsQuery         string
-	completionsPositionStart image.Point // x,y where user typed '@'
+	completionsPositionStart image.Point // x,y where user typed the trigger
+
+	// promptHighlighter styles @file and /skill tokens inline as the user
+	// types. Installed on the textarea via SetHighlighter.
+	promptHighlighter *promptHighlighter
 
 	// lastCompletionEnd tracks the end index of the most recently
 	// inserted completion text so that a single backspace can delete
@@ -308,6 +317,11 @@ type UI struct {
 
 	// skills
 	skillStates []*skills.SkillState
+
+	// skillCatalog is the effective visible skill set (post-override,
+	// post-disable) with frontmatter descriptions, refreshed alongside the
+	// custom commands. It backs the '/' completions popup.
+	skillCatalog []skills.CatalogEntry
 
 	// sidebarLogo keeps a cached version of the sidebar sidebarLogo.
 	sidebarLogo string
@@ -399,6 +413,12 @@ func New(com *common.Common, initialSessionID string, continueLast bool) *UI {
 	ta.MaxHeight = TextareaMaxHeight
 	ta.Focus()
 
+	promptHL := newPromptHighlighter(
+		com.Styles.Editor.TokenFile,
+		com.Styles.Editor.TokenSkill,
+	)
+	ta.SetHighlighter(promptHL)
+
 	scrollbarMode := config.ScrollbarDefault
 	if cfg := com.Config(); cfg.Options.TUI != nil && cfg.Options.TUI.Scrollbar != "" {
 		scrollbarMode = cfg.Options.TUI.Scrollbar
@@ -448,6 +468,7 @@ func New(com *common.Common, initialSessionID string, continueLast bool) *UI {
 		completions:         comp,
 		attachments:         attachments,
 		todoSpinner:         todoSpinner,
+		promptHighlighter:   promptHL,
 		lspStates:           make(map[string]workspace.LSPClientInfo),
 		mcpStates:           make(map[string]mcp.ClientInfo),
 		notifyBackend:       notification.NoopBackend{},
@@ -456,6 +477,7 @@ func New(com *common.Common, initialSessionID string, continueLast bool) *UI {
 		continueLastSession: continueLast,
 		skillStates:         skills.GetLatestStates(),
 	}
+	ui.refreshSkillNames()
 
 	status := NewStatus(com, ui)
 
@@ -663,7 +685,7 @@ func (m *UI) loadCustomCommands() tea.Cmd {
 			slog.Error("Failed to load skill commands", "error", err)
 		}
 		customCommands = append(customCommands, commands.FromSkillCatalog(skillEntries)...)
-		return userCommandsLoadedMsg{Commands: customCommands}
+		return userCommandsLoadedMsg{Commands: customCommands, SkillEntries: skillEntries}
 	}
 }
 
@@ -795,8 +817,17 @@ func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			cmds = append(cmds, cmd)
 		}
 
+	case a2uiActionResultMsg:
+		// An a2ui_action round-trip returned: update the originating
+		// surface in place (or land plain text) without an agent turn.
+		if cmd := m.handleA2UIActionResult(msg); cmd != nil {
+			cmds = append(cmds, cmd)
+		}
+
 	case userCommandsLoadedMsg:
 		m.customCommands = msg.Commands
+		m.skillCatalog = msg.SkillEntries
+		m.refreshSkillNames()
 		dia := m.dialog.Dialog(dialog.CommandsID)
 		if dia == nil {
 			break
@@ -929,6 +960,12 @@ func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.lspStates = m.com.Workspace.LSPGetStates()
 	case pubsub.Event[skills.Event]:
 		m.skillStates = msg.Payload.States
+		m.refreshSkillNames()
+		// Discovery states carry no descriptions and no override/disable
+		// resolution, so re-read the catalog too: a ctrl+r reload in the
+		// skills dialog must move both the command palette and the '/'
+		// completions popup.
+		cmds = append(cmds, m.loadCustomCommands())
 	case pubsub.Event[mcp.Event]:
 		switch msg.Payload.Type {
 		case mcp.EventStateChanged:
@@ -1355,7 +1392,9 @@ func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case util.ClearStatusMsg:
 		m.status.ClearInfoMsg()
 	case completions.CompletionItemsLoadedMsg:
-		if m.completionsOpen {
+		// Guard against a stale async file load landing after the popup
+		// switched to (or was reopened in) skill mode.
+		if m.completionsOpen && m.completionsTrigger == completions.TriggerFile {
 			m.completions.SetItems(msg.Files, msg.Resources)
 		}
 	case uv.KittyGraphicsEvent:
@@ -2477,6 +2516,11 @@ func (m *UI) handleKeyPressMsg(msg tea.KeyPressMsg) tea.Cmd {
 			if m.completionsOpen {
 				if msg, ok := m.completions.Update(msg); ok {
 					switch msg := msg.(type) {
+					case completions.SelectionMsg[completions.SkillCompletionValue]:
+						cmds = append(cmds, m.insertSkillCompletion(msg.Value))
+						if !msg.KeepOpen {
+							m.closeCompletions()
+						}
 					case completions.SelectionMsg[completions.FileCompletionValue]:
 						cmds = append(cmds, m.insertFileCompletion(msg.Value.Path))
 						if !msg.KeepOpen {
@@ -2489,6 +2533,7 @@ func (m *UI) handleKeyPressMsg(msg tea.KeyPressMsg) tea.Cmd {
 						}
 					case completions.ClosedMsg:
 						m.completionsOpen = false
+						m.completionsTrigger = completions.TriggerNone
 					}
 					return tea.Batch(cmds...)
 				}
@@ -2666,20 +2711,32 @@ func (m *UI) handleKeyPressMsg(msg tea.KeyPressMsg) tea.Cmd {
 					m.clearCompletionRange()
 				}
 
-				// Check for @ trigger before passing to textarea.
+				// Check for completion triggers before passing to textarea.
 				curValue := m.textarea.Value()
 				curIdx := len(curValue)
 
-				// Trigger completions on @.
+				// Trigger file completions on @.
 				if msg.String() == "@" && !m.completionsOpen {
 					// Only show if beginning of prompt or after whitespace.
 					if curIdx == 0 || (curIdx > 0 && isWhitespace(curValue[curIdx-1])) {
 						m.completionsOpen = true
+						m.completionsTrigger = completions.TriggerFile
 						m.completionsQuery = ""
 						m.completionsStartIndex = curIdx
 						m.completionsPositionStart = m.completionsPosition()
 						depth, limit := m.com.Config().Options.TUI.Completions.Limits()
 						cmds = append(cmds, m.completions.Open(depth, limit))
+					}
+				}
+
+				// Trigger skill completions on / mid-prompt. At the start of
+				// an empty prompt the commands dialog handles '/' instead
+				// (see the Editor.Commands binding above), so here we only
+				// fire when the textarea already has content and '/' begins
+				// a new word.
+				if msg.String() == "/" && !m.completionsOpen && !m.bangMode {
+					if curIdx > 0 && isWhitespace(curValue[curIdx-1]) {
+						m.openSkillCompletions(curIdx)
 					}
 				}
 
@@ -2723,8 +2780,9 @@ func (m *UI) handleKeyPressMsg(msg tea.KeyPressMsg) tea.Cmd {
 				m.updateHistoryDraft(curValue)
 
 				// After updating textarea, check if we need to filter completions.
-				// Skip filtering on the initial @ keystroke since items are loading async.
-				if m.completionsOpen && msg.String() != "@" {
+				// Skip filtering on the initial trigger keystroke since items
+				// are loading async.
+				if m.completionsOpen && msg.String() != string(m.completionsTrigger) {
 					newValue := m.textarea.Value()
 					newIdx := len(newValue)
 
@@ -2737,7 +2795,7 @@ func (m *UI) handleKeyPressMsg(msg tea.KeyPressMsg) tea.Cmd {
 					} else {
 						// Extract current word and filter.
 						word := m.textareaWord()
-						if strings.HasPrefix(word, "@") {
+						if strings.HasPrefix(word, string(m.completionsTrigger)) {
 							m.completionsQuery = word[1:]
 							m.completions.Filter(m.completionsQuery)
 						} else if m.completionsOpen {
@@ -3827,9 +3885,73 @@ func (m *UI) bangPromptFunc(info textarea.PromptInfo) string {
 // closeCompletions closes the completions popup and resets state.
 func (m *UI) closeCompletions() {
 	m.completionsOpen = false
+	m.completionsTrigger = completions.TriggerNone
 	m.completionsQuery = ""
 	m.completionsStartIndex = 0
 	m.completions.Close()
+}
+
+// skillCompletionValues returns the skills offered by the '/' popup.
+//
+// The catalog is the right source: it is the effective, post-dedup,
+// post-disable set, it includes the builtin skills the raw discovery states
+// omit, and it carries each skill's frontmatter description. The discovery
+// states are only a fallback for the window between startup and the first
+// catalog load, where a name-only list still beats an empty popup.
+func (m *UI) skillCompletionValues() []completions.SkillCompletionValue {
+	var values []completions.SkillCompletionValue
+	if len(m.skillCatalog) > 0 {
+		for _, entry := range m.skillCatalog {
+			if entry.Name == "" {
+				continue
+			}
+			values = append(values, completions.SkillCompletionValue{
+				Name:        entry.Name,
+				Description: entry.Description,
+				Path:        entry.ID,
+			})
+		}
+	} else {
+		seen := make(map[string]struct{}, len(m.skillStates))
+		for _, s := range m.skillStates {
+			if s == nil || s.Name == "" || s.State != skills.StateNormal {
+				continue
+			}
+			if _, dup := seen[s.Name]; dup {
+				continue
+			}
+			seen[s.Name] = struct{}{}
+			values = append(values, completions.SkillCompletionValue{
+				Name: s.Name,
+				Path: s.Path,
+			})
+		}
+	}
+	slices.SortFunc(values, func(a, b completions.SkillCompletionValue) int {
+		return strings.Compare(a.Name, b.Name)
+	})
+	return values
+}
+
+// openSkillCompletions opens the completions popup in skill mode at the
+// given trigger index. Skills are already in memory, so no async load is
+// needed.
+func (m *UI) openSkillCompletions(startIndex int) {
+	values := m.skillCompletionValues()
+	if len(values) == 0 {
+		// An open-but-empty popup still consumes enter and the arrow keys,
+		// so a user with no skills configured could not submit a prompt
+		// containing a '/'. Unlike '@' there is nothing to wait on here —
+		// no skills means no popup.
+		return
+	}
+
+	m.completionsOpen = true
+	m.completionsTrigger = completions.TriggerSkill
+	m.completionsQuery = ""
+	m.completionsStartIndex = startIndex
+	m.completionsPositionStart = m.completionsPosition()
+	m.completions.SetSkillItems(values)
 }
 
 // insertCompletionText replaces the @query in the textarea with the given text.
@@ -3916,15 +4038,27 @@ func (m *UI) insertFileCompletion(path string) tea.Cmd {
 }
 
 // insertMCPResourceCompletion inserts the selected resource into the textarea,
-// replacing the @query, and adds the resource as an attachment.
+// replacing the @query, and adds the resource as an attachment. An unexpanded
+// resource template is only inserted as text: its URI still carries RFC 6570
+// placeholders ("cairn://run/{id}"), so reading it now would send the literal
+// braces to the server and fail — the read happens once someone (user or
+// agent) has substituted real values.
 func (m *UI) insertMCPResourceCompletion(item completions.ResourceCompletionValue) tea.Cmd {
 	displayText := cmp.Or(item.Title, item.URI)
+	if item.IsTemplate() {
+		// Insert the raw template URI, not the title: the placeholders are
+		// the point — they show what needs filling in.
+		displayText = item.URI
+	}
 
 	prevHeight := m.textarea.Height()
 	if !m.insertCompletionText(displayText) {
 		return nil
 	}
 	heightCmd := m.handleTextareaHeightChange(prevHeight)
+	if item.IsTemplate() {
+		return heightCmd
+	}
 
 	resourceCmd := func() tea.Msg {
 		contents, err := m.com.Workspace.ReadMCPResource(
@@ -3967,6 +4101,17 @@ func (m *UI) insertMCPResourceCompletion(item completions.ResourceCompletionValu
 		}
 	}
 	return tea.Batch(heightCmd, resourceCmd)
+}
+
+// insertSkillCompletion inserts the selected skill name into the textarea,
+// replacing the /query. Unlike files, skills are not attached — the
+// "/skill-name" text in the prompt is the signal to load the skill.
+func (m *UI) insertSkillCompletion(skill completions.SkillCompletionValue) tea.Cmd {
+	prevHeight := m.textarea.Height()
+	if !m.insertCompletionText("/" + skill.Name) {
+		return nil
+	}
+	return m.handleTextareaHeightChange(prevHeight)
 }
 
 // completionsPosition returns the X and Y position for the completions popup.
@@ -4088,6 +4233,19 @@ func (m *UI) renderEditorView(width int) string {
 	var attachmentsView string
 	if len(m.attachments.List()) > 0 {
 		attachmentsView = m.attachments.Render(width)
+	}
+	// Retokenize @file and /skill tokens on every render. The scan is
+	// linear in prompt length and render happens every frame anyway, so
+	// this is the single seam that stays correct for every value-mutation
+	// path (typing, paste, history, completion inserts). Bang mode is a
+	// shell prompt — its slashes are paths, not skills — so tokens are
+	// suppressed there.
+	if m.promptHighlighter != nil {
+		if m.bangMode {
+			m.promptHighlighter.Rescan("")
+		} else {
+			m.promptHighlighter.Rescan(m.textarea.Value())
+		}
 	}
 	return strings.Join([]string{
 		attachmentsView,
@@ -4228,6 +4386,12 @@ func (m *UI) sendMessage(content string, attachments ...message.Attachment) tea.
 
 	// Capture session ID to avoid race with main goroutine updating m.session.
 	sessionID := m.session.ID
+	// The turn's content width hint: tools that read width-sensitive remote
+	// content (A2UI surfaces with server-pre-rendered bar geometry) get the
+	// surface card's interior width so the server sizes its rows to fill
+	// the card. The chat package owns the computation — it must track the
+	// real render chain, not constants copied here.
+	contentWidth := chat.ToolA2UISurfaceWidth(m.layout.main.Dx())
 	// Optimistically mark the agent busy: the prompt we are about to submit
 	// either starts a run or is enqueued behind one. This keeps esc pressed
 	// right after enter routing to cancelAgent instead of reading a stale
@@ -4243,7 +4407,7 @@ func (m *UI) sendMessage(content string, attachments ...message.Attachment) tea.
 		// been accepted (HTTP 202) or synchronously with a validation
 		// or transport error. Run failures and cancellation surface
 		// through SSE-derived events, not this return value.
-		err := m.com.Workspace.AgentRun(context.Background(), sessionID, content, attachments...)
+		err := m.com.Workspace.AgentRun(agent.WithContentWidth(context.Background(), contentWidth), sessionID, content, attachments...)
 		if err != nil && !errors.Is(err, context.Canceled) {
 			return util.InfoMsg{
 				Type: util.InfoTypeError,
@@ -4268,11 +4432,174 @@ func (m *UI) sendMessage(content string, attachments ...message.Attachment) tea.
 // the surface rebuilt without an ID — in which case the submission still
 // goes out with just the button identity rather than being dropped.
 func (m *UI) handleA2UIButtonClicked(clicked a2uievent.ButtonClicked) tea.Cmd {
-	values, _ := m.chat.RetireA2UISurface(clicked.SurfaceID)
+	// A cancel/dismiss button only ever dismisses the surface locally —
+	// it never starts an agent turn nor round-trips to an MCP server.
+	// Checked first, before any provenance branch.
 	if chat.A2UIButtonIsCancel(clicked) {
+		m.chat.RetireA2UISurface(clicked.SurfaceID)
 		return nil
 	}
+	// MCP-served surface: route the interaction back to the owning server
+	// when it speaks the action round-trip, instead of starting an agent
+	// turn. The button press is itself the consent, so the a2ui_action
+	// call is not gated on permission. The surface is long-lived — it is
+	// NOT retired, and a surface payload in the response updates it in
+	// place.
+	// Provenance resolves through the item that owns the surface, falling
+	// back to the global surfaceID-keyed registry only when no live item
+	// claims it: surface IDs are server-scoped (typically "default"), so two
+	// servers would otherwise clobber each other in that registry and route
+	// one another's clicks.
+	mcpName, isMCP := m.chat.A2UISurfaceOwner(clicked.SurfaceID)
+	if !isMCP {
+		mcpName, isMCP = chat.A2UISurfaceProvenance(clicked.SurfaceID)
+	}
+	if isMCP && clicked.Action != nil {
+		if mcp.HasTool(mcpName, "a2ui_action") {
+			return m.runA2UIAction(mcpName, clicked)
+		}
+		// The server serves surfaces but not the action round-trip: keep
+		// today's behavior so a dumb server still works.
+	}
+	// RetireA2UISurface only matches assistant items, so an MCP surface's
+	// values must be read from the tool item that holds it — otherwise the
+	// fallback submits the button identity with everything the user typed
+	// silently dropped.
+	values, ok := m.chat.RetireA2UISurface(clicked.SurfaceID)
+	if !ok {
+		values, _ = m.chat.A2UISurfaceFieldValues(clicked.SurfaceID)
+	}
 	return m.sendMessage(chat.A2UISubmissionPrompt(clicked, values))
+}
+
+// a2uiActionResultMsg carries the outcome of an a2ui_action round-trip back
+// to the UI so the surface updates in place (or a plain-text reply lands as
+// tool output) without an agent turn.
+type a2uiActionResultMsg struct {
+	surfaceID string
+	mcpName   string
+	// surfaces holds any A2UI payloads the response embedded, applied to
+	// the surface in place. content holds plain text from the response.
+	surfaces []string
+	content  string
+	err      error
+}
+
+// runA2UIAction calls the owning server's a2ui_action tool with the
+// button's action name and the surface's resolved input values as the
+// context. The call runs off the UI goroutine; the result returns as an
+// a2uiActionResultMsg.
+func (m *UI) runA2UIAction(mcpName string, clicked a2uievent.ButtonClicked) tea.Cmd {
+	values, _ := m.chat.A2UISurfaceFieldValues(clicked.SurfaceID)
+	if values == nil {
+		values = map[string]any{}
+	}
+	args := map[string]any{
+		"name":    clicked.Action.Name,
+		"context": values,
+	}
+	surfaceID := clicked.SurfaceID
+	return func() tea.Msg {
+		res, err := m.com.Workspace.CallMCPTool(context.Background(), mcpName, "a2ui_action", args)
+		if err != nil {
+			return a2uiActionResultMsg{surfaceID: surfaceID, mcpName: mcpName, err: err}
+		}
+		out := a2uiActionResultMsg{surfaceID: surfaceID, mcpName: mcpName, content: res.Content}
+		for _, s := range res.Surfaces {
+			out.surfaces = append(out.surfaces, s.Payload)
+		}
+		return out
+	}
+}
+
+// handleA2UIActionResult applies an a2ui_action response: any A2UI payload
+// updates the originating surface in place (the surface stays live), and any
+// plain text lands as an informational note. A transport/server error is
+// surfaced as an error note — the surface is left untouched.
+func (m *UI) handleA2UIActionResult(msg a2uiActionResultMsg) tea.Cmd {
+	if msg.err != nil {
+		return util.ReportError(fmt.Errorf("A2UI action failed: %w", msg.err))
+	}
+	var cmds []tea.Cmd
+	for _, payload := range msg.surfaces {
+		if cmd := m.applyA2UIPayloadToSurface(msg.mcpName, msg.surfaceID, payload); cmd != nil {
+			cmds = append(cmds, cmd)
+		}
+	}
+	if msg.content != "" {
+		cmds = append(cmds, util.ReportInfo(msg.content))
+	}
+	if len(cmds) == 0 {
+		return nil
+	}
+	return tea.Batch(cmds...)
+}
+
+// applyA2UIPayloadToSurface scans an A2UI payload and feeds its server
+// messages into the surface the payload targets, which updates in place. A
+// payload that does not scan, or that targets a surface nothing holds, is
+// reported back to the owning server as an a2ui_error when it exposes that
+// tool. clickedID is the surface the interaction came from — the fallback
+// target for a payload that declares no surface of its own — and mcpName is
+// the server that sent it, which is who any error is reported to.
+func (m *UI) applyA2UIPayloadToSurface(mcpName, clickedID, payload string) tea.Cmd {
+	msgs, err := chat.A2UIMessagesFromPayload(payload)
+	if err != nil {
+		return m.reportA2UIError(mcpName, clickedID, "INVALID_JSON",
+			"Failed to parse A2UI payload.")
+	}
+	if len(msgs) == 0 {
+		// The payload parsed but carried no server messages — it scanned
+		// as prose, not A2UI. Applying it would be a silent no-op, which
+		// looks to the user like a dead button.
+		return m.reportA2UIError(mcpName, clickedID, "INVALID_PAYLOAD",
+			"Payload carried no A2UI server messages.")
+	}
+	// Honor the surface the payload itself declares: a server may answer an
+	// action by updating a sibling surface, not the clicked one. Forcing
+	// every payload onto the clicked ID would corrupt that surface instead.
+	target := chat.A2UIMessagesSurfaceID(msgs)
+	if target == "" {
+		target = clickedID
+	}
+	if !m.chat.ApplyA2UISurfaceUpdate(target, msgs) {
+		// Either nothing holds that surface, or the server just deleted
+		// it. A delete is the expected end of a surface's life; a payload
+		// aimed at a surface we never had is a real mismatch worth
+		// reporting back.
+		if !chat.A2UIMessagesDeleteSurface(msgs) {
+			return m.reportA2UIError(mcpName, target, "SURFACE_NOT_FOUND",
+				fmt.Sprintf("No live surface %q to apply the payload to.", target))
+		}
+	}
+	return nil
+}
+
+// reportA2UIError reports a render failure to mcpName via its a2ui_error
+// tool, when it exposes one. Otherwise the failure is only shown to the user
+// (the existing render-failure alert path). mcpName may be empty when the
+// caller only holds a surface ID, in which case the owner is resolved from
+// the surface — item-scoped first, same as the action path, because the
+// global registry is keyed by surface ID alone and two servers sharing an ID
+// clobber each other there.
+func (m *UI) reportA2UIError(mcpName, surfaceID, code, message string) tea.Cmd {
+	ok := mcpName != ""
+	if !ok {
+		if mcpName, ok = m.chat.A2UISurfaceOwner(surfaceID); !ok {
+			mcpName, ok = chat.A2UISurfaceProvenance(surfaceID)
+		}
+	}
+	if !ok || !mcp.HasTool(mcpName, "a2ui_error") {
+		return nil
+	}
+	args := map[string]any{"code": code, "message": message, "surfaceId": surfaceID}
+	return func() tea.Msg {
+		_, err := m.com.Workspace.CallMCPTool(context.Background(), mcpName, "a2ui_error", args)
+		if err != nil {
+			return util.InfoMsg{Type: util.InfoTypeError, Msg: fmt.Sprintf("A2UI error report failed: %v", err)}
+		}
+		return nil
+	}
 }
 
 // handleChannelMessage injects a channel event pushed by an MCP server into a

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -4176,9 +4176,10 @@ func (m *UI) sendMessage(content string, attachments ...message.Attachment) tea.
 	sessionID := m.session.ID
 	// The turn's content width hint: tools that read width-sensitive remote
 	// content (A2UI surfaces with server-pre-rendered bar geometry) get the
-	// surface card's interior width so the server sizes its rows to fill the
-	// card — the message cap minus the tool-item indent and the card chrome.
-	contentWidth := min(m.layout.main.Dx()-2, 120) - 6
+	// surface card's interior width so the server sizes its rows to fill
+	// the card. The chat package owns the computation — it must track the
+	// real render chain, not constants copied here.
+	contentWidth := chat.ToolA2UISurfaceWidth(m.layout.main.Dx())
 	// Optimistically mark the agent busy: the prompt we are about to submit
 	// either starts a run or is enqueued behind one. This keeps esc pressed
 	// right after enter routing to cancelAgent instead of reading a stale

--- a/internal/ui/styles/quickstyle.go
+++ b/internal/ui/styles/quickstyle.go
@@ -5,12 +5,12 @@ import (
 
 	"charm.land/bubbles/v2/filepicker"
 	"charm.land/bubbles/v2/help"
-	"charm.land/bubbles/v2/textarea"
 	"charm.land/bubbles/v2/textinput"
 	tea "charm.land/bubbletea/v2"
 	"charm.land/glamour/v2/ansi"
 	"charm.land/lipgloss/v2"
 	"github.com/charmbracelet/crush/internal/ui/diffview"
+	"github.com/charmbracelet/crush/internal/ui/textarea"
 	uv "github.com/charmbracelet/ultraviolet"
 	"github.com/charmbracelet/x/exp/charmtone"
 )
@@ -752,6 +752,12 @@ func quickStyle(o quickStyleOpts) Styles {
 	s.Editor.QuestionRadioOff = lipgloss.NewStyle().Foreground(o.fgSubtle).SetString(RadioOff)
 	s.Editor.QuestionCheckOn = lipgloss.NewStyle().Foreground(o.secondary).SetString(RadioOn)
 	s.Editor.QuestionCheckOff = lipgloss.NewStyle().Foreground(o.fgSubtle).SetString(RadioOff)
+
+	// Inline prompt tokens: @file mentions use the primary accent, /skill
+	// references the secondary, both bolded so they stand apart from prompt
+	// prose.
+	s.Editor.TokenFile = lipgloss.NewStyle().Foreground(o.primary).Bold(true)
+	s.Editor.TokenSkill = lipgloss.NewStyle().Foreground(o.secondary).Bold(true)
 
 	s.Radio.On = lipgloss.NewStyle().Foreground(o.fgSubtle).SetString(RadioOn)
 	s.Radio.Off = lipgloss.NewStyle().Foreground(o.fgSubtle).SetString(RadioOff)

--- a/internal/ui/styles/styles.go
+++ b/internal/ui/styles/styles.go
@@ -8,12 +8,12 @@ import (
 
 	"charm.land/bubbles/v2/filepicker"
 	"charm.land/bubbles/v2/help"
-	"charm.land/bubbles/v2/textarea"
 	"charm.land/bubbles/v2/textinput"
 	"charm.land/glamour/v2/ansi"
 	"charm.land/lipgloss/v2"
 	"github.com/alecthomas/chroma/v2"
 	"github.com/charmbracelet/crush/internal/ui/diffview"
+	"github.com/charmbracelet/crush/internal/ui/textarea"
 	uv "github.com/charmbracelet/ultraviolet"
 )
 
@@ -165,6 +165,11 @@ type Styles struct {
 		QuestionRadioOff   lipgloss.Style // Unselected single-choice radio.
 		QuestionCheckOn    lipgloss.Style // Checked multi-choice indicator.
 		QuestionCheckOff   lipgloss.Style // Unchecked multi-choice indicator.
+
+		// Inline token highlighting in the prompt textarea: @file mentions
+		// and /skill references typed into the prompt.
+		TokenFile  lipgloss.Style
+		TokenSkill lipgloss.Style
 	}
 
 	// Radio

--- a/internal/ui/textarea/highlighter.go
+++ b/internal/ui/textarea/highlighter.go
@@ -87,16 +87,17 @@ func styleSegment(
 	return lipgloss.StyleRanges(base.Render(string(seg)), toStyleRanges(seg, ranges, base)...)
 }
 
-// toStyleRanges converts rune-offset ranges into lipgloss display-cell
-// ranges (1-based), inheriting the base style's attributes under each token
-// style so tokens only override what they set.
+// toStyleRanges converts rune-offset ranges into the display-cell ranges
+// lipgloss.StyleRanges expects: zero-based and half-open over the cells of
+// the ANSI-stripped string. Each token style inherits the base style's
+// attributes so tokens only override what they set.
 func toStyleRanges(seg []rune, ranges []lipgloss.Range, base lipgloss.Style) []lipgloss.Range {
 	out := make([]lipgloss.Range, 0, len(ranges))
 	for _, r := range ranges {
 		startCell := runeDisplayWidth(seg[:r.Start])
 		endCell := startCell + runeDisplayWidth(seg[r.Start:r.End])
 		style := r.Style.Inherit(base)
-		out = append(out, lipgloss.NewRange(startCell+1, endCell+1, style))
+		out = append(out, lipgloss.NewRange(startCell, endCell, style))
 	}
 	return out
 }

--- a/internal/ui/textarea/highlighter.go
+++ b/internal/ui/textarea/highlighter.go
@@ -1,0 +1,111 @@
+package textarea
+
+import (
+	"charm.land/lipgloss/v2"
+	rw "github.com/mattn/go-runewidth"
+)
+
+// LineHighlighter is an optional hook that applies per-token styling to
+// rendered lines. It is consulted once per logical line per render and
+// returns style ranges over the line's runes: range Start (inclusive) and
+// End (exclusive) are rune offsets within the line, and Style is composed
+// with the line's base style by the renderer.
+//
+// The hook runs after wrapping: the textarea asks for ranges on the raw
+// logical line, then intersects those ranges with each wrapped segment at
+// render time. Implementations must therefore return ranges in rune offsets
+// of the logical line they are given — never byte offsets, and never ranges
+// derived from a different string.
+//
+// The cell under the virtual cursor is never styled by ranges: the renderer
+// splits cursor-line content into pre- and post-cursor segments and renders
+// the cursor cell itself separately.
+//
+// Keeping this interface range-based (rather than bubbline's
+// func(string) string ANSI rewriting) means implementations never have to
+// parse or preserve escape sequences, and the textarea's wrap/cursor math
+// always operates on raw runes.
+type LineHighlighter interface {
+	// Highlight returns the style ranges for the given logical line.
+	// lineIdx is the zero-based logical line number; line is the raw rune
+	// content (no trailing newline). Implementations should return nil for
+	// lines with nothing to style.
+	Highlight(lineIdx int, line []rune) []lipgloss.Range
+}
+
+// SetHighlighter installs an optional line highlighter. Pass nil to disable
+// highlighting. The highlighter is consulted at render time only; it does
+// not affect editing, wrapping, or cursor positioning.
+func (m *Model) SetHighlighter(h LineHighlighter) {
+	m.highlighter = h
+}
+
+// highlightRanges returns the highlighter's ranges for a logical line, or
+// nil when no highlighter is installed.
+func (m *Model) highlightRanges(lineIdx int, line []rune) []lipgloss.Range {
+	if m.highlighter == nil {
+		return nil
+	}
+	return m.highlighter.Highlight(lineIdx, line)
+}
+
+// styleSegment renders a wrapped-line segment, applying any highlighter
+// ranges that intersect it. segStart is the rune offset of the segment
+// within its logical line. The cell under the virtual cursor never reaches
+// this function: the renderer splits cursor-line content into pre- and
+// post-cursor segments and renders the cursor cell itself separately, so
+// token styling and cursor styling can never fight over the same cell.
+func styleSegment(
+	base lipgloss.Style,
+	seg []rune,
+	segStart int,
+	lineRanges []lipgloss.Range,
+) string {
+	if len(lineRanges) == 0 || len(seg) == 0 {
+		return base.Render(string(seg))
+	}
+
+	segEnd := segStart + len(seg)
+	var ranges []lipgloss.Range
+	for _, r := range lineRanges {
+		// Intersect the token range with this segment.
+		start := max(r.Start, segStart) - segStart
+		end := min(r.End, segEnd) - segStart
+		if start >= end {
+			continue
+		}
+		ranges = append(ranges, lipgloss.NewRange(start, end, r.Style))
+	}
+
+	if len(ranges) == 0 {
+		return base.Render(string(seg))
+	}
+
+	// StyleRanges composes each range's style over the base-rendered string.
+	// Range offsets are 1-based display cells in lipgloss; map rune offsets
+	// through display widths to stay correct for double-width runes.
+	return lipgloss.StyleRanges(base.Render(string(seg)), toStyleRanges(seg, ranges, base)...)
+}
+
+// toStyleRanges converts rune-offset ranges into lipgloss display-cell
+// ranges (1-based), inheriting the base style's attributes under each token
+// style so tokens only override what they set.
+func toStyleRanges(seg []rune, ranges []lipgloss.Range, base lipgloss.Style) []lipgloss.Range {
+	out := make([]lipgloss.Range, 0, len(ranges))
+	for _, r := range ranges {
+		startCell := runeDisplayWidth(seg[:r.Start])
+		endCell := startCell + runeDisplayWidth(seg[r.Start:r.End])
+		style := r.Style.Inherit(base)
+		out = append(out, lipgloss.NewRange(startCell+1, endCell+1, style))
+	}
+	return out
+}
+
+// runeDisplayWidth returns the total display width of runes.
+func runeDisplayWidth(r []rune) int {
+	w := 0
+	for _, ru := range r {
+		w += rw.RuneWidth(ru)
+	}
+	return w
+}

--- a/internal/ui/textarea/highlighter.go
+++ b/internal/ui/textarea/highlighter.go
@@ -1,0 +1,112 @@
+package textarea
+
+import (
+	"charm.land/lipgloss/v2"
+	rw "github.com/mattn/go-runewidth"
+)
+
+// LineHighlighter is an optional hook that applies per-token styling to
+// rendered lines. It is consulted once per logical line per render and
+// returns style ranges over the line's runes: range Start (inclusive) and
+// End (exclusive) are rune offsets within the line, and Style is composed
+// with the line's base style by the renderer.
+//
+// The hook runs after wrapping: the textarea asks for ranges on the raw
+// logical line, then intersects those ranges with each wrapped segment at
+// render time. Implementations must therefore return ranges in rune offsets
+// of the logical line they are given — never byte offsets, and never ranges
+// derived from a different string.
+//
+// The cell under the virtual cursor is never styled by ranges: the renderer
+// splits cursor-line content into pre- and post-cursor segments and renders
+// the cursor cell itself separately.
+//
+// Keeping this interface range-based (rather than bubbline's
+// func(string) string ANSI rewriting) means implementations never have to
+// parse or preserve escape sequences, and the textarea's wrap/cursor math
+// always operates on raw runes.
+type LineHighlighter interface {
+	// Highlight returns the style ranges for the given logical line.
+	// lineIdx is the zero-based logical line number; line is the raw rune
+	// content (no trailing newline). Implementations should return nil for
+	// lines with nothing to style.
+	Highlight(lineIdx int, line []rune) []lipgloss.Range
+}
+
+// SetHighlighter installs an optional line highlighter. Pass nil to disable
+// highlighting. The highlighter is consulted at render time only; it does
+// not affect editing, wrapping, or cursor positioning.
+func (m *Model) SetHighlighter(h LineHighlighter) {
+	m.highlighter = h
+}
+
+// highlightRanges returns the highlighter's ranges for a logical line, or
+// nil when no highlighter is installed.
+func (m *Model) highlightRanges(lineIdx int, line []rune) []lipgloss.Range {
+	if m.highlighter == nil {
+		return nil
+	}
+	return m.highlighter.Highlight(lineIdx, line)
+}
+
+// styleSegment renders a wrapped-line segment, applying any highlighter
+// ranges that intersect it. segStart is the rune offset of the segment
+// within its logical line. The cell under the virtual cursor never reaches
+// this function: the renderer splits cursor-line content into pre- and
+// post-cursor segments and renders the cursor cell itself separately, so
+// token styling and cursor styling can never fight over the same cell.
+func styleSegment(
+	base lipgloss.Style,
+	seg []rune,
+	segStart int,
+	lineRanges []lipgloss.Range,
+) string {
+	if len(lineRanges) == 0 || len(seg) == 0 {
+		return base.Render(string(seg))
+	}
+
+	segEnd := segStart + len(seg)
+	var ranges []lipgloss.Range
+	for _, r := range lineRanges {
+		// Intersect the token range with this segment.
+		start := max(r.Start, segStart) - segStart
+		end := min(r.End, segEnd) - segStart
+		if start >= end {
+			continue
+		}
+		ranges = append(ranges, lipgloss.NewRange(start, end, r.Style))
+	}
+
+	if len(ranges) == 0 {
+		return base.Render(string(seg))
+	}
+
+	// StyleRanges composes each range's style over the base-rendered string.
+	// Range offsets are 1-based display cells in lipgloss; map rune offsets
+	// through display widths to stay correct for double-width runes.
+	return lipgloss.StyleRanges(base.Render(string(seg)), toStyleRanges(seg, ranges, base)...)
+}
+
+// toStyleRanges converts rune-offset ranges into the display-cell ranges
+// lipgloss.StyleRanges expects: zero-based and half-open over the cells of
+// the ANSI-stripped string. Each token style inherits the base style's
+// attributes so tokens only override what they set.
+func toStyleRanges(seg []rune, ranges []lipgloss.Range, base lipgloss.Style) []lipgloss.Range {
+	out := make([]lipgloss.Range, 0, len(ranges))
+	for _, r := range ranges {
+		startCell := runeDisplayWidth(seg[:r.Start])
+		endCell := startCell + runeDisplayWidth(seg[r.Start:r.End])
+		style := r.Style.Inherit(base)
+		out = append(out, lipgloss.NewRange(startCell, endCell, style))
+	}
+	return out
+}
+
+// runeDisplayWidth returns the total display width of runes.
+func runeDisplayWidth(r []rune) int {
+	w := 0
+	for _, ru := range r {
+		w += rw.RuneWidth(ru)
+	}
+	return w
+}

--- a/internal/ui/textarea/highlighter_test.go
+++ b/internal/ui/textarea/highlighter_test.go
@@ -50,6 +50,38 @@ func TestStyleSegmentAppliesRanges(t *testing.T) {
 	require.Contains(t, ansi.Strip(got), "see @foo.go here")
 }
 
+// TestStyleSegmentStylesExactlyTheToken pins which cells the token style
+// lands on. Regression: the rune-to-cell conversion used to add one, so
+// every token rendered shifted a cell to the right — the trigger character
+// stayed unstyled and the following space picked the style up instead.
+func TestStyleSegmentStylesExactlyTheToken(t *testing.T) {
+	t.Parallel()
+
+	base := lipgloss.NewStyle()
+	tokenStyle := lipgloss.NewStyle().Bold(true)
+
+	seg := []rune("ab @foo cd")
+	got := styleSegment(base, seg, 0, []lipgloss.Range{lipgloss.NewRange(3, 7, tokenStyle)})
+
+	require.Equal(t, "ab \x1b[1m@foo\x1b[m cd", got)
+}
+
+// TestStyleSegmentStylesExactlyTheTokenWideRunes is the same pin with
+// double-width runes ahead of the token, where a rune offset and a cell
+// offset diverge.
+func TestStyleSegmentStylesExactlyTheTokenWideRunes(t *testing.T) {
+	t.Parallel()
+
+	base := lipgloss.NewStyle()
+	tokenStyle := lipgloss.NewStyle().Bold(true)
+
+	// "世界" is two runes but four cells.
+	seg := []rune("世界 @foo")
+	got := styleSegment(base, seg, 0, []lipgloss.Range{lipgloss.NewRange(3, 7, tokenStyle)})
+
+	require.Equal(t, "世界 \x1b[1m@foo\x1b[m", got)
+}
+
 func TestStyleSegmentOffsetsBySegStart(t *testing.T) {
 	t.Parallel()
 	base := lipgloss.NewStyle()

--- a/internal/ui/textarea/highlighter_test.go
+++ b/internal/ui/textarea/highlighter_test.go
@@ -1,0 +1,176 @@
+package textarea
+
+import (
+	"strings"
+	"testing"
+
+	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/stretchr/testify/require"
+)
+
+// tokenHighlighter is a test LineHighlighter that marks every "@"-prefixed
+// word with a fixed style.
+type tokenHighlighter struct {
+	style lipgloss.Style
+}
+
+func (h tokenHighlighter) Highlight(_ int, line []rune) []lipgloss.Range {
+	var ranges []lipgloss.Range
+	i := 0
+	for i < len(line) {
+		if line[i] == '@' {
+			end := i + 1
+			for end < len(line) && line[end] != ' ' {
+				end++
+			}
+			ranges = append(ranges, lipgloss.NewRange(i, end, h.style))
+			i = end
+			continue
+		}
+		i++
+	}
+	return ranges
+}
+
+func TestStyleSegmentAppliesRanges(t *testing.T) {
+	t.Parallel()
+
+	base := lipgloss.NewStyle()
+	tokenStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("2"))
+
+	seg := []rune("see @foo.go here")
+	ranges := []lipgloss.Range{lipgloss.NewRange(4, 11, tokenStyle)}
+
+	got := styleSegment(base, seg, 0, ranges)
+
+	// The rendered segment must differ from the plain render and the token
+	// text must survive styling.
+	require.NotEqual(t, base.Render(string(seg)), got)
+	require.Contains(t, ansi.Strip(got), "see @foo.go here")
+}
+
+// TestStyleSegmentStylesExactlyTheToken pins which cells the token style
+// lands on. Regression: the rune-to-cell conversion used to add one, so
+// every token rendered shifted a cell to the right — the trigger character
+// stayed unstyled and the following space picked the style up instead.
+func TestStyleSegmentStylesExactlyTheToken(t *testing.T) {
+	t.Parallel()
+
+	base := lipgloss.NewStyle()
+	tokenStyle := lipgloss.NewStyle().Bold(true)
+
+	seg := []rune("ab @foo cd")
+	got := styleSegment(base, seg, 0, []lipgloss.Range{lipgloss.NewRange(3, 7, tokenStyle)})
+
+	require.Equal(t, "ab \x1b[1m@foo\x1b[m cd", got)
+}
+
+// TestStyleSegmentStylesExactlyTheTokenWideRunes is the same pin with
+// double-width runes ahead of the token, where a rune offset and a cell
+// offset diverge.
+func TestStyleSegmentStylesExactlyTheTokenWideRunes(t *testing.T) {
+	t.Parallel()
+
+	base := lipgloss.NewStyle()
+	tokenStyle := lipgloss.NewStyle().Bold(true)
+
+	// "世界" is two runes but four cells.
+	seg := []rune("世界 @foo")
+	got := styleSegment(base, seg, 0, []lipgloss.Range{lipgloss.NewRange(3, 7, tokenStyle)})
+
+	require.Equal(t, "世界 \x1b[1m@foo\x1b[m", got)
+}
+
+func TestStyleSegmentOffsetsBySegStart(t *testing.T) {
+	t.Parallel()
+	base := lipgloss.NewStyle()
+	tokenStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("2"))
+
+	// Logical line: "see @foo.go here", wrapped segment is "foo.go here"
+	// starting at rune 7. The token range (4,11) intersects as (0,4).
+	seg := []rune("foo.go here")
+	ranges := []lipgloss.Range{lipgloss.NewRange(4, 11, tokenStyle)}
+
+	got := styleSegment(base, seg, 7, ranges)
+	require.Contains(t, ansi.Strip(got), "foo.go here")
+	require.NotEqual(t, base.Render(string(seg)), got)
+}
+
+func TestStyleSegmentNoRangesIsPlainRender(t *testing.T) {
+	t.Parallel()
+
+	base := lipgloss.NewStyle()
+	seg := []rune("plain text")
+
+	require.Equal(t, base.Render(string(seg)), styleSegment(base, seg, 0, nil))
+	require.Equal(t, base.Render(string(seg)), styleSegment(base, seg, 0, []lipgloss.Range{
+		lipgloss.NewRange(50, 60, lipgloss.NewStyle().Bold(true)), // outside segment
+	}))
+}
+
+func TestViewWithHighlighterStylesTokens(t *testing.T) {
+	t.Parallel()
+	m := New()
+	m.SetValue("see @foo.go and @bar.md")
+	m.SetWidth(80)
+	m.SetHighlighter(tokenHighlighter{style: lipgloss.NewStyle().Foreground(lipgloss.Color("2"))})
+
+	plain := New()
+	plain.SetValue("see @foo.go and @bar.md")
+	plain.SetWidth(80)
+
+	highlighted := m.View()
+	require.NotEqual(t, plain.View(), highlighted, "highlighter should change the rendered view")
+	// Content must survive styling: stripping ANSI yields the same text.
+	require.Equal(t, ansi.Strip(plain.View()), ansi.Strip(highlighted))
+}
+
+func TestViewWithoutHighlighterUnchanged(t *testing.T) {
+	t.Parallel()
+
+	m := New()
+	m.SetValue("see @foo.go")
+	m.SetWidth(80)
+
+	before := m.View()
+	m.SetHighlighter(nil)
+	require.Equal(t, before, m.View())
+}
+
+func TestViewHighlighterOnCursorLine(t *testing.T) {
+	t.Parallel()
+	m := New()
+	m.Focus()
+	m.SetValue("go @foo.go now")
+	m.SetWidth(80)
+	m.SetHighlighter(tokenHighlighter{style: lipgloss.NewStyle().Foreground(lipgloss.Color("2"))})
+
+	// Move cursor into the middle of the token to exercise the
+	// pre/post-cursor split paths.
+	m.SetCursorColumn(5)
+
+	highlighted := m.View()
+	// Cursor-line rendering must not corrupt content.
+	require.Contains(t, ansi.Strip(highlighted), "go @foo.go now")
+}
+
+func TestViewHighlighterTokenSurvivesWrap(t *testing.T) {
+	t.Parallel()
+	m := New()
+	// Force a wrap inside the second word region: width 10 wraps
+	// "ab @longtoken cd" into multiple segments.
+	m.SetValue("ab @longtoken cd")
+	m.SetWidth(10)
+	m.SetHeight(6)
+	m.SetHighlighter(tokenHighlighter{style: lipgloss.NewStyle().Foreground(lipgloss.Color("2"))})
+
+	highlighted := m.View()
+	stripped := ansi.Strip(highlighted)
+	// All token characters still render after wrapping + styling (the wrap
+	// splits the token across segments; assert on the wrap chunks).
+	for _, part := range []string{"ab", "@lon", "gtok", "en", "cd"} {
+		require.Contains(t, stripped, part)
+	}
+	require.True(t, strings.Contains(highlighted, "\x1b["), "expected ANSI styling in output")
+}

--- a/internal/ui/textarea/highlighter_test.go
+++ b/internal/ui/textarea/highlighter_test.go
@@ -1,0 +1,144 @@
+package textarea
+
+import (
+	"strings"
+	"testing"
+
+	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/stretchr/testify/require"
+)
+
+// tokenHighlighter is a test LineHighlighter that marks every "@"-prefixed
+// word with a fixed style.
+type tokenHighlighter struct {
+	style lipgloss.Style
+}
+
+func (h tokenHighlighter) Highlight(_ int, line []rune) []lipgloss.Range {
+	var ranges []lipgloss.Range
+	i := 0
+	for i < len(line) {
+		if line[i] == '@' {
+			end := i + 1
+			for end < len(line) && line[end] != ' ' {
+				end++
+			}
+			ranges = append(ranges, lipgloss.NewRange(i, end, h.style))
+			i = end
+			continue
+		}
+		i++
+	}
+	return ranges
+}
+
+func TestStyleSegmentAppliesRanges(t *testing.T) {
+	t.Parallel()
+
+	base := lipgloss.NewStyle()
+	tokenStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("2"))
+
+	seg := []rune("see @foo.go here")
+	ranges := []lipgloss.Range{lipgloss.NewRange(4, 11, tokenStyle)}
+
+	got := styleSegment(base, seg, 0, ranges)
+
+	// The rendered segment must differ from the plain render and the token
+	// text must survive styling.
+	require.NotEqual(t, base.Render(string(seg)), got)
+	require.Contains(t, ansi.Strip(got), "see @foo.go here")
+}
+
+func TestStyleSegmentOffsetsBySegStart(t *testing.T) {
+	t.Parallel()
+	base := lipgloss.NewStyle()
+	tokenStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("2"))
+
+	// Logical line: "see @foo.go here", wrapped segment is "foo.go here"
+	// starting at rune 7. The token range (4,11) intersects as (0,4).
+	seg := []rune("foo.go here")
+	ranges := []lipgloss.Range{lipgloss.NewRange(4, 11, tokenStyle)}
+
+	got := styleSegment(base, seg, 7, ranges)
+	require.Contains(t, ansi.Strip(got), "foo.go here")
+	require.NotEqual(t, base.Render(string(seg)), got)
+}
+
+func TestStyleSegmentNoRangesIsPlainRender(t *testing.T) {
+	t.Parallel()
+
+	base := lipgloss.NewStyle()
+	seg := []rune("plain text")
+
+	require.Equal(t, base.Render(string(seg)), styleSegment(base, seg, 0, nil))
+	require.Equal(t, base.Render(string(seg)), styleSegment(base, seg, 0, []lipgloss.Range{
+		lipgloss.NewRange(50, 60, lipgloss.NewStyle().Bold(true)), // outside segment
+	}))
+}
+
+func TestViewWithHighlighterStylesTokens(t *testing.T) {
+	t.Parallel()
+	m := New()
+	m.SetValue("see @foo.go and @bar.md")
+	m.SetWidth(80)
+	m.SetHighlighter(tokenHighlighter{style: lipgloss.NewStyle().Foreground(lipgloss.Color("2"))})
+
+	plain := New()
+	plain.SetValue("see @foo.go and @bar.md")
+	plain.SetWidth(80)
+
+	highlighted := m.View()
+	require.NotEqual(t, plain.View(), highlighted, "highlighter should change the rendered view")
+	// Content must survive styling: stripping ANSI yields the same text.
+	require.Equal(t, ansi.Strip(plain.View()), ansi.Strip(highlighted))
+}
+
+func TestViewWithoutHighlighterUnchanged(t *testing.T) {
+	t.Parallel()
+
+	m := New()
+	m.SetValue("see @foo.go")
+	m.SetWidth(80)
+
+	before := m.View()
+	m.SetHighlighter(nil)
+	require.Equal(t, before, m.View())
+}
+
+func TestViewHighlighterOnCursorLine(t *testing.T) {
+	t.Parallel()
+	m := New()
+	m.Focus()
+	m.SetValue("go @foo.go now")
+	m.SetWidth(80)
+	m.SetHighlighter(tokenHighlighter{style: lipgloss.NewStyle().Foreground(lipgloss.Color("2"))})
+
+	// Move cursor into the middle of the token to exercise the
+	// pre/post-cursor split paths.
+	m.SetCursorColumn(5)
+
+	highlighted := m.View()
+	// Cursor-line rendering must not corrupt content.
+	require.Contains(t, ansi.Strip(highlighted), "go @foo.go now")
+}
+
+func TestViewHighlighterTokenSurvivesWrap(t *testing.T) {
+	t.Parallel()
+	m := New()
+	// Force a wrap inside the second word region: width 10 wraps
+	// "ab @longtoken cd" into multiple segments.
+	m.SetValue("ab @longtoken cd")
+	m.SetWidth(10)
+	m.SetHeight(6)
+	m.SetHighlighter(tokenHighlighter{style: lipgloss.NewStyle().Foreground(lipgloss.Color("2"))})
+
+	highlighted := m.View()
+	stripped := ansi.Strip(highlighted)
+	// All token characters still render after wrapping + styling (the wrap
+	// splits the token across segments; assert on the wrap chunks).
+	for _, part := range []string{"ab", "@lon", "gtok", "en", "cd"} {
+		require.Contains(t, stripped, part)
+	}
+	require.True(t, strings.Contains(highlighted, "\x1b["), "expected ANSI styling in output")
+}

--- a/internal/ui/textarea/internal/memoization/memoization.go
+++ b/internal/ui/textarea/internal/memoization/memoization.go
@@ -1,0 +1,125 @@
+// Package memoization implement a simple memoization cache. It's designed to
+// improve performance in textarea.
+package memoization
+
+import (
+	"container/list"
+	"crypto/sha256"
+	"fmt"
+	"sync"
+)
+
+// Hasher is an interface that requires a Hash method. The Hash method is
+// expected to return a string representation of the hash of the object.
+type Hasher interface {
+	Hash() string
+}
+
+// entry is a struct that holds a key-value pair. It is used as an element
+// in the evictionList of the MemoCache.
+type entry[T any] struct {
+	key   string
+	value T
+}
+
+// MemoCache is a struct that represents a cache with a set capacity. It
+// uses an LRU (Least Recently Used) eviction policy. It is safe for
+// concurrent use.
+type MemoCache[H Hasher, T any] struct {
+	capacity      int
+	mutex         sync.Mutex
+	cache         map[string]*list.Element // The cache holding the results
+	evictionList  *list.List               // A list to keep track of the order for LRU
+	hashableItems map[string]T             // This map keeps track of the original hashable items (optional)
+}
+
+// NewMemoCache is a function that creates a new MemoCache with a given
+// capacity. It returns a pointer to the created MemoCache.
+func NewMemoCache[H Hasher, T any](capacity int) *MemoCache[H, T] {
+	return &MemoCache[H, T]{
+		capacity:      capacity,
+		cache:         make(map[string]*list.Element),
+		evictionList:  list.New(),
+		hashableItems: make(map[string]T),
+	}
+}
+
+// Capacity is a method that returns the capacity of the MemoCache.
+func (m *MemoCache[H, T]) Capacity() int {
+	return m.capacity
+}
+
+// Size is a method that returns the current size of the MemoCache. It is
+// the number of items currently stored in the cache.
+func (m *MemoCache[H, T]) Size() int {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	return m.evictionList.Len()
+}
+
+// Get is a method that returns the value associated with the given
+// hashable item in the MemoCache. If there is no corresponding value, the
+// method returns nil.
+func (m *MemoCache[H, T]) Get(h H) (T, bool) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	hashedKey := h.Hash()
+	if element, found := m.cache[hashedKey]; found {
+		m.evictionList.MoveToFront(element)
+		return element.Value.(*entry[T]).value, true
+	}
+	var result T
+	return result, false
+}
+
+// Set is a method that sets the value for the given hashable item in the
+// MemoCache. If the cache is at capacity, it evicts the least recently
+// used item before adding the new item.
+func (m *MemoCache[H, T]) Set(h H, value T) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	hashedKey := h.Hash()
+	if element, found := m.cache[hashedKey]; found {
+		m.evictionList.MoveToFront(element)
+		element.Value.(*entry[T]).value = value
+		return
+	}
+
+	// Check if the cache is at capacity
+	if m.evictionList.Len() >= m.capacity {
+		// Evict the least recently used item from the cache
+		toEvict := m.evictionList.Back()
+		if toEvict != nil {
+			evictedEntry := m.evictionList.Remove(toEvict).(*entry[T])
+			delete(m.cache, evictedEntry.key)
+			delete(m.hashableItems, evictedEntry.key) // if you're keeping track of original items
+		}
+	}
+
+	// Add the value to the cache and the evictionList
+	newEntry := &entry[T]{
+		key:   hashedKey,
+		value: value,
+	}
+	element := m.evictionList.PushFront(newEntry)
+	m.cache[hashedKey] = element
+	m.hashableItems[hashedKey] = value // if you're keeping track of original items
+}
+
+// HString is a type that implements the Hasher interface for strings.
+type HString string
+
+// Hash is a method that returns the hash of the string.
+func (h HString) Hash() string {
+	return fmt.Sprintf("%x", sha256.Sum256([]byte(h)))
+}
+
+// HInt is a type that implements the Hasher interface for integers.
+type HInt int
+
+// Hash is a method that returns the hash of the integer.
+func (h HInt) Hash() string {
+	return fmt.Sprintf("%x", sha256.Sum256(fmt.Appendf(nil, "%d", h)))
+}

--- a/internal/ui/textarea/internal/runeutil/runeutil.go
+++ b/internal/ui/textarea/internal/runeutil/runeutil.go
@@ -1,0 +1,102 @@
+// Package runeutil provides utility functions for tidying up incoming runes
+// from Key messages.
+package runeutil
+
+import (
+	"unicode"
+	"unicode/utf8"
+)
+
+// Sanitizer is a helper for bubble widgets that want to process
+// Runes from input key messages.
+type Sanitizer interface {
+	// Sanitize removes control characters from runes in a KeyRunes
+	// message, and optionally replaces newline/carriage return/tabs by a
+	// specified character.
+	//
+	// The rune array is modified in-place if possible. In that case, the
+	// returned slice is the original slice shortened after the control
+	// characters have been removed/translated.
+	Sanitize(runes []rune) []rune
+}
+
+// NewSanitizer constructs a rune sanitizer.
+func NewSanitizer(opts ...Option) Sanitizer {
+	s := sanitizer{
+		replaceNewLine: []rune("\n"),
+		replaceTab:     []rune("    "),
+	}
+	for _, o := range opts {
+		s = o(s)
+	}
+	return &s
+}
+
+// Option is the type of option that can be passed to Sanitize().
+type Option func(sanitizer) sanitizer
+
+// ReplaceTabs replaces tabs by the specified string.
+func ReplaceTabs(tabRepl string) Option {
+	return func(s sanitizer) sanitizer {
+		s.replaceTab = []rune(tabRepl)
+		return s
+	}
+}
+
+// ReplaceNewlines replaces newline characters by the specified string.
+func ReplaceNewlines(nlRepl string) Option {
+	return func(s sanitizer) sanitizer {
+		s.replaceNewLine = []rune(nlRepl)
+		return s
+	}
+}
+
+func (s *sanitizer) Sanitize(runes []rune) []rune {
+	// dstrunes are where we are storing the result.
+	dstrunes := runes[:0:len(runes)]
+	// copied indicates whether dstrunes is an alias of runes
+	// or a copy. We need a copy when dst moves past src.
+	// We use this as an optimization to avoid allocating
+	// a new rune slice in the common case where the output
+	// is smaller or equal to the input.
+	copied := false
+
+	for src := range runes {
+		r := runes[src]
+		switch {
+		case r == utf8.RuneError:
+			// skip
+
+		case r == '\r' || r == '\n':
+			if len(dstrunes)+len(s.replaceNewLine) > src && !copied {
+				dst := len(dstrunes)
+				dstrunes = make([]rune, dst, len(runes)+len(s.replaceNewLine))
+				copy(dstrunes, runes[:dst])
+				copied = true
+			}
+			dstrunes = append(dstrunes, s.replaceNewLine...)
+
+		case r == '\t':
+			if len(dstrunes)+len(s.replaceTab) > src && !copied {
+				dst := len(dstrunes)
+				dstrunes = make([]rune, dst, len(runes)+len(s.replaceTab))
+				copy(dstrunes, runes[:dst])
+				copied = true
+			}
+			dstrunes = append(dstrunes, s.replaceTab...)
+
+		case unicode.IsControl(r):
+			// Other control characters: skip.
+
+		default:
+			// Keep the character.
+			dstrunes = append(dstrunes, runes[src])
+		}
+	}
+	return dstrunes
+}
+
+type sanitizer struct {
+	replaceNewLine []rune
+	replaceTab     []rune
+}

--- a/internal/ui/textarea/textarea.go
+++ b/internal/ui/textarea/textarea.go
@@ -1,0 +1,1923 @@
+// This file is vendored from charm.land/bubbles/v2/textarea (MIT License,
+// Copyright (c) 2020-2026 Charmbracelet, Inc.) with local modifications:
+//
+//   - Internal imports rewritten to the vendored copies under
+//     internal/ui/textarea/internal/.
+//   - Adds an optional line Highlighter hook (see highlighter.go) that lets
+//     callers apply per-token styling (e.g. @file and /skill mentions) to
+//     rendered lines without forking the render loop.
+//
+// Package textarea provides a multi-line text input component for Bubble Tea
+// applications.
+package textarea
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"image/color"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
+	"unicode"
+
+	"charm.land/bubbles/v2/cursor"
+	"charm.land/bubbles/v2/key"
+	"charm.land/bubbles/v2/viewport"
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+	"github.com/atotto/clipboard"
+	"github.com/charmbracelet/crush/internal/ui/textarea/internal/memoization"
+	"github.com/charmbracelet/crush/internal/ui/textarea/internal/runeutil"
+	"github.com/charmbracelet/x/ansi"
+	rw "github.com/mattn/go-runewidth"
+	"github.com/rivo/uniseg"
+)
+
+const (
+	minHeight        = 1
+	defaultHeight    = 6
+	defaultWidth     = 40
+	defaultCharLimit = 0 // no limit
+	defaultMaxHeight = 99
+	defaultMaxWidth  = 500
+
+	// XXX: in v2, make max lines dynamic and default max lines configurable.
+	maxLines = 10000
+)
+
+// Internal messages for clipboard operations.
+type (
+	pasteMsg    string
+	pasteErrMsg struct{ error }
+)
+
+// KeyMap is the key bindings for different actions within the textarea.
+type KeyMap struct {
+	CharacterBackward       key.Binding
+	CharacterForward        key.Binding
+	DeleteAfterCursor       key.Binding
+	DeleteBeforeCursor      key.Binding
+	DeleteCharacterBackward key.Binding
+	DeleteCharacterForward  key.Binding
+	DeleteWordBackward      key.Binding
+	DeleteWordForward       key.Binding
+	InsertNewline           key.Binding
+	LineEnd                 key.Binding
+	LineNext                key.Binding
+	LinePrevious            key.Binding
+	LineStart               key.Binding
+	PageUp                  key.Binding
+	PageDown                key.Binding
+	Paste                   key.Binding
+	WordBackward            key.Binding
+	WordForward             key.Binding
+	InputBegin              key.Binding
+	InputEnd                key.Binding
+
+	UppercaseWordForward  key.Binding
+	LowercaseWordForward  key.Binding
+	CapitalizeWordForward key.Binding
+
+	TransposeCharacterBackward key.Binding
+}
+
+// DefaultKeyMap returns the default set of key bindings for navigating and acting
+// upon the textarea.
+func DefaultKeyMap() KeyMap {
+	return KeyMap{
+		CharacterForward:        key.NewBinding(key.WithKeys("right", "ctrl+f"), key.WithHelp("right", "character forward")),
+		CharacterBackward:       key.NewBinding(key.WithKeys("left", "ctrl+b"), key.WithHelp("left", "character backward")),
+		WordForward:             key.NewBinding(key.WithKeys("alt+right", "alt+f"), key.WithHelp("alt+right", "word forward")),
+		WordBackward:            key.NewBinding(key.WithKeys("alt+left", "alt+b"), key.WithHelp("alt+left", "word backward")),
+		LineNext:                key.NewBinding(key.WithKeys("down", "ctrl+n"), key.WithHelp("down", "next line")),
+		LinePrevious:            key.NewBinding(key.WithKeys("up", "ctrl+p"), key.WithHelp("up", "previous line")),
+		DeleteWordBackward:      key.NewBinding(key.WithKeys("alt+backspace", "ctrl+w"), key.WithHelp("alt+backspace", "delete word backward")),
+		DeleteWordForward:       key.NewBinding(key.WithKeys("alt+delete", "alt+d"), key.WithHelp("alt+delete", "delete word forward")),
+		DeleteAfterCursor:       key.NewBinding(key.WithKeys("ctrl+k"), key.WithHelp("ctrl+k", "delete after cursor")),
+		DeleteBeforeCursor:      key.NewBinding(key.WithKeys("ctrl+u"), key.WithHelp("ctrl+u", "delete before cursor")),
+		InsertNewline:           key.NewBinding(key.WithKeys("enter", "ctrl+m"), key.WithHelp("enter", "insert newline")),
+		DeleteCharacterBackward: key.NewBinding(key.WithKeys("backspace", "ctrl+h"), key.WithHelp("backspace", "delete character backward")),
+		DeleteCharacterForward:  key.NewBinding(key.WithKeys("delete", "ctrl+d"), key.WithHelp("delete", "delete character forward")),
+		LineStart:               key.NewBinding(key.WithKeys("home", "ctrl+a"), key.WithHelp("home", "line start")),
+		LineEnd:                 key.NewBinding(key.WithKeys("end", "ctrl+e"), key.WithHelp("end", "line end")),
+		PageUp:                  key.NewBinding(key.WithKeys("pgup"), key.WithHelp("pgup", "page up")),
+		PageDown:                key.NewBinding(key.WithKeys("pgdown"), key.WithHelp("pgdown", "page down")),
+		Paste:                   key.NewBinding(key.WithKeys("ctrl+v"), key.WithHelp("ctrl+v", "paste")),
+		InputBegin:              key.NewBinding(key.WithKeys("alt+<", "ctrl+home"), key.WithHelp("alt+<", "input begin")),
+		InputEnd:                key.NewBinding(key.WithKeys("alt+>", "ctrl+end"), key.WithHelp("alt+>", "input end")),
+
+		CapitalizeWordForward: key.NewBinding(key.WithKeys("alt+c"), key.WithHelp("alt+c", "capitalize word forward")),
+		LowercaseWordForward:  key.NewBinding(key.WithKeys("alt+l"), key.WithHelp("alt+l", "lowercase word forward")),
+		UppercaseWordForward:  key.NewBinding(key.WithKeys("alt+u"), key.WithHelp("alt+u", "uppercase word forward")),
+
+		TransposeCharacterBackward: key.NewBinding(key.WithKeys("ctrl+t"), key.WithHelp("ctrl+t", "transpose character backward")),
+	}
+}
+
+// LineInfo is a helper for keeping track of line information regarding
+// soft-wrapped lines.
+type LineInfo struct {
+	// Width is the number of columns in the line.
+	Width int
+
+	// CharWidth is the number of characters in the line to account for
+	// double-width runes.
+	CharWidth int
+
+	// Height is the number of rows in the line.
+	Height int
+
+	// StartColumn is the index of the first column of the line.
+	StartColumn int
+
+	// ColumnOffset is the number of columns that the cursor is offset from the
+	// start of the line.
+	ColumnOffset int
+
+	// RowOffset is the number of rows that the cursor is offset from the start
+	// of the line.
+	RowOffset int
+
+	// CharOffset is the number of characters that the cursor is offset
+	// from the start of the line. This will generally be equivalent to
+	// ColumnOffset, but will be different there are double-width runes before
+	// the cursor.
+	CharOffset int
+}
+
+// PromptInfo is a struct that can be used to store information about the
+// prompt.
+type PromptInfo struct {
+	LineNumber int
+	Focused    bool
+}
+
+// CursorStyle is the style for real and virtual cursors.
+type CursorStyle struct {
+	// Style styles the cursor block.
+	//
+	// For real cursors, the foreground color set here will be used as the
+	// cursor color.
+	Color color.Color
+
+	// Shape is the cursor shape. The following shapes are available:
+	//
+	// - tea.CursorBlock
+	// - tea.CursorUnderline
+	// - tea.CursorBar
+	//
+	// This is only used for real cursors.
+	Shape tea.CursorShape
+
+	// CursorBlink determines whether or not the cursor should blink.
+	Blink bool
+
+	// BlinkSpeed is the speed at which the virtual cursor blinks. This has no
+	// effect on real cursors as well as no effect if the cursor is set not to
+	// [CursorBlink].
+	//
+	// By default, the blink speed is set to about 500ms.
+	BlinkSpeed time.Duration
+}
+
+// Styles are the styles for the textarea, separated into focused and blurred
+// states. The appropriate styles will be chosen based on the focus state of
+// the textarea.
+type Styles struct {
+	Focused StyleState
+	Blurred StyleState
+	Cursor  CursorStyle
+}
+
+// StyleState that will be applied to the text area.
+//
+// StyleState can be applied to focused and unfocused states to change the styles
+// depending on the focus state.
+//
+// For an introduction to styling with Lip Gloss see:
+// https://github.com/charmbracelet/lipgloss
+type StyleState struct {
+	Base             lipgloss.Style
+	Text             lipgloss.Style
+	LineNumber       lipgloss.Style
+	CursorLineNumber lipgloss.Style
+	CursorLine       lipgloss.Style
+	EndOfBuffer      lipgloss.Style
+	Placeholder      lipgloss.Style
+	Prompt           lipgloss.Style
+}
+
+func (s StyleState) computedCursorLine() lipgloss.Style {
+	return s.CursorLine.Inherit(s.Base).Inline(true)
+}
+
+func (s StyleState) computedCursorLineNumber() lipgloss.Style {
+	return s.CursorLineNumber.
+		Inherit(s.CursorLine).
+		Inherit(s.Base).
+		Inline(true)
+}
+
+func (s StyleState) computedEndOfBuffer() lipgloss.Style {
+	return s.EndOfBuffer.Inherit(s.Base).Inline(true)
+}
+
+func (s StyleState) computedLineNumber() lipgloss.Style {
+	return s.LineNumber.Inherit(s.Base).Inline(true)
+}
+
+func (s StyleState) computedPlaceholder() lipgloss.Style {
+	return s.Placeholder.Inherit(s.Base).Inline(true)
+}
+
+func (s StyleState) computedPrompt() lipgloss.Style {
+	return s.Prompt.Inherit(s.Base).Inline(true)
+}
+
+func (s StyleState) computedText() lipgloss.Style {
+	return s.Text.Inherit(s.Base).Inline(true)
+}
+
+// line is the input to the text wrapping function. This is stored in a struct
+// so that it can be hashed and memoized.
+type line struct {
+	runes []rune
+	width int
+}
+
+// Hash returns a hash of the line.
+func (w line) Hash() string {
+	v := fmt.Sprintf("%s:%d", string(w.runes), w.width)
+	return fmt.Sprintf("%x", sha256.Sum256([]byte(v)))
+}
+
+// Model is the Bubble Tea model for this text area element.
+type Model struct {
+	Err error
+
+	// General settings.
+	cache *memoization.MemoCache[line, [][]rune]
+
+	// Prompt is printed at the beginning of each line.
+	//
+	// When changing the value of Prompt after the model has been
+	// initialized, ensure that SetWidth() gets called afterwards.
+	//
+	// See also [SetPromptFunc] for a dynamic prompt.
+	Prompt string
+
+	// Placeholder is the text displayed when the user
+	// hasn't entered anything yet.
+	Placeholder string
+
+	// ShowLineNumbers, if enabled, causes line numbers to be printed
+	// after the prompt.
+	ShowLineNumbers bool
+
+	// EndOfBufferCharacter is displayed at the end of the input.
+	EndOfBufferCharacter rune
+
+	// KeyMap encodes the keybindings recognized by the widget.
+	KeyMap KeyMap
+
+	// virtualCursor manages the virtual cursor.
+	virtualCursor cursor.Model
+
+	// CharLimit is the maximum number of characters this input element will
+	// accept. If 0 or less, there's no limit.
+	CharLimit int
+
+	// MaxHeight is the maximum height of the text area in rows. If 0 or less,
+	// there's no limit.
+	MaxHeight int
+
+	// MaxWidth is the maximum width of the text area in columns. If 0 or less,
+	// there's no limit.
+	MaxWidth int
+
+	// DynamicHeight, when true, causes the textarea to automatically grow
+	// and shrink its height to fit the content. The height is clamped between
+	// MinHeight and MaxHeight.
+	DynamicHeight bool
+
+	// MinHeight is the minimum height of the text area in rows when
+	// DynamicHeight is enabled. If 0 or less, defaults to 1.
+	MinHeight int
+
+	// MaxContentHeight is the maximum content height in visual rows
+	// (accounting for soft wraps). When set (> 0), input is blocked once
+	// the total visual lines reach this limit, while MaxHeight controls
+	// only the visible viewport height. When 0, the content guard falls
+	// back to the legacy MaxHeight behavior (blocking at MaxHeight
+	// logical lines) for backward compatibility.
+	MaxContentHeight int
+
+	// Styling. Styles are defined in [Styles]. Use [SetStyles] and [GetStyles]
+	// to work with this value publicly.
+	styles Styles
+
+	// useVirtualCursor determines whether or not to use the virtual cursor.
+	// Use [SetVirtualCursor] and [VirtualCursor] to work with this this
+	// value publicly.
+	useVirtualCursor bool
+
+	// If promptFunc is set, it replaces Prompt as a generator for
+	// prompt strings at the beginning of each line.
+	promptFunc func(PromptInfo) string
+
+	// promptWidth is the width of the prompt.
+	promptWidth int
+
+	// width is the maximum number of characters that can be displayed at once.
+	// If 0 or less this setting is ignored.
+	width int
+
+	// height is the maximum number of lines that can be displayed at once. It
+	// essentially treats the text field like a vertically scrolling viewport
+	// if there are more lines than the permitted height.
+	height int
+
+	// Underlying text value.
+	value [][]rune
+
+	// focus indicates whether user input focus should be on this input
+	// component. When false, ignore keyboard input and hide the cursor.
+	focus bool
+
+	// Cursor column.
+	col int
+
+	// Cursor row.
+	row int
+
+	// Last character offset, used to maintain state when the cursor is moved
+	// vertically such that we can maintain the same navigating position.
+	lastCharOffset int
+
+	// viewport is the vertically-scrollable viewport of the multi-line text
+	// input.
+	viewport *viewport.Model
+
+	// rune sanitizer for input.
+	rsan runeutil.Sanitizer
+
+	// highlighter is the optional per-line token highlighter installed via
+	// SetHighlighter. Consulted at render time only.
+	highlighter LineHighlighter
+}
+
+// New creates a new model with default settings.
+func New() Model {
+	vp := viewport.New()
+	vp.KeyMap = viewport.KeyMap{}
+	cur := cursor.New()
+
+	styles := DefaultDarkStyles()
+
+	m := Model{
+		CharLimit:            defaultCharLimit,
+		MaxHeight:            defaultMaxHeight,
+		MaxWidth:             defaultMaxWidth,
+		Prompt:               lipgloss.ThickBorder().Left + " ",
+		styles:               styles,
+		cache:                memoization.NewMemoCache[line, [][]rune](maxLines),
+		EndOfBufferCharacter: ' ',
+		ShowLineNumbers:      true,
+		useVirtualCursor:     true,
+		virtualCursor:        cur,
+		KeyMap:               DefaultKeyMap(),
+
+		value: make([][]rune, minHeight, maxLines),
+		focus: false,
+		col:   0,
+		row:   0,
+
+		viewport: &vp,
+	}
+
+	m.SetHeight(defaultHeight)
+	m.SetWidth(defaultWidth)
+
+	return m
+}
+
+// DefaultStyles returns the default styles for focused and blurred states for
+// the textarea.
+func DefaultStyles(isDark bool) Styles {
+	lightDark := lipgloss.LightDark(isDark)
+
+	var s Styles
+	s.Focused = StyleState{
+		Base:             lipgloss.NewStyle(),
+		CursorLine:       lipgloss.NewStyle().Background(lightDark(lipgloss.Color("255"), lipgloss.Color("0"))),
+		CursorLineNumber: lipgloss.NewStyle().Foreground(lightDark(lipgloss.Color("240"), lipgloss.Color("240"))),
+		EndOfBuffer:      lipgloss.NewStyle().Foreground(lightDark(lipgloss.Color("254"), lipgloss.Color("0"))),
+		LineNumber:       lipgloss.NewStyle().Foreground(lightDark(lipgloss.Color("249"), lipgloss.Color("7"))),
+		Placeholder:      lipgloss.NewStyle().Foreground(lipgloss.Color("240")),
+		Prompt:           lipgloss.NewStyle().Foreground(lipgloss.Color("7")),
+		Text:             lipgloss.NewStyle(),
+	}
+	s.Blurred = StyleState{
+		Base:             lipgloss.NewStyle(),
+		CursorLine:       lipgloss.NewStyle().Foreground(lightDark(lipgloss.Color("245"), lipgloss.Color("7"))),
+		CursorLineNumber: lipgloss.NewStyle().Foreground(lightDark(lipgloss.Color("249"), lipgloss.Color("7"))),
+		EndOfBuffer:      lipgloss.NewStyle().Foreground(lightDark(lipgloss.Color("254"), lipgloss.Color("0"))),
+		LineNumber:       lipgloss.NewStyle().Foreground(lightDark(lipgloss.Color("249"), lipgloss.Color("7"))),
+		Placeholder:      lipgloss.NewStyle().Foreground(lipgloss.Color("240")),
+		Prompt:           lipgloss.NewStyle().Foreground(lipgloss.Color("7")),
+		Text:             lipgloss.NewStyle().Foreground(lightDark(lipgloss.Color("245"), lipgloss.Color("7"))),
+	}
+	s.Cursor = CursorStyle{
+		Color: lipgloss.Color("7"),
+		Shape: tea.CursorBlock,
+		Blink: true,
+	}
+	return s
+}
+
+// DefaultLightStyles returns the default styles for a light background.
+func DefaultLightStyles() Styles {
+	return DefaultStyles(false)
+}
+
+// DefaultDarkStyles returns the default styles for a dark background.
+func DefaultDarkStyles() Styles {
+	return DefaultStyles(true)
+}
+
+// Styles returns the current styles for the textarea.
+func (m Model) Styles() Styles {
+	return m.styles
+}
+
+// SetStyles updates styling for the textarea.
+func (m *Model) SetStyles(s Styles) {
+	m.styles = s
+	m.updateVirtualCursorStyle()
+}
+
+// VirtualCursor returns whether or not the virtual cursor is enabled.
+func (m Model) VirtualCursor() bool {
+	return m.useVirtualCursor
+}
+
+// SetVirtualCursor sets whether or not to use the virtual cursor.
+func (m *Model) SetVirtualCursor(v bool) {
+	m.useVirtualCursor = v
+	m.updateVirtualCursorStyle()
+}
+
+// updateVirtualCursorStyle sets styling on the virtual cursor based on the
+// textarea's style settings.
+func (m *Model) updateVirtualCursorStyle() {
+	if !m.useVirtualCursor {
+		m.virtualCursor.SetMode(cursor.CursorHide)
+		return
+	}
+
+	m.virtualCursor.Style = lipgloss.NewStyle().Foreground(m.styles.Cursor.Color)
+
+	// By default, the blink speed of the cursor is set to a default
+	// internally.
+	if m.styles.Cursor.Blink {
+		if m.styles.Cursor.BlinkSpeed > 0 {
+			m.virtualCursor.BlinkSpeed = m.styles.Cursor.BlinkSpeed
+		}
+		m.virtualCursor.SetMode(cursor.CursorBlink)
+		return
+	}
+	m.virtualCursor.SetMode(cursor.CursorStatic)
+}
+
+// SetValue sets the value of the text input.
+func (m *Model) SetValue(s string) {
+	m.Reset()
+	m.InsertString(s)
+	m.recalculateHeight()
+}
+
+// InsertString inserts a string at the cursor position.
+func (m *Model) InsertString(s string) {
+	m.insertRunesFromUserInput([]rune(s))
+	m.recalculateHeight()
+}
+
+// InsertRune inserts a rune at the cursor position.
+func (m *Model) InsertRune(r rune) {
+	m.insertRunesFromUserInput([]rune{r})
+	m.recalculateHeight()
+}
+
+// insertRunesFromUserInput inserts runes at the current cursor position.
+func (m *Model) insertRunesFromUserInput(runes []rune) {
+	// Clean up any special characters in the input provided by the
+	// clipboard. This avoids bugs due to e.g. tab characters and
+	// whatnot.
+	runes = m.san().Sanitize(runes)
+
+	if m.CharLimit > 0 {
+		availSpace := m.CharLimit - m.Length()
+		// If the char limit's been reached, cancel.
+		if availSpace <= 0 {
+			return
+		}
+		// If there's not enough space to paste the whole thing cut the pasted
+		// runes down so they'll fit.
+		if availSpace < len(runes) {
+			runes = runes[:availSpace]
+		}
+	}
+
+	// Split the input into lines.
+	var lines [][]rune
+	lstart := 0
+	for i := range runes {
+		if runes[i] == '\n' {
+			// Queue a line to become a new row in the text area below.
+			// Beware to clamp the max capacity of the slice, to ensure no
+			// data from different rows get overwritten when later edits
+			// will modify this line.
+			lines = append(lines, runes[lstart:i:i])
+			lstart = i + 1
+		}
+	}
+	if lstart <= len(runes) {
+		// The last line did not end with a newline character.
+		// Take it now.
+		lines = append(lines, runes[lstart:])
+	}
+
+	// Obey the maximum line limit.
+	if maxLines > 0 && len(m.value)+len(lines)-1 > maxLines {
+		allowedHeight := max(0, maxLines-len(m.value)+1)
+		lines = lines[:allowedHeight]
+	}
+
+	// Obey MaxContentHeight in visual rows when set.
+	if m.MaxContentHeight > 0 {
+		budget := m.MaxContentHeight - m.totalVisualLines()
+		// Trim lines from the end until we fit within the budget.
+		for len(lines) > 1 && m.visualLinesForInsert(lines) > budget {
+			lines = lines[:len(lines)-1]
+		}
+		if m.visualLinesForInsert(lines) > budget {
+			return
+		}
+	}
+
+	if len(lines) == 0 {
+		// Nothing left to insert.
+		return
+	}
+
+	// Save the remainder of the original line at the current
+	// cursor position.
+	tail := make([]rune, len(m.value[m.row][m.col:]))
+	copy(tail, m.value[m.row][m.col:])
+
+	// Paste the first line at the current cursor position.
+	m.value[m.row] = append(m.value[m.row][:m.col], lines[0]...)
+	m.col += len(lines[0])
+
+	if numExtraLines := len(lines) - 1; numExtraLines > 0 {
+		// Add the new lines.
+		// We try to reuse the slice if there's already space.
+		var newGrid [][]rune
+		if cap(m.value) >= len(m.value)+numExtraLines {
+			// Can reuse the extra space.
+			newGrid = m.value[:len(m.value)+numExtraLines]
+		} else {
+			// No space left; need a new slice.
+			newGrid = make([][]rune, len(m.value)+numExtraLines)
+			copy(newGrid, m.value[:m.row+1])
+		}
+		// Add all the rows that were after the cursor in the original
+		// grid at the end of the new grid.
+		copy(newGrid[m.row+1+numExtraLines:], m.value[m.row+1:])
+		m.value = newGrid
+		// Insert all the new lines in the middle.
+		for _, l := range lines[1:] {
+			m.row++
+			m.value[m.row] = l
+			m.col = len(l)
+		}
+	}
+
+	// Finally add the tail at the end of the last line inserted.
+	m.value[m.row] = append(m.value[m.row], tail...)
+
+	m.SetCursorColumn(m.col)
+}
+
+// Value returns the value of the text input.
+func (m Model) Value() string {
+	if m.value == nil {
+		return ""
+	}
+
+	var v strings.Builder
+	for _, l := range m.value {
+		v.WriteString(string(l))
+		v.WriteByte('\n')
+	}
+
+	return strings.TrimSuffix(v.String(), "\n")
+}
+
+// Length returns the number of characters currently in the text input.
+func (m *Model) Length() int {
+	var l int
+	for _, row := range m.value {
+		l += uniseg.StringWidth(string(row))
+	}
+	// We add len(m.value) to include the newline characters.
+	return l + len(m.value) - 1
+}
+
+// LineCount returns the number of lines that are currently in the text input.
+func (m *Model) LineCount() int {
+	return len(m.value)
+}
+
+// Line returns the 0-indexed row position of the cursor.
+func (m Model) Line() int {
+	return m.row
+}
+
+// Column returns the 0-indexed column position of the cursor.
+func (m Model) Column() int {
+	return m.col
+}
+
+// ScrollYOffset returns the Y offset (top row) index of the current view, which
+// can be used to calculate the current scroll position.
+func (m Model) ScrollYOffset() int {
+	return m.viewport.YOffset()
+}
+
+// ScrollPercent returns the amount of the textarea that is currently scrolled
+// through, clamped between 0 and 1.
+func (m Model) ScrollPercent() float64 {
+	return m.viewport.ScrollPercent()
+}
+
+// setCursorLineRelative moves the cursor by the given number of lines. Negative
+// values move the cursor up, positive values move the cursor down.
+func (m *Model) setCursorLineRelative(delta int) {
+	if delta == 0 {
+		return
+	}
+
+	li := m.LineInfo()
+	charOffset := max(m.lastCharOffset, li.CharOffset)
+	m.lastCharOffset = charOffset
+
+	// 2 columns to account for the trailing space wrapping.
+	const trailingSpace = 2
+
+	if delta > 0 { //nolint:nestif
+		// Moving down.
+		for range delta {
+			if li.RowOffset+1 >= li.Height && m.row < len(m.value)-1 {
+				m.row++
+				m.col = 0
+			} else {
+				// Move the cursor to the start of the next virtual line.
+				m.col = min(li.StartColumn+li.Width+trailingSpace, len(m.value[m.row])-1)
+			}
+			li = m.LineInfo()
+		}
+	} else {
+		// Moving up.
+		for range -delta {
+			if li.RowOffset <= 0 && m.row > 0 {
+				m.row--
+				m.col = len(m.value[m.row])
+			} else {
+				// Move the cursor to the end of the previous line.
+				m.col = li.StartColumn - trailingSpace
+			}
+			li = m.LineInfo()
+		}
+	}
+
+	nli := m.LineInfo()
+	m.col = nli.StartColumn
+
+	if nli.Width <= 0 {
+		m.repositionView()
+		return
+	}
+
+	offset := 0
+	for offset < charOffset {
+		if m.row >= len(m.value) || m.col >= len(m.value[m.row]) || offset >= nli.CharWidth-1 {
+			break
+		}
+		offset += rw.RuneWidth(m.value[m.row][m.col])
+		m.col++
+	}
+	m.repositionView()
+}
+
+// CursorDown moves the cursor down by one line.
+func (m *Model) CursorDown() {
+	m.setCursorLineRelative(1)
+}
+
+// CursorUp moves the cursor up by one line.
+func (m *Model) CursorUp() {
+	m.setCursorLineRelative(-1)
+}
+
+// SetCursorColumn moves the cursor to the given position. If the position is
+// out of bounds the cursor will be moved to the start or end accordingly.
+func (m *Model) SetCursorColumn(col int) {
+	m.col = clamp(col, 0, len(m.value[m.row]))
+	// Any time that we move the cursor horizontally we need to reset the last
+	// offset so that the horizontal position when navigating is adjusted.
+	m.lastCharOffset = 0
+}
+
+// CursorStart moves the cursor to the start of the input field.
+func (m *Model) CursorStart() {
+	m.SetCursorColumn(0)
+}
+
+// CursorEnd moves the cursor to the end of the input field.
+func (m *Model) CursorEnd() {
+	m.SetCursorColumn(len(m.value[m.row]))
+}
+
+// Focused returns the focus state on the model.
+func (m Model) Focused() bool {
+	return m.focus
+}
+
+// activeStyle returns the appropriate set of styles to use depending on
+// whether the textarea is focused or blurred.
+func (m Model) activeStyle() *StyleState {
+	if m.focus {
+		return &m.styles.Focused
+	}
+	return &m.styles.Blurred
+}
+
+// Focus sets the focus state on the model. When the model is in focus it can
+// receive keyboard input and the cursor will be hidden.
+func (m *Model) Focus() tea.Cmd {
+	m.focus = true
+	return m.virtualCursor.Focus()
+}
+
+// Blur removes the focus state on the model. When the model is blurred it can
+// not receive keyboard input and the cursor will be hidden.
+func (m *Model) Blur() {
+	m.focus = false
+	m.virtualCursor.Blur()
+}
+
+// Reset sets the input to its default state with no input.
+func (m *Model) Reset() {
+	m.value = make([][]rune, minHeight, maxLines)
+	m.col = 0
+	m.row = 0
+	m.viewport.GotoTop()
+	m.SetCursorColumn(0)
+	m.recalculateHeight()
+}
+
+// Word returns the word at the cursor position.
+// A word is delimited by spaces or line-breaks.
+func (m *Model) Word() string {
+	line := m.value[m.row]
+	col := m.col - 1
+
+	if col < 0 {
+		return ""
+	}
+
+	// If cursor is beyond the line, return empty string
+	if col >= len(line) {
+		return ""
+	}
+
+	// If cursor is on a space, return empty string
+	if unicode.IsSpace(line[col]) {
+		return ""
+	}
+
+	// Find the start of the word by moving left
+	start := col
+	for start > 0 && !unicode.IsSpace(line[start-1]) {
+		start--
+	}
+
+	// Find the end of the word by moving right
+	end := col
+	for end < len(line) && !unicode.IsSpace(line[end]) {
+		end++
+	}
+
+	return string(line[start:end])
+}
+
+// san initializes or retrieves the rune sanitizer.
+func (m *Model) san() runeutil.Sanitizer {
+	if m.rsan == nil {
+		// Textinput has all its input on a single line so collapse
+		// newlines/tabs to single spaces.
+		m.rsan = runeutil.NewSanitizer()
+	}
+	return m.rsan
+}
+
+// deleteBeforeCursor deletes all text before the cursor. Returns whether or
+// not the cursor blink should be reset.
+func (m *Model) deleteBeforeCursor() {
+	m.value[m.row] = m.value[m.row][m.col:]
+	m.SetCursorColumn(0)
+}
+
+// deleteAfterCursor deletes all text after the cursor. Returns whether or not
+// the cursor blink should be reset. If input is masked delete everything after
+// the cursor so as not to reveal word breaks in the masked input.
+func (m *Model) deleteAfterCursor() {
+	m.value[m.row] = m.value[m.row][:m.col]
+	m.SetCursorColumn(len(m.value[m.row]))
+}
+
+// transposeLeft exchanges the runes at the cursor and immediately
+// before. No-op if the cursor is at the beginning of the line.  If
+// the cursor is not at the end of the line yet, moves the cursor to
+// the right.
+func (m *Model) transposeLeft() {
+	if m.col == 0 || len(m.value[m.row]) < 2 {
+		return
+	}
+	if m.col >= len(m.value[m.row]) {
+		m.SetCursorColumn(m.col - 1)
+	}
+	m.value[m.row][m.col-1], m.value[m.row][m.col] = m.value[m.row][m.col], m.value[m.row][m.col-1]
+	if m.col < len(m.value[m.row]) {
+		m.SetCursorColumn(m.col + 1)
+	}
+}
+
+// deleteWordLeft deletes the word left to the cursor. Returns whether or not
+// the cursor blink should be reset.
+func (m *Model) deleteWordLeft() {
+	if m.col == 0 || len(m.value[m.row]) == 0 {
+		return
+	}
+
+	// Linter note: it's critical that we acquire the initial cursor position
+	// here prior to altering it via SetCursor() below. As such, moving this
+	// call into the corresponding if clause does not apply here.
+	oldCol := m.col
+
+	m.SetCursorColumn(m.col - 1)
+	for unicode.IsSpace(m.value[m.row][m.col]) {
+		if m.col <= 0 {
+			break
+		}
+		// ignore series of whitespace before cursor
+		m.SetCursorColumn(m.col - 1)
+	}
+
+	for m.col > 0 {
+		if !unicode.IsSpace(m.value[m.row][m.col]) {
+			m.SetCursorColumn(m.col - 1)
+		} else {
+			if m.col > 0 {
+				// keep the previous space
+				m.SetCursorColumn(m.col + 1)
+			}
+			break
+		}
+	}
+
+	if oldCol > len(m.value[m.row]) {
+		m.value[m.row] = m.value[m.row][:m.col]
+	} else {
+		m.value[m.row] = append(m.value[m.row][:m.col], m.value[m.row][oldCol:]...)
+	}
+}
+
+// deleteWordRight deletes the word right to the cursor.
+func (m *Model) deleteWordRight() {
+	if m.col >= len(m.value[m.row]) || len(m.value[m.row]) == 0 {
+		return
+	}
+
+	oldCol := m.col
+
+	for m.col < len(m.value[m.row]) && unicode.IsSpace(m.value[m.row][m.col]) {
+		// ignore series of whitespace after cursor
+		m.SetCursorColumn(m.col + 1)
+	}
+
+	for m.col < len(m.value[m.row]) {
+		if !unicode.IsSpace(m.value[m.row][m.col]) {
+			m.SetCursorColumn(m.col + 1)
+		} else {
+			break
+		}
+	}
+
+	if m.col > len(m.value[m.row]) {
+		m.value[m.row] = m.value[m.row][:oldCol]
+	} else {
+		m.value[m.row] = append(m.value[m.row][:oldCol], m.value[m.row][m.col:]...)
+	}
+
+	m.SetCursorColumn(oldCol)
+}
+
+// characterRight moves the cursor one character to the right.
+func (m *Model) characterRight() {
+	if m.col < len(m.value[m.row]) {
+		m.SetCursorColumn(m.col + 1)
+	} else {
+		if m.row < len(m.value)-1 {
+			m.row++
+			m.CursorStart()
+		}
+	}
+}
+
+// characterLeft moves the cursor one character to the left.
+// If insideLine is set, the cursor is moved to the last
+// character in the previous line, instead of one past that.
+func (m *Model) characterLeft(insideLine bool) {
+	if m.col == 0 && m.row != 0 {
+		m.row--
+		m.CursorEnd()
+		if !insideLine {
+			return
+		}
+	}
+	if m.col > 0 {
+		m.SetCursorColumn(m.col - 1)
+	}
+}
+
+// wordLeft moves the cursor one word to the left. Returns whether or not the
+// cursor blink should be reset. If input is masked, move input to the start
+// so as not to reveal word breaks in the masked input.
+func (m *Model) wordLeft() {
+	for {
+		m.characterLeft(true /* insideLine */)
+		if m.col < len(m.value[m.row]) && !unicode.IsSpace(m.value[m.row][m.col]) {
+			break
+		}
+	}
+
+	for m.col > 0 {
+		if unicode.IsSpace(m.value[m.row][m.col-1]) {
+			break
+		}
+		m.SetCursorColumn(m.col - 1)
+	}
+}
+
+// wordRight moves the cursor one word to the right. Returns whether or not the
+// cursor blink should be reset. If the input is masked, move input to the end
+// so as not to reveal word breaks in the masked input.
+func (m *Model) wordRight() {
+	m.doWordRight(func(int, int) { /* nothing */ })
+}
+
+func (m *Model) doWordRight(fn func(charIdx int, pos int)) {
+	// Skip spaces forward.
+	for m.col >= len(m.value[m.row]) || unicode.IsSpace(m.value[m.row][m.col]) {
+		if m.row == len(m.value)-1 && m.col == len(m.value[m.row]) {
+			// End of text.
+			break
+		}
+		m.characterRight()
+	}
+
+	charIdx := 0
+	for m.col < len(m.value[m.row]) {
+		if unicode.IsSpace(m.value[m.row][m.col]) {
+			break
+		}
+		fn(charIdx, m.col)
+		m.SetCursorColumn(m.col + 1)
+		charIdx++
+	}
+}
+
+// uppercaseRight changes the word to the right to uppercase.
+func (m *Model) uppercaseRight() {
+	m.doWordRight(func(_ int, i int) {
+		m.value[m.row][i] = unicode.ToUpper(m.value[m.row][i])
+	})
+}
+
+// lowercaseRight changes the word to the right to lowercase.
+func (m *Model) lowercaseRight() {
+	m.doWordRight(func(_ int, i int) {
+		m.value[m.row][i] = unicode.ToLower(m.value[m.row][i])
+	})
+}
+
+// capitalizeRight changes the word to the right to title case.
+func (m *Model) capitalizeRight() {
+	m.doWordRight(func(charIdx int, i int) {
+		if charIdx == 0 {
+			m.value[m.row][i] = unicode.ToTitle(m.value[m.row][i])
+		}
+	})
+}
+
+// LineInfo returns the number of characters from the start of the
+// (soft-wrapped) line and the (soft-wrapped) line width.
+func (m Model) LineInfo() LineInfo {
+	grid := m.memoizedWrap(m.value[m.row], m.width)
+
+	// Find out which line we are currently on. This can be determined by the
+	// m.col and counting the number of runes that we need to skip.
+	var counter int
+	for i, line := range grid {
+		// We've found the line that we are on
+		if counter+len(line) == m.col && i+1 < len(grid) {
+			// We wrap around to the next line if we are at the end of the
+			// previous line so that we can be at the very beginning of the row
+			return LineInfo{
+				CharOffset:   0,
+				ColumnOffset: 0,
+				Height:       len(grid),
+				RowOffset:    i + 1,
+				StartColumn:  m.col,
+				Width:        len(grid[i+1]),
+				CharWidth:    uniseg.StringWidth(string(line)),
+			}
+		}
+
+		if counter+len(line) >= m.col {
+			return LineInfo{
+				CharOffset:   uniseg.StringWidth(string(line[:max(0, m.col-counter)])),
+				ColumnOffset: m.col - counter,
+				Height:       len(grid),
+				RowOffset:    i,
+				StartColumn:  counter,
+				Width:        len(line),
+				CharWidth:    uniseg.StringWidth(string(line)),
+			}
+		}
+
+		counter += len(line)
+	}
+	return LineInfo{}
+}
+
+// repositionView repositions the view of the viewport based on the defined
+// scrolling behavior.
+func (m *Model) repositionView() {
+	minimum := m.viewport.YOffset()
+	maximum := minimum + m.viewport.Height() - 1
+	if row := m.cursorLineNumber(); row < minimum {
+		m.viewport.ScrollUp(minimum - row)
+	} else if row > maximum {
+		m.viewport.ScrollDown(row - maximum)
+	}
+}
+
+// Width returns the width of the textarea.
+func (m Model) Width() int {
+	return m.width
+}
+
+// MoveToBegin moves the cursor to the beginning of the input.
+func (m *Model) MoveToBegin() {
+	m.row = 0
+	m.SetCursorColumn(0)
+	m.repositionView()
+}
+
+// MoveToEnd moves the cursor to the end of the input.
+func (m *Model) MoveToEnd() {
+	m.row = len(m.value) - 1
+	m.SetCursorColumn(len(m.value[m.row]))
+	m.repositionView()
+}
+
+// PageUp moves the cursor up by one page. First call snaps to the first visible
+// line, subsequent calls move up by a full page.
+func (m *Model) PageUp() {
+	// If not on the first visible line, snap to it.
+	if offset := m.viewport.YOffset() - m.cursorLineNumber(); offset < 0 {
+		m.setCursorLineRelative(offset)
+		return
+	}
+
+	// Already on first visible line, move up by a full page.
+	m.setCursorLineRelative(-m.height)
+}
+
+// PageDown moves the cursor down by one page. First call snaps to the last
+// visible line, subsequent calls move down by a full page.
+func (m *Model) PageDown() {
+	// If not on the last visible line, snap to it.
+	if offset := m.cursorLineNumber() - m.viewport.YOffset(); offset < m.height-1 {
+		m.setCursorLineRelative(m.height - 1 - offset)
+		return
+	}
+
+	// Already on last visible line, move down by a full page.
+	m.setCursorLineRelative(m.height)
+}
+
+// SetWidth sets the width of the textarea to fit exactly within the given width.
+// This means that the textarea will account for the width of the prompt and
+// whether or not line numbers are being shown.
+//
+// Ensure that SetWidth is called after setting the Prompt and ShowLineNumbers,
+// It is important that the width of the textarea be exactly the given width
+// and no more.
+func (m *Model) SetWidth(w int) {
+	// Update prompt width only if there is no prompt function as
+	// [SetPromptFunc] updates the prompt width when it is called.
+	if m.promptFunc == nil {
+		// XXX: Do we even need this or can we calculate the prompt width
+		// at render time?
+		m.promptWidth = uniseg.StringWidth(m.Prompt)
+	}
+
+	// Add base style borders and padding to reserved outer width.
+	reservedOuter := m.activeStyle().Base.GetHorizontalFrameSize()
+
+	// Add prompt width to reserved inner width.
+	reservedInner := m.promptWidth
+
+	// Add line number width to reserved inner width.
+	if m.ShowLineNumbers {
+		// XXX: this was originally documented as needing "1 cell" but was,
+		// in practice, effectively hardcoded to 2 cells. We can, and should,
+		// reduce this to one gap and update the tests accordingly.
+		const gap = 2
+
+		// Number of digits plus 1 cell for the margin.
+		reservedInner += numDigits(m.MaxHeight) + gap
+	}
+
+	// Input width must be at least one more than the reserved inner and outer
+	// width. This gives us a minimum input width of 1.
+	minWidth := reservedInner + reservedOuter + 1
+	inputWidth := max(w, minWidth)
+
+	// Input width must be no more than maximum width.
+	if m.MaxWidth > 0 {
+		inputWidth = min(inputWidth, m.MaxWidth)
+	}
+
+	// Since the width of the viewport and input area is dependent on the width of
+	// borders, prompt and line numbers, we need to calculate it by subtracting
+	// the reserved width from them.
+
+	m.viewport.SetWidth(inputWidth - reservedOuter)
+	m.width = inputWidth - reservedOuter - reservedInner
+	m.recalculateHeight()
+}
+
+// SetPromptFunc supersedes the Prompt field and sets a dynamic prompt instead.
+//
+// If the function returns a prompt that is shorter than the specified
+// promptWidth, it will be padded to the left. If it returns a prompt that is
+// longer, display artifacts may occur; the caller is responsible for computing
+// an adequate promptWidth.
+func (m *Model) SetPromptFunc(promptWidth int, fn func(PromptInfo) string) {
+	m.promptFunc = fn
+	m.promptWidth = promptWidth
+}
+
+// Height returns the current height of the textarea.
+func (m Model) Height() int {
+	return m.height
+}
+
+// SetHeight sets the height of the textarea.
+func (m *Model) SetHeight(h int) {
+	if m.MaxHeight > 0 {
+		m.height = clamp(h, minHeight, m.MaxHeight)
+		m.viewport.SetHeight(clamp(h, minHeight, m.MaxHeight))
+	} else {
+		m.height = max(h, minHeight)
+		m.viewport.SetHeight(max(h, minHeight))
+	}
+
+	m.repositionView()
+}
+
+// Update is the Bubble Tea update loop.
+func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
+	if !m.focus {
+		m.virtualCursor.Blur()
+		return m, nil
+	}
+
+	// Used to determine if the cursor should blink.
+	oldRow, oldCol := m.cursorLineNumber(), m.col
+
+	var cmds []tea.Cmd
+
+	if m.value[m.row] == nil {
+		m.value[m.row] = make([]rune, 0)
+	}
+
+	if m.MaxHeight > 0 && m.MaxHeight != m.cache.Capacity() {
+		m.cache = memoization.NewMemoCache[line, [][]rune](m.MaxHeight)
+	}
+
+	switch msg := msg.(type) {
+	case tea.PasteMsg:
+		m.insertRunesFromUserInput([]rune(msg.Content))
+	case tea.KeyPressMsg:
+		switch {
+		case key.Matches(msg, m.KeyMap.DeleteAfterCursor):
+			m.col = clamp(m.col, 0, len(m.value[m.row]))
+			if m.col >= len(m.value[m.row]) {
+				m.mergeLineBelow(m.row)
+				break
+			}
+			m.deleteAfterCursor()
+		case key.Matches(msg, m.KeyMap.DeleteBeforeCursor):
+			m.col = clamp(m.col, 0, len(m.value[m.row]))
+			if m.col <= 0 {
+				m.mergeLineAbove(m.row)
+				break
+			}
+			m.deleteBeforeCursor()
+		case key.Matches(msg, m.KeyMap.DeleteCharacterBackward):
+			m.col = clamp(m.col, 0, len(m.value[m.row]))
+			if m.col <= 0 {
+				m.mergeLineAbove(m.row)
+				break
+			}
+			if len(m.value[m.row]) > 0 {
+				m.value[m.row] = append(m.value[m.row][:max(0, m.col-1)], m.value[m.row][m.col:]...)
+				if m.col > 0 {
+					m.SetCursorColumn(m.col - 1)
+				}
+			}
+		case key.Matches(msg, m.KeyMap.DeleteCharacterForward):
+			if len(m.value[m.row]) > 0 && m.col < len(m.value[m.row]) {
+				m.value[m.row] = slices.Delete(m.value[m.row], m.col, m.col+1)
+			}
+			if m.col >= len(m.value[m.row]) {
+				m.mergeLineBelow(m.row)
+				break
+			}
+		case key.Matches(msg, m.KeyMap.DeleteWordBackward):
+			if m.col <= 0 {
+				m.mergeLineAbove(m.row)
+				break
+			}
+			m.deleteWordLeft()
+		case key.Matches(msg, m.KeyMap.DeleteWordForward):
+			m.col = clamp(m.col, 0, len(m.value[m.row]))
+			if m.col >= len(m.value[m.row]) {
+				m.mergeLineBelow(m.row)
+				break
+			}
+			m.deleteWordRight()
+		case key.Matches(msg, m.KeyMap.InsertNewline):
+			if m.atContentLimit() {
+				return m, nil
+			}
+			m.col = clamp(m.col, 0, len(m.value[m.row]))
+			m.splitLine(m.row, m.col)
+		case key.Matches(msg, m.KeyMap.LineEnd):
+			m.CursorEnd()
+		case key.Matches(msg, m.KeyMap.LineStart):
+			m.CursorStart()
+		case key.Matches(msg, m.KeyMap.CharacterForward):
+			m.characterRight()
+		case key.Matches(msg, m.KeyMap.LineNext):
+			m.CursorDown()
+		case key.Matches(msg, m.KeyMap.WordForward):
+			m.wordRight()
+		case key.Matches(msg, m.KeyMap.Paste):
+			return m, Paste
+		case key.Matches(msg, m.KeyMap.CharacterBackward):
+			m.characterLeft(false /* insideLine */)
+		case key.Matches(msg, m.KeyMap.LinePrevious):
+			m.CursorUp()
+		case key.Matches(msg, m.KeyMap.WordBackward):
+			m.wordLeft()
+		case key.Matches(msg, m.KeyMap.InputBegin):
+			m.MoveToBegin()
+		case key.Matches(msg, m.KeyMap.InputEnd):
+			m.MoveToEnd()
+		case key.Matches(msg, m.KeyMap.PageUp):
+			m.PageUp()
+		case key.Matches(msg, m.KeyMap.PageDown):
+			m.PageDown()
+		case key.Matches(msg, m.KeyMap.LowercaseWordForward):
+			m.lowercaseRight()
+		case key.Matches(msg, m.KeyMap.UppercaseWordForward):
+			m.uppercaseRight()
+		case key.Matches(msg, m.KeyMap.CapitalizeWordForward):
+			m.capitalizeRight()
+		case key.Matches(msg, m.KeyMap.TransposeCharacterBackward):
+			m.transposeLeft()
+
+		default:
+			m.insertRunesFromUserInput([]rune(msg.Text))
+		}
+
+	case pasteMsg:
+		m.insertRunesFromUserInput([]rune(msg))
+
+	case pasteErrMsg:
+		m.Err = msg
+	}
+
+	m.recalculateHeight()
+
+	// Make sure we set the content of the viewport before updating it.
+	view := m.view()
+	m.viewport.SetContent(view)
+	vp, cmd := m.viewport.Update(msg)
+	m.viewport = &vp
+	cmds = append(cmds, cmd)
+
+	if m.useVirtualCursor {
+		m.virtualCursor, cmd = m.virtualCursor.Update(msg)
+
+		// If the cursor has moved, reset the blink state. This is a small UX
+		// nuance that makes cursor movement obvious and feel snappy.
+		newRow, newCol := m.cursorLineNumber(), m.col
+		if (newRow != oldRow || newCol != oldCol) && m.virtualCursor.Mode() == cursor.CursorBlink {
+			m.virtualCursor.IsBlinked = false
+			cmd = m.virtualCursor.Blink()
+		}
+		cmds = append(cmds, cmd)
+	}
+
+	m.repositionView()
+
+	return m, tea.Batch(cmds...)
+}
+
+func (m *Model) view() string {
+	if len(m.Value()) == 0 && m.row == 0 && m.col == 0 && m.Placeholder != "" {
+		return m.placeholderView()
+	}
+	m.virtualCursor.TextStyle = m.activeStyle().computedCursorLine()
+
+	var (
+		s                strings.Builder
+		style            lipgloss.Style
+		newLines         int
+		widestLineNumber int
+		lineInfo         = m.LineInfo()
+		styles           = m.activeStyle()
+	)
+
+	displayLine := 0
+	for l, line := range m.value {
+		wrappedLines := m.memoizedWrap(line, m.width)
+
+		if m.row == l {
+			style = styles.computedCursorLine()
+		} else {
+			style = styles.computedText()
+		}
+
+		// Consult the optional token highlighter once per logical line.
+		// Ranges are rune offsets within the logical line; each wrapped
+		// segment intersects them at render time.
+		var lineRanges []lipgloss.Range
+		if m.highlighter != nil {
+			lineRanges = m.highlightRanges(l, line)
+		}
+
+		segStart := 0
+		for wl, wrappedLine := range wrappedLines {
+			prompt := m.promptView(displayLine)
+			s.WriteString(style.Render(prompt))
+			displayLine++
+
+			var ln string
+			if m.ShowLineNumbers {
+				if wl == 0 { // normal line
+					isCursorLine := m.row == l
+					s.WriteString(m.lineNumberView(l+1, isCursorLine))
+				} else { // soft wrapped line
+					isCursorLine := m.row == l
+					s.WriteString(m.lineNumberView(-1, isCursorLine))
+				}
+			}
+
+			// Note the widest line number for padding purposes later.
+			lnw := uniseg.StringWidth(ln)
+			if lnw > widestLineNumber {
+				widestLineNumber = lnw
+			}
+
+			strwidth := uniseg.StringWidth(string(wrappedLine))
+			padding := m.width - strwidth
+			// SegLen is captured before the trailing-space trim below so
+			// segStart tracking stays aligned with the raw logical line.
+			segLen := len(wrappedLine)
+			// If the trailing space causes the line to be wider than the
+			// width, we should not draw it to the screen since it will result
+			// in an extra space at the end of the line which can look off when
+			// the cursor line is showing.
+			if strwidth > m.width {
+				// The character causing the line to be wider than the width is
+				// guaranteed to be a space since any other character would
+				// have been wrapped.
+				wrappedLine = []rune(strings.TrimSuffix(string(wrappedLine), " "))
+				padding -= m.width - strwidth
+			}
+			if m.row == l && lineInfo.RowOffset == wl {
+				s.WriteString(styleSegment(style, wrappedLine[:lineInfo.ColumnOffset], segStart, lineRanges))
+				if m.col >= len(line) && lineInfo.CharOffset >= m.width {
+					m.virtualCursor.SetChar(" ")
+					s.WriteString(m.virtualCursor.View())
+				} else {
+					m.virtualCursor.SetChar(string(wrappedLine[lineInfo.ColumnOffset]))
+					s.WriteString(style.Render(m.virtualCursor.View()))
+					s.WriteString(styleSegment(style, wrappedLine[lineInfo.ColumnOffset+1:], segStart+lineInfo.ColumnOffset+1, lineRanges))
+				}
+			} else {
+				s.WriteString(styleSegment(style, wrappedLine, segStart, lineRanges))
+			}
+			s.WriteString(style.Render(strings.Repeat(" ", max(0, padding))))
+			s.WriteRune('\n')
+			newLines++
+			segStart += segLen
+		}
+	}
+
+	// Always show at least `m.Height` lines at all times.
+	// To do this we can simply pad out a few extra new lines in the view.
+	for range m.height {
+		s.WriteString(m.promptView(displayLine))
+		displayLine++
+
+		// Write end of buffer content
+		leftGutter := string(m.EndOfBufferCharacter)
+		rightGapWidth := m.Width() - uniseg.StringWidth(leftGutter) + widestLineNumber
+		rightGap := strings.Repeat(" ", max(0, rightGapWidth))
+		s.WriteString(styles.computedEndOfBuffer().Render(leftGutter + rightGap))
+		s.WriteRune('\n')
+	}
+
+	return s.String()
+}
+
+// View renders the text area in its current state.
+func (m Model) View() string {
+	// XXX: This is a workaround for the case where the viewport hasn't
+	// been initialized yet like during the initial render. In that case,
+	// we need to render the view again because Update hasn't been called
+	// yet to set the content of the viewport.
+	m.viewport.SetContent(m.view())
+	view := m.viewport.View()
+	styles := m.activeStyle()
+	return styles.Base.Render(view)
+}
+
+// promptView renders a single line of the prompt.
+func (m Model) promptView(displayLine int) (prompt string) {
+	prompt = m.Prompt
+	if m.promptFunc != nil {
+		prompt = m.promptFunc(PromptInfo{
+			LineNumber: displayLine,
+			Focused:    m.focus,
+		})
+		width := lipgloss.Width(prompt)
+		if width < m.promptWidth {
+			prompt = fmt.Sprintf("%*s%s", m.promptWidth-width, "", prompt)
+		}
+	}
+
+	return m.activeStyle().computedPrompt().Render(prompt)
+}
+
+// lineNumberView renders the line number.
+//
+// If the argument is less than 0, a space styled as a line number is returned
+// instead. Such cases are used for soft-wrapped lines.
+//
+// The second argument indicates whether this line number is for a 'cursorline'
+// line number.
+func (m Model) lineNumberView(n int, isCursorLine bool) (str string) {
+	if !m.ShowLineNumbers {
+		return ""
+	}
+
+	if n <= 0 {
+		str = " "
+	} else {
+		str = strconv.Itoa(n)
+	}
+
+	// XXX: is textStyle really necessary here?
+	textStyle := m.activeStyle().computedText()
+	lineNumberStyle := m.activeStyle().computedLineNumber()
+	if isCursorLine {
+		textStyle = m.activeStyle().computedCursorLine()
+		lineNumberStyle = m.activeStyle().computedCursorLineNumber()
+	}
+
+	// Format line number dynamically based on the maximum number of lines.
+	digits := len(strconv.Itoa(m.MaxHeight))
+	str = fmt.Sprintf(" %*v ", digits, str)
+
+	return textStyle.Render(lineNumberStyle.Render(str))
+}
+
+// placeholderView returns the prompt and placeholder, if any.
+func (m Model) placeholderView() string {
+	var (
+		s      strings.Builder
+		p      = m.Placeholder
+		styles = m.activeStyle()
+	)
+	// word wrap lines
+	pwordwrap := ansi.Wordwrap(p, m.width, "")
+	// hard wrap lines (handles lines that could not be word wrapped)
+	pwrap := ansi.Hardwrap(pwordwrap, m.width, true)
+	// split string by new lines
+	plines := strings.Split(strings.TrimSpace(pwrap), "\n")
+
+	for i := range m.height {
+		isLineNumber := len(plines) > i
+
+		lineStyle := styles.computedPlaceholder()
+		if len(plines) > i {
+			lineStyle = styles.computedCursorLine()
+		}
+
+		// render prompt
+		prompt := m.promptView(i)
+		s.WriteString(lineStyle.Render(prompt))
+
+		// when show line numbers enabled:
+		// - render line number for only the cursor line
+		// - indent other placeholder lines
+		// this is consistent with vim with line numbers enabled
+		if m.ShowLineNumbers {
+			var ln int
+
+			switch {
+			case i == 0:
+				ln = i + 1
+				fallthrough
+			case len(plines) > i:
+				s.WriteString(m.lineNumberView(ln, isLineNumber))
+			default:
+			}
+		}
+
+		switch {
+		// first line
+		case i == 0:
+			// first character of first line as cursor with character
+			m.virtualCursor.TextStyle = styles.computedPlaceholder()
+
+			ch, rest, _, _ := uniseg.FirstGraphemeClusterInString(plines[0], 0)
+			m.virtualCursor.SetChar(ch)
+			s.WriteString(lineStyle.Render(m.virtualCursor.View()))
+
+			// the rest of the first line
+			s.WriteString(lineStyle.Render(styles.computedPlaceholder().Render(rest)))
+
+			// extend the first line with spaces to fill the width, so that
+			// the entire line is filled when cursorline is enabled.
+			gap := strings.Repeat(" ", max(0, m.width-lipgloss.Width(plines[0])))
+			s.WriteString(lineStyle.Render(gap))
+		// remaining lines
+		case len(plines) > i:
+			// current line placeholder text
+			if len(plines) > i {
+				placeholderLine := plines[i]
+				gap := strings.Repeat(" ", max(0, m.width-uniseg.StringWidth(plines[i])))
+				s.WriteString(lineStyle.Render(placeholderLine + gap))
+			}
+		default:
+			// end of line buffer character
+			eob := styles.computedEndOfBuffer().Render(string(m.EndOfBufferCharacter))
+			s.WriteString(eob)
+		}
+
+		// terminate with new line
+		s.WriteRune('\n')
+	}
+
+	m.viewport.SetContent(s.String())
+	return styles.Base.Render(m.viewport.View())
+}
+
+// Blink returns the blink command for the virtual cursor.
+func Blink() tea.Msg {
+	return cursor.Blink()
+}
+
+// Cursor returns a [tea.Cursor] for rendering a real cursor in a Bubble Tea
+// program. This requires that [Model.VirtualCursor] is set to false.
+//
+// Note that you will almost certainly also need to adjust the offset cursor
+// position per the textarea's per the textarea's position in the terminal.
+//
+// Example:
+//
+//	// In your top-level View function:
+//	f := tea.NewFrame(m.textarea.View())
+//	f.Cursor = m.textarea.Cursor()
+//	f.Cursor.Position.X += offsetX
+//	f.Cursor.Position.Y += offsetY
+func (m Model) Cursor() *tea.Cursor {
+	if m.useVirtualCursor || !m.Focused() {
+		return nil
+	}
+
+	lineInfo := m.LineInfo()
+	w := lipgloss.Width
+	baseStyle := m.activeStyle().Base
+
+	xOffset := lineInfo.CharOffset +
+		w(m.promptView(0)) +
+		w(m.lineNumberView(0, false)) +
+		baseStyle.GetMarginLeft() +
+		baseStyle.GetPaddingLeft() +
+		baseStyle.GetBorderLeftSize()
+
+	yOffset := m.cursorLineNumber() -
+		m.viewport.YOffset() +
+		baseStyle.GetMarginTop() +
+		baseStyle.GetPaddingTop() +
+		baseStyle.GetBorderTopSize()
+
+	c := tea.NewCursor(xOffset, yOffset)
+	c.Blink = m.styles.Cursor.Blink
+	c.Color = m.styles.Cursor.Color
+	c.Shape = m.styles.Cursor.Shape
+	return c
+}
+
+func (m Model) memoizedWrap(runes []rune, width int) [][]rune {
+	input := line{runes: runes, width: width}
+	if v, ok := m.cache.Get(input); ok {
+		return v
+	}
+	v := wrap(runes, width)
+	m.cache.Set(input, v)
+	return v
+}
+
+// cursorLineNumber returns the line number that the cursor is on.
+// This accounts for soft wrapped lines.
+func (m Model) cursorLineNumber() int {
+	line := 0
+	for i := range m.row {
+		// Calculate the number of lines that the current line will be split
+		// into.
+		line += len(m.memoizedWrap(m.value[i], m.width))
+	}
+	line += m.LineInfo().RowOffset
+	return line
+}
+
+// totalVisualLines returns the total number of display lines across all
+// logical lines, accounting for soft wraps.
+func (m *Model) totalVisualLines() int {
+	n := 0
+	for _, line := range m.value {
+		n += len(m.memoizedWrap(line, m.width))
+	}
+	return n
+}
+
+// recalculateHeight recomputes and applies the textarea height based on
+// content when DynamicHeight is enabled. It is a no-op otherwise.
+func (m *Model) recalculateHeight() {
+	if !m.DynamicHeight {
+		return
+	}
+	minH := max(m.MinHeight, minHeight)
+	total := m.totalVisualLines()
+	h := max(total, minH)
+	if m.MaxHeight > 0 {
+		h = min(h, m.MaxHeight)
+	}
+	if maxOffset := total - h; m.viewport.YOffset() > maxOffset {
+		m.viewport.SetYOffset(max(0, maxOffset))
+	}
+	m.SetHeight(h)
+}
+
+// atContentLimit reports whether the textarea has reached its content limit.
+// When MaxContentHeight is set (> 0), it checks total visual lines.
+// Otherwise it falls back to the legacy MaxHeight logical-line check for
+// backward compatibility.
+func (m *Model) atContentLimit() bool {
+	if m.MaxContentHeight > 0 {
+		return m.totalVisualLines() >= m.MaxContentHeight
+	}
+	return m.MaxHeight > 0 && len(m.value) >= m.MaxHeight
+}
+
+// visualLinesForInsert estimates how many additional visual lines would result
+// from inserting the given lines at the current cursor position. The first
+// element merges into the current line; subsequent elements become new lines.
+func (m *Model) visualLinesForInsert(lines [][]rune) int {
+	if len(lines) == 0 {
+		return 0
+	}
+
+	// The current row's visual line count before insertion.
+	currentRowVisual := len(m.memoizedWrap(m.value[m.row], m.width))
+
+	// Simulate merging the first paste line into the current row.
+	merged := make([]rune, m.col+len(lines[0]))
+	copy(merged, m.value[m.row][:m.col])
+	copy(merged[m.col:], lines[0])
+	if len(lines) == 1 {
+		merged = append(merged, m.value[m.row][m.col:]...)
+	}
+	delta := len(m.memoizedWrap(merged, m.width)) - currentRowVisual
+
+	// Each additional line is a new logical line.
+	for i, content := range lines {
+		if i == len(lines)-1 {
+			content = append(content, m.value[m.row][m.col:]...)
+		}
+		delta += len(m.memoizedWrap(content, m.width))
+	}
+
+	return delta
+}
+
+// mergeLineBelow merges the current line the cursor is on with the line below.
+func (m *Model) mergeLineBelow(row int) {
+	if row >= len(m.value)-1 {
+		return
+	}
+
+	// To perform a merge, we will need to combine the two lines and then
+	m.value[row] = append(m.value[row], m.value[row+1]...)
+
+	// Shift all lines up by one
+	for i := row + 1; i < len(m.value)-1; i++ {
+		m.value[i] = m.value[i+1]
+	}
+
+	// And, remove the last line
+	if len(m.value) > 0 {
+		m.value = m.value[:len(m.value)-1]
+	}
+}
+
+// mergeLineAbove merges the current line the cursor is on with the line above.
+func (m *Model) mergeLineAbove(row int) {
+	if row <= 0 {
+		return
+	}
+
+	m.col = len(m.value[row-1])
+	m.row = m.row - 1
+
+	// To perform a merge, we will need to combine the two lines and then
+	m.value[row-1] = append(m.value[row-1], m.value[row]...)
+
+	// Shift all lines up by one
+	for i := row; i < len(m.value)-1; i++ {
+		m.value[i] = m.value[i+1]
+	}
+
+	// And, remove the last line
+	if len(m.value) > 0 {
+		m.value = m.value[:len(m.value)-1]
+	}
+}
+
+func (m *Model) splitLine(row, col int) {
+	// To perform a split, take the current line and keep the content before
+	// the cursor, take the content after the cursor and make it the content of
+	// the line underneath, and shift the remaining lines down by one
+	head, tailSrc := m.value[row][:col], m.value[row][col:]
+	tail := make([]rune, len(tailSrc))
+	copy(tail, tailSrc)
+
+	m.value = append(m.value[:row+1], m.value[row:]...)
+
+	m.value[row] = head
+	m.value[row+1] = tail
+
+	m.col = 0
+	m.row++
+}
+
+// Paste is a command for pasting from the clipboard into the text input.
+func Paste() tea.Msg {
+	str, err := clipboard.ReadAll()
+	if err != nil {
+		return pasteErrMsg{err}
+	}
+	return pasteMsg(str)
+}
+
+func wrap(runes []rune, width int) [][]rune {
+	var (
+		lines  = [][]rune{{}}
+		word   = []rune{}
+		row    int
+		spaces int
+	)
+
+	// Word wrap the runes
+	for _, r := range runes {
+		if unicode.IsSpace(r) {
+			spaces++
+		} else {
+			word = append(word, r)
+		}
+
+		if spaces > 0 { //nolint:nestif
+			if uniseg.StringWidth(string(lines[row]))+uniseg.StringWidth(string(word))+spaces > width {
+				row++
+				lines = append(lines, []rune{})
+				lines[row] = append(lines[row], word...)
+				lines[row] = append(lines[row], repeatSpaces(spaces)...)
+				spaces = 0
+				word = nil
+			} else {
+				lines[row] = append(lines[row], word...)
+				lines[row] = append(lines[row], repeatSpaces(spaces)...)
+				spaces = 0
+				word = nil
+			}
+		} else {
+			// If the last character is a double-width rune, then we may not be able to add it to this line
+			// as it might cause us to go past the width.
+			lastCharLen := rw.RuneWidth(word[len(word)-1])
+			if uniseg.StringWidth(string(word))+lastCharLen > width {
+				// If the current line has any content, let's move to the next
+				// line because the current word fills up the entire line.
+				if len(lines[row]) > 0 {
+					row++
+					lines = append(lines, []rune{})
+				}
+				lines[row] = append(lines[row], word...)
+				word = nil
+			}
+		}
+	}
+
+	if uniseg.StringWidth(string(lines[row]))+uniseg.StringWidth(string(word))+spaces >= width {
+		lines = append(lines, []rune{})
+		lines[row+1] = append(lines[row+1], word...)
+		// We add an extra space at the end of the line to account for the
+		// trailing space at the end of the previous soft-wrapped lines so that
+		// behaviour when navigating is consistent and so that we don't need to
+		// continually add edges to handle the last line of the wrapped input.
+		spaces++
+		lines[row+1] = append(lines[row+1], repeatSpaces(spaces)...)
+	} else {
+		lines[row] = append(lines[row], word...)
+		spaces++
+		lines[row] = append(lines[row], repeatSpaces(spaces)...)
+	}
+
+	return lines
+}
+
+func repeatSpaces(n int) []rune {
+	return []rune(strings.Repeat(string(' '), n))
+}
+
+// numDigits returns the number of digits in an integer.
+func numDigits(n int) int {
+	if n == 0 {
+		return 1
+	}
+	count := 0
+	num := abs(n)
+	for num > 0 {
+		count++
+		num /= 10
+	}
+	return count
+}
+
+func clamp(v, low, high int) int {
+	if high < low {
+		low, high = high, low
+	}
+	return min(high, max(low, v))
+}
+
+func abs(n int) int {
+	if n < 0 {
+		return -n
+	}
+	return n
+}

--- a/internal/ui/textarea/textarea_test.go
+++ b/internal/ui/textarea/textarea_test.go
@@ -1,0 +1,2431 @@
+package textarea
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"unicode"
+
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+	"github.com/MakeNowJust/heredoc"
+	"github.com/charmbracelet/x/ansi"
+)
+
+func TestVerticalScrolling(t *testing.T) {
+	textarea := newTextArea()
+	textarea.Prompt = ""
+	textarea.ShowLineNumbers = false
+	textarea.SetHeight(1)
+	textarea.SetWidth(20)
+	textarea.CharLimit = 100
+
+	textarea, _ = textarea.Update(nil)
+
+	input := "This is a really long line that should wrap around the text area."
+
+	for _, k := range input {
+		textarea, _ = textarea.Update(keyPress(k))
+	}
+
+	view := textarea.View()
+
+	// The view should contain the end of "line" of the input.
+	if !strings.Contains(view, "the text area.") {
+		t.Log(view)
+		t.Error("Text area did not render the input")
+	}
+
+	// But we should be able to scroll to see the next line.
+	// Let's scroll down for each line to view the full input.
+	lines := []string{
+		"This is a really",
+		"long line that",
+		"should wrap around",
+		"the text area.",
+	}
+	textarea.viewport.GotoTop()
+	for _, line := range lines {
+		view = textarea.View()
+		if !strings.Contains(view, line) {
+			t.Log(view)
+			t.Error("Text area did not render the correct scrolled input")
+		}
+		textarea.viewport.ScrollDown(1)
+	}
+}
+
+func TestWordWrapOverflowing(t *testing.T) {
+	// An interesting edge case is when the user enters many words that fill up
+	// the text area and then goes back up and inserts a few words which causes
+	// a cascading wrap and causes an overflow of the last line.
+	//
+	// In this case, we should not let the user insert more words if, after the
+	// entire wrap is complete, the last line is overflowing.
+	textarea := newTextArea()
+
+	textarea.SetHeight(3)
+	textarea.SetWidth(20)
+	textarea.CharLimit = 500
+
+	textarea, _ = textarea.Update(nil)
+
+	input := "Testing Testing Testing Testing Testing Testing Testing Testing"
+
+	for _, k := range input {
+		textarea, _ = textarea.Update(keyPress(k))
+		textarea.View()
+	}
+
+	// We have essentially filled the text area with input.
+	// Let's see if we can cause wrapping to overflow the last line.
+	textarea.row = 0
+	textarea.col = 0
+
+	input = "Testing"
+
+	for _, k := range input {
+		textarea, _ = textarea.Update(keyPress(k))
+		textarea.View()
+	}
+
+	lastLineWidth := textarea.LineInfo().Width
+	if lastLineWidth > 20 {
+		t.Log(lastLineWidth)
+		t.Log(textarea.View())
+		t.Fail()
+	}
+}
+
+func TestValueSoftWrap(t *testing.T) {
+	textarea := newTextArea()
+	textarea.SetWidth(16)
+	textarea.SetHeight(10)
+	textarea.CharLimit = 500
+
+	textarea, _ = textarea.Update(nil)
+
+	input := "Testing Testing Testing Testing Testing Testing Testing Testing"
+
+	for _, k := range []rune(input) {
+		textarea, _ = textarea.Update(keyPress(k))
+		textarea.View()
+	}
+
+	value := textarea.Value()
+	if value != input {
+		t.Log(value)
+		t.Log(input)
+		t.Fatal("The text area does not have the correct value")
+	}
+}
+
+func TestSetValue(t *testing.T) {
+	textarea := newTextArea()
+	textarea.SetValue(strings.Join([]string{"Foo", "Bar", "Baz"}, "\n"))
+
+	if textarea.row != 2 && textarea.col != 3 {
+		t.Log(textarea.row, textarea.col)
+		t.Fatal("Cursor Should be on row 2 column 3 after inserting 2 new lines")
+	}
+
+	value := textarea.Value()
+	if value != "Foo\nBar\nBaz" {
+		t.Fatal("Value should be Foo\nBar\nBaz")
+	}
+
+	// SetValue should reset text area
+	textarea.SetValue("Test")
+	value = textarea.Value()
+	if value != "Test" {
+		t.Log(value)
+		t.Fatal("Text area was not reset when SetValue() was called")
+	}
+}
+
+func TestInsertString(t *testing.T) {
+	textarea := newTextArea()
+
+	// Insert some text
+	input := "foo baz"
+
+	for _, k := range []rune(input) {
+		textarea, _ = textarea.Update(keyPress(k))
+	}
+
+	// Put cursor in the middle of the text
+	textarea.col = 4
+
+	textarea.InsertString("bar ")
+
+	value := textarea.Value()
+	if value != "foo bar baz" {
+		t.Log(value)
+		t.Fatal("Expected insert string to insert bar between foo and baz")
+	}
+}
+
+func TestCanHandleEmoji(t *testing.T) {
+	textarea := newTextArea()
+	input := "🧋"
+
+	for _, k := range []rune(input) {
+		textarea, _ = textarea.Update(keyPress(k))
+	}
+
+	value := textarea.Value()
+	if value != input {
+		t.Log(value)
+		t.Fatal("Expected emoji to be inserted")
+	}
+
+	input = "🧋🧋🧋"
+
+	textarea.SetValue(input)
+
+	value = textarea.Value()
+	if value != input {
+		t.Log(value)
+		t.Fatal("Expected emoji to be inserted")
+	}
+
+	if textarea.col != 3 {
+		t.Log(textarea.col)
+		t.Fatal("Expected cursor to be on the third character")
+	}
+
+	if charOffset := textarea.LineInfo().CharOffset; charOffset != 6 {
+		t.Log(charOffset)
+		t.Fatal("Expected cursor to be on the sixth character")
+	}
+}
+
+func TestVerticalNavigationKeepsCursorHorizontalPosition(t *testing.T) {
+	textarea := newTextArea()
+	textarea.SetWidth(20)
+
+	textarea.SetValue(strings.Join([]string{"你好你好", "Hello"}, "\n"))
+
+	textarea.row = 0
+	textarea.col = 2
+
+	// 你好|你好
+	// Hell|o
+	// 1234|
+
+	// Let's imagine our cursor is on the first line where the pipe is.
+	// We press the down arrow to get to the next line.
+	// The issue is that if we keep the cursor on the same column, the cursor will jump to after the `e`.
+	//
+	// 你好|你好
+	// He|llo
+	//
+	// But this is wrong because visually we were at the 4th character due to
+	// the first line containing double-width runes.
+	// We want to keep the cursor on the same visual column.
+	//
+	// 你好|你好
+	// Hell|o
+	//
+	// This test ensures that the cursor is kept on the same visual column by
+	// ensuring that the column offset goes from 2 -> 4.
+
+	lineInfo := textarea.LineInfo()
+	if lineInfo.CharOffset != 4 || lineInfo.ColumnOffset != 2 {
+		t.Log(lineInfo.CharOffset)
+		t.Log(lineInfo.ColumnOffset)
+		t.Fatal("Expected cursor to be on the fourth character because there are two double width runes on the first line.")
+	}
+
+	downMsg := tea.KeyPressMsg{Code: tea.KeyDown}
+	textarea, _ = textarea.Update(downMsg)
+
+	lineInfo = textarea.LineInfo()
+	if lineInfo.CharOffset != 4 || lineInfo.ColumnOffset != 4 {
+		t.Log(lineInfo.CharOffset)
+		t.Log(lineInfo.ColumnOffset)
+		t.Fatal("Expected cursor to be on the fourth character because we came down from the first line.")
+	}
+}
+
+func TestVerticalNavigationShouldRememberPositionWhileTraversing(t *testing.T) {
+	textarea := newTextArea()
+	textarea.SetWidth(40)
+
+	// Let's imagine we have a text area with the following content:
+	//
+	// Hello
+	// World
+	// This is a long line.
+	//
+	// If we are at the end of the last line and go up, we should be at the end
+	// of the second line.
+	// And, if we go up again we should be at the end of the first line.
+	// But, if we go back down twice, we should be at the end of the last line
+	// again and not the fifth (length of second line) character of the last line.
+	//
+	// In other words, we should remember the last horizontal position while
+	// traversing vertically.
+
+	textarea.SetValue(strings.Join([]string{"Hello", "World", "This is a long line."}, "\n"))
+
+	// We are at the end of the last line.
+	if textarea.col != 20 || textarea.row != 2 {
+		t.Log(textarea.col)
+		t.Fatal("Expected cursor to be on the 20th character of the last line")
+	}
+
+	// Let's go up.
+	upMsg := tea.KeyPressMsg{Code: tea.KeyUp}
+	textarea, _ = textarea.Update(upMsg)
+
+	// We should be at the end of the second line.
+	if textarea.col != 5 || textarea.row != 1 {
+		t.Log(textarea.col)
+		t.Fatal("Expected cursor to be on the 5th character of the second line")
+	}
+
+	// And, again.
+	textarea, _ = textarea.Update(upMsg)
+
+	// We should be at the end of the first line.
+	if textarea.col != 5 || textarea.row != 0 {
+		t.Log(textarea.col)
+		t.Fatal("Expected cursor to be on the 5th character of the first line")
+	}
+
+	// Let's go down, twice.
+	downMsg := tea.KeyPressMsg{Code: tea.KeyDown}
+	textarea, _ = textarea.Update(downMsg)
+	textarea, _ = textarea.Update(downMsg)
+
+	// We should be at the end of the last line.
+	if textarea.col != 20 || textarea.row != 2 {
+		t.Log(textarea.col)
+		t.Fatal("Expected cursor to be on the 20th character of the last line")
+	}
+
+	// Now, for correct behavior, if we move right or left, we should forget
+	// (reset) the saved horizontal position. Since we assume the user wants to
+	// keep the cursor where it is horizontally. This is how most text areas
+	// work.
+
+	textarea, _ = textarea.Update(upMsg)
+	leftMsg := tea.KeyPressMsg{Code: tea.KeyLeft}
+	textarea, _ = textarea.Update(leftMsg)
+
+	if textarea.col != 4 || textarea.row != 1 {
+		t.Log(textarea.col)
+		t.Fatal("Expected cursor to be on the 5th character of the second line")
+	}
+
+	// Going down now should keep us at the 4th column since we moved left and
+	// reset the horizontal position saved state.
+	textarea, _ = textarea.Update(downMsg)
+	if textarea.col != 4 || textarea.row != 2 {
+		t.Log(textarea.col)
+		t.Fatal("Expected cursor to be on the 4th character of the last line")
+	}
+}
+
+func TestView(t *testing.T) {
+	t.Parallel()
+
+	type want struct {
+		view      string
+		cursorRow int
+		cursorCol int
+	}
+
+	tests := []struct {
+		name      string
+		modelFunc func(Model) Model
+		want      want
+	}{
+		{
+			name: "placeholder",
+			want: want{
+				view: heredoc.Doc(`
+					>   1 Hello, World!
+					>
+					>
+					>
+					>
+					>
+				`),
+			},
+		},
+		{
+			name: "single line",
+			modelFunc: func(m Model) Model {
+				m.SetValue("the first line")
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					>   1 the first line
+					>
+					>
+					>
+					>
+					>
+				`),
+				cursorRow: 0,
+				cursorCol: 14,
+			},
+		},
+		{
+			name: "multiple lines",
+			modelFunc: func(m Model) Model {
+				m.SetValue("the first line\nthe second line\nthe third line")
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					>   1 the first line
+					>   2 the second line
+					>   3 the third line
+					>
+					>
+					>
+				`),
+				cursorRow: 2,
+				cursorCol: 14,
+			},
+		},
+		{
+			name: "single line without line numbers",
+			modelFunc: func(m Model) Model {
+				m.SetValue("the first line")
+				m.ShowLineNumbers = false
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					> the first line
+					>
+					>
+					>
+					>
+					>
+				`),
+				cursorRow: 0,
+				cursorCol: 14,
+			},
+		},
+		{
+			name: "multipline lines without line numbers",
+			modelFunc: func(m Model) Model {
+				m.SetValue("the first line\nthe second line\nthe third line")
+				m.ShowLineNumbers = false
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					> the first line
+					> the second line
+					> the third line
+					>
+					>
+					>
+				`),
+				cursorRow: 2,
+				cursorCol: 14,
+			},
+		},
+		{
+			name: "single line and custom end of buffer character",
+			modelFunc: func(m Model) Model {
+				m.SetValue("the first line")
+				m.EndOfBufferCharacter = '*'
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					>   1 the first line
+					> *
+					> *
+					> *
+					> *
+					> *
+				`),
+				cursorRow: 0,
+				cursorCol: 14,
+			},
+		},
+		{
+			name: "multiple lines and custom end of buffer character",
+			modelFunc: func(m Model) Model {
+				m.SetValue("the first line\nthe second line\nthe third line")
+				m.EndOfBufferCharacter = '*'
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					>   1 the first line
+					>   2 the second line
+					>   3 the third line
+					> *
+					> *
+					> *
+				`),
+				cursorRow: 2,
+				cursorCol: 14,
+			},
+		},
+		{
+			name: "single line without line numbers and custom end of buffer character",
+			modelFunc: func(m Model) Model {
+				m.SetValue("the first line")
+				m.ShowLineNumbers = false
+				m.EndOfBufferCharacter = '*'
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					> the first line
+					> *
+					> *
+					> *
+					> *
+					> *
+				`),
+				cursorRow: 0,
+				cursorCol: 14,
+			},
+		},
+		{
+			name: "multiple lines without line numbers and custom end of buffer character",
+			modelFunc: func(m Model) Model {
+				m.SetValue("the first line\nthe second line\nthe third line")
+				m.ShowLineNumbers = false
+				m.EndOfBufferCharacter = '*'
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					> the first line
+					> the second line
+					> the third line
+					> *
+					> *
+					> *
+				`),
+				cursorRow: 2,
+				cursorCol: 14,
+			},
+		},
+		{
+			name: "single line and custom prompt",
+			modelFunc: func(m Model) Model {
+				m.SetValue("the first line")
+				m.Prompt = "* "
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					*   1 the first line
+					*
+					*
+					*
+					*
+					*
+				`),
+				cursorRow: 0,
+				cursorCol: 14,
+			},
+		},
+		{
+			name: "multiple lines and custom prompt",
+			modelFunc: func(m Model) Model {
+				m.SetValue("the first line\nthe second line\nthe third line")
+				m.Prompt = "* "
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					*   1 the first line
+					*   2 the second line
+					*   3 the third line
+					*
+					*
+					*
+				`),
+				cursorRow: 2,
+				cursorCol: 14,
+			},
+		},
+		{
+			name: "type single line",
+			modelFunc: func(m Model) Model {
+				input := "foo"
+				m = sendString(m, input)
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					>   1 foo
+					>
+					>
+					>
+					>
+					>
+				`),
+				cursorRow: 0,
+				cursorCol: 3,
+			},
+		},
+		{
+			name: "type multiple lines",
+			modelFunc: func(m Model) Model {
+				input := "foo\nbar\nbaz"
+				m = sendString(m, input)
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					>   1 foo
+					>   2 bar
+					>   3 baz
+					>
+					>
+					>
+				`),
+				cursorRow: 2,
+				cursorCol: 3,
+			},
+		},
+		{
+			name: "softwrap",
+			modelFunc: func(m Model) Model {
+				m.ShowLineNumbers = false
+				m.Prompt = ""
+				m.SetWidth(5)
+
+				input := "foo bar baz"
+				m = sendString(m, input)
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					foo
+					bar
+					baz
+
+
+
+				`),
+				cursorRow: 2,
+				cursorCol: 3,
+			},
+		},
+		{
+			name: "single line character limit",
+			modelFunc: func(m Model) Model {
+				m.CharLimit = 7
+
+				input := "foo bar baz"
+				m = sendString(m, input)
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					>   1 foo bar
+					>
+					>
+					>
+					>
+					>
+				`),
+				cursorRow: 0,
+				cursorCol: 7,
+			},
+		},
+		{
+			name: "multiple lines character limit",
+			modelFunc: func(m Model) Model {
+				m.CharLimit = 19
+
+				input := "foo bar baz\nfoo bar baz"
+				m = sendString(m, input)
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					>   1 foo bar baz
+					>   2 foo bar
+					>
+					>
+					>
+					>
+				`),
+				cursorRow: 1,
+				cursorCol: 7,
+			},
+		},
+		{
+			name: "set width",
+			modelFunc: func(m Model) Model {
+				m.SetWidth(10)
+
+				input := "12"
+				m = sendString(m, input)
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					>   1 12
+					>
+					>
+					>
+					>
+					>
+				`),
+				cursorRow: 0,
+				cursorCol: 2,
+			},
+		},
+		{
+			name: "set width max length text minus one",
+			modelFunc: func(m Model) Model {
+				m.SetWidth(10)
+
+				input := "123"
+				m = sendString(m, input)
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					>   1 123
+					>
+					>
+					>
+					>
+					>
+				`),
+				cursorRow: 0,
+				cursorCol: 3,
+			},
+		},
+		{
+			name: "set width max length text",
+			modelFunc: func(m Model) Model {
+				m.SetWidth(10)
+
+				input := "1234"
+				m = sendString(m, input)
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					>   1 1234
+					>
+					>
+					>
+					>
+					>
+				`),
+				cursorRow: 1,
+				cursorCol: 0,
+			},
+		},
+		{
+			name: "set width max length text plus one",
+			modelFunc: func(m Model) Model {
+				m.SetWidth(10)
+
+				input := "12345"
+				m = sendString(m, input)
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					>   1 1234
+					>     5
+					>
+					>
+					>
+					>
+				`),
+				cursorRow: 1,
+				cursorCol: 1,
+			},
+		},
+		{
+			name: "set width set max width minus one",
+			modelFunc: func(m Model) Model {
+				m.MaxWidth = 10
+				m.SetWidth(11)
+
+				input := "123"
+				m = sendString(m, input)
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					>   1 123
+					>
+					>
+					>
+					>
+					>
+				`),
+				cursorRow: 0,
+				cursorCol: 3,
+			},
+		},
+		{
+			name: "set width set max width",
+			modelFunc: func(m Model) Model {
+				m.MaxWidth = 10
+				m.SetWidth(11)
+
+				input := "1234"
+				m = sendString(m, input)
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					>   1 1234
+					>
+					>
+					>
+					>
+					>
+				`),
+				cursorRow: 1,
+				cursorCol: 0,
+			},
+		},
+		{
+			name: "set width set max width plus one",
+			modelFunc: func(m Model) Model {
+				m.MaxWidth = 10
+				m.SetWidth(11)
+
+				input := "12345"
+				m = sendString(m, input)
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					>   1 1234
+					>     5
+					>
+					>
+					>
+					>
+				`),
+				cursorRow: 1,
+				cursorCol: 1,
+			},
+		},
+		{
+			name: "set width min width minus one",
+			modelFunc: func(m Model) Model {
+				m.SetWidth(6)
+
+				input := "123"
+				m = sendString(m, input)
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					>   1 1
+					>     2
+					>     3
+					>
+					>
+					>
+				`),
+				cursorRow: 3,
+				cursorCol: 0,
+			},
+		},
+		{
+			name: "set width min width",
+			modelFunc: func(m Model) Model {
+				m.SetWidth(7)
+
+				input := "123"
+				m = sendString(m, input)
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					>   1 1
+					>     2
+					>     3
+					>
+					>
+					>
+				`),
+				cursorRow: 3,
+				cursorCol: 0,
+			},
+		},
+		{
+			name: "set width min width no line numbers",
+			modelFunc: func(m Model) Model {
+				m.ShowLineNumbers = false
+				m.SetWidth(0)
+
+				input := "123"
+				m = sendString(m, input)
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					> 1
+					> 2
+					> 3
+					>
+					>
+					>
+				`),
+				cursorRow: 3,
+				cursorCol: 0,
+			},
+		},
+		{
+			name: "set width min width no line numbers no prompt",
+			modelFunc: func(m Model) Model {
+				m.ShowLineNumbers = false
+				m.Prompt = ""
+				m.SetWidth(0)
+
+				input := "123"
+				m = sendString(m, input)
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					1
+					2
+					3
+
+
+
+				`),
+				cursorRow: 3,
+				cursorCol: 0,
+			},
+		},
+		{
+			name: "set width min width plus one",
+			modelFunc: func(m Model) Model {
+				m.SetWidth(8)
+
+				input := "123"
+				m = sendString(m, input)
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					>   1 12
+					>     3
+					>
+					>
+					>
+					>
+				`),
+				cursorRow: 1,
+				cursorCol: 1,
+			},
+		},
+		{
+			name: "set width without line numbers max length text minus one",
+			modelFunc: func(m Model) Model {
+				m.ShowLineNumbers = false
+				m.SetWidth(6)
+
+				input := "123"
+				m = sendString(m, input)
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					> 123
+					>
+					>
+					>
+					>
+					>
+				`),
+				cursorRow: 0,
+				cursorCol: 3,
+			},
+		},
+		{
+			name: "set width without line numbers max length text",
+			modelFunc: func(m Model) Model {
+				m.ShowLineNumbers = false
+				m.SetWidth(6)
+
+				input := "1234"
+				m = sendString(m, input)
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					> 1234
+					>
+					>
+					>
+					>
+					>
+				`),
+				cursorRow: 1,
+				cursorCol: 0,
+			},
+		},
+		{
+			name: "set width without line numbers max length text plus one",
+			modelFunc: func(m Model) Model {
+				m.ShowLineNumbers = false
+				m.SetWidth(6)
+
+				input := "12345"
+				m = sendString(m, input)
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					> 1234
+					> 5
+					>
+					>
+					>
+					>
+				`),
+				cursorRow: 1,
+				cursorCol: 1,
+			},
+		},
+		{
+			name: "set width with style",
+			modelFunc: func(m Model) Model {
+				s := m.Styles()
+				s.Focused.Base = lipgloss.NewStyle().Border(lipgloss.NormalBorder())
+				m.SetStyles(s)
+				m.Focus()
+
+				m.SetWidth(12)
+
+				input := "1"
+				m = sendString(m, input)
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					┌──────────┐
+					│>   1 1   │
+					│>         │
+					│>         │
+					│>         │
+					│>         │
+					│>         │
+					└──────────┘
+				`),
+				cursorRow: 0,
+				cursorCol: 1,
+			},
+		},
+		{
+			name: "set width with style max width minus one",
+			modelFunc: func(m Model) Model {
+				s := m.Styles()
+				s.Focused.Base = lipgloss.NewStyle().Border(lipgloss.NormalBorder())
+				m.SetStyles(s)
+				m.Focus()
+
+				m.SetWidth(12)
+
+				input := "123"
+				m = sendString(m, input)
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					┌──────────┐
+					│>   1 123 │
+					│>         │
+					│>         │
+					│>         │
+					│>         │
+					│>         │
+					└──────────┘
+				`),
+				cursorRow: 0,
+				cursorCol: 3,
+			},
+		},
+		{
+			name: "set width with style max width",
+			modelFunc: func(m Model) Model {
+				s := m.Styles()
+				s.Focused.Base = lipgloss.NewStyle().Border(lipgloss.NormalBorder())
+				m.SetStyles(s)
+				m.Focus()
+
+				m.SetWidth(12)
+
+				input := "1234"
+				m = sendString(m, input)
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					┌──────────┐
+					│>   1 1234│
+					│>         │
+					│>         │
+					│>         │
+					│>         │
+					│>         │
+					└──────────┘
+				`),
+				cursorRow: 1,
+				cursorCol: 0,
+			},
+		},
+		{
+			name: "set width with style max width plus one",
+			modelFunc: func(m Model) Model {
+				s := m.Styles()
+				s.Focused.Base = lipgloss.NewStyle().Border(lipgloss.NormalBorder())
+				m.SetStyles(s)
+				m.Focus()
+
+				m.SetWidth(12)
+
+				input := "12345"
+				m = sendString(m, input)
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					┌──────────┐
+					│>   1 1234│
+					│>     5   │
+					│>         │
+					│>         │
+					│>         │
+					│>         │
+					└──────────┘
+				`),
+				cursorRow: 1,
+				cursorCol: 1,
+			},
+		},
+		{
+			name: "set width without line numbers with style",
+			modelFunc: func(m Model) Model {
+				s := m.Styles()
+				s.Focused.Base = lipgloss.NewStyle().Border(lipgloss.NormalBorder())
+				m.SetStyles(s)
+				m.Focus()
+
+				m.ShowLineNumbers = false
+				m.SetWidth(12)
+
+				input := "123456"
+				m = sendString(m, input)
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					┌──────────┐
+					│> 123456  │
+					│>         │
+					│>         │
+					│>         │
+					│>         │
+					│>         │
+					└──────────┘
+				`),
+				cursorRow: 0,
+				cursorCol: 6,
+			},
+		},
+		{
+			name: "set width without line numbers with style max width minus one",
+			modelFunc: func(m Model) Model {
+				s := m.Styles()
+				s.Focused.Base = lipgloss.NewStyle().Border(lipgloss.NormalBorder())
+				m.SetStyles(s)
+				m.Focus()
+
+				m.ShowLineNumbers = false
+				m.SetWidth(12)
+
+				input := "1234567"
+				m = sendString(m, input)
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					┌──────────┐
+					│> 1234567 │
+					│>         │
+					│>         │
+					│>         │
+					│>         │
+					│>         │
+					└──────────┘
+				`),
+				cursorRow: 0,
+				cursorCol: 7,
+			},
+		},
+		{
+			name: "set width without line numbers with style max width",
+			modelFunc: func(m Model) Model {
+				s := m.Styles()
+				s.Focused.Base = lipgloss.NewStyle().Border(lipgloss.NormalBorder())
+				m.SetStyles(s)
+				m.Focus()
+
+				m.ShowLineNumbers = false
+				m.SetWidth(12)
+
+				input := "12345678"
+				m = sendString(m, input)
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					┌──────────┐
+					│> 12345678│
+					│>         │
+					│>         │
+					│>         │
+					│>         │
+					│>         │
+					└──────────┘
+				`),
+				cursorRow: 1,
+				cursorCol: 0,
+			},
+		},
+		{
+			name: "set width without line numbers with style max width plus one",
+			modelFunc: func(m Model) Model {
+				s := m.Styles()
+				s.Focused.Base = lipgloss.NewStyle().Border(lipgloss.NormalBorder())
+				m.SetStyles(s)
+				m.Focus()
+
+				m.ShowLineNumbers = false
+				m.SetWidth(12)
+
+				input := "123456789"
+				m = sendString(m, input)
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					┌──────────┐
+					│> 12345678│
+					│> 9       │
+					│>         │
+					│>         │
+					│>         │
+					│>         │
+					└──────────┘
+				`),
+				cursorRow: 1,
+				cursorCol: 1,
+			},
+		},
+		{
+			name: "placeholder min width",
+			modelFunc: func(m Model) Model {
+				m.SetWidth(0)
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					>   1 H
+					>     e
+					>     l
+					>     l
+					>     o
+					>     ,
+				`),
+			},
+		},
+		{
+			name: "placeholder single line",
+			modelFunc: func(m Model) Model {
+				m.Placeholder = "placeholder the first line"
+				m.ShowLineNumbers = false
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					> placeholder the first line
+					>
+					>
+					>
+					>
+					>
+					`),
+			},
+		},
+		{
+			name: "placeholder multiple lines",
+			modelFunc: func(m Model) Model {
+				m.Placeholder = "placeholder the first line\nplaceholder the second line\nplaceholder the third line"
+				m.ShowLineNumbers = false
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					> placeholder the first line
+					> placeholder the second line
+					> placeholder the third line
+					>
+					>
+					>
+				`),
+			},
+		},
+		{
+			name: "placeholder single line with line numbers",
+			modelFunc: func(m Model) Model {
+				m.Placeholder = "placeholder the first line"
+				m.ShowLineNumbers = true
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					>   1 placeholder the first line
+					>
+					>
+					>
+					>
+					>
+				`),
+			},
+		},
+		{
+			name: "placeholder multiple lines with line numbers",
+			modelFunc: func(m Model) Model {
+				m.Placeholder = "placeholder the first line\nplaceholder the second line\nplaceholder the third line"
+				m.ShowLineNumbers = true
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					>   1 placeholder the first line
+					>     placeholder the second line
+					>     placeholder the third line
+					>
+					>
+					>
+				`),
+			},
+		},
+		{
+			name: "placeholder single line with end of buffer character",
+			modelFunc: func(m Model) Model {
+				m.Placeholder = "placeholder the first line"
+				m.ShowLineNumbers = false
+				m.EndOfBufferCharacter = '*'
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					> placeholder the first line
+					> *
+					> *
+					> *
+					> *
+					> *
+				`),
+			},
+		},
+		{
+			name: "placeholder multiple lines with with end of buffer character",
+			modelFunc: func(m Model) Model {
+				m.Placeholder = "placeholder the first line\nplaceholder the second line\nplaceholder the third line"
+				m.ShowLineNumbers = false
+				m.EndOfBufferCharacter = '*'
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					> placeholder the first line
+					> placeholder the second line
+					> placeholder the third line
+					> *
+					> *
+					> *
+				`),
+			},
+		},
+		{
+			name: "placeholder single line with line numbers and end of buffer character",
+			modelFunc: func(m Model) Model {
+				m.Placeholder = "placeholder the first line"
+				m.ShowLineNumbers = true
+				m.EndOfBufferCharacter = '*'
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					>   1 placeholder the first line
+					> *
+					> *
+					> *
+					> *
+					> *
+				`),
+			},
+		},
+		{
+			name: "placeholder multiple lines with line numbers and end of buffer character",
+			modelFunc: func(m Model) Model {
+				m.Placeholder = "placeholder the first line\nplaceholder the second line\nplaceholder the third line"
+				m.ShowLineNumbers = true
+				m.EndOfBufferCharacter = '*'
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					>   1 placeholder the first line
+					>     placeholder the second line
+					>     placeholder the third line
+					> *
+					> *
+					> *
+				`),
+			},
+		},
+		{
+			name: "placeholder single line that is longer than max width",
+			modelFunc: func(m Model) Model {
+				m.Placeholder = "placeholder the first line that is longer than the max width"
+				m.SetWidth(40)
+				m.ShowLineNumbers = false
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					> placeholder the first line that is
+					> longer than the max width
+					>
+					>
+					>
+					>
+				`),
+			},
+		},
+		{
+			name: "placeholder multiple lines that are longer than max width",
+			modelFunc: func(m Model) Model {
+				m.Placeholder = "placeholder the first line that is longer than the max width\nplaceholder the second line that is longer than the max width"
+				m.ShowLineNumbers = false
+				m.SetWidth(40)
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					> placeholder the first line that is
+					> longer than the max width
+					> placeholder the second line that is
+					> longer than the max width
+					>
+					>
+				`),
+			},
+		},
+		{
+			name: "placeholder single line that is longer than max width with line numbers",
+			modelFunc: func(m Model) Model {
+				m.Placeholder = "placeholder the first line that is longer than the max width"
+				m.ShowLineNumbers = true
+				m.SetWidth(40)
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					>   1 placeholder the first line that is
+					>     longer than the max width
+					>
+					>
+					>
+					>
+				`),
+			},
+		},
+		{
+			name: "placeholder multiple lines that are longer than max width with line numbers",
+			modelFunc: func(m Model) Model {
+				m.Placeholder = "placeholder the first line that is longer than the max width\nplaceholder the second line that is longer than the max width"
+				m.ShowLineNumbers = true
+				m.SetWidth(40)
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					>   1 placeholder the first line that is
+					>     longer than the max width
+					>     placeholder the second line that
+					>     is longer than the max width
+					>
+					>
+				`),
+			},
+		},
+		{
+			name: "placeholder single line that is longer than max width at limit",
+			modelFunc: func(m Model) Model {
+				m.Placeholder = "123456789012345678"
+				m.ShowLineNumbers = false
+				m.SetWidth(20)
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					> 123456789012345678
+					>
+					>
+					>
+					>
+					>
+				`),
+			},
+		},
+		{
+			name: "placeholder single line that is longer than max width at limit plus one",
+			modelFunc: func(m Model) Model {
+				m.Placeholder = "1234567890123456789"
+				m.ShowLineNumbers = false
+				m.SetWidth(20)
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					> 123456789012345678
+					> 9
+					>
+					>
+					>
+					>
+				`),
+			},
+		},
+		{
+			name: "placeholder single line that is longer than max width with line numbers at limit",
+			modelFunc: func(m Model) Model {
+				m.Placeholder = "12345678901234"
+				m.ShowLineNumbers = true
+				m.SetWidth(20)
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					>   1 12345678901234
+					>
+					>
+					>
+					>
+					>
+				`),
+			},
+		},
+		{
+			name: "placeholder single line that is longer than max width with line numbers at limit plus one",
+			modelFunc: func(m Model) Model {
+				m.Placeholder = "123456789012345"
+				m.ShowLineNumbers = true
+				m.SetWidth(20)
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					>   1 12345678901234
+					>     5
+					>
+					>
+					>
+					>
+				`),
+			},
+		},
+		{
+			name: "placeholder multiple lines that are longer than max width at limit",
+			modelFunc: func(m Model) Model {
+				m.Placeholder = "123456789012345678\n123456789012345678"
+				m.ShowLineNumbers = false
+				m.SetWidth(20)
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					> 123456789012345678
+					> 123456789012345678
+					>
+					>
+					>
+					>
+				`),
+			},
+		},
+		{
+			name: "placeholder multiple lines that are longer than max width at limit plus one",
+			modelFunc: func(m Model) Model {
+				m.Placeholder = "1234567890123456789\n1234567890123456789"
+				m.ShowLineNumbers = false
+				m.SetWidth(20)
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					> 123456789012345678
+					> 9
+					> 123456789012345678
+					> 9
+					>
+					>
+				`),
+			},
+		},
+		{
+			name: "placeholder multiple lines that are longer than max width with line numbers at limit",
+			modelFunc: func(m Model) Model {
+				m.Placeholder = "12345678901234\n12345678901234"
+				m.ShowLineNumbers = true
+				m.SetWidth(20)
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					>   1 12345678901234
+					>     12345678901234
+					>
+					>
+					>
+					>
+				`),
+			},
+		},
+		{
+			name: "placeholder multiple lines that are longer than max width with line numbers at limit plus one",
+			modelFunc: func(m Model) Model {
+				m.Placeholder = "123456789012345\n123456789012345"
+				m.ShowLineNumbers = true
+				m.SetWidth(20)
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					>   1 12345678901234
+					>     5
+					>     12345678901234
+					>     5
+					>
+					>
+				`),
+			},
+		},
+		{
+			name: "placeholder chinese character",
+			modelFunc: func(m Model) Model {
+				m.Placeholder = "输入消息..."
+				m.ShowLineNumbers = true
+				m.SetWidth(20)
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					>   1 输入消息...
+					>
+					>
+					>
+					>
+					>
+
+				`),
+			},
+		},
+		{
+			name: "page up moves to beginning when near top",
+			modelFunc: func(m Model) Model {
+				m.ShowLineNumbers = true
+				m.SetHeight(4)
+				m.SetWidth(20)
+
+				lines := make([]string, 10)
+				for i := range 10 {
+					lines[i] = fmt.Sprintf("Line %d", i+1)
+				}
+				m.SetValue(strings.Join(lines, "\n"))
+				m.viewport.SetContent(m.view()) // force setting of viewport content.
+
+				m.row = 3
+				m.col = 0
+				m.viewport.SetYOffset(0)
+				m.PageUp()
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					>   1 Line 1
+					>   2 Line 2
+					>   3 Line 3
+					>   4 Line 4
+				`),
+				cursorRow: 0,
+			},
+		},
+		{
+			name: "page up snaps to first visible line when not on it",
+			modelFunc: func(m Model) Model {
+				m.ShowLineNumbers = true
+				m.SetHeight(4)
+				m.SetWidth(20)
+
+				lines := make([]string, 10)
+				for i := range 10 {
+					lines[i] = fmt.Sprintf("Line %d", i+1)
+				}
+				m.SetValue(strings.Join(lines, "\n"))
+				m.viewport.SetContent(m.view()) // force setting of viewport content.
+
+				m.row = 5
+				m.col = 0
+				m.viewport.SetYOffset(3)
+				m.PageUp()
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					>   4 Line 4
+					>   5 Line 5
+					>   6 Line 6
+					>   7 Line 7
+				`),
+				cursorRow: 3,
+			},
+		},
+		{
+			name: "page up moves up by full page when on first visible line",
+			modelFunc: func(m Model) Model {
+				m.ShowLineNumbers = true
+				m.SetHeight(3)
+				m.SetWidth(20)
+
+				lines := make([]string, 10)
+				for i := range 10 {
+					lines[i] = fmt.Sprintf("Line %d", i+1)
+				}
+				m.SetValue(strings.Join(lines, "\n"))
+				m.viewport.SetContent(m.view()) // force setting of viewport content.
+
+				m.row = 5
+				m.col = 0
+				m.viewport.SetYOffset(5)
+				m.PageUp()
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					>   3 Line 3
+					>   4 Line 4
+					>   5 Line 5
+				`),
+				cursorRow: 2,
+			},
+		},
+		{
+			name: "page down moves to end when near bottom",
+			modelFunc: func(m Model) Model {
+				m.SetHeight(3)
+				m.SetWidth(20)
+
+				lines := make([]string, 10)
+				for i := range 10 {
+					lines[i] = fmt.Sprintf("Line %d", i+1)
+				}
+				m.SetValue(strings.Join(lines, "\n"))
+				m.viewport.SetContent(m.view()) // force setting of viewport content.
+
+				m.row = 8
+				m.col = 0
+				m.viewport.SetYOffset(7)
+				m.PageDown()
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					>   8 Line 8
+					>   9 Line 9
+					>  10 Line 10
+				`),
+				cursorRow: 9,
+			},
+		},
+		{
+			name: "page down snaps to last visible line when not on it",
+			modelFunc: func(m Model) Model {
+				m.SetHeight(3)
+				m.SetWidth(20)
+
+				lines := make([]string, 10)
+				for i := range 10 {
+					lines[i] = fmt.Sprintf("Line %d", i+1)
+				}
+				m.SetValue(strings.Join(lines, "\n"))
+				m.viewport.SetContent(m.view()) // force setting of viewport content.
+
+				m.row = 3
+				m.col = 0
+				m.viewport.SetYOffset(3)
+				m.PageDown()
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					>   4 Line 4
+					>   5 Line 5
+					>   6 Line 6
+				`),
+				cursorRow: 5,
+			},
+		},
+		{
+			name: "page down moves down by full page when on last visible line",
+			modelFunc: func(m Model) Model {
+				m.SetHeight(3)
+				m.SetWidth(20)
+
+				lines := make([]string, 10)
+				for i := range 10 {
+					lines[i] = fmt.Sprintf("Line %d", i+1)
+				}
+				m.SetValue(strings.Join(lines, "\n"))
+				m.viewport.SetContent(m.view()) // force setting of viewport content.
+
+				m.row = 4
+				m.col = 0
+				m.viewport.SetYOffset(2)
+				m.PageDown()
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					>   6 Line 6
+					>   7 Line 7
+					>   8 Line 8
+				`),
+				cursorRow: 7,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			textarea := newTextArea()
+
+			if tt.modelFunc != nil {
+				textarea = tt.modelFunc(textarea)
+			}
+
+			view := stripString(textarea.View())
+			wantView := stripString(tt.want.view)
+
+			if view != wantView {
+				t.Fatalf("Want:\n%v\nGot:\n%v\n", wantView, view)
+			}
+
+			cursorRow := textarea.cursorLineNumber()
+			cursorCol := textarea.LineInfo().ColumnOffset
+			if tt.want.cursorRow != cursorRow || tt.want.cursorCol != cursorCol {
+				format := "Want cursor at row: %v, col: %v Got: row: %v col: %v\n"
+				t.Fatalf(format, tt.want.cursorRow, tt.want.cursorCol, cursorRow, cursorCol)
+			}
+		})
+	}
+}
+
+func TestWord(t *testing.T) {
+	textarea := newTextArea()
+
+	textarea.SetHeight(3)
+	textarea.SetWidth(20)
+	textarea.CharLimit = 500
+
+	textarea, _ = textarea.Update(nil)
+
+	t.Run("regular input", func(t *testing.T) {
+		input := "Word1 Word2 Word3 Word4"
+		for _, k := range input {
+			textarea, _ = textarea.Update(keyPress(k))
+			textarea.View()
+		}
+
+		expect := "Word4"
+		if word := textarea.Word(); word != expect {
+			t.Fatalf("Expected last word to be '%s', got '%s'", expect, word)
+		}
+	})
+
+	t.Run("navigate", func(t *testing.T) {
+		for _, k := range []tea.KeyPressMsg{
+			{Code: tea.KeyLeft, Mod: tea.ModAlt, Text: "alt+left"},
+			{Code: tea.KeyLeft, Mod: tea.ModAlt, Text: "alt+left"},
+			{Code: tea.KeyRight, Text: "right"},
+		} {
+			textarea, _ = textarea.Update(k)
+			textarea.View()
+		}
+
+		expect := "Word3"
+		if word := textarea.Word(); word != expect {
+			t.Fatalf("Expected last word to be '%s', got '%s'", expect, word)
+		}
+	})
+
+	t.Run("delete", func(t *testing.T) {
+		for _, k := range []tea.KeyPressMsg{
+			{Code: tea.KeyEnd, Text: "end"},
+			{Code: tea.KeyBackspace, Mod: tea.ModAlt, Text: "alt+backspace"},
+			{Code: tea.KeyBackspace, Mod: tea.ModAlt, Text: "alt+backspace"},
+			{Code: tea.KeyBackspace, Text: "backspace"},
+		} {
+			textarea, _ = textarea.Update(k)
+			textarea.View()
+		}
+
+		expect := "Word2"
+		if word := textarea.Word(); word != expect {
+			t.Fatalf("Expected last word to be '%s', got '%s'", expect, word)
+		}
+	})
+}
+
+func newDynamicTextArea(minH, maxH int) Model {
+	ta := New()
+	ta.Prompt = ""
+	ta.ShowLineNumbers = false
+	ta.DynamicHeight = true
+	ta.MinHeight = minH
+	ta.MaxHeight = maxH
+	ta.SetWidth(20)
+	ta.Focus()
+	ta, _ = ta.Update(nil)
+	return ta
+}
+
+func TestDynamicHeight_DefaultUnchanged(t *testing.T) {
+	ta := newTextArea()
+	ta.SetHeight(6)
+	ta.SetWidth(40)
+
+	for _, k := range "hello\nworld\n" {
+		ta, _ = ta.Update(keyPress(k))
+	}
+
+	if ta.Height() != 6 {
+		t.Errorf("expected static height 6, got %d", ta.Height())
+	}
+}
+
+func TestDynamicHeight_GrowsOnNewline(t *testing.T) {
+	ta := newDynamicTextArea(1, 20)
+
+	ta, _ = ta.Update(keyPress('a'))
+	if ta.Height() != 1 {
+		t.Errorf("expected height 1 after single char, got %d", ta.Height())
+	}
+
+	enter := tea.KeyPressMsg{Code: tea.KeyEnter}
+	ta, _ = ta.Update(enter)
+	if ta.Height() != 2 {
+		t.Errorf("expected height 2 after first newline, got %d", ta.Height())
+	}
+
+	ta, _ = ta.Update(enter)
+	if ta.Height() != 3 {
+		t.Errorf("expected height 3 after second newline, got %d", ta.Height())
+	}
+}
+
+func TestDynamicHeight_GrowsOnSoftWrap(t *testing.T) {
+	ta := newDynamicTextArea(1, 20)
+	// width=20, so typing >20 chars should cause a soft wrap
+	input := "abcdefghijklmnopqrstuvwxyz"
+	for _, k := range input {
+		ta, _ = ta.Update(keyPress(k))
+	}
+
+	if ta.Height() < 2 {
+		t.Errorf("expected height >= 2 after soft wrap, got %d", ta.Height())
+	}
+}
+
+func TestDynamicHeight_ShrinksOnLineDeletion(t *testing.T) {
+	ta := newDynamicTextArea(1, 20)
+
+	enter := tea.KeyPressMsg{Code: tea.KeyEnter}
+	ta, _ = ta.Update(keyPress('a'))
+	ta, _ = ta.Update(enter)
+	ta, _ = ta.Update(keyPress('b'))
+	ta, _ = ta.Update(enter)
+	ta, _ = ta.Update(keyPress('c'))
+
+	if ta.Height() != 3 {
+		t.Fatalf("expected height 3 before deletion, got %d", ta.Height())
+	}
+
+	// Backspace at start of line 3 merges with line 2
+	ta.CursorStart()
+	backspace := tea.KeyPressMsg{Code: tea.KeyBackspace}
+	ta, _ = ta.Update(backspace)
+
+	if ta.Height() != 2 {
+		t.Errorf("expected height 2 after line merge, got %d", ta.Height())
+	}
+}
+
+func TestDynamicHeight_RespectsMinHeight(t *testing.T) {
+	ta := newDynamicTextArea(5, 20)
+
+	ta, _ = ta.Update(keyPress('a'))
+
+	if ta.Height() != 5 {
+		t.Errorf("expected min height 5, got %d", ta.Height())
+	}
+}
+
+func TestDynamicHeight_RespectsMaxHeight(t *testing.T) {
+	ta := newDynamicTextArea(1, 5)
+
+	enter := tea.KeyPressMsg{Code: tea.KeyEnter}
+	for range 10 {
+		ta, _ = ta.Update(keyPress('x'))
+		ta, _ = ta.Update(enter)
+	}
+
+	if ta.Height() != 5 {
+		t.Errorf("expected max height 5, got %d", ta.Height())
+	}
+}
+
+func TestDynamicHeight_GrowsOnPaste(t *testing.T) {
+	ta := newDynamicTextArea(1, 20)
+
+	paste := tea.PasteMsg{Content: "line1\nline2\nline3\nline4\nline5"}
+	ta, _ = ta.Update(paste)
+
+	if ta.Height() != 5 {
+		t.Errorf("expected height 5 after pasting 5 lines, got %d", ta.Height())
+	}
+}
+
+func TestDynamicHeight_RecalculatesOnSetWidth(t *testing.T) {
+	ta := newDynamicTextArea(1, 50)
+	ta.SetWidth(40)
+
+	// Insert a line that fits in 40 cols but wraps in 10 cols
+	ta.SetValue("abcdefghijklmnopqrstuvwxyz")
+
+	if ta.Height() != 1 {
+		t.Fatalf("expected height 1 at width 40, got %d", ta.Height())
+	}
+
+	ta.SetWidth(10)
+
+	if ta.Height() < 3 {
+		t.Errorf("expected height >= 3 after narrowing to width 10, got %d", ta.Height())
+	}
+}
+
+func TestDynamicHeight_RecalculatesOnSetValue(t *testing.T) {
+	ta := newDynamicTextArea(1, 20)
+
+	ta.SetValue("a\nb\nc\nd\ne")
+
+	if ta.Height() != 5 {
+		t.Errorf("expected height 5 after SetValue with 5 lines, got %d", ta.Height())
+	}
+}
+
+func TestDynamicHeight_CursorPositionAfterGrow(t *testing.T) {
+	ta := newDynamicTextArea(1, 20)
+
+	enter := tea.KeyPressMsg{Code: tea.KeyEnter}
+	for i := range 5 {
+		ta, _ = ta.Update(keyPress(rune('a' + i)))
+		ta, _ = ta.Update(enter)
+	}
+	ta, _ = ta.Update(keyPress('f'))
+
+	// Cursor should be on the last line (row 5, 0-indexed)
+	if ta.Line() != 5 {
+		t.Errorf("expected cursor on row 5, got %d", ta.Line())
+	}
+
+	// Cursor visual line should be within the viewport
+	cursorLine := ta.cursorLineNumber()
+	minVisible := ta.viewport.YOffset()
+	maxVisible := minVisible + ta.viewport.Height() - 1
+	if cursorLine < minVisible || cursorLine > maxVisible {
+		t.Errorf("cursor line %d outside viewport [%d, %d]", cursorLine, minVisible, maxVisible)
+	}
+}
+
+func TestDynamicHeight_CursorPositionAfterShrink(t *testing.T) {
+	ta := newDynamicTextArea(1, 20)
+
+	enter := tea.KeyPressMsg{Code: tea.KeyEnter}
+	for i := range 5 {
+		ta, _ = ta.Update(keyPress(rune('a' + i)))
+		ta, _ = ta.Update(enter)
+	}
+	ta, _ = ta.Update(keyPress('f'))
+
+	if ta.Height() != 6 {
+		t.Fatalf("expected height 6 before shrink, got %d", ta.Height())
+	}
+
+	// Delete lines by backspacing
+	backspace := tea.KeyPressMsg{Code: tea.KeyBackspace}
+	ta, _ = ta.Update(backspace) // delete 'f'
+	ta, _ = ta.Update(backspace) // merge line 5 into 4
+	ta, _ = ta.Update(backspace) // delete 'e'
+	ta, _ = ta.Update(backspace) // merge line 4 into 3
+
+	cursorLine := ta.cursorLineNumber()
+	minVisible := ta.viewport.YOffset()
+	maxVisible := minVisible + ta.viewport.Height() - 1
+	if cursorLine < minVisible || cursorLine > maxVisible {
+		t.Errorf("cursor line %d outside viewport [%d, %d] after shrink", cursorLine, minVisible, maxVisible)
+	}
+}
+
+func TestDynamicHeight_CursorPositionAfterPaste(t *testing.T) {
+	ta := newDynamicTextArea(1, 20)
+
+	paste := tea.PasteMsg{Content: "line1\nline2\nline3\nline4\nline5"}
+	ta, _ = ta.Update(paste)
+
+	// Cursor should be at the end of the last pasted line
+	if ta.Line() != 4 {
+		t.Errorf("expected cursor on row 4, got %d", ta.Line())
+	}
+
+	cursorLine := ta.cursorLineNumber()
+	minVisible := ta.viewport.YOffset()
+	maxVisible := minVisible + ta.viewport.Height() - 1
+	if cursorLine < minVisible || cursorLine > maxVisible {
+		t.Errorf("cursor line %d outside viewport [%d, %d] after paste", cursorLine, minVisible, maxVisible)
+	}
+}
+
+func TestMaxContentHeight_ScrollsBeyondMaxHeight(t *testing.T) {
+	ta := newDynamicTextArea(1, 5)
+	ta.MaxContentHeight = 10
+
+	enter := tea.KeyPressMsg{Code: tea.KeyEnter}
+	for range 8 {
+		ta, _ = ta.Update(keyPress('x'))
+		ta, _ = ta.Update(enter)
+	}
+
+	if ta.Height() != 5 {
+		t.Errorf("expected visible height capped at 5, got %d", ta.Height())
+	}
+
+	if ta.LineCount() != 9 {
+		t.Errorf("expected 9 logical lines, got %d", ta.LineCount())
+	}
+}
+
+func TestMaxContentHeight_BlocksAtLimit(t *testing.T) {
+	ta := New()
+	ta.Prompt = ""
+	ta.ShowLineNumbers = false
+	ta.MaxContentHeight = 5
+	ta.SetWidth(20)
+	ta.Focus()
+	ta, _ = ta.Update(nil)
+
+	enter := tea.KeyPressMsg{Code: tea.KeyEnter}
+	for range 10 {
+		ta, _ = ta.Update(keyPress('x'))
+		ta, _ = ta.Update(enter)
+	}
+
+	if ta.totalVisualLines() > 5 {
+		t.Errorf("expected total visual lines <= 5, got %d", ta.totalVisualLines())
+	}
+}
+
+func TestMaxContentHeight_BackwardCompat(t *testing.T) {
+	ta := New()
+	ta.Prompt = ""
+	ta.ShowLineNumbers = false
+	ta.MaxHeight = 10
+	ta.SetWidth(20)
+	ta.Focus()
+	ta, _ = ta.Update(nil)
+
+	enter := tea.KeyPressMsg{Code: tea.KeyEnter}
+	for range 15 {
+		ta, _ = ta.Update(keyPress('x'))
+		ta, _ = ta.Update(enter)
+	}
+
+	if ta.LineCount() > 10 {
+		t.Errorf("expected logical line count <= 10 (legacy behavior), got %d", ta.LineCount())
+	}
+}
+
+func TestMaxContentHeight_WithoutDynamicHeight(t *testing.T) {
+	ta := New()
+	ta.Prompt = ""
+	ta.ShowLineNumbers = false
+	ta.MaxContentHeight = 5
+	ta.SetHeight(3)
+	ta.SetWidth(20)
+	ta.Focus()
+	ta, _ = ta.Update(nil)
+
+	enter := tea.KeyPressMsg{Code: tea.KeyEnter}
+	for range 10 {
+		ta, _ = ta.Update(keyPress('x'))
+		ta, _ = ta.Update(enter)
+	}
+
+	if ta.Height() != 3 {
+		t.Errorf("expected fixed height 3, got %d", ta.Height())
+	}
+
+	if ta.totalVisualLines() > 5 {
+		t.Errorf("expected content capped at 5 visual lines, got %d", ta.totalVisualLines())
+	}
+}
+
+func TestMaxContentHeight_CursorVisibleWhileScrolling(t *testing.T) {
+	ta := newDynamicTextArea(1, 5)
+	ta.MaxContentHeight = 10
+
+	enter := tea.KeyPressMsg{Code: tea.KeyEnter}
+	for range 8 {
+		ta, _ = ta.Update(keyPress('x'))
+		ta, _ = ta.Update(enter)
+	}
+	ta, _ = ta.Update(keyPress('y'))
+
+	cursorLine := ta.cursorLineNumber()
+	minVisible := ta.viewport.YOffset()
+	maxVisible := minVisible + ta.viewport.Height() - 1
+	if cursorLine < minVisible || cursorLine > maxVisible {
+		t.Errorf("cursor line %d outside viewport [%d, %d] while scrolling", cursorLine, minVisible, maxVisible)
+	}
+}
+
+func TestMaxContentHeight_PasteCapped(t *testing.T) {
+	ta := New()
+	ta.Prompt = ""
+	ta.ShowLineNumbers = false
+	ta.MaxContentHeight = 5
+	ta.SetWidth(20)
+	ta.Focus()
+	ta, _ = ta.Update(nil)
+
+	paste := tea.PasteMsg{Content: "1\n2\n3\n4\n5\n6\n7\n8\n9\n10"}
+	ta, _ = ta.Update(paste)
+
+	if ta.totalVisualLines() > 5 {
+		t.Errorf("expected paste capped at 5 visual lines, got %d", ta.totalVisualLines())
+	}
+}
+
+func TestDynamicHeight_ShrinksWhenScrolledAndLinesDeleted(t *testing.T) {
+	ta := newDynamicTextArea(1, 5)
+	ta.MaxContentHeight = 10
+
+	enter := tea.KeyPressMsg{Code: tea.KeyEnter}
+	// Type 8 lines so we exceed MaxHeight (5) and start scrolling
+	for range 7 {
+		ta, _ = ta.Update(keyPress('x'))
+		ta, _ = ta.Update(enter)
+	}
+	ta, _ = ta.Update(keyPress('x'))
+
+	if ta.Height() != 5 {
+		t.Fatalf("expected height 5 (capped at MaxHeight), got %d", ta.Height())
+	}
+	if ta.LineCount() != 8 {
+		t.Fatalf("expected 8 lines, got %d", ta.LineCount())
+	}
+
+	// Now delete lines from the bottom by selecting all on current line and backspacing
+	backspace := tea.KeyPressMsg{Code: tea.KeyBackspace}
+	for ta.LineCount() > 4 {
+		ta.CursorEnd()
+		for len(ta.value[ta.row]) > 0 {
+			ta, _ = ta.Update(backspace)
+		}
+		ta, _ = ta.Update(backspace) // merge with previous line
+	}
+
+	// Now we have 4 lines, which is less than MaxHeight (5).
+	// Height should shrink to 4.
+	if ta.Height() != 4 {
+		t.Errorf("expected height to shrink to 4 (matching content), got %d", ta.Height())
+	}
+	if ta.viewport.YOffset() != 0 {
+		t.Errorf("expected yOffset 0 after shrinking, got %d", ta.viewport.YOffset())
+	}
+}
+
+func TestDynamicHeight_ShrinksWhenScrolledNoMaxContent(t *testing.T) {
+	// DynamicHeight with MaxHeight but no MaxContentHeight
+	ta := newDynamicTextArea(1, 99)
+
+	enter := tea.KeyPressMsg{Code: tea.KeyEnter}
+	// Type 8 lines
+	for range 7 {
+		ta, _ = ta.Update(keyPress('x'))
+		ta, _ = ta.Update(enter)
+	}
+	ta, _ = ta.Update(keyPress('x'))
+
+	if ta.Height() != 8 {
+		t.Fatalf("expected height 8, got %d", ta.Height())
+	}
+
+	// Manually set a smaller MaxHeight to simulate scrolling scenario
+	ta.MaxHeight = 5
+	ta, _ = ta.Update(nil)
+
+	// Now delete lines from the bottom
+	backspace := tea.KeyPressMsg{Code: tea.KeyBackspace}
+	for ta.LineCount() > 3 {
+		ta.CursorEnd()
+		for len(ta.value[ta.row]) > 0 {
+			ta, _ = ta.Update(backspace)
+		}
+		ta, _ = ta.Update(backspace)
+	}
+
+	if ta.Height() != 3 {
+		t.Errorf("expected height to shrink to 3 (matching content), got %d", ta.Height())
+	}
+	if ta.viewport.YOffset() != 0 {
+		t.Errorf("expected yOffset 0 after shrinking, got %d", ta.viewport.YOffset())
+	}
+}
+
+func newTextArea() Model {
+	textarea := New()
+
+	textarea.Prompt = "> "
+	textarea.Placeholder = "Hello, World!"
+
+	textarea.Focus()
+
+	textarea, _ = textarea.Update(nil)
+
+	return textarea
+}
+
+func keyPress(key rune) tea.Msg {
+	return tea.KeyPressMsg{Code: key, Text: string(key)}
+}
+
+func sendString(m Model, str string) Model {
+	for _, k := range []rune(str) {
+		m, _ = m.Update(keyPress(k))
+	}
+
+	return m
+}
+
+func stripString(str string) string {
+	s := ansi.Strip(str)
+	ss := strings.Split(s, "\n")
+
+	var lines []string
+	for _, l := range ss {
+		trim := strings.TrimRightFunc(l, unicode.IsSpace)
+		if trim != "" {
+			lines = append(lines, trim)
+		}
+	}
+
+	return strings.Join(lines, "\n")
+}

--- a/internal/workspace/app_workspace.go
+++ b/internal/workspace/app_workspace.go
@@ -2,6 +2,7 @@ package workspace
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -489,6 +490,24 @@ func (w *AppWorkspace) ReadMCPResource(ctx context.Context, name, uri string) ([
 
 func (w *AppWorkspace) ListMCPPrompts(context.Context) ([]commands.MCPPrompt, error) {
 	return commands.LoadMCPPrompts()
+}
+
+// CallMCPTool invokes a tool on a named MCP server and returns its text
+// content plus any A2UI surface payload it embedded.
+func (w *AppWorkspace) CallMCPTool(ctx context.Context, name, toolName string, args map[string]any) (MCPToolCallResult, error) {
+	input, err := json.Marshal(args)
+	if err != nil {
+		return MCPToolCallResult{}, fmt.Errorf("failed to encode tool arguments: %w", err)
+	}
+	res, err := mcptools.RunTool(ctx, w.store, name, toolName, string(input))
+	if err != nil {
+		return MCPToolCallResult{}, err
+	}
+	out := MCPToolCallResult{Content: res.Content}
+	for _, s := range res.Surfaces {
+		out.Surfaces = append(out.Surfaces, MCPToolCallSurface{Payload: s.Payload, URI: s.URI})
+	}
+	return out, nil
 }
 
 func (w *AppWorkspace) GetMCPPrompt(clientID, promptID string, args map[string]string) (string, error) {

--- a/internal/workspace/client_workspace.go
+++ b/internal/workspace/client_workspace.go
@@ -766,6 +766,20 @@ func (w *ClientWorkspace) GetMCPPrompt(clientID, promptID string, args map[strin
 	return w.client.GetMCPPrompt(context.Background(), w.workspaceID(), clientID, promptID, args)
 }
 
+// CallMCPTool invokes a tool on a named MCP server via the server and
+// returns its text content plus any A2UI surface payload it embedded.
+func (w *ClientWorkspace) CallMCPTool(ctx context.Context, name, toolName string, args map[string]any) (MCPToolCallResult, error) {
+	res, err := w.client.CallMCPTool(ctx, w.workspaceID(), name, toolName, args)
+	if err != nil {
+		return MCPToolCallResult{}, err
+	}
+	out := MCPToolCallResult{Content: res.Content}
+	for _, s := range res.Surfaces {
+		out.Surfaces = append(out.Surfaces, MCPToolCallSurface{Payload: s.Payload, URI: s.URI})
+	}
+	return out, nil
+}
+
 func (w *ClientWorkspace) EnableDockerMCP(ctx context.Context) error {
 	return w.client.EnableDockerMCP(ctx, w.workspaceID())
 }

--- a/internal/workspace/client_workspace.go
+++ b/internal/workspace/client_workspace.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/crush/internal/agent"
 	"github.com/charmbracelet/crush/internal/agent/notify"
 	"github.com/charmbracelet/crush/internal/agent/tools/mcp"
 	"github.com/charmbracelet/crush/internal/app"
@@ -236,11 +237,15 @@ func (w *ClientWorkspace) AgentRun(ctx context.Context, sessionID, prompt string
 	// completion detection (it observes message events directly),
 	// so passing an empty RunID is correct here: it skips the
 	// correlator stamping path without functional consequences.
-	return w.client.SendMessage(ctx, w.workspaceID(), sessionID, "", "", prompt, attachments...)
+	//
+	// The content-width hint rides the context locally but cannot cross
+	// the HTTP boundary as a context value, so it is lifted onto the wire
+	// message here and re-attached server-side (backend.runAgent).
+	return w.client.SendMessage(ctx, w.workspaceID(), sessionID, "", "", agent.ContentWidthFromContext(ctx), prompt, attachments...)
 }
 
 func (w *ClientWorkspace) AgentRunChannel(ctx context.Context, channel, sessionID, prompt string, attachments ...message.Attachment) error {
-	return w.client.SendMessage(ctx, w.workspaceID(), sessionID, "", channel, prompt, attachments...)
+	return w.client.SendMessage(ctx, w.workspaceID(), sessionID, "", channel, 0, prompt, attachments...)
 }
 
 func (w *ClientWorkspace) AgentRunShellCommand(ctx context.Context, sessionID, command string, termWidth int, _ func(string), _ bool) (proto.ShellCommandResponse, error) {

--- a/internal/workspace/client_workspace.go
+++ b/internal/workspace/client_workspace.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/crush/internal/agent"
 	"github.com/charmbracelet/crush/internal/agent/notify"
 	"github.com/charmbracelet/crush/internal/agent/tools/mcp"
 	"github.com/charmbracelet/crush/internal/app"
@@ -236,11 +237,15 @@ func (w *ClientWorkspace) AgentRun(ctx context.Context, sessionID, prompt string
 	// completion detection (it observes message events directly),
 	// so passing an empty RunID is correct here: it skips the
 	// correlator stamping path without functional consequences.
-	return w.client.SendMessage(ctx, w.workspaceID(), sessionID, "", "", prompt, attachments...)
+	//
+	// The content-width hint rides the context locally but cannot cross
+	// the HTTP boundary as a context value, so it is lifted onto the wire
+	// message here and re-attached server-side (backend.runAgent).
+	return w.client.SendMessage(ctx, w.workspaceID(), sessionID, "", "", agent.ContentWidthFromContext(ctx), prompt, attachments...)
 }
 
 func (w *ClientWorkspace) AgentRunChannel(ctx context.Context, channel, sessionID, prompt string, attachments ...message.Attachment) error {
-	return w.client.SendMessage(ctx, w.workspaceID(), sessionID, "", channel, prompt, attachments...)
+	return w.client.SendMessage(ctx, w.workspaceID(), sessionID, "", channel, 0, prompt, attachments...)
 }
 
 func (w *ClientWorkspace) AgentRunShellCommand(ctx context.Context, sessionID, command string, termWidth int, _ func(string), _ bool) (proto.ShellCommandResponse, error) {
@@ -759,6 +764,20 @@ func (w *ClientWorkspace) ListMCPPrompts(ctx context.Context) ([]commands.MCPPro
 
 func (w *ClientWorkspace) GetMCPPrompt(clientID, promptID string, args map[string]string) (string, error) {
 	return w.client.GetMCPPrompt(context.Background(), w.workspaceID(), clientID, promptID, args)
+}
+
+// CallMCPTool invokes a tool on a named MCP server via the server and
+// returns its text content plus any A2UI surface payload it embedded.
+func (w *ClientWorkspace) CallMCPTool(ctx context.Context, name, toolName string, args map[string]any) (MCPToolCallResult, error) {
+	res, err := w.client.CallMCPTool(ctx, w.workspaceID(), name, toolName, args)
+	if err != nil {
+		return MCPToolCallResult{}, err
+	}
+	out := MCPToolCallResult{Content: res.Content}
+	for _, s := range res.Surfaces {
+		out.Surfaces = append(out.Surfaces, MCPToolCallSurface{Payload: s.Payload, URI: s.URI})
+	}
+	return out, nil
 }
 
 func (w *ClientWorkspace) EnableDockerMCP(ctx context.Context) error {

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -208,6 +208,12 @@ type Workspace interface {
 	RefreshMCPTools(ctx context.Context, name string)
 	ReadMCPResource(ctx context.Context, name, uri string) ([]MCPResourceContents, error)
 	ListMCPPrompts(ctx context.Context) ([]commands.MCPPrompt, error)
+	// CallMCPTool invokes a tool on a named MCP server and returns its
+	// text content plus any A2UI surface payload it embedded. It backs the
+	// A2UI action round-trip: a button press on an MCP-served surface
+	// routes back to the owning server as an a2ui_action (or a render
+	// failure as an a2ui_error) without an agent turn.
+	CallMCPTool(ctx context.Context, name, toolName string, args map[string]any) (MCPToolCallResult, error)
 	GetMCPPrompt(clientID, promptID string, args map[string]string) (string, error)
 	EnableDockerMCP(ctx context.Context) error
 	DisableDockerMCP() error
@@ -232,4 +238,19 @@ type MCPResourceContents struct {
 	MIMEType string `json:"mime_type,omitempty"`
 	Text     string `json:"text,omitempty"`
 	Blob     []byte `json:"blob,omitempty"`
+}
+
+// MCPToolCallResult holds the model-facing text and any A2UI surface
+// payloads from an MCP tool call.
+type MCPToolCallResult struct {
+	// Content is the result's text (its TextContent, joined).
+	Content string `json:"content"`
+	// Surfaces carries any A2UI surface payloads the result embedded.
+	Surfaces []MCPToolCallSurface `json:"surfaces,omitempty"`
+}
+
+// MCPToolCallSurface is a single A2UI surface payload from a tool call.
+type MCPToolCallSurface struct {
+	Payload string `json:"payload"`
+	URI     string `json:"uri"`
 }


### PR DESCRIPTION
Brings the `/skill` inline completions popup and `@file`/`/skill` token highlighting from `feat/prompt-token-highlighting` onto main.

**What changed:**
- Inline `/skill` completions popup in the prompt editor (type `/` mid-prompt to search skills by name and description)
- `@file` and `/skill` tokens highlighted inline as you type and preserved in posted messages
- A2UI surface rendering improvements (resource surfaces, width hints, action round-trips)
- Resolved merge conflict between atomic backspace (#250) and the completion trigger refactor
- Fixed `completion_backspace_test.go` textarea import to use the custom `internal/ui/textarea` package

**Verified:** `go build ./...`, `go test ./...`, `gofumpt -l .` all clean.

🤖 Posted on behalf of `@joestump` by [`qwen3.8-max`](https://openrouter.ai/qwen/qwen3.8-max) using [Crush](https://github.com/charmbracelet/crush).

💘 Generated with Crush