### PR TITLE
feat(a2ui): render MCP resource surfaces inline and round-trip interactions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -43,7 +43,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/invopop/jsonschema v0.14.0
 	github.com/itchyny/gojq v0.12.19
-	github.com/joestump-agent/a2tea v0.0.0-20260718201420-b797da386eaf
+	github.com/joestump-agent/a2tea v0.1.0
 	github.com/joho/godotenv v1.5.1
 	github.com/jordanella/go-ansi-paintbrush v0.0.0-20240728195301-b7ad996ecf3d
 	github.com/lucasb-eyer/go-colorful v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -256,8 +256,8 @@ github.com/jackmordaunt/icns/v3 v3.0.1 h1:xxot6aNuGrU+lNgxz5I5H0qSeCjNKp8uTXB1j8
 github.com/jackmordaunt/icns/v3 v3.0.1/go.mod h1:5sHL59nqTd2ynTnowxB/MDQFhKNqkK8X687uKNygaSQ=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
-github.com/joestump-agent/a2tea v0.0.0-20260718201420-b797da386eaf h1:Yw8XzyZXewOiewpHLd4SQPhu7CeWlFeqjpz7uE7f5as=
-github.com/joestump-agent/a2tea v0.0.0-20260718201420-b797da386eaf/go.mod h1:pg6ATa4oTrJfhPmfQ9a/Y/5xU9DTXZ8rGVvLj3NpEaE=
+github.com/joestump-agent/a2tea v0.1.0 h1:pIlPNDSB3HV4Tz8KqoAVlwwF0YSdaX5S8Rta/ISEdNI=
+github.com/joestump-agent/a2tea v0.1.0/go.mod h1:pg6ATa4oTrJfhPmfQ9a/Y/5xU9DTXZ8rGVvLj3NpEaE=
 github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
 github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/jordanella/go-ansi-paintbrush v0.0.0-20240728195301-b7ad996ecf3d h1:on25kP+Sx7sxUMRQiA8gdcToAGet4DK/EIA30mXre+4=

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -83,8 +83,13 @@ type SessionAgentCall struct {
 	// reliable completion contract (e.g. `crush run` against a
 	// session that may be busy) MUST set it; SessionID alone is
 	// ambiguous when concurrent turns share the same session.
-	RunID            string
-	Channel          string
+	RunID   string
+	Channel string
+	// ContentWidth is the UI's chat content width hint in cells (0 when
+	// the turn has no interactive UI). Tools rendering width-sensitive
+	// remote content (e.g. A2UI surfaces with pre-sized bar geometry)
+	// use it to ask the server for exactly the right size.
+	ContentWidth     int
 	Prompt           string
 	ProviderOptions  fantasy.ProviderOptions
 	Attachments      []message.Attachment
@@ -914,6 +919,7 @@ func (a *sessionAgent) Run(ctx context.Context, call SessionAgentCall) (result *
 			callContext = context.WithValue(callContext, tools.ChannelContextKey, call.Channel)
 			callContext = context.WithValue(callContext, tools.SupportsImagesContextKey, largeModel.CatwalkCfg.SupportsImages)
 			callContext = context.WithValue(callContext, tools.ModelNameContextKey, largeModel.CatwalkCfg.Name)
+			callContext = context.WithValue(callContext, tools.ContentWidthContextKey, call.ContentWidth)
 			currentAssistant = &assistantMsg
 			return callContext, prepared, err
 		},

--- a/internal/agent/content_width.go
+++ b/internal/agent/content_width.go
@@ -1,0 +1,23 @@
+package agent
+
+import "context"
+
+type contentWidthContextKey struct{}
+
+// WithContentWidth returns ctx tagged with the UI's current chat content
+// width in cells. Tools that read width-sensitive remote content (e.g. an
+// A2UI resource whose server pre-renders bar geometry) use it to ask the
+// server for exactly the right size. Zero means "no hint".
+func WithContentWidth(ctx context.Context, width int) context.Context {
+	return context.WithValue(ctx, contentWidthContextKey{}, width)
+}
+
+// ContentWidthFromContext returns the UI content width in cells, or 0 when
+// the turn did not originate from an interactive UI (remote clients, headless
+// runs, channels).
+func ContentWidthFromContext(ctx context.Context) int {
+	if w, ok := ctx.Value(contentWidthContextKey{}).(int); ok {
+		return w
+	}
+	return 0
+}

--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -335,6 +335,7 @@ func (c *coordinator) run(ctx context.Context, accept *AcceptedRun, sessionID st
 			SessionID:        sessionID,
 			RunID:            runID,
 			Channel:          ChannelFromContext(ctx),
+			ContentWidth:     ContentWidthFromContext(ctx),
 			Prompt:           prompt,
 			Attachments:      attachments,
 			MaxOutputTokens:  maxTokens,
@@ -1499,7 +1500,12 @@ func (c *coordinator) runSubAgent(ctx context.Context, params subAgentParams) (f
 	// Run the agent
 	run := func() (*fantasy.AgentResult, error) {
 		return params.Agent.Run(ctx, SessionAgentCall{
-			SessionID:        session.ID,
+			SessionID: session.ID,
+			// Inherit the parent turn's UI width hint: the sub-agent's
+			// PrepareStep stamps call.ContentWidth over the tool-call
+			// context unconditionally, so leaving this zero would clobber
+			// the value the parent already carries.
+			ContentWidth:     tools.GetContentWidthFromContext(ctx),
 			Prompt:           params.Prompt,
 			MaxOutputTokens:  maxTokens,
 			ProviderOptions:  getProviderOptions(model, providerCfg),

--- a/internal/agent/tools/list_mcp_resources.go
+++ b/internal/agent/tools/list_mcp_resources.go
@@ -63,15 +63,16 @@ func NewListMCPResourcesTool(cfg *config.ConfigStore, permissions permission.Ser
 				return NewPermissionDeniedResponse(), nil
 			}
 
-			resources, err := mcp.ListResources(ctx, cfg, params.MCPName)
+			resources, templates, err := mcp.ListResources(ctx, cfg, params.MCPName)
 			if err != nil {
 				return fantasy.NewTextErrorResponse(err.Error()), nil
 			}
-			if len(resources) == 0 {
+			if len(resources) == 0 && len(templates) == 0 {
 				return fantasy.NewTextResponse("No resources found"), nil
 			}
 
-			lines := make([]string, 0, len(resources))
+			lines := make([]string, 0, len(resources)+len(templates))
+
 			for _, resource := range resources {
 				if resource == nil {
 					continue
@@ -89,6 +90,24 @@ func NewListMCPResourcesTool(cfg *config.ConfigStore, permissions permission.Ser
 				}
 				if resource.Size > 0 {
 					line = fmt.Sprintf("%s [size: %d]", line, resource.Size)
+				}
+				lines = append(lines, line)
+			}
+
+			for _, template := range templates {
+				if template == nil {
+					continue
+				}
+				title := cmp.Or(template.Title, template.Name, template.URITemplate)
+				line := fmt.Sprintf("- [template] %s", title)
+				if template.URITemplate != "" {
+					line = fmt.Sprintf("%s (%s)", line, template.URITemplate)
+				}
+				if template.Description != "" {
+					line = fmt.Sprintf("%s: %s", line, template.Description)
+				}
+				if template.MIMEType != "" {
+					line = fmt.Sprintf("%s [mime: %s]", line, template.MIMEType)
 				}
 				lines = append(lines, line)
 			}

--- a/internal/agent/tools/list_mcp_resources.md
+++ b/internal/agent/tools/list_mcp_resources.md
@@ -1,1 +1,4 @@
-List available resource URIs from an MCP server by name; use before read_mcp_resource.
+List available resource URIs and resource templates from an MCP server by name; use before read_mcp_resource.
+
+Resource templates have URI templates (e.g. `cairn://run/{id}/a2ui`) that can be expanded to concrete URIs.
+To read a template resource, substitute the `{id}` parameter and pass the resulting URI to read_mcp_resource.

--- a/internal/agent/tools/mcp-tools.go
+++ b/internal/agent/tools/mcp-tools.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"slices"
+	"strings"
 
 	"charm.land/fantasy"
 	"github.com/charmbracelet/crush/internal/agent/tools/mcp"
@@ -133,6 +134,17 @@ func (m *Tool) Run(ctx context.Context, params fantasy.ToolCall) (fantasy.ToolRe
 		return fantasy.NewTextErrorResponse(err.Error()), nil
 	}
 
+	// Divert A2UI surface payloads to UI-only metadata only when a chat UI
+	// will actually render them: on channel-originated turns the reply
+	// travels back over the channel and the model needs the payload to
+	// relay it, disable_a2ui deployments opted out of surfaces entirely,
+	// and a zero content width means no interactive UI tagged this turn.
+	// Mirrors the diversion rule in read_mcp_resource.go.
+	divert := GetChannelFromContext(ctx) == "" &&
+		!m.cfg.Config().Options.DisableA2UI &&
+		GetContentWidthFromContext(ctx) > 0
+	content, metadata := splitMCPToolResult(result, m.mcpName, divert)
+
 	switch result.Type {
 	case "image", "media":
 		if !GetSupportsImagesFromContext(ctx) {
@@ -146,9 +158,51 @@ func (m *Tool) Run(ctx context.Context, params fantasy.ToolCall) (fantasy.ToolRe
 		} else {
 			response = fantasy.NewMediaResponse(result.Data, result.MediaType)
 		}
-		response.Content = result.Content
+		response.Content = content
+		if len(metadata.A2UISurfaces) > 0 {
+			response = fantasy.WithResponseMetadata(response, metadata)
+		}
 		return response, nil
 	default:
-		return fantasy.NewTextResponse(result.Content), nil
+		resp := fantasy.NewTextResponse(content)
+		if len(metadata.A2UISurfaces) > 0 {
+			resp = fantasy.WithResponseMetadata(resp, metadata)
+		}
+		return resp, nil
 	}
+}
+
+// splitMCPToolResult partitions an MCP tool result into model-facing text
+// and, when divert is set, UI-only A2UI surface payloads carried in response
+// metadata. The surfaces travel exactly like read_mcp_resource's: wrapped in
+// <a2ui-json> tags on ReadMCPResourceResponseMetadata, with a single-line
+// placeholder left for the model so it cannot echo the JSON back and
+// double-render the surface. When divert is false the raw payload is folded
+// back into the model-facing content (except payloads the server annotated
+// for the user only — hiding those from the model is the annotation's whole
+// point), so the model can still relay or summarize the data.
+func splitMCPToolResult(result mcp.ToolResult, mcpName string, divert bool) (string, ReadMCPResourceResponseMetadata) {
+	var metadata ReadMCPResourceResponseMetadata
+	content := result.Content
+	for _, surface := range result.Surfaces {
+		if divert {
+			metadata.A2UISurfaces = append(metadata.A2UISurfaces, "<a2ui-json>"+surface.Payload+"</a2ui-json>")
+			metadata.MCPSurfaceProvenance = append(metadata.MCPSurfaceProvenance, mcpName)
+			uri := strings.NewReplacer("\n", " ", "\r", " ").Replace(surface.URI)
+			placeholder := A2UISurfacePlaceholderPrefix + uri + " from MCP server " + mcpName + " — the user can already see it; do not repeat or echo its JSON payload]"
+			if content != "" {
+				content += "\n"
+			}
+			content += placeholder
+			continue
+		}
+		if !surface.AssistantVisible {
+			continue
+		}
+		if content != "" {
+			content += "\n"
+		}
+		content += surface.Payload
+	}
+	return content, metadata
 }

--- a/internal/agent/tools/mcp-tools.go
+++ b/internal/agent/tools/mcp-tools.go
@@ -178,15 +178,20 @@ func (m *Tool) Run(ctx context.Context, params fantasy.ToolCall) (fantasy.ToolRe
 // <a2ui-json> tags on ReadMCPResourceResponseMetadata, with a single-line
 // placeholder left for the model so it cannot echo the JSON back and
 // double-render the surface. When divert is false the raw payload is folded
-// back into the model-facing content (except payloads the server annotated
-// for the user only — hiding those from the model is the annotation's whole
-// point), so the model can still relay or summarize the data.
+// back into the model-facing content, so the model can still relay or
+// summarize the data.
 //
-// The audience annotation decides each surface's path (see a2uiAudience):
-// a ["user"]-only payload renders but never reaches the model; an
-// ["assistant"]-only payload reaches the model but is never rendered; an
-// empty audience does both (renders, and folds back to the model when no
-// chat UI is consuming it) — the established default.
+// The audience annotation decides each surface's path (see a2uiAudience),
+// but only among renderers that actually exist: a ["user"]-only payload
+// renders and is withheld from the model; an ["assistant"]-only payload
+// reaches the model but is never rendered; an empty audience does both.
+//
+// The ["user"] case is conditional on something rendering it. The
+// annotation means "the user can already see this, don't repeat it" — so
+// when divert is false nothing renders the surface, the user sees nothing,
+// and the model is their only path to it. Withholding the payload there
+// leaves a channel-originated turn with an empty tool result and the agent
+// replying with nothing or a hallucinated summary.
 func splitMCPToolResult(result mcp.ToolResult, mcpName string, divert bool) (string, ReadMCPResourceResponseMetadata) {
 	var metadata ReadMCPResourceResponseMetadata
 	content := result.Content
@@ -206,8 +211,16 @@ func splitMCPToolResult(result mcp.ToolResult, mcpName string, divert bool) (str
 			appendToContent(A2UISurfacePlaceholderPrefix + uri + " from MCP server " + mcpName + " — the user can already see it; do not repeat or echo its JSON payload]")
 			continue
 		}
-		// Not rendered: either divert is off (no chat UI) or the surface is
-		// ["assistant"]-only. It reaches the model only when assistant-visible.
+		if !divert {
+			// Nothing will render this surface — the turn came in over a
+			// channel, it is a headless run, or the deployment disabled
+			// surfaces. The model is the user's only path to the payload,
+			// so fold it back whatever the audience says.
+			appendToContent(surface.Payload)
+			continue
+		}
+		// A chat UI is rendering this turn's surfaces, but not this one:
+		// it is ["assistant"]-only. It reaches the model alone.
 		if !surface.AssistantVisible {
 			continue
 		}

--- a/internal/agent/tools/mcp-tools.go
+++ b/internal/agent/tools/mcp-tools.go
@@ -181,28 +181,37 @@ func (m *Tool) Run(ctx context.Context, params fantasy.ToolCall) (fantasy.ToolRe
 // back into the model-facing content (except payloads the server annotated
 // for the user only — hiding those from the model is the annotation's whole
 // point), so the model can still relay or summarize the data.
+//
+// The audience annotation decides each surface's path (see a2uiAudience):
+// a ["user"]-only payload renders but never reaches the model; an
+// ["assistant"]-only payload reaches the model but is never rendered; an
+// empty audience does both (renders, and folds back to the model when no
+// chat UI is consuming it) — the established default.
 func splitMCPToolResult(result mcp.ToolResult, mcpName string, divert bool) (string, ReadMCPResourceResponseMetadata) {
 	var metadata ReadMCPResourceResponseMetadata
 	content := result.Content
-	for _, surface := range result.Surfaces {
-		if divert {
-			metadata.A2UISurfaces = append(metadata.A2UISurfaces, "<a2ui-json>"+surface.Payload+"</a2ui-json>")
-			metadata.MCPSurfaceProvenance = append(metadata.MCPSurfaceProvenance, mcpName)
-			uri := strings.NewReplacer("\n", " ", "\r", " ").Replace(surface.URI)
-			placeholder := A2UISurfacePlaceholderPrefix + uri + " from MCP server " + mcpName + " — the user can already see it; do not repeat or echo its JSON payload]"
-			if content != "" {
-				content += "\n"
-			}
-			content += placeholder
-			continue
-		}
-		if !surface.AssistantVisible {
-			continue
-		}
+	appendToContent := func(s string) {
 		if content != "" {
 			content += "\n"
 		}
-		content += surface.Payload
+		content += s
+	}
+	for _, surface := range result.Surfaces {
+		if divert && surface.RenderForUser {
+			// Render for the user via metadata; the model gets a
+			// placeholder so it cannot echo the JSON back and double-render.
+			metadata.A2UISurfaces = append(metadata.A2UISurfaces, "<a2ui-json>"+surface.Payload+"</a2ui-json>")
+			metadata.MCPSurfaceProvenance = append(metadata.MCPSurfaceProvenance, mcpName)
+			uri := strings.NewReplacer("\n", " ", "\r", " ").Replace(surface.URI)
+			appendToContent(A2UISurfacePlaceholderPrefix + uri + " from MCP server " + mcpName + " — the user can already see it; do not repeat or echo its JSON payload]")
+			continue
+		}
+		// Not rendered: either divert is off (no chat UI) or the surface is
+		// ["assistant"]-only. It reaches the model only when assistant-visible.
+		if !surface.AssistantVisible {
+			continue
+		}
+		appendToContent(surface.Payload)
 	}
 	return content, metadata
 }

--- a/internal/agent/tools/mcp/init.go
+++ b/internal/agent/tools/mcp/init.go
@@ -501,6 +501,19 @@ func connectAndRegister(ctx context.Context, cfg *config.ConfigStore, name strin
 
 	updatePrompts(name, prompts)
 
+	// Fetch resources and templates eagerly so the status display reflects
+	// the real count from the first connection, not a stale zero.  Both
+	// helpers are no-ops when the server doesn't advertise the resources
+	// capability, and gracefully handle "method not found". Bound the
+	// listing with the same per-server timeout createSession enforces:
+	// initClient runs on the startup critical path under the per-name
+	// lock, and a server that connects but then hangs on resources/list
+	// would otherwise stall WaitForInit indefinitely — with the bound it
+	// degrades to a warn and a zero count.
+	listCtx, cancelList := context.WithTimeout(ctx, mcpTimeout(m))
+	resourceCount := refreshSessionResources(listCtx, name, session)
+	cancelList()
+
 	// A repeated init must not overwrite a live session without closing it —
 	// that leaks the child process and pipes.
 	if old, ok := sessions.Take(name); ok && old != session {
@@ -509,8 +522,9 @@ func connectAndRegister(ctx context.Context, cfg *config.ConfigStore, name strin
 	sessions.Set(name, session)
 
 	updateState(name, StateConnected, nil, session, Counts{
-		Tools:   toolCount,
-		Prompts: len(prompts),
+		Tools:     toolCount,
+		Prompts:   len(prompts),
+		Resources: resourceCount,
 	})
 
 	return session, nil
@@ -522,7 +536,7 @@ func DisableSingle(cfg *config.ConfigStore, name string) error {
 		closeSession(name, session)
 	}
 
-	// Clear tools, prompts, resources, and auth state for this MCP.
+	// Clear tools, prompts, resources, templates, and auth state for this MCP.
 	clearMCPData(name)
 
 	// Update state to disabled.
@@ -591,12 +605,12 @@ func getOrRenewClient(ctx context.Context, cfg *config.ConfigStore, name string)
 		return nil, err
 	}
 
-	// StateError cleared this server's tools, prompts, and resources from the
-	// registry. Re-list and re-register them all on the fresh session and
-	// recompute the counts from what actually registered; otherwise the agent
-	// reconnects but the registries stay empty (the next tool call fails with
-	// "tool not found") while the reported counts still advertise capabilities
-	// that are no longer there.
+	// StateError cleared this server's tools, prompts, resources, and resource
+	// templates from the registry. Re-list and re-register them all on the
+	// fresh session and recompute the counts from what actually registered;
+	// otherwise the agent reconnects but the registries stay empty (the next
+	// tool call fails with "tool not found") while the reported counts still
+	// advertise capabilities that are no longer there.
 	var counts Counts
 	counts.Tools, err = registerSessionTools(ctx, cfg, name, newSess)
 	if err != nil {
@@ -614,13 +628,12 @@ func getOrRenewClient(ctx context.Context, cfg *config.ConfigStore, name string)
 	updatePrompts(name, prompts)
 	counts.Prompts = len(prompts)
 
-	resources, err := getResources(ctx, newSess)
-	if err != nil {
-		updateState(name, StateError, err, nil, Counts{})
-		closeSession(name, newSess)
-		return nil, err
-	}
-	counts.Resources = updateResources(name, resources)
+	// The StateError transition also purged this server's resources and
+	// resource templates, but counts still carries the pre-error value.
+	// Re-fetch both on the fresh session so the registries and the status
+	// count agree with what the reconnected server actually serves,
+	// instead of advertising N resources over an empty registry.
+	counts.Resources = refreshSessionResources(ctx, name, newSess)
 
 	sessions.Set(name, newSess)
 	updateState(name, StateConnected, nil, newSess, counts)
@@ -672,13 +685,14 @@ func updateState(name string, state State, err error, client *ClientSession, cou
 		if old, ok := sessions.Take(name); ok {
 			closeSession(name, old)
 		}
-		// Drop every registry entry for the dead server. Leaving prompts or
-		// resources behind lets a disconnected server keep advertising
-		// capabilities the agent can no longer fulfil, the same divergence the
-		// tool clear prevents.
+		// Drop every registry entry for the dead server. Leaving prompts,
+		// resources, or resource templates behind lets a disconnected server
+		// keep advertising capabilities the agent can no longer fulfil, the
+		// same divergence the tool clear prevents.
 		allTools.Del(name)
 		allPrompts.Del(name)
 		allResources.Del(name)
+		allResourceTemplates.Del(name)
 	}
 	states.Set(name, info)
 
@@ -1085,12 +1099,13 @@ func clearOAuthToken(cfg *config.ConfigStore, name string) {
 }
 
 // clearMCPData removes a stale MCP server's tools, prompts,
-// resources, and auth handlers from global state so they are not
-// served to the agent.
+// resources, resource templates, and auth handlers from global state so they
+// are not served to the agent.
 func clearMCPData(name string) {
 	allTools.Del(name)
 	allPrompts.Del(name)
 	allResources.Del(name)
+	allResourceTemplates.Del(name)
 	if h, ok := authURLs.Get(name); ok {
 		h.Close()
 		authURLs.Del(name)

--- a/internal/agent/tools/mcp/init.go
+++ b/internal/agent/tools/mcp/init.go
@@ -198,6 +198,20 @@ type ClientInfo struct {
 	// Channel reports whether this server is an active channel, for the MCP
 	// list marker and the channels dialog.
 	Channel bool
+	// A2UITools lists the a2ui_* tools this server exposes. It rides on the
+	// state rather than being read from the tool registry via HasTool
+	// because the registry only exists in the process that owns the MCP
+	// sessions: a client/server TUI has an empty one, so a HasTool gate
+	// there is permanently false and the surface round-trip it guards can
+	// never fire. Only the a2ui_* subset is carried — the UI asks nothing
+	// else, and a full tool list would put every server's whole catalog on
+	// the wire on every state change.
+	A2UITools []string
+}
+
+// ServesA2UITool reports whether the server exposes the named a2ui_* tool.
+func (c ClientInfo) ServesA2UITool(toolName string) bool {
+	return slices.Contains(c.A2UITools, toolName)
 }
 
 // SubscribeEvents returns a channel for MCP events, including channel-message
@@ -511,7 +525,7 @@ func connectAndRegister(ctx context.Context, cfg *config.ConfigStore, name strin
 	// would otherwise stall WaitForInit indefinitely — with the bound it
 	// degrades to a warn and a zero count.
 	listCtx, cancelList := context.WithTimeout(ctx, mcpTimeout(m))
-	resourceCount := refreshSessionResources(listCtx, name, session)
+	resourceCount, _ := refreshSessionResources(listCtx, name, session)
 	cancelList()
 
 	// A repeated init must not overwrite a live session without closing it —
@@ -633,7 +647,18 @@ func getOrRenewClient(ctx context.Context, cfg *config.ConfigStore, name string)
 	// Re-fetch both on the fresh session so the registries and the status
 	// count agree with what the reconnected server actually serves,
 	// instead of advertising N resources over an empty registry.
-	counts.Resources = refreshSessionResources(ctx, name, newSess)
+	//
+	// A listing failure here is fatal, exactly as it is for tools and
+	// prompts above: this is a renewal of a session we already refused
+	// once, so handing the caller a server that reports StateConnected
+	// with an empty resource registry hides the breakage behind a healthy
+	// status while every '@' completion for it silently disappears.
+	counts.Resources, err = refreshSessionResources(ctx, name, newSess)
+	if err != nil {
+		updateState(name, StateError, err, nil, Counts{})
+		closeSession(name, newSess)
+		return nil, err
+	}
 
 	sessions.Set(name, newSess)
 	updateState(name, StateConnected, nil, newSess, counts)
@@ -670,6 +695,9 @@ func updateState(name string, state State, err error, client *ClientSession, cou
 		// Channel marks a server that is an active channel, for the MCP list
 		// marker and the channels dialog.
 		Channel: client != nil && client.channel,
+		// Snapshot the a2ui_* capability alongside the counts so a remote
+		// client learns it without reading this process's tool registry.
+		A2UITools: a2uiToolNames(name),
 	}
 	switch state {
 	case StateConnected:

--- a/internal/agent/tools/mcp/lifecycle_test.go
+++ b/internal/agent/tools/mcp/lifecycle_test.go
@@ -373,3 +373,75 @@ func TestMaybeStdioErr_UnwrapsChannelTransport(t *testing.T) {
 	require.Contains(t, got.Error(), "startup failed: bad config",
 		"the re-executed child's stderr must surface in the error")
 }
+
+// TestUpdateState_ErrorClearsResources pins that StateError teardown clears the
+// resources and resource-template registries alongside tools and prompts — a
+// dead server must not keep advertising resources (or templates) it can no
+// longer serve. Both entry shapes are covered: the registered session itself
+// erroring, and an error with no session at all (connect failed).
+func TestUpdateState_ErrorClearsResources(t *testing.T) {
+	const name = "test-error-clears-resources"
+	t.Cleanup(func() {
+		sessions.Del(name)
+		allTools.Del(name)
+		allResources.Del(name)
+		allResourceTemplates.Del(name)
+		states.Del(name)
+	})
+
+	sess, _ := liveSession(t, "res_tool")
+	sessions.Set(name, sess)
+	allResources.Set(name, []*Resource{{Name: "doc"}})
+	allResourceTemplates.Set(name, []*ResourceTemplate{{Name: "tmpl"}})
+
+	updateState(name, StateError, errors.New("listing broke"), sess, Counts{})
+	_, ok := allResources.Get(name)
+	require.False(t, ok, "current-session error must clear the resources registry")
+	_, ok = allResourceTemplates.Get(name)
+	require.False(t, ok, "current-session error must clear the resource-template registry")
+
+	sess2, _ := liveSession(t, "res_tool2")
+	sessions.Set(name, sess2)
+	allResources.Set(name, []*Resource{{Name: "doc2"}})
+	allResourceTemplates.Set(name, []*ResourceTemplate{{Name: "tmpl2"}})
+
+	updateState(name, StateError, errors.New("connect broke"), nil, Counts{})
+	_, ok = allResources.Get(name)
+	require.False(t, ok, "no-session error must clear the resources registry")
+	_, ok = allResourceTemplates.Get(name)
+	require.False(t, ok, "no-session error must clear the resource-template registry")
+}
+
+// TestDisableSingle_ClearsResourceTemplates pins that disabling a server
+// removes its resource templates (alongside tools, prompts, and resources)
+// from the registries — a disabled server's templates must stop appearing
+// as @-completions.
+func TestDisableSingle_ClearsResourceTemplates(t *testing.T) {
+	const name = "test-disable-clears-templates"
+	t.Cleanup(func() {
+		sessions.Del(name)
+		allTools.Del(name)
+		allResources.Del(name)
+		allResourceTemplates.Del(name)
+		states.Del(name)
+	})
+
+	cfg := config.NewTestStore(&config.Config{MCP: config.MCPs{name: {Type: config.MCPStdio}}})
+
+	sess, sessCtx := liveSession(t, "tmpl_tool")
+	sessions.Set(name, sess)
+	allResources.Set(name, []*Resource{{Name: "doc"}})
+	allResourceTemplates.Set(name, []*ResourceTemplate{{Name: "tmpl", URITemplate: "x://{id}"}})
+
+	require.NoError(t, DisableSingle(cfg, name))
+
+	require.ErrorIs(t, sessCtx.Err(), context.Canceled, "disable must close the session")
+	_, ok := allResources.Get(name)
+	require.False(t, ok, "disable must clear the resources registry")
+	_, ok = allResourceTemplates.Get(name)
+	require.False(t, ok, "disable must clear the resource-template registry")
+
+	info, ok := GetState(name)
+	require.True(t, ok)
+	require.Equal(t, StateDisabled, info.State)
+}

--- a/internal/agent/tools/mcp/resources.go
+++ b/internal/agent/tools/mcp/resources.go
@@ -116,19 +116,25 @@ func getResources(ctx context.Context, c *ClientSession) ([]*Resource, error) {
 }
 
 // refreshSessionResources re-fetches a session's resources and resource
-// templates (best-effort: a listing failure degrades to an empty registry
-// and a warn, never an error) and installs them in the registries. It
-// returns the combined count for ClientInfo.Counts.Resources, so callers
-// publishing a StateConnected transition report exactly what the
-// registries hold.
-func refreshSessionResources(ctx context.Context, name string, session *ClientSession) int {
+// templates and installs them in the registries. It returns the combined
+// count for ClientInfo.Counts.Resources, so callers publishing a
+// StateConnected transition report exactly what the registries hold.
+//
+// The resources/list error is returned rather than swallowed: publishing
+// StateConnected over a failed listing shows the server as healthy while
+// every one of its resources has silently vanished from the completions
+// popup. Callers that must not fail on it — the startup path, where a
+// hang would stall WaitForInit — ignore it explicitly. Templates stay
+// best-effort: they are genuinely optional, and getResourceTemplates
+// already swallows method-not-found.
+func refreshSessionResources(ctx context.Context, name string, session *ClientSession) (int, error) {
 	resources, err := getResources(ctx, session)
 	if err != nil {
 		slog.Warn("Error listing MCP resources", "name", name, "error", err)
 		resources = nil
 	}
 	templates := listTemplatesBestEffort(ctx, session, name)
-	return updateResources(name, resources) + updateResourceTemplates(name, templates)
+	return updateResources(name, resources) + updateResourceTemplates(name, templates), err
 }
 
 // listTemplatesBestEffort lists a session's resource templates, treating any

--- a/internal/agent/tools/mcp/resources.go
+++ b/internal/agent/tools/mcp/resources.go
@@ -14,32 +14,45 @@ import (
 
 type Resource = mcp.Resource
 
+type ResourceTemplate = mcp.ResourceTemplate
+
 type ResourceContents = mcp.ResourceContents
 
-var allResources = csync.NewMap[string, []*Resource]()
+var (
+	allResources         = csync.NewMap[string, []*Resource]()
+	allResourceTemplates = csync.NewMap[string, []*ResourceTemplate]()
+)
 
 // Resources returns all available MCP resources.
 func Resources() iter.Seq2[string, []*Resource] {
 	return allResources.Seq2()
 }
 
-// ListResources returns the current resources for an MCP server.
-func ListResources(ctx context.Context, cfg *config.ConfigStore, name string) ([]*Resource, error) {
+// ResourceTemplates returns all available MCP resource templates.
+func ResourceTemplates() iter.Seq2[string, []*ResourceTemplate] {
+	return allResourceTemplates.Seq2()
+}
+
+// ListResources returns the current resources (including resource templates) for an MCP server.
+func ListResources(ctx context.Context, cfg *config.ConfigStore, name string) ([]*Resource, []*ResourceTemplate, error) {
 	session, err := getOrRenewClient(ctx, cfg, name)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	resources, err := getResources(ctx, session)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
+	templates := listTemplatesBestEffort(ctx, session, name)
+
 	resourceCount := updateResources(name, resources)
+	templateCount := updateResourceTemplates(name, templates)
 	prev, _ := states.Get(name)
-	prev.Counts.Resources = resourceCount
+	prev.Counts.Resources = resourceCount + templateCount
 	updateState(name, StateConnected, nil, session, prev.Counts)
-	return resources, nil
+	return resources, templates, nil
 }
 
 // ReadResource reads the contents of a resource from an MCP server.
@@ -55,7 +68,7 @@ func ReadResource(ctx context.Context, cfg *config.ConfigStore, name, uri string
 	return result.Contents, nil
 }
 
-// RefreshResources gets the updated list of resources from the MCP and updates the
+// RefreshResources gets the updated list of resources and resource templates from the MCP and updates the
 // global state.
 func RefreshResources(ctx context.Context, name string) {
 	// Runs under the per-name lifecycle lock so a concurrent renewal can't
@@ -76,10 +89,13 @@ func RefreshResources(ctx context.Context, name string) {
 		return
 	}
 
+	templates := listTemplatesBestEffort(ctx, session, name)
+
 	resourceCount := updateResources(name, resources)
+	templateCount := updateResourceTemplates(name, templates)
 
 	prev, _ := states.Get(name)
-	prev.Counts.Resources = resourceCount
+	prev.Counts.Resources = resourceCount + templateCount
 	updateState(name, StateConnected, nil, session, prev.Counts)
 }
 
@@ -99,6 +115,50 @@ func getResources(ctx context.Context, c *ClientSession) ([]*Resource, error) {
 	return result.Resources, nil
 }
 
+// refreshSessionResources re-fetches a session's resources and resource
+// templates (best-effort: a listing failure degrades to an empty registry
+// and a warn, never an error) and installs them in the registries. It
+// returns the combined count for ClientInfo.Counts.Resources, so callers
+// publishing a StateConnected transition report exactly what the
+// registries hold.
+func refreshSessionResources(ctx context.Context, name string, session *ClientSession) int {
+	resources, err := getResources(ctx, session)
+	if err != nil {
+		slog.Warn("Error listing MCP resources", "name", name, "error", err)
+		resources = nil
+	}
+	templates := listTemplatesBestEffort(ctx, session, name)
+	return updateResources(name, resources) + updateResourceTemplates(name, templates)
+}
+
+// listTemplatesBestEffort lists a session's resource templates, treating any
+// failure as "no templates". getResourceTemplates already swallows
+// method-not-found, so an error reaching here is a timeout, transport
+// failure, or server bug — never lack of support — and is logged as such,
+// with the server name so a multi-server config stays debuggable.
+func listTemplatesBestEffort(ctx context.Context, session *ClientSession, name string) []*ResourceTemplate {
+	templates, err := getResourceTemplates(ctx, session)
+	if err != nil {
+		slog.Warn("Error listing MCP resource templates", "name", name, "error", err)
+		return nil
+	}
+	return templates
+}
+
+func getResourceTemplates(ctx context.Context, c *ClientSession) ([]*ResourceTemplate, error) {
+	if c.InitializeResult().Capabilities.Resources == nil {
+		return nil, nil
+	}
+	result, err := c.ListResourceTemplates(ctx, &mcp.ListResourceTemplatesParams{})
+	if err != nil {
+		if isMethodNotFoundError(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return result.ResourceTemplates, nil
+}
+
 // isMethodNotFoundError checks if the error is a JSON-RPC "Method not found" error.
 func isMethodNotFoundError(err error) bool {
 	var rpcErr *jsonrpc.Error
@@ -112,4 +172,13 @@ func updateResources(name string, resources []*Resource) int {
 	}
 	allResources.Set(name, resources)
 	return len(resources)
+}
+
+func updateResourceTemplates(name string, templates []*ResourceTemplate) int {
+	if len(templates) == 0 {
+		allResourceTemplates.Del(name)
+		return 0
+	}
+	allResourceTemplates.Set(name, templates)
+	return len(templates)
 }

--- a/internal/agent/tools/mcp/resources_test.go
+++ b/internal/agent/tools/mcp/resources_test.go
@@ -1,0 +1,154 @@
+package mcp
+
+import (
+	"context"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/require"
+)
+
+// liveResourceSession spins up a real in-memory MCP server advertising the
+// given resources and resource templates and returns a connected client
+// session, mirroring liveSession for the resources side of the protocol.
+func liveResourceSession(t *testing.T, resources []*mcp.Resource, templates []*mcp.ResourceTemplate) *ClientSession {
+	t.Helper()
+
+	serverTransport, clientTransport := mcp.NewInMemoryTransports()
+	server := mcp.NewServer(&mcp.Implementation{Name: "srv"}, nil)
+	handler := func(context.Context, *mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
+		return &mcp.ReadResourceResult{}, nil
+	}
+	for _, r := range resources {
+		server.AddResource(r, handler)
+	}
+	for _, tmpl := range templates {
+		server.AddResourceTemplate(tmpl, handler)
+	}
+	serverSession, err := server.Connect(context.Background(), serverTransport, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = serverSession.Close() })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	client := mcp.NewClient(&mcp.Implementation{Name: "crush-test"}, nil)
+	clientSession, err := client.Connect(ctx, clientTransport, nil)
+	require.NoError(t, err)
+
+	sess := &ClientSession{ClientSession: clientSession, cancel: cancel}
+	t.Cleanup(func() { _ = sess.Close() })
+	return sess
+}
+
+// TestUpdateResourceTemplates_SetAndDelOnEmpty pins the registry-write
+// semantics updateResourceTemplates shares with updateResources: a non-empty
+// list is installed and counted, an empty (or nil) list deletes the entry
+// outright — so a server that stops advertising templates does not linger
+// with an empty-but-present registry row.
+func TestUpdateResourceTemplates_SetAndDelOnEmpty(t *testing.T) {
+	const name = "test-update-resource-templates"
+	t.Cleanup(func() { allResourceTemplates.Del(name) })
+
+	count := updateResourceTemplates(name, []*ResourceTemplate{
+		{Name: "run", URITemplate: "cairn://run/{id}"},
+		{Name: "bundle", URITemplate: "cairn://bundle/{id}"},
+	})
+	require.Equal(t, 2, count)
+	got, ok := allResourceTemplates.Get(name)
+	require.True(t, ok)
+	require.Len(t, got, 2)
+
+	count = updateResourceTemplates(name, nil)
+	require.Equal(t, 0, count)
+	_, ok = allResourceTemplates.Get(name)
+	require.False(t, ok, "an empty template list must delete the registry entry")
+}
+
+// TestGetResourceTemplates_NoResourcesCapability pins the capability gate: a
+// server that does not advertise the resources capability yields (nil, nil)
+// without a wire call, so servers with no resources at all never produce
+// warns or errors from the template fetch.
+func TestGetResourceTemplates_NoResourcesCapability(t *testing.T) {
+	sess, _ := liveSession(t, "no_resources_tool")
+	t.Cleanup(func() { _ = sess.Close() })
+
+	templates, err := getResourceTemplates(context.Background(), sess)
+	require.NoError(t, err)
+	require.Nil(t, templates)
+}
+
+// TestGetResourceTemplates_ListsTemplates pins the happy path over a real
+// in-memory server: the declared templates come back with their URI
+// templates intact.
+func TestGetResourceTemplates_ListsTemplates(t *testing.T) {
+	sess := liveResourceSession(t, nil, []*mcp.ResourceTemplate{
+		{Name: "run", URITemplate: "cairn://run/{id}/a2ui"},
+	})
+
+	templates, err := getResourceTemplates(context.Background(), sess)
+	require.NoError(t, err)
+	require.Len(t, templates, 1)
+	require.Equal(t, "cairn://run/{id}/a2ui", templates[0].URITemplate)
+}
+
+// TestRefreshSessionResources_CountsSumResourcesAndTemplates pins the seam
+// initClient and the renewal path share: both registries are populated from
+// the session and the returned count — what Counts.Resources reports — is
+// the sum of concrete resources and templates.
+func TestRefreshSessionResources_CountsSumResourcesAndTemplates(t *testing.T) {
+	const name = "test-refresh-session-resources"
+	t.Cleanup(func() {
+		allResources.Del(name)
+		allResourceTemplates.Del(name)
+	})
+
+	sess := liveResourceSession(t,
+		[]*mcp.Resource{
+			{Name: "doc-a", URI: "test://doc-a"},
+			{Name: "doc-b", URI: "test://doc-b"},
+		},
+		[]*mcp.ResourceTemplate{
+			{Name: "run", URITemplate: "test://run/{id}"},
+		},
+	)
+
+	count := refreshSessionResources(context.Background(), name, sess)
+	require.Equal(t, 3, count, "count must sum resources and templates")
+
+	resources, ok := allResources.Get(name)
+	require.True(t, ok)
+	require.Len(t, resources, 2)
+	templates, ok := allResourceTemplates.Get(name)
+	require.True(t, ok)
+	require.Len(t, templates, 1)
+}
+
+// TestRefreshResources_UpdatesRegistriesAndCount pins the notification-driven
+// refresh path end to end: RefreshResources lists both resources and
+// templates from the live session and publishes their sum on the state.
+func TestRefreshResources_UpdatesRegistriesAndCount(t *testing.T) {
+	const name = "test-refresh-resources"
+	t.Cleanup(func() {
+		sessions.Del(name)
+		allResources.Del(name)
+		allResourceTemplates.Del(name)
+		states.Del(name)
+	})
+
+	sess := liveResourceSession(t,
+		[]*mcp.Resource{{Name: "doc", URI: "test://doc"}},
+		[]*mcp.ResourceTemplate{{Name: "run", URITemplate: "test://run/{id}"}},
+	)
+	sessions.Set(name, sess)
+
+	RefreshResources(context.Background(), name)
+
+	_, ok := allResources.Get(name)
+	require.True(t, ok, "refresh must install the listed resources")
+	_, ok = allResourceTemplates.Get(name)
+	require.True(t, ok, "refresh must install the listed templates")
+
+	info, ok := GetState(name)
+	require.True(t, ok)
+	require.Equal(t, StateConnected, info.State)
+	require.Equal(t, 2, info.Counts.Resources, "state count must sum resources and templates")
+}

--- a/internal/agent/tools/mcp/resources_test.go
+++ b/internal/agent/tools/mcp/resources_test.go
@@ -111,7 +111,8 @@ func TestRefreshSessionResources_CountsSumResourcesAndTemplates(t *testing.T) {
 		},
 	)
 
-	count := refreshSessionResources(context.Background(), name, sess)
+	count, err := refreshSessionResources(context.Background(), name, sess)
+	require.NoError(t, err)
 	require.Equal(t, 3, count, "count must sum resources and templates")
 
 	resources, ok := allResources.Get(name)
@@ -151,4 +152,36 @@ func TestRefreshResources_UpdatesRegistriesAndCount(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, StateConnected, info.State)
 	require.Equal(t, 2, info.Counts.Resources, "state count must sum resources and templates")
+}
+
+// TestRefreshSessionResources_ReturnsListingError pins that a resources/list
+// failure is reported rather than swallowed.
+//
+// The reconnect path (getOrRenewClient) treats it as fatal: it is renewing a
+// session that already failed once, so publishing StateConnected over a
+// failed listing shows the server as healthy in the MCP sidebar while every
+// one of its resources silently vanishes from the '@' completions popup. The
+// startup path deliberately ignores the error instead — a server that hangs
+// on resources/list must not stall WaitForInit — so the decision has to
+// belong to the caller, which means the error has to reach it.
+func TestRefreshSessionResources_ReturnsListingError(t *testing.T) {
+	const name = "test-refresh-resources-error"
+	t.Cleanup(func() {
+		allResources.Del(name)
+		allResourceTemplates.Del(name)
+	})
+
+	sess := liveResourceSession(t,
+		[]*mcp.Resource{{Name: "doc-a", URI: "test://doc-a"}},
+		nil,
+	)
+
+	// A cancelled context fails the listing the same way a wedged transport
+	// or a server bug on resources/list would.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	count, err := refreshSessionResources(ctx, name, sess)
+	require.Error(t, err, "a resources/list failure must reach the caller")
+	require.Zero(t, count, "a failed listing must not report a resource count")
 }

--- a/internal/agent/tools/mcp/tools.go
+++ b/internal/agent/tools/mcp/tools.go
@@ -39,6 +39,10 @@ type A2UISurface struct {
 	Payload string
 	// URI is the embedded resource's URI, for display/diagnostics.
 	URI string
+	// RenderForUser reports whether the payload should be rendered for the
+	// user. False only when the audience is ["assistant"] alone: the spec's
+	// verbalization contract renders for every audience except that one.
+	RenderForUser bool
 	// AssistantVisible reports whether the server annotated the payload
 	// for the LLM as well as the user (empty audience or one containing
 	// "assistant"). An audience of ["user"] alone hides the raw JSON from
@@ -63,6 +67,31 @@ var allTools = csync.NewMap[string, []*Tool]()
 // Tools returns all available MCP tools.
 func Tools() iter.Seq2[string, []*Tool] {
 	return allTools.Seq2()
+}
+
+// HasTool reports whether the named MCP server currently exposes a tool with
+// the given name. It backs the A2UI action round-trip: a server that serves
+// interactive surfaces may also expose the a2ui_action / a2ui_error tools
+// the client round-trips interactions through, and the client needs to know
+// before it commits to that path.
+func HasTool(name, toolName string) bool {
+	tools, ok := allTools.Get(name)
+	if !ok {
+		return false
+	}
+	return slices.ContainsFunc(tools, func(t *Tool) bool { return t.Name == toolName })
+}
+
+// SetToolsForTest installs the given tool names for an MCP server in the
+// shared registry and returns a cleanup that removes them. It exists for
+// tests outside this package that need HasTool to observe a server's tools.
+func SetToolsForTest(name string, toolNames ...string) func() {
+	tools := make([]*Tool, len(toolNames))
+	for i, n := range toolNames {
+		tools[i] = &Tool{Name: n}
+	}
+	allTools.Set(name, tools)
+	return func() { allTools.Del(name) }
 }
 
 // RunTool runs an MCP tool with the given input parameters.
@@ -126,10 +155,12 @@ func extractToolResult(result *mcp.CallToolResult) ToolResult {
 					payload = string(content.Resource.Blob)
 				}
 				if payload != "" {
+					render, assistantVisible := a2uiAudience(content.Annotations)
 					surfaces = append(surfaces, A2UISurface{
 						Payload:          payload,
 						URI:              content.Resource.URI,
-						AssistantVisible: a2uiAssistantVisible(content.Annotations),
+						RenderForUser:    render,
+						AssistantVisible: assistantVisible,
 					})
 				}
 				continue
@@ -171,16 +202,22 @@ func extractToolResult(result *mcp.CallToolResult) ToolResult {
 	}
 }
 
-// a2uiAssistantVisible reports whether an A2UI embedded resource's audience
-// annotations leave the payload visible to the LLM. Per the A2UI-over-MCP
-// verbalization contract: an empty audience is visible to both user and
-// assistant; an audience of ["user"] alone renders for the user but hides
-// the raw JSON from the model.
-func a2uiAssistantVisible(annotations *mcp.Annotations) bool {
+// a2uiAudience resolves an A2UI embedded resource's audience annotations
+// into the spec's verbalization contract:
+//
+//	audience (empty)      → render for the user, visible to the model
+//	["user"]              → render for the user, hidden from the model
+//	["assistant"]         → visible to the model, NOT rendered
+//	["user","assistant"]  → both
+//
+// It returns (renderForUser, assistantVisible).
+func a2uiAudience(annotations *mcp.Annotations) (bool, bool) {
 	if annotations == nil || len(annotations.Audience) == 0 {
-		return true
+		return true, true
 	}
-	return slices.Contains(annotations.Audience, mcp.Role("assistant"))
+	forUser := slices.Contains(annotations.Audience, mcp.Role("user"))
+	forAssistant := slices.Contains(annotations.Audience, mcp.Role("assistant"))
+	return forUser, forAssistant
 }
 
 // RefreshTools gets the updated list of tools from the MCP and updates the

--- a/internal/agent/tools/mcp/tools.go
+++ b/internal/agent/tools/mcp/tools.go
@@ -69,29 +69,22 @@ func Tools() iter.Seq2[string, []*Tool] {
 	return allTools.Seq2()
 }
 
-// HasTool reports whether the named MCP server currently exposes a tool with
-// the given name. It backs the A2UI action round-trip: a server that serves
-// interactive surfaces may also expose the a2ui_action / a2ui_error tools
-// the client round-trips interactions through, and the client needs to know
-// before it commits to that path.
-func HasTool(name, toolName string) bool {
+// a2uiToolNames returns the a2ui_* tools an MCP server exposes, for
+// ClientInfo.A2UITools. The names travel with the state so a client/server
+// TUI — which never populates this registry — can still tell whether a
+// server speaks the surface round-trip.
+func a2uiToolNames(name string) []string {
 	tools, ok := allTools.Get(name)
 	if !ok {
-		return false
+		return nil
 	}
-	return slices.ContainsFunc(tools, func(t *Tool) bool { return t.Name == toolName })
-}
-
-// SetToolsForTest installs the given tool names for an MCP server in the
-// shared registry and returns a cleanup that removes them. It exists for
-// tests outside this package that need HasTool to observe a server's tools.
-func SetToolsForTest(name string, toolNames ...string) func() {
-	tools := make([]*Tool, len(toolNames))
-	for i, n := range toolNames {
-		tools[i] = &Tool{Name: n}
+	var out []string
+	for _, t := range tools {
+		if strings.HasPrefix(t.Name, "a2ui_") {
+			out = append(out, t.Name)
+		}
 	}
-	allTools.Set(name, tools)
-	return func() { allTools.Del(name) }
+	return out
 }
 
 // RunTool runs an MCP tool with the given input parameters.

--- a/internal/agent/tools/mcp/tools.go
+++ b/internal/agent/tools/mcp/tools.go
@@ -17,12 +17,45 @@ import (
 
 type Tool = mcp.Tool
 
+// A2UIJSONMIMEType is the canonical MIME type identifying an A2UI surface
+// payload, per the A2UI-over-MCP contract. A2UILegacyMIMEType is the legacy
+// spelling reference clients also accept.
+const (
+	A2UIJSONMIMEType   = "application/a2ui+json"
+	A2UILegacyMIMEType = "application/json+a2ui"
+)
+
+// IsA2UIMIMEType reports whether mime identifies an A2UI surface payload,
+// accepting both the canonical and legacy spellings.
+func IsA2UIMIMEType(mime string) bool {
+	return mime == A2UIJSONMIMEType || mime == A2UILegacyMIMEType
+}
+
+// A2UISurface is a UI-only A2UI surface payload extracted from a tool
+// result's EmbeddedResource content. The chat UI renders it as a live
+// surface; the model never sees the raw JSON.
+type A2UISurface struct {
+	// Payload is the raw A2UI JSON.
+	Payload string
+	// URI is the embedded resource's URI, for display/diagnostics.
+	URI string
+	// AssistantVisible reports whether the server annotated the payload
+	// for the LLM as well as the user (empty audience or one containing
+	// "assistant"). An audience of ["user"] alone hides the raw JSON from
+	// the model.
+	AssistantVisible bool
+}
+
 // ToolResult represents the result of running an MCP tool.
 type ToolResult struct {
 	Type      string
 	Content   string
 	Data      []byte
 	MediaType string
+	// Surfaces carries any A2UI surface payloads found in the result's
+	// EmbeddedResource content. They are kept out of Content: the chat UI
+	// draws them, and the model only ever echoed the JSON back.
+	Surfaces []A2UISurface
 }
 
 var allTools = csync.NewMap[string, []*Tool]()
@@ -55,7 +88,15 @@ func RunTool(ctx context.Context, cfg *config.ConfigStore, name, toolName string
 		return ToolResult{Type: "text", Content: ""}, nil
 	}
 
+	return extractToolResult(result), nil
+}
+
+// extractToolResult partitions a CallToolResult's content into model-facing
+// text, binary media, and UI-only A2UI surfaces — the extraction half of
+// RunTool, split out so tests can drive it through a live in-memory server.
+func extractToolResult(result *mcp.CallToolResult) ToolResult {
 	var textParts []string
+	var surfaces []A2UISurface
 	var imageData []byte
 	var imageMimeType string
 	var audioData []byte
@@ -75,6 +116,25 @@ func RunTool(ctx context.Context, cfg *config.ConfigStore, name, toolName string
 				audioData = content.Data
 				audioMimeType = content.MIMEType
 			}
+		case *mcp.EmbeddedResource:
+			// A2UI surfaces arrive as embedded resources — pull them
+			// aside for the UI instead of stringifying them into the
+			// model-facing text.
+			if content.Resource != nil && IsA2UIMIMEType(content.Resource.MIMEType) {
+				payload := content.Resource.Text
+				if payload == "" && len(content.Resource.Blob) > 0 {
+					payload = string(content.Resource.Blob)
+				}
+				if payload != "" {
+					surfaces = append(surfaces, A2UISurface{
+						Payload:          payload,
+						URI:              content.Resource.URI,
+						AssistantVisible: a2uiAssistantVisible(content.Annotations),
+					})
+				}
+				continue
+			}
+			textParts = append(textParts, fmt.Sprintf("%v", v))
 		default:
 			textParts = append(textParts, fmt.Sprintf("%v", v))
 		}
@@ -90,7 +150,8 @@ func RunTool(ctx context.Context, cfg *config.ConfigStore, name, toolName string
 			Content:   textContent,
 			Data:      ensureRawBytes(imageData),
 			MediaType: imageMimeType,
-		}, nil
+			Surfaces:  surfaces,
+		}
 	}
 
 	if audioData != nil {
@@ -99,13 +160,27 @@ func RunTool(ctx context.Context, cfg *config.ConfigStore, name, toolName string
 			Content:   textContent,
 			Data:      ensureRawBytes(audioData),
 			MediaType: audioMimeType,
-		}, nil
+			Surfaces:  surfaces,
+		}
 	}
 
 	return ToolResult{
-		Type:    "text",
-		Content: textContent,
-	}, nil
+		Type:     "text",
+		Content:  textContent,
+		Surfaces: surfaces,
+	}
+}
+
+// a2uiAssistantVisible reports whether an A2UI embedded resource's audience
+// annotations leave the payload visible to the LLM. Per the A2UI-over-MCP
+// verbalization contract: an empty audience is visible to both user and
+// assistant; an audience of ["user"] alone renders for the user but hides
+// the raw JSON from the model.
+func a2uiAssistantVisible(annotations *mcp.Annotations) bool {
+	if annotations == nil || len(annotations.Audience) == 0 {
+		return true
+	}
+	return slices.Contains(annotations.Audience, mcp.Role("assistant"))
 }
 
 // RefreshTools gets the updated list of tools from the MCP and updates the

--- a/internal/agent/tools/mcp/tools_a2ui_test.go
+++ b/internal/agent/tools/mcp/tools_a2ui_test.go
@@ -1,0 +1,145 @@
+package mcp
+
+import (
+	"context"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/require"
+)
+
+const testA2UIToolPayload = `{"version":"v0.9","updateComponents":{"surfaceId":"card","components":[` +
+	`{"component":"Text","id":"t","text":"Recipe"}]}}`
+
+// liveA2UIToolSession spins up an in-memory MCP server whose single tool
+// returns the given content items, and returns a connected client session.
+func liveA2UIToolSession(t *testing.T, toolName string, content []mcp.Content) *ClientSession {
+	t.Helper()
+
+	serverTransport, clientTransport := mcp.NewInMemoryTransports()
+	server := mcp.NewServer(&mcp.Implementation{Name: "srv"}, nil)
+	mcp.AddTool(
+		server,
+		&mcp.Tool{Name: toolName, Description: "test tool"},
+		func(context.Context, *mcp.CallToolRequest, struct{}) (*mcp.CallToolResult, any, error) {
+			return &mcp.CallToolResult{Content: content}, nil, nil
+		},
+	)
+	serverSession, err := server.Connect(context.Background(), serverTransport, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = serverSession.Close() })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	client := mcp.NewClient(&mcp.Implementation{Name: "crush-test"}, nil)
+	clientSession, err := client.Connect(ctx, clientTransport, nil)
+	require.NoError(t, err)
+
+	sess := &ClientSession{ClientSession: clientSession, cancel: cancel}
+	t.Cleanup(func() { _ = sess.Close() })
+	return sess
+}
+
+// runToolWithSession calls the tool through the same extraction path RunTool
+// uses, without needing a registered config client.
+func runToolWithSession(t *testing.T, sess *ClientSession, toolName string) ToolResult {
+	t.Helper()
+	result, err := sess.CallTool(context.Background(), &mcp.CallToolParams{
+		Name:      toolName,
+		Arguments: map[string]any{},
+	})
+	require.NoError(t, err)
+	return extractToolResult(result)
+}
+
+func TestRunTool_A2UISurfaceExtraction(t *testing.T) {
+	t.Parallel()
+
+	t.Run("embedded A2UI resource becomes a surface, not text", func(t *testing.T) {
+		sess := liveA2UIToolSession(t, "get_card", []mcp.Content{
+			&mcp.TextContent{Text: "Your recipe card"},
+			&mcp.EmbeddedResource{
+				Resource: &mcp.ResourceContents{
+					URI:      "a2ui://recipe-card",
+					MIMEType: A2UIJSONMIMEType,
+					Text:     testA2UIToolPayload,
+				},
+			},
+		})
+		res := runToolWithSession(t, sess, "get_card")
+
+		require.Equal(t, "Your recipe card", res.Content)
+		require.Len(t, res.Surfaces, 1)
+		require.Equal(t, testA2UIToolPayload, res.Surfaces[0].Payload)
+		require.Equal(t, "a2ui://recipe-card", res.Surfaces[0].URI)
+		require.True(t, res.Surfaces[0].AssistantVisible, "no audience annotation means visible to both")
+		require.NotContains(t, res.Content, "updateComponents")
+	})
+
+	t.Run("legacy MIME spelling is recognized", func(t *testing.T) {
+		sess := liveA2UIToolSession(t, "get_card", []mcp.Content{
+			&mcp.EmbeddedResource{
+				Resource: &mcp.ResourceContents{
+					URI:      "a2ui://form",
+					MIMEType: A2UILegacyMIMEType,
+					Text:     testA2UIToolPayload,
+				},
+			},
+		})
+		res := runToolWithSession(t, sess, "get_card")
+		require.Len(t, res.Surfaces, 1)
+	})
+
+	t.Run("user-only audience hides the payload from the model", func(t *testing.T) {
+		sess := liveA2UIToolSession(t, "get_card", []mcp.Content{
+			&mcp.EmbeddedResource{
+				Resource: &mcp.ResourceContents{
+					URI:      "a2ui://card",
+					MIMEType: A2UIJSONMIMEType,
+					Text:     testA2UIToolPayload,
+				},
+				Annotations: &mcp.Annotations{Audience: []mcp.Role{"user"}},
+			},
+		})
+		res := runToolWithSession(t, sess, "get_card")
+		require.Len(t, res.Surfaces, 1)
+		require.False(t, res.Surfaces[0].AssistantVisible)
+	})
+
+	t.Run("blob-delivered surface is normalized to text", func(t *testing.T) {
+		sess := liveA2UIToolSession(t, "get_card", []mcp.Content{
+			&mcp.EmbeddedResource{
+				Resource: &mcp.ResourceContents{
+					URI:      "a2ui://card",
+					MIMEType: A2UIJSONMIMEType,
+					Blob:     []byte(testA2UIToolPayload),
+				},
+			},
+		})
+		res := runToolWithSession(t, sess, "get_card")
+		require.Len(t, res.Surfaces, 1)
+		require.Equal(t, testA2UIToolPayload, res.Surfaces[0].Payload)
+	})
+
+	t.Run("non-A2UI embedded resource stays in the text", func(t *testing.T) {
+		sess := liveA2UIToolSession(t, "get_doc", []mcp.Content{
+			&mcp.EmbeddedResource{
+				Resource: &mcp.ResourceContents{
+					URI:      "file:///doc.md",
+					MIMEType: "text/markdown",
+					Text:     "# hello",
+				},
+			},
+		})
+		res := runToolWithSession(t, sess, "get_doc")
+		require.Empty(t, res.Surfaces)
+		require.NotEmpty(t, res.Content)
+	})
+}
+
+func TestIsA2UIMIMEType(t *testing.T) {
+	t.Parallel()
+	require.True(t, IsA2UIMIMEType("application/a2ui+json"))
+	require.True(t, IsA2UIMIMEType("application/json+a2ui"))
+	require.False(t, IsA2UIMIMEType("application/json"))
+	require.False(t, IsA2UIMIMEType("text/plain"))
+}

--- a/internal/agent/tools/mcp/tools_a2ui_test.go
+++ b/internal/agent/tools/mcp/tools_a2ui_test.go
@@ -55,6 +55,8 @@ func TestRunTool_A2UISurfaceExtraction(t *testing.T) {
 	t.Parallel()
 
 	t.Run("embedded A2UI resource becomes a surface, not text", func(t *testing.T) {
+		t.Parallel()
+
 		sess := liveA2UIToolSession(t, "get_card", []mcp.Content{
 			&mcp.TextContent{Text: "Your recipe card"},
 			&mcp.EmbeddedResource{
@@ -76,6 +78,8 @@ func TestRunTool_A2UISurfaceExtraction(t *testing.T) {
 	})
 
 	t.Run("legacy MIME spelling is recognized", func(t *testing.T) {
+		t.Parallel()
+
 		sess := liveA2UIToolSession(t, "get_card", []mcp.Content{
 			&mcp.EmbeddedResource{
 				Resource: &mcp.ResourceContents{
@@ -90,6 +94,8 @@ func TestRunTool_A2UISurfaceExtraction(t *testing.T) {
 	})
 
 	t.Run("user-only audience hides the payload from the model", func(t *testing.T) {
+		t.Parallel()
+
 		sess := liveA2UIToolSession(t, "get_card", []mcp.Content{
 			&mcp.EmbeddedResource{
 				Resource: &mcp.ResourceContents{
@@ -103,9 +109,29 @@ func TestRunTool_A2UISurfaceExtraction(t *testing.T) {
 		res := runToolWithSession(t, sess, "get_card")
 		require.Len(t, res.Surfaces, 1)
 		require.False(t, res.Surfaces[0].AssistantVisible)
+		require.True(t, res.Surfaces[0].RenderForUser, "user audience still renders")
+	})
+
+	t.Run("assistant-only audience is visible to the model but not rendered", func(t *testing.T) {
+		sess := liveA2UIToolSession(t, "get_card", []mcp.Content{
+			&mcp.EmbeddedResource{
+				Resource: &mcp.ResourceContents{
+					URI:      "a2ui://card",
+					MIMEType: A2UIJSONMIMEType,
+					Text:     testA2UIToolPayload,
+				},
+				Annotations: &mcp.Annotations{Audience: []mcp.Role{"assistant"}},
+			},
+		})
+		res := runToolWithSession(t, sess, "get_card")
+		require.Len(t, res.Surfaces, 1)
+		require.True(t, res.Surfaces[0].AssistantVisible)
+		require.False(t, res.Surfaces[0].RenderForUser, "assistant-only audience must not render")
 	})
 
 	t.Run("blob-delivered surface is normalized to text", func(t *testing.T) {
+		t.Parallel()
+
 		sess := liveA2UIToolSession(t, "get_card", []mcp.Content{
 			&mcp.EmbeddedResource{
 				Resource: &mcp.ResourceContents{
@@ -121,6 +147,8 @@ func TestRunTool_A2UISurfaceExtraction(t *testing.T) {
 	})
 
 	t.Run("non-A2UI embedded resource stays in the text", func(t *testing.T) {
+		t.Parallel()
+
 		sess := liveA2UIToolSession(t, "get_doc", []mcp.Content{
 			&mcp.EmbeddedResource{
 				Resource: &mcp.ResourceContents{

--- a/internal/agent/tools/mcp_tools_a2ui_test.go
+++ b/internal/agent/tools/mcp_tools_a2ui_test.go
@@ -48,8 +48,14 @@ func TestSplitMCPToolResult(t *testing.T) {
 		require.Contains(t, content, testA2UIPayload)
 	})
 
-	t.Run("user-only payload stays hidden when not diverting", func(t *testing.T) {
+	t.Run("user-only payload reaches the model when nothing renders it", func(t *testing.T) {
 		t.Parallel()
+		// divert=false means no chat UI is consuming this turn's surfaces —
+		// a channel-originated turn, a headless `crush run`, or disable_a2ui.
+		// The ["user"] annotation means "the user can already see this", and
+		// here they cannot see anything: the model's reply is the only path
+		// back to them. Withholding the payload left the tool result empty
+		// and the agent replying with nothing at all.
 		userOnly := surface
 		userOnly.AssistantVisible = false
 		content, meta := splitMCPToolResult(mcp.ToolResult{
@@ -59,7 +65,26 @@ func TestSplitMCPToolResult(t *testing.T) {
 		}, "recipe", false)
 
 		require.Empty(t, meta.A2UISurfaces)
-		require.Equal(t, "fallback text", content)
+		require.Contains(t, content, "fallback text")
+		require.Contains(t, content, testA2UIPayload,
+			"a user-audience payload must fold back to the model when no UI renders it")
+	})
+
+	t.Run("user-only surface with no fallback text is not an empty result", func(t *testing.T) {
+		t.Parallel()
+		// The pathological shape: the tool's ONLY content is a ["user"]
+		// surface. On a channel turn this used to produce a completely
+		// empty tool result.
+		userOnly := surface
+		userOnly.AssistantVisible = false
+		content, _ := splitMCPToolResult(mcp.ToolResult{
+			Type:     "text",
+			Content:  "",
+			Surfaces: []mcp.A2UISurface{userOnly},
+		}, "recipe", false)
+
+		require.NotEmpty(t, content, "the model must not be handed an empty tool result")
+		require.Contains(t, content, testA2UIPayload)
 	})
 
 	t.Run("surface without fallback text still gets a placeholder", func(t *testing.T) {

--- a/internal/agent/tools/mcp_tools_a2ui_test.go
+++ b/internal/agent/tools/mcp_tools_a2ui_test.go
@@ -1,0 +1,75 @@
+package tools
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/crush/internal/agent/tools/mcp"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSplitMCPToolResult(t *testing.T) {
+	t.Parallel()
+
+	surface := mcp.A2UISurface{
+		Payload:          testA2UIPayload,
+		URI:              "a2ui://recipe-card",
+		AssistantVisible: true,
+	}
+
+	t.Run("surfaces divert to metadata with provenance", func(t *testing.T) {
+		t.Parallel()
+		content, meta := splitMCPToolResult(mcp.ToolResult{
+			Type:     "text",
+			Content:  "Your recipe card",
+			Surfaces: []mcp.A2UISurface{surface},
+		}, "recipe", true)
+
+		require.Len(t, meta.A2UISurfaces, 1)
+		require.Equal(t, "<a2ui-json>"+testA2UIPayload+"</a2ui-json>", meta.A2UISurfaces[0])
+		require.Equal(t, []string{"recipe"}, meta.MCPSurfaceProvenance)
+		require.Contains(t, content, "Your recipe card")
+		require.True(t, strings.Contains(content, A2UISurfacePlaceholderPrefix))
+		require.NotContains(t, content, "updateComponents")
+	})
+
+	t.Run("no diversion folds the payload back for the model", func(t *testing.T) {
+		t.Parallel()
+		// Channel-originated turns keep the payload so the model can relay it.
+		content, meta := splitMCPToolResult(mcp.ToolResult{
+			Type:     "text",
+			Content:  "fallback text",
+			Surfaces: []mcp.A2UISurface{surface},
+		}, "recipe", false)
+
+		require.Empty(t, meta.A2UISurfaces)
+		require.Contains(t, content, "fallback text")
+		require.Contains(t, content, testA2UIPayload)
+	})
+
+	t.Run("user-only payload stays hidden when not diverting", func(t *testing.T) {
+		t.Parallel()
+		userOnly := surface
+		userOnly.AssistantVisible = false
+		content, meta := splitMCPToolResult(mcp.ToolResult{
+			Type:     "text",
+			Content:  "fallback text",
+			Surfaces: []mcp.A2UISurface{userOnly},
+		}, "recipe", false)
+
+		require.Empty(t, meta.A2UISurfaces)
+		require.Equal(t, "fallback text", content)
+	})
+
+	t.Run("surface without fallback text still gets a placeholder", func(t *testing.T) {
+		t.Parallel()
+		content, meta := splitMCPToolResult(mcp.ToolResult{
+			Type:     "text",
+			Content:  "",
+			Surfaces: []mcp.A2UISurface{surface},
+		}, "recipe", true)
+
+		require.Len(t, meta.A2UISurfaces, 1)
+		require.True(t, strings.HasPrefix(content, A2UISurfacePlaceholderPrefix))
+	})
+}

--- a/internal/agent/tools/mcp_tools_a2ui_test.go
+++ b/internal/agent/tools/mcp_tools_a2ui_test.go
@@ -14,6 +14,7 @@ func TestSplitMCPToolResult(t *testing.T) {
 	surface := mcp.A2UISurface{
 		Payload:          testA2UIPayload,
 		URI:              "a2ui://recipe-card",
+		RenderForUser:    true,
 		AssistantVisible: true,
 	}
 
@@ -71,5 +72,59 @@ func TestSplitMCPToolResult(t *testing.T) {
 
 		require.Len(t, meta.A2UISurfaces, 1)
 		require.True(t, strings.HasPrefix(content, A2UISurfacePlaceholderPrefix))
+	})
+
+	t.Run("user-only surface renders but stays hidden from the model", func(t *testing.T) {
+		t.Parallel()
+		userOnly := surface
+		userOnly.RenderForUser = true
+		userOnly.AssistantVisible = false
+		content, meta := splitMCPToolResult(mcp.ToolResult{
+			Type:     "text",
+			Content:  "",
+			Surfaces: []mcp.A2UISurface{userOnly},
+		}, "recipe", true)
+
+		// Renders for the user via metadata, but the model sees a
+		// placeholder, not the JSON.
+		require.Len(t, meta.A2UISurfaces, 1)
+		require.True(t, strings.HasPrefix(content, A2UISurfacePlaceholderPrefix))
+		require.NotContains(t, content, "updateComponents")
+
+		// The model-facing content — what the next agent request's history
+		// carries — holds the placeholder and none of the raw payload.
+		require.NotContains(t, content, testA2UIPayload)
+		require.NotContains(t, content, `"surfaceId"`)
+	})
+
+	t.Run("assistant-only surface reaches the model but never renders", func(t *testing.T) {
+		t.Parallel()
+		assistantOnly := surface
+		assistantOnly.RenderForUser = false
+		assistantOnly.AssistantVisible = true
+		content, meta := splitMCPToolResult(mcp.ToolResult{
+			Type:     "text",
+			Content:  "",
+			Surfaces: []mcp.A2UISurface{assistantOnly},
+		}, "recipe", true)
+
+		// No surface for the UI; the JSON goes to the model for reasoning.
+		require.Empty(t, meta.A2UISurfaces)
+		require.Contains(t, content, testA2UIPayload)
+	})
+
+	t.Run("assistant-only surface reaches the model when not diverting too", func(t *testing.T) {
+		t.Parallel()
+		assistantOnly := surface
+		assistantOnly.RenderForUser = false
+		assistantOnly.AssistantVisible = true
+		content, meta := splitMCPToolResult(mcp.ToolResult{
+			Type:     "text",
+			Content:  "",
+			Surfaces: []mcp.A2UISurface{assistantOnly},
+		}, "recipe", false)
+
+		require.Empty(t, meta.A2UISurfaces)
+		require.Contains(t, content, testA2UIPayload)
 	})
 }

--- a/internal/agent/tools/read_mcp_resource.go
+++ b/internal/agent/tools/read_mcp_resource.go
@@ -6,6 +6,7 @@ import (
 	_ "embed"
 	"fmt"
 	"log/slog"
+	"net/url"
 	"strings"
 
 	"charm.land/fantasy"
@@ -27,8 +28,121 @@ type ReadMCPResourcePermissionsParams struct {
 
 const ReadMCPResourceToolName = "read_mcp_resource"
 
+// a2uiMIMEType is the MIME type MCP resource templates use for A2UI surfaces.
+// A2UI payloads are delivered to the UI through response metadata (never to
+// the model): the model gets a compact placeholder instead of the raw JSON,
+// so it cannot echo the payload back and double-render the surface.
+const a2uiMIMEType = mcp.A2UIJSONMIMEType
+
+// ReadMCPResourceResponseMetadata carries the UI-only A2UI surface payload
+// for a resource whose MIME type is application/a2ui+json (or a tool result
+// that embedded one). MCPSurfaceProvenance records which MCP server each
+// surface came from — by slice position — so a later interaction event can
+// route back to the owning server.
+type ReadMCPResourceResponseMetadata struct {
+	A2UISurfaces         []string `json:"a2ui_surfaces,omitempty"`
+	MCPSurfaceProvenance []string `json:"mcp_surface_provenance,omitempty"`
+}
+
+// A2UISurfacePlaceholderPrefix starts every model-facing placeholder that
+// stands in for a diverted A2UI surface. The chat renderer uses it to strip
+// placeholder lines from the tool content it shows the user.
+const A2UISurfacePlaceholderPrefix = "[A2UI surface rendered in the chat UI from "
+
+// splitMCPResourceContents partitions resource contents into model-facing
+// text parts and, when divert is set, UI-only A2UI surface payloads carried
+// in response metadata. divert is false when no chat UI will render the
+// metadata (channel-originated turns, disable_a2ui deployments): the raw
+// payload then stays in the model-facing content so the model can still
+// relay or summarize the data.
+func splitMCPResourceContents(contents []*mcp.ResourceContents, divert bool, provenance string) ([]string, ReadMCPResourceResponseMetadata) {
+	var textParts []string
+	var metadata ReadMCPResourceResponseMetadata
+	for _, content := range contents {
+		if content == nil {
+			continue
+		}
+		text := content.Text
+		if text == "" && len(content.Blob) > 0 {
+			// Blob is a legal delivery for any MIME type, including
+			// application/a2ui+json — normalize it to text here so a
+			// blob-delivered surface cannot slip past the diversion below.
+			text = string(content.Blob)
+		}
+		if text == "" {
+			slog.Debug("MCP resource content missing text/blob", "uri", content.URI)
+			continue
+		}
+		// A2UI surfaces go to the UI via metadata, not the model-facing
+		// content: the chat renderer draws the surface itself, and the
+		// model only ever echoed the raw JSON back, double-rendering the
+		// surface. Both the canonical and legacy MIME spellings match.
+		if divert && mcp.IsA2UIMIMEType(content.MIMEType) {
+			metadata.A2UISurfaces = append(metadata.A2UISurfaces, "<a2ui-json>"+text+"</a2ui-json>")
+			metadata.MCPSurfaceProvenance = append(metadata.MCPSurfaceProvenance, provenance)
+			// The placeholder is a single-line protocol the chat renderer
+			// strips line-wise — a server-controlled URI must not be able
+			// to break out of it with embedded newlines. The injected
+			// width hint is stripped too: servers echo the request URI
+			// verbatim, and a model that re-reads the echoed ?w=N URI
+			// after a terminal resize would freeze the surface at the old
+			// width (a2uiWidthHint respects an existing w=).
+			uri := strings.NewReplacer("\n", " ", "\r", " ").Replace(content.URI)
+			uri = stripA2UIWidthParam(uri)
+			textParts = append(textParts, A2UISurfacePlaceholderPrefix+uri+" — the user can already see it; do not repeat or echo its JSON payload]")
+			continue
+		}
+		textParts = append(textParts, text)
+	}
+	return textParts, metadata
+}
+
 //go:embed read_mcp_resource.md
 var readMCPResourceDescription string
+
+// a2uiWidthHint appends w=N to an A2UI surface URI so the server sizes its
+// pre-rendered geometry to the host's content width. It is a no-op for
+// non-A2UI URIs and for URIs that already carry a width hint (an explicit
+// w= is respected wherever it came from). The /a2ui path suffix is the
+// convention the in-house A2UI resource templates share (cairn,
+// switchboard); the template registry's MIME types would be the
+// protocol-level signal, but templates can legitimately fail to list, so
+// the convention stays the trigger.
+//
+// The URI is parsed only to decide — the hint is appended to the original
+// string, never re-serialized, because MCP servers match URIs textually
+// against their templates.
+func a2uiWidthHint(uri string, width int) string {
+	u, err := url.Parse(uri)
+	if err != nil || !strings.HasSuffix(u.Path, "/a2ui") {
+		return uri
+	}
+	if u.Query().Has("w") {
+		return uri
+	}
+	sep := "?"
+	if u.RawQuery != "" {
+		sep = "&"
+	}
+	return fmt.Sprintf("%s%sw=%d", uri, sep, width)
+}
+
+// stripA2UIWidthParam removes the w= query parameter from a URI for display
+// in the model-facing placeholder. This URI is informational (never
+// fetched), so re-encoding any remaining query parameters is harmless.
+func stripA2UIWidthParam(uri string) string {
+	u, err := url.Parse(uri)
+	if err != nil || !u.Query().Has("w") {
+		return uri
+	}
+	q := u.Query()
+	q.Del("w")
+	base, _, _ := strings.Cut(uri, "?")
+	if enc := q.Encode(); enc != "" {
+		return base + "?" + enc
+	}
+	return base
+}
 
 func NewReadMCPResourceTool(cfg *config.ConfigStore, permissions permission.Service) fantasy.AgentTool {
 	return fantasy.NewParallelAgentTool(
@@ -69,6 +183,16 @@ func NewReadMCPResourceTool(cfg *config.ConfigStore, permissions permission.Serv
 				return NewPermissionDeniedResponse(), nil
 			}
 
+			// A2UI surface templates (…/a2ui) pre-render their bar
+			// geometry server-side, so pass the UI's content width as
+			// the ?w= hint — the surface then fills the chat card
+			// instead of a fixed default budget. Only when the URI
+			// carries no width of its own and the turn has a UI width
+			// (0 = headless/remote turn).
+			if w := GetContentWidthFromContext(ctx); w > 0 {
+				params.URI = a2uiWidthHint(params.URI, w)
+			}
+
 			contents, err := mcp.ReadResource(ctx, cfg, params.MCPName, params.URI)
 			if err != nil {
 				return fantasy.NewTextErrorResponse(err.Error()), nil
@@ -77,27 +201,27 @@ func NewReadMCPResourceTool(cfg *config.ConfigStore, permissions permission.Serv
 				return fantasy.NewTextResponse(""), nil
 			}
 
-			var textParts []string
-			for _, content := range contents {
-				if content == nil {
-					continue
-				}
-				if content.Text != "" {
-					textParts = append(textParts, content.Text)
-					continue
-				}
-				if len(content.Blob) > 0 {
-					textParts = append(textParts, string(content.Blob))
-					continue
-				}
-				slog.Debug("MCP resource content missing text/blob", "uri", content.URI)
-			}
+			// Divert A2UI payloads to UI-only metadata only when a chat UI
+			// will actually render them: on channel-originated turns the
+			// reply travels back over the channel and the model needs the
+			// payload to relay it, disable_a2ui deployments opted out of
+			// surfaces entirely, and a zero content width means no
+			// interactive UI tagged this turn (headless crush run, remote
+			// clients that predate the wire field).
+			divert := GetChannelFromContext(ctx) == "" &&
+				!cfg.Config().Options.DisableA2UI &&
+				GetContentWidthFromContext(ctx) > 0
+			textParts, metadata := splitMCPResourceContents(contents, divert, params.MCPName)
 
 			if len(textParts) == 0 {
 				return fantasy.NewTextResponse(""), nil
 			}
 
-			return fantasy.NewTextResponse(strings.Join(textParts, "\n")), nil
+			resp := fantasy.NewTextResponse(strings.Join(textParts, "\n"))
+			if len(metadata.A2UISurfaces) > 0 {
+				resp = fantasy.WithResponseMetadata(resp, metadata)
+			}
+			return resp, nil
 		},
 	)
 }

--- a/internal/agent/tools/read_mcp_resource_contents_test.go
+++ b/internal/agent/tools/read_mcp_resource_contents_test.go
@@ -1,0 +1,105 @@
+package tools
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/crush/internal/agent/tools/mcp"
+	"github.com/stretchr/testify/require"
+)
+
+const testA2UIPayload = `{"version":"v0.9","updateComponents":{"surfaceId":"s","components":[` +
+	`{"component":"Text","id":"t","text":"hi"}]}}`
+
+func TestSplitMCPResourceContents(t *testing.T) {
+	t.Parallel()
+
+	t.Run("a2ui text content is diverted to metadata", func(t *testing.T) {
+		t.Parallel()
+		textParts, meta := splitMCPResourceContents([]*mcp.ResourceContents{
+			{URI: "cairn://run/x/a2ui", MIMEType: a2uiMIMEType, Text: testA2UIPayload},
+		}, true, "test-mcp")
+		require.Len(t, meta.A2UISurfaces, 1)
+		require.Equal(t, "<a2ui-json>"+testA2UIPayload+"</a2ui-json>", meta.A2UISurfaces[0])
+		require.Equal(t, []string{"test-mcp"}, meta.MCPSurfaceProvenance)
+		require.Len(t, textParts, 1)
+		require.True(t, strings.HasPrefix(textParts[0], A2UISurfacePlaceholderPrefix))
+		require.NotContains(t, textParts[0], "updateComponents")
+	})
+
+	t.Run("legacy MIME spelling is diverted too", func(t *testing.T) {
+		t.Parallel()
+		_, meta := splitMCPResourceContents([]*mcp.ResourceContents{
+			{URI: "a2ui://form", MIMEType: mcp.A2UILegacyMIMEType, Text: testA2UIPayload},
+		}, true, "test-mcp")
+		require.Len(t, meta.A2UISurfaces, 1)
+		require.Equal(t, []string{"test-mcp"}, meta.MCPSurfaceProvenance)
+	})
+
+	t.Run("a2ui blob content is diverted too", func(t *testing.T) {
+		t.Parallel()
+		// Blob is a legal delivery for any MIME type — a blob-delivered
+		// surface must not leak raw JSON into the model-facing content.
+		textParts, meta := splitMCPResourceContents([]*mcp.ResourceContents{
+			{URI: "cairn://run/x/a2ui", MIMEType: a2uiMIMEType, Blob: []byte(testA2UIPayload)},
+		}, true, "test-mcp")
+		require.Len(t, meta.A2UISurfaces, 1)
+		require.Len(t, textParts, 1)
+		require.True(t, strings.HasPrefix(textParts[0], A2UISurfacePlaceholderPrefix))
+		require.NotContains(t, textParts[0], "updateComponents")
+	})
+
+	t.Run("no diversion when no UI renders metadata", func(t *testing.T) {
+		t.Parallel()
+		// Channel-originated and disable_a2ui turns keep the raw payload so
+		// the model can relay or summarize the data.
+		textParts, meta := splitMCPResourceContents([]*mcp.ResourceContents{
+			{URI: "cairn://run/x/a2ui", MIMEType: a2uiMIMEType, Text: testA2UIPayload},
+		}, false, "test-mcp")
+		require.Empty(t, meta.A2UISurfaces)
+		require.Equal(t, []string{testA2UIPayload}, textParts)
+	})
+
+	t.Run("plain text passes through", func(t *testing.T) {
+		t.Parallel()
+		textParts, meta := splitMCPResourceContents([]*mcp.ResourceContents{
+			{URI: "cairn://artifact/x", MIMEType: "text/markdown", Text: "# hello"},
+		}, true, "test-mcp")
+		require.Empty(t, meta.A2UISurfaces)
+		require.Equal(t, []string{"# hello"}, textParts)
+	})
+
+	t.Run("mixed text and a2ui keeps both", func(t *testing.T) {
+		t.Parallel()
+		textParts, meta := splitMCPResourceContents([]*mcp.ResourceContents{
+			{URI: "cairn://artifact/x", MIMEType: "text/markdown", Text: "summary"},
+			{URI: "cairn://artifact/x/a2ui", MIMEType: a2uiMIMEType, Text: testA2UIPayload},
+		}, true, "test-mcp")
+		require.Len(t, meta.A2UISurfaces, 1)
+		require.Len(t, textParts, 2)
+		require.Equal(t, "summary", textParts[0])
+		require.True(t, strings.HasPrefix(textParts[1], A2UISurfacePlaceholderPrefix))
+	})
+
+	t.Run("placeholder hides the injected width hint", func(t *testing.T) {
+		t.Parallel()
+		// Servers echo the request URI verbatim, ?w=N included; the model
+		// must not learn a width-frozen URI it could reuse after a resize.
+		textParts, _ := splitMCPResourceContents([]*mcp.ResourceContents{
+			{URI: "cairn://run/x/a2ui?w=114", MIMEType: a2uiMIMEType, Text: testA2UIPayload},
+		}, true, "test-mcp")
+		require.Len(t, textParts, 1)
+		require.Contains(t, textParts[0], "cairn://run/x/a2ui ")
+		require.NotContains(t, textParts[0], "w=114")
+	})
+
+	t.Run("nil and empty entries are skipped", func(t *testing.T) {
+		t.Parallel()
+		textParts, meta := splitMCPResourceContents([]*mcp.ResourceContents{
+			nil,
+			{URI: "cairn://artifact/empty"},
+		}, true, "test-mcp")
+		require.Empty(t, meta.A2UISurfaces)
+		require.Empty(t, textParts)
+	})
+}

--- a/internal/agent/tools/read_mcp_resource_test.go
+++ b/internal/agent/tools/read_mcp_resource_test.go
@@ -1,0 +1,85 @@
+package tools
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestA2UIWidthHint(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name  string
+		uri   string
+		width int
+		want  string
+	}{
+		{
+			name:  "a2ui run template gets the width",
+			uri:   "mcp://cairn/run/vitkuUpp/a2ui",
+			width: 114,
+			want:  "mcp://cairn/run/vitkuUpp/a2ui?w=114",
+		},
+		{
+			name:  "cairn-scheme alias gets the width",
+			uri:   "cairn://run/abc123/a2ui",
+			width: 90,
+			want:  "cairn://run/abc123/a2ui?w=90",
+		},
+		{
+			name:  "artifact and bundle templates get the width",
+			uri:   "mcp://cairn/artifact/PIMfMan7/a2ui",
+			width: 80,
+			want:  "mcp://cairn/artifact/PIMfMan7/a2ui?w=80",
+		},
+		{
+			name:  "an existing width hint is left alone",
+			uri:   "mcp://cairn/run/vitkuUpp/a2ui?w=60",
+			width: 114,
+			want:  "mcp://cairn/run/vitkuUpp/a2ui?w=60",
+		},
+		{
+			name:  "a non-width query still gets the width appended",
+			uri:   "mcp://cairn/run/vitkuUpp/a2ui?theme=dark",
+			width: 114,
+			want:  "mcp://cairn/run/vitkuUpp/a2ui?theme=dark&w=114",
+		},
+		{
+			name:  "non-a2ui resources are untouched",
+			uri:   "mcp://cairn/run/vitkuUpp",
+			width: 114,
+			want:  "mcp://cairn/run/vitkuUpp",
+		},
+		{
+			name:  "a2ui-looking substring outside the suffix is untouched",
+			uri:   "mcp://cairn/artifact/a2ui-notes",
+			width: 114,
+			want:  "mcp://cairn/artifact/a2ui-notes",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.want, a2uiWidthHint(tc.uri, tc.width))
+		})
+	}
+}
+
+func TestStripA2UIWidthParam(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, "cairn://run/x/a2ui", stripA2UIWidthParam("cairn://run/x/a2ui?w=114"))
+	require.Equal(t, "cairn://run/x/a2ui?theme=dark", stripA2UIWidthParam("cairn://run/x/a2ui?theme=dark&w=114"))
+	require.Equal(t, "cairn://run/x/a2ui", stripA2UIWidthParam("cairn://run/x/a2ui"))
+	require.Equal(t, "mcp://cairn/artifact/y", stripA2UIWidthParam("mcp://cairn/artifact/y"))
+}
+
+func TestGetContentWidthFromContext(t *testing.T) {
+	t.Parallel()
+
+	require.Zero(t, GetContentWidthFromContext(context.Background()))
+	ctx := context.WithValue(context.Background(), ContentWidthContextKey, 114)
+	require.Equal(t, 114, GetContentWidthFromContext(ctx))
+}

--- a/internal/agent/tools/tools.go
+++ b/internal/agent/tools/tools.go
@@ -16,6 +16,7 @@ type (
 	supportsImagesKey   string
 	modelNameKey        string
 	channelContextKey   string
+	contentWidthKey     string
 )
 
 const (
@@ -29,6 +30,8 @@ const (
 	ModelNameContextKey modelNameKey = "model_name"
 	// ChannelContextKey is the key for the channel that originated the turn.
 	ChannelContextKey channelContextKey = "channel"
+	// ContentWidthContextKey is the key for the UI content width hint in cells.
+	ContentWidthContextKey contentWidthKey = "content_width"
 )
 
 // getContextValue is a generic helper that retrieves a typed value from context.
@@ -67,6 +70,12 @@ func GetSupportsImagesFromContext(ctx context.Context) bool {
 // GetModelNameFromContext retrieves the model name from the context.
 func GetModelNameFromContext(ctx context.Context) string {
 	return getContextValue(ctx, ModelNameContextKey, "")
+}
+
+// GetContentWidthFromContext retrieves the UI content width hint in cells,
+// or 0 when no hint was provided for this turn.
+func GetContentWidthFromContext(ctx context.Context) int {
+	return getContextValue(ctx, ContentWidthContextKey, 0)
 }
 
 // NewPermissionDeniedResponse returns a tool response indicating the user

--- a/internal/backend/agent.go
+++ b/internal/backend/agent.go
@@ -97,6 +97,9 @@ func (b *Backend) runAgent(ws *Workspace, msg proto.AgentMessage, accept *agent.
 	if msg.Channel != "" {
 		ctx = agent.WithChannel(ctx, msg.Channel)
 	}
+	if msg.ContentWidth > 0 {
+		ctx = agent.WithContentWidth(ctx, msg.ContentWidth)
+	}
 	_, err := ws.AgentCoordinator.RunAccepted(ctx, accept, msg.SessionID, msg.Prompt, proto.AttachmentsToMessage(msg.Attachments)...)
 	if err == nil || errors.Is(err, context.Canceled) {
 		return

--- a/internal/backend/config.go
+++ b/internal/backend/config.go
@@ -2,6 +2,7 @@ package backend
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -36,6 +37,19 @@ type MCPResourceContents struct {
 	MIMEType string `json:"mime_type,omitempty"`
 	Text     string `json:"text,omitempty"`
 	Blob     []byte `json:"blob,omitempty"`
+}
+
+// MCPToolCallResult holds the model-facing text and any A2UI surface
+// payloads from an MCP tool call.
+type MCPToolCallResult struct {
+	Content  string               `json:"content"`
+	Surfaces []MCPToolCallSurface `json:"surfaces,omitempty"`
+}
+
+// MCPToolCallSurface is a single A2UI surface payload from a tool call.
+type MCPToolCallSurface struct {
+	Payload string `json:"payload"`
+	URI     string `json:"uri"`
 }
 
 // SetConfigField sets a key/value pair in the config file for the
@@ -321,6 +335,28 @@ func (b *Backend) ReadMCPResource(ctx context.Context, workspaceID, name, uri st
 		}
 	}
 	return result, nil
+}
+
+// CallMCPTool invokes a tool on a named MCP server and returns its text
+// content plus any A2UI surface payload it embedded.
+func (b *Backend) CallMCPTool(ctx context.Context, workspaceID, name, toolName string, args map[string]any) (MCPToolCallResult, error) {
+	ws, err := b.GetWorkspace(workspaceID)
+	if err != nil {
+		return MCPToolCallResult{}, err
+	}
+	input, err := json.Marshal(args)
+	if err != nil {
+		return MCPToolCallResult{}, fmt.Errorf("failed to encode tool arguments: %w", err)
+	}
+	res, err := mcptools.RunTool(ctx, ws.Cfg, name, toolName, string(input))
+	if err != nil {
+		return MCPToolCallResult{}, err
+	}
+	out := MCPToolCallResult{Content: res.Content}
+	for _, s := range res.Surfaces {
+		out.Surfaces = append(out.Surfaces, MCPToolCallSurface{Payload: s.Payload, URI: s.URI})
+	}
+	return out, nil
 }
 
 // GetMCPPrompt retrieves a prompt from a named MCP server.

--- a/internal/client/config.go
+++ b/internal/client/config.go
@@ -291,6 +291,19 @@ type MCPResourceContents struct {
 	Blob     []byte `json:"blob,omitempty"`
 }
 
+// MCPToolCallResult holds the model-facing text and any A2UI surface
+// payloads from an MCP tool call.
+type MCPToolCallResult struct {
+	Content  string               `json:"content"`
+	Surfaces []MCPToolCallSurface `json:"surfaces,omitempty"`
+}
+
+// MCPToolCallSurface is a single A2UI surface payload from a tool call.
+type MCPToolCallSurface struct {
+	Payload string `json:"payload"`
+	URI     string `json:"uri"`
+}
+
 // EnableDockerMCP enables the Docker MCP server on the workspace.
 func (c *Client) EnableDockerMCP(ctx context.Context, id string) error {
 	rsp, err := c.post(ctx, fmt.Sprintf("/workspaces/%s/mcp/docker/enable", id), nil, nil, nil)
@@ -381,6 +394,27 @@ func (c *Client) ListMCPPrompts(ctx context.Context, id string) ([]proto.MCPProm
 		return nil, fmt.Errorf("failed to decode MCP prompts: %w", err)
 	}
 	return prompts, nil
+}
+
+// CallMCPTool calls a tool on a named MCP server.
+func (c *Client) CallMCPTool(ctx context.Context, id, name, toolName string, args map[string]any) (MCPToolCallResult, error) {
+	rsp, err := c.post(ctx, fmt.Sprintf("/workspaces/%s/mcp/call-tool", id), nil, jsonBody(struct {
+		Name     string         `json:"name"`
+		ToolName string         `json:"tool_name"`
+		Args     map[string]any `json:"args"`
+	}{Name: name, ToolName: toolName, Args: args}), http.Header{"Content-Type": []string{"application/json"}})
+	if err != nil {
+		return MCPToolCallResult{}, fmt.Errorf("failed to call MCP tool: %w", err)
+	}
+	defer rsp.Body.Close()
+	if rsp.StatusCode != http.StatusOK {
+		return MCPToolCallResult{}, fmt.Errorf("failed to call MCP tool: status code %d", rsp.StatusCode)
+	}
+	var result MCPToolCallResult
+	if err := json.NewDecoder(rsp.Body).Decode(&result); err != nil {
+		return MCPToolCallResult{}, fmt.Errorf("failed to decode MCP tool result: %w", err)
+	}
+	return result, nil
 }
 
 // GetMCPPrompt retrieves a prompt from a named MCP server.

--- a/internal/client/proto.go
+++ b/internal/client/proto.go
@@ -430,13 +430,14 @@ func (c *Client) UpdateAgent(ctx context.Context, id string) error {
 // for completion detection. Pass "" when the caller does not need
 // to distinguish its own turn's terminal event from any concurrent
 // turn on the same session (e.g. interactive TUI usage).
-func (c *Client) SendMessage(ctx context.Context, id string, sessionID, runID, channel, prompt string, attachments ...message.Attachment) error {
+func (c *Client) SendMessage(ctx context.Context, id string, sessionID, runID, channel string, contentWidth int, prompt string, attachments ...message.Attachment) error {
 	rsp, err := c.post(ctx, fmt.Sprintf("/workspaces/%s/agent", id), nil, jsonBody(proto.AgentMessage{
-		SessionID:   sessionID,
-		RunID:       runID,
-		Channel:     channel,
-		Prompt:      prompt,
-		Attachments: proto.AttachmentsFromMessage(attachments),
+		SessionID:    sessionID,
+		RunID:        runID,
+		Channel:      channel,
+		ContentWidth: contentWidth,
+		Prompt:       prompt,
+		Attachments:  proto.AttachmentsFromMessage(attachments),
 	}), http.Header{"Content-Type": []string{"application/json"}})
 	if err != nil {
 		return fmt.Errorf("failed to send message to agent: %w", err)

--- a/internal/client/proto_test.go
+++ b/internal/client/proto_test.go
@@ -97,7 +97,7 @@ func TestSendMessageAcceptsStatusAccepted(t *testing.T) {
 	defer srv.Close()
 
 	c := captureClient(t, srv)
-	require.NoError(t, c.SendMessage(context.Background(), "ws1", "sess1", "", "", "hello"))
+	require.NoError(t, c.SendMessage(context.Background(), "ws1", "sess1", "", "", 0, "hello"))
 }
 
 func TestSendMessageIncludesChannelOrigin(t *testing.T) {
@@ -111,8 +111,25 @@ func TestSendMessageIncludesChannelOrigin(t *testing.T) {
 	defer srv.Close()
 
 	c := captureClient(t, srv)
-	require.NoError(t, c.SendMessage(context.Background(), "ws1", "sess1", "", "signal", "hello"))
+	require.NoError(t, c.SendMessage(context.Background(), "ws1", "sess1", "", "signal", 0, "hello"))
 	require.Equal(t, "signal", got.Channel)
+}
+
+// The content-width hint must travel as a wire field: it is a context value
+// locally, and context values do not cross the HTTP boundary.
+func TestSendMessageIncludesContentWidth(t *testing.T) {
+	t.Parallel()
+
+	var got proto.AgentMessage
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&got))
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer srv.Close()
+
+	c := captureClient(t, srv)
+	require.NoError(t, c.SendMessage(context.Background(), "ws1", "sess1", "", "", 114, "hello"))
+	require.Equal(t, 114, got.ContentWidth)
 }
 
 func TestSendMessageAcceptsStatusOK(t *testing.T) {
@@ -124,7 +141,7 @@ func TestSendMessageAcceptsStatusOK(t *testing.T) {
 	defer srv.Close()
 
 	c := captureClient(t, srv)
-	require.NoError(t, c.SendMessage(context.Background(), "ws1", "sess1", "", "", "hello"))
+	require.NoError(t, c.SendMessage(context.Background(), "ws1", "sess1", "", "", 0, "hello"))
 }
 
 func TestSendMessageDecodesErrorBody(t *testing.T) {
@@ -137,7 +154,7 @@ func TestSendMessageDecodesErrorBody(t *testing.T) {
 	defer srv.Close()
 
 	c := captureClient(t, srv)
-	err := c.SendMessage(context.Background(), "ws1", "", "", "", "hello")
+	err := c.SendMessage(context.Background(), "ws1", "", "", "", 0, "hello")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "status code 400")
 	require.Contains(t, err.Error(), "session id is required")
@@ -153,7 +170,7 @@ func TestSendMessageFallsBackOnMalformedErrorBody(t *testing.T) {
 	defer srv.Close()
 
 	c := captureClient(t, srv)
-	err := c.SendMessage(context.Background(), "ws1", "sess1", "", "", "hello")
+	err := c.SendMessage(context.Background(), "ws1", "sess1", "", "", 0, "hello")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "status code 500")
 	require.NotContains(t, err.Error(), "not json")
@@ -168,7 +185,7 @@ func TestSendMessageFallsBackOnEmptyErrorBody(t *testing.T) {
 	defer srv.Close()
 
 	c := captureClient(t, srv)
-	err := c.SendMessage(context.Background(), "ws1", "sess1", "", "", "hello")
+	err := c.SendMessage(context.Background(), "ws1", "sess1", "", "", 0, "hello")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "status code 500")
 }

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -257,7 +257,7 @@ func runNonInteractive(
 	// loop would exit on whichever RunComplete arrived first for
 	// the same session and drop the queued prompt's output.
 	runID := uuid.New().String()
-	if err := c.SendMessage(ctx, ws.ID, sess.ID, runID, "", prompt); err != nil {
+	if err := c.SendMessage(ctx, ws.ID, sess.ID, runID, "", 0, prompt); err != nil {
 		return fmt.Errorf("failed to send message: %w", err)
 	}
 

--- a/internal/proto/mcp.go
+++ b/internal/proto/mcp.go
@@ -145,6 +145,10 @@ type MCPClientInfo struct {
 	ConnectedAt   time.Time `json:"connected_at"`
 	// Channel reports whether this server is an active channel.
 	Channel bool `json:"channel,omitempty"`
+	// A2UITools lists the a2ui_* tools the server exposes, so a client can
+	// tell whether an A2UI surface interaction round-trips to the server
+	// without access to the server-side tool registry.
+	A2UITools []string `json:"a2ui_tools,omitempty"`
 }
 
 type MCPPromptArgument struct {

--- a/internal/proto/proto.go
+++ b/internal/proto/proto.go
@@ -156,11 +156,17 @@ func (a AgentInfo) IsZero() bool {
 // remains correct only when no other turns are in flight for the
 // same session.
 type AgentMessage struct {
-	SessionID   string       `json:"session_id"`
-	RunID       string       `json:"run_id,omitempty"`
-	Channel     string       `json:"channel,omitempty"`
-	Prompt      string       `json:"prompt"`
-	Attachments []Attachment `json:"attachments,omitempty"`
+	SessionID string `json:"session_id"`
+	RunID     string `json:"run_id,omitempty"`
+	Channel   string `json:"channel,omitempty"`
+	// ContentWidth is the client UI's chat content width hint in cells
+	// (0 when the turn has no interactive UI). Like Channel it is a
+	// per-turn context value on the server side, so it must travel as an
+	// explicit wire field — context values do not cross the HTTP
+	// boundary. See ShellCommandRequest.TermWidth for the same pattern.
+	ContentWidth int          `json:"content_width,omitempty"`
+	Prompt       string       `json:"prompt"`
+	Attachments  []Attachment `json:"attachments,omitempty"`
 }
 
 // ShellCommandRequest represents a request to run a shell command directly.

--- a/internal/proto/requests.go
+++ b/internal/proto/requests.go
@@ -129,6 +129,13 @@ type MCPReadResourceRequest struct {
 	URI  string `json:"uri"`
 }
 
+// MCPCallToolRequest represents a request to call a tool on an MCP server.
+type MCPCallToolRequest struct {
+	Name     string         `json:"name"`
+	ToolName string         `json:"tool_name"`
+	Args     map[string]any `json:"args"`
+}
+
 // MCPGetPromptRequest represents a request to get an MCP prompt.
 type MCPGetPromptRequest struct {
 	ClientID string            `json:"client_id"`

--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -498,6 +498,56 @@ func (c *controllerV1) handleGetWorkspaceMCPPrompts(w http.ResponseWriter, r *ht
 	jsonEncode(w, prompts)
 }
 
+// a2uiCallableTools is the allow-list this route will invoke. The route
+// exists solely for the A2UI surface round-trip, which is not gated on the
+// agent's permission system (a button press is its own consent). Accepting an
+// arbitrary tool name here would turn it into remote execution of any tool on
+// any configured MCP server — file writes, shell-backed tools, network calls —
+// with no permission prompt at all.
+var a2uiCallableTools = map[string]bool{
+	"a2ui_action": true,
+	"a2ui_error":  true,
+}
+
+// handlePostWorkspaceMCPCallTool calls a tool on an MCP server. Only the A2UI
+// round-trip tools are callable; see [a2uiCallableTools].
+//
+//	@Summary		Call MCP tool
+//	@Tags			mcp
+//	@Accept			json
+//	@Produce		json
+//	@Param			id		path		string					true	"Workspace ID"
+//	@Param			request	body		proto.MCPCallToolRequest	true	"MCP call tool request"
+//	@Success		200		{object}	object
+//	@Failure		400		{object}	proto.Error
+//	@Failure		403		{object}	proto.Error
+//	@Failure		404		{object}	proto.Error
+//	@Failure		500		{object}	proto.Error
+//	@Router			/workspaces/{id}/mcp/call-tool [post]
+func (c *controllerV1) handlePostWorkspaceMCPCallTool(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+
+	var req proto.MCPCallToolRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		c.server.logError(r, "Failed to decode request", "error", err)
+		jsonError(w, http.StatusBadRequest, "failed to decode request")
+		return
+	}
+
+	if !a2uiCallableTools[req.ToolName] {
+		c.server.logError(r, "Rejected non-A2UI MCP tool call", "tool", req.ToolName)
+		jsonError(w, http.StatusForbidden, "only the A2UI round-trip tools may be called over this route")
+		return
+	}
+
+	result, err := c.backend.CallMCPTool(r.Context(), id, req.Name, req.ToolName, req.Args)
+	if err != nil {
+		c.handleError(w, r, err)
+		return
+	}
+	jsonEncode(w, result)
+}
+
 // handlePostWorkspaceMCPGetPrompt retrieves a prompt from an MCP server.
 //
 //	@Summary		Get MCP prompt

--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -603,6 +603,7 @@ func (c *controllerV1) handleGetWorkspaceMCPStates(w http.ResponseWriter, r *htt
 			ResourceCount: v.Counts.Resources,
 			ConnectedAt:   v.ConnectedAt,
 			Channel:       v.Channel,
+			A2UITools:     v.A2UITools,
 		}
 	}
 	jsonEncode(w, result)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -210,6 +210,7 @@ func (s *Server) installHandler() {
 	mux.HandleFunc("POST /v1/workspaces/{id}/mcp/refresh-tools", c.handlePostWorkspaceMCPRefreshTools)
 	mux.HandleFunc("POST /v1/workspaces/{id}/mcp/read-resource", c.handlePostWorkspaceMCPReadResource)
 	mux.HandleFunc("GET /v1/workspaces/{id}/mcp/prompts", c.handleGetWorkspaceMCPPrompts)
+	mux.HandleFunc("POST /v1/workspaces/{id}/mcp/call-tool", c.handlePostWorkspaceMCPCallTool)
 	mux.HandleFunc("POST /v1/workspaces/{id}/mcp/get-prompt", c.handlePostWorkspaceMCPGetPrompt)
 	mux.HandleFunc("GET /v1/workspaces/{id}/mcp/states", c.handleGetWorkspaceMCPStates)
 	mux.HandleFunc("POST /v1/workspaces/{id}/mcp/refresh-prompts", c.handlePostWorkspaceMCPRefreshPrompts)

--- a/internal/ui/chat/a2ui.go
+++ b/internal/ui/chat/a2ui.go
@@ -731,6 +731,57 @@ func a2uiPartSurfaceID(msgs []a2ui.ServerMessage) string {
 	return ""
 }
 
+// A2UIMessagesFromPayload converts a raw A2UI JSON payload (the body of an
+// MCP-served surface) into the server messages it encodes, so a follow-up
+// payload can be applied to a live surface. The payload is wrapped in the
+// wire tags before scanning because a2tea's scanner treats a bare JSON array
+// of messages as several separate bare objects; the tags make it one block.
+// An error means the payload could not be parsed at all.
+func A2UIMessagesFromPayload(payload string) ([]a2ui.ServerMessage, error) {
+	parts, err := a2tea.Scan(a2uiOpenTag + payload + a2uiCloseTag)
+	if err != nil {
+		return nil, err
+	}
+	var msgs []a2ui.ServerMessage
+	for _, p := range parts {
+		msgs = append(msgs, p.Messages...)
+	}
+	return msgs, nil
+}
+
+// A2UIMessagesSurfaceID reports the surface a batch of server messages
+// targets — the first surfaceId any of them names, whichever payload field
+// carries it. A response to an a2ui_action may update a sibling surface
+// rather than the clicked one, so the payload's own target wins over the
+// surface the interaction came from. Empty means the batch names none.
+func A2UIMessagesSurfaceID(msgs []a2ui.ServerMessage) string {
+	for _, m := range msgs {
+		switch {
+		case m.UpdateComponents != nil:
+			return m.UpdateComponents.SurfaceID
+		case m.CreateSurface != nil:
+			return m.CreateSurface.SurfaceID
+		case m.DeleteSurface != nil:
+			return m.DeleteSurface.SurfaceID
+		case m.UpdateDataModel != nil:
+			return m.UpdateDataModel.SurfaceID
+		}
+	}
+	return ""
+}
+
+// A2UIMessagesDeleteSurface reports whether a batch of server messages
+// deletes a surface. A delete that lands on a surface already gone is the
+// expected end of its life, not a mismatch worth reporting to the server.
+func A2UIMessagesDeleteSurface(msgs []a2ui.ServerMessage) bool {
+	for _, m := range msgs {
+		if m.DeleteSurface != nil {
+			return true
+		}
+	}
+	return false
+}
+
 // a2uiSurfaceRetired reports whether the surface at part-index i has been
 // retired after a submission (#45). Retired surfaces still render (showing
 // their final state) but no longer receive focus or keys.

--- a/internal/ui/chat/a2ui.go
+++ b/internal/ui/chat/a2ui.go
@@ -9,10 +9,14 @@ import (
 	"regexp"
 	"slices"
 	"strings"
+	"sync"
 	"unicode"
 
 	tea "charm.land/bubbletea/v2"
+	"charm.land/glamour/v2"
+	"charm.land/lipgloss/v2"
 	"github.com/charmbracelet/crush/internal/ui/common"
+	"github.com/charmbracelet/crush/internal/ui/styles"
 	"github.com/joestump-agent/a2tea"
 	"github.com/joestump-agent/a2tea/event"
 	"github.com/joestump-agent/a2tea/render"
@@ -560,6 +564,107 @@ func repairA2UIMessage(msg map[string]any) bool {
 	return true
 }
 
+// a2uiThemeStyles builds a2tea render.Styles from the active crush theme so
+// surfaces draw with the same palette as the rest of the chat. Card borders
+// pick up the same border color the old A2UISurface frame used (the theme's
+// visible background), headings and buttons use the brand colors, captions
+// use the muted foreground, and the focused button inverts to a
+// primary-background highlight — matching the dialog selected-item pattern.
+func a2uiThemeStyles(sty *styles.Styles) render.Styles {
+	st := render.DefaultStyles()
+	if sty == nil {
+		return st
+	}
+	st.CardBorder = st.CardBorder.
+		BorderForeground(sty.Messages.A2UISurface.GetBorderTopForeground())
+	st.Heading = st.Heading.Foreground(sty.WorkingGradFromColor)
+	st.Subheading = st.Subheading.Foreground(sty.WorkingGradToColor)
+	st.Caption = st.Caption.Foreground(sty.Dialog.SecondaryText.GetForeground())
+	st.Button = st.Button.Foreground(sty.WorkingGradFromColor)
+	st.ButtonFocused = st.ButtonFocused.
+		Background(sty.Dialog.SelectedItem.GetBackground()).
+		Foreground(sty.Dialog.SelectedItem.GetForeground()).
+		Reverse(false)
+	// Inject Crush's glamour renderer so body-variant Text containing
+	// Markdown (tables, lists, bold, code) renders with the same styling
+	// as the rest of the chat. Rendered output is memoized per
+	// (renderer, text): items holding live surfaces bypass the chat render
+	// caches, so without a memo every repaint re-runs a full glamour parse
+	// per markdown body. The renderer lock is scoped to the Render call —
+	// callers must never hold the same renderer's lock while a surface
+	// View runs (see renderContentWithA2UI), or this hook would deadlock.
+	st.MarkdownRenderer = func(text string, width int) string {
+		renderer := common.MarkdownRenderer(sty, width)
+		if out, ok := a2uiMarkdownMemoGet(renderer, text); ok {
+			return out
+		}
+		mu := common.LockMarkdownRenderer(renderer)
+		mu.Lock()
+		out, err := renderer.Render(text)
+		mu.Unlock()
+		if err != nil {
+			return text
+		}
+		out = strings.TrimSpace(out)
+		a2uiMarkdownMemoPut(renderer, text, out)
+		return out
+	}
+	return st
+}
+
+// a2uiMarkdownMemo caches glamour output for surface body Text. Keyed by the
+// memoized renderer pointer — which already encodes the width and is dropped
+// on theme change via InvalidateMarkdownRendererCache — plus the source text.
+// Bounded crudely: the map resets once it grows past a2uiMarkdownMemoMax.
+var (
+	a2uiMarkdownMemoMu sync.Mutex
+	a2uiMarkdownMemo   = map[a2uiMarkdownMemoKey]string{}
+)
+
+type a2uiMarkdownMemoKey struct {
+	renderer *glamour.TermRenderer
+	text     string
+}
+
+const a2uiMarkdownMemoMax = 512
+
+func a2uiMarkdownMemoGet(r *glamour.TermRenderer, text string) (string, bool) {
+	a2uiMarkdownMemoMu.Lock()
+	defer a2uiMarkdownMemoMu.Unlock()
+	out, ok := a2uiMarkdownMemo[a2uiMarkdownMemoKey{r, text}]
+	return out, ok
+}
+
+func a2uiMarkdownMemoPut(r *glamour.TermRenderer, text, out string) {
+	a2uiMarkdownMemoMu.Lock()
+	defer a2uiMarkdownMemoMu.Unlock()
+	if len(a2uiMarkdownMemo) >= a2uiMarkdownMemoMax {
+		clear(a2uiMarkdownMemo)
+	}
+	a2uiMarkdownMemo[a2uiMarkdownMemoKey{r, text}] = out
+}
+
+// renderA2UILoading renders a "✨ Rendering UI…" placeholder for when an
+// assistant message is still streaming and an unclosed <a2ui-json> tag
+// indicates a surface is being composed. The raw partial JSON is replaced
+// with a styled shimmer that reads as intentional rather than broken.
+func renderA2UILoading(sty *styles.Styles, width int) string {
+	sparkle := lipgloss.NewStyle().
+		Foreground(sty.WorkingGradFromColor).
+		Bold(true).
+		Render("✨")
+	label := lipgloss.NewStyle().
+		Foreground(sty.WorkingLabelColor).
+		Render(" Rendering UI…")
+	box := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(sty.WorkingGradFromColor).
+		Padding(0, 1).
+		Width(width).
+		Render(sparkle + label)
+	return box
+}
+
 // syncA2UISurfaces builds — or reuses — the live a2tea models for the
 // scanned parts (#44). Surfaces are keyed by a hash of the scanned source:
 // streaming deltas rebuild them, while pure re-renders (width changes,
@@ -577,7 +682,10 @@ func (a *AssistantMessageItem) syncA2UISurfaces(src string, parts []a2tea.Part) 
 		if len(p.Messages) == 0 {
 			continue
 		}
-		model, err := a2tea.Render(p.Messages)
+		// Render with the crush theme: a2tea's CardBorder picks up the
+		// palette, and crush no longer wraps the surface in its own frame —
+		// a2tea's box is the only one.
+		model, err := a2tea.Render(p.Messages, render.WithStyles(a2uiThemeStyles(a.sty)))
 		if err != nil {
 			// Valid A2UI with nothing to draw (e.g. a bare data-model
 			// update). The render loop skips nil entries; the block-stats
@@ -868,7 +976,10 @@ func a2uiSurfaceWantsKey(s render.Model, key tea.KeyMsg) bool {
 //
 // This deliberately bypasses the streaming-markdown prefix cache (which assumes
 // a single glamour render per item) and renders each segment directly. The
-// renderer is shared, so the whole multi-render sequence holds its lock.
+// renderer is shared, so each Render call takes its lock — scoped to the call,
+// never held across model.View(): a surface body Text re-enters the same
+// memoized renderer through the a2uiThemeStyles MarkdownRenderer hook, and
+// holding the lock across View would self-deadlock the UI goroutine.
 func (a *AssistantMessageItem) renderContentWithA2UI(content string, width int, finished bool) string {
 	masked, codeReps := maskMarkdownCode(content)
 	// Repair childless-but-labeled buttons on the raw JSON before parsing —
@@ -891,8 +1002,6 @@ func (a *AssistantMessageItem) renderContentWithA2UI(content string, width int, 
 
 	renderer := common.MarkdownRenderer(a.sty, width)
 	mu := common.LockMarkdownRenderer(renderer)
-	mu.Lock()
-	defer mu.Unlock()
 
 	renderMarkdown := func(text string) string {
 		if strings.TrimSpace(text) == "" {
@@ -900,7 +1009,9 @@ func (a *AssistantMessageItem) renderContentWithA2UI(content string, width int, 
 		}
 		// Restore masked code before markdown rendering.
 		text = unmaskMarkdownCode(text, codeReps)
+		mu.Lock()
 		out, err := renderer.Render(text)
+		mu.Unlock()
 		if err != nil {
 			return strings.TrimSpace(text)
 		}
@@ -918,11 +1029,9 @@ func (a *AssistantMessageItem) renderContentWithA2UI(content string, width int, 
 		b.WriteString(s)
 	}
 
-	// a2tea's chrome renders with terminal defaults (monochrome by design),
-	// so each surface is wrapped in a themed container to match the rest of
-	// the chat. The a2tea model is sized to the container's inner width.
-	surface := a.sty.Messages.A2UISurface
-	innerWidth := max(width-surface.GetHorizontalFrameSize(), 1)
+	// a2tea renders its own themed chrome (CardBorder, headings, buttons)
+	// via render.WithStyles — crush no longer wraps the surface in its own
+	// frame. The model is sized to the full content width.
 	for i, p := range parts {
 		writeChunk(renderMarkdown(p.Text))
 		if len(p.Messages) == 0 {
@@ -936,9 +1045,17 @@ func (a *AssistantMessageItem) renderContentWithA2UI(content string, width int, 
 		}
 		// Render from the live model each call: its View reflects the
 		// current focus ring and edited values, not a frozen snapshot.
-		model.SetSize(innerWidth, 0)
+		model.SetSize(width, 0)
 		rendered := strings.TrimRight(model.View().Content, "\n")
-		writeChunk(surface.Width(max(width-surface.GetHorizontalBorderSize(), 1)).Render(rendered))
+		writeChunk(rendered)
+	}
+
+	// While streaming, an unclosed <a2ui-json> tag means the model is
+	// still composing the surface — the parser consumed the raw JSON but
+	// produced no messages, so it doesn't appear in any part. Show a
+	// magical loading placeholder instead of leaving a blank gap.
+	if !finished && hasUnclosedA2UITag(masked) {
+		writeChunk(renderA2UILoading(a.sty, width))
 	}
 
 	// Alert when the parser dropped a complete tagged block (#7) — checked

--- a/internal/ui/chat/a2ui.go
+++ b/internal/ui/chat/a2ui.go
@@ -792,6 +792,25 @@ func (a *AssistantMessageItem) a2uiSurfaceRetired(i int) bool {
 	return a.a2uiRetired[a.a2uiSurfaceIDs[i]]
 }
 
+// HasLiveA2UISurface reports whether this assistant message holds a
+// non-retired surface with the given ID. Surface IDs are only unique within
+// the thing that authored them — an assistant-authored form and an MCP
+// server both commonly use "default" — so callers deciding where a button
+// press should go must ask this before consulting any MCP provenance, or an
+// ID collision routes the user's form submission to an unrelated server.
+func (a *AssistantMessageItem) HasLiveA2UISurface(surfaceID string) bool {
+	if surfaceID == "" {
+		return false
+	}
+	for i, s := range a.a2uiSurfaces {
+		if s == nil || i >= len(a.a2uiSurfaceIDs) || a.a2uiSurfaceIDs[i] != surfaceID {
+			continue
+		}
+		return !a.a2uiRetired[surfaceID]
+	}
+	return false
+}
+
 // RetireA2UISurface retires the live surface with the given A2UI surface ID
 // after a button press (#45): it reads the surface's current field values,
 // revokes its focus, and marks it retired so the form cannot be re-submitted

--- a/internal/ui/chat/a2ui_surface_host.go
+++ b/internal/ui/chat/a2ui_surface_host.go
@@ -1,0 +1,175 @@
+package chat
+
+import (
+	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/crush/internal/csync"
+	"github.com/charmbracelet/crush/internal/ui/styles"
+	"github.com/joestump-agent/a2tea"
+	"github.com/joestump-agent/a2tea/render"
+)
+
+// a2uiSurfaceHost holds the live a2tea surface models for one message item —
+// an assistant message whose content scanned as A2UI, or a tool result
+// that delivered an MCP A2UI surface. The slice is indexed by
+// scan-part (assistant) or surface (tool result); entries without a
+// renderable surface hold nil.
+//
+// Assistant surfaces stream and rebuild as deltas arrive, so the assistant
+// item keys its models by source hash and retires them on first submission
+// . MCP tool-result surfaces are long-lived app UIs: they build once
+// from a fixed payload, are never retired on interaction, and feed a button
+// back to the owning server. The host carries the shared state and
+// behavior both kinds need; the items own their lifecycle.
+type a2uiSurfaceHost struct {
+	// surfaces holds the live a2tea models so they can receive focus and
+	// key input instead of being frozen to a rendered string.
+	surfaces []render.Model
+	// surfaceIDs holds the A2UI surface ID for each entry (empty where the
+	// part has no renderable surface), so a ButtonClicked event's
+	// SurfaceID can be routed back to the model that emitted it.
+	surfaceIDs []string
+	// sty themes the surfaces with the crush palette.
+	sty *styles.Styles
+}
+
+// buildSurfaces renders each part's messages into a live a2tea model,
+// returning the surfaces and their IDs. Parts with no messages or nothing
+// to draw (e.g. a bare data-model update) leave nil/empty entries.
+func buildA2UISurfaces(sty *styles.Styles, parts []a2tea.Part) ([]render.Model, []string) {
+	surfaces := make([]render.Model, len(parts))
+	ids := make([]string, len(parts))
+	for i, p := range parts {
+		if len(p.Messages) == 0 {
+			continue
+		}
+		model, err := a2tea.Render(p.Messages, render.WithStyles(a2uiThemeStyles(sty)))
+		if err != nil {
+			continue
+		}
+		if rm, ok := model.(render.Model); ok {
+			surfaces[i] = rm
+			ids[i] = a2uiPartSurfaceID(p.Messages)
+		}
+	}
+	return surfaces, ids
+}
+
+// hasLive reports whether the host holds at least one live surface model.
+// While true, the item's content-hash render caches are bypassed so surface
+// interaction is never served a frozen frame.
+func (h *a2uiSurfaceHost) hasLive() bool {
+	for _, s := range h.surfaces {
+		if s != nil {
+			return true
+		}
+	}
+	return false
+}
+
+// surfaceAt returns the live surface at index i, or nil.
+func (h *a2uiSurfaceHost) surfaceAt(i int) render.Model {
+	if i < 0 || i >= len(h.surfaces) {
+		return nil
+	}
+	return h.surfaces[i]
+}
+
+// focusedIndex returns the index of the surface currently holding keyboard
+// focus, or -1 when none does.
+func (h *a2uiSurfaceHost) focusedIndex() int {
+	for i, s := range h.surfaces {
+		if s != nil && s.Focused() {
+			return i
+		}
+	}
+	return -1
+}
+
+// update forwards msg into surface i's Update and stores the returned model.
+func (h *a2uiSurfaceHost) update(i int, msg tea.Msg) tea.Cmd {
+	model, cmd := h.surfaces[i].Update(msg)
+	if rm, ok := model.(render.Model); ok {
+		h.surfaces[i] = rm
+	}
+	return cmd
+}
+
+// fieldValues reads the surface's current values, if it supports them.
+func (h *a2uiSurfaceHost) fieldValues(i int) map[string]any {
+	s := h.surfaceAt(i)
+	if s == nil {
+		return nil
+	}
+	if fv, ok := s.(interface{ FieldValues() map[string]any }); ok {
+		return fv.FieldValues()
+	}
+	return nil
+}
+
+// surfaceIDFor returns the A2UI surface ID at index i.
+func (h *a2uiSurfaceHost) surfaceIDFor(i int) string {
+	if i < 0 || i >= len(h.surfaceIDs) {
+		return ""
+	}
+	return h.surfaceIDs[i]
+}
+
+// findByID returns the index of the surface with the given A2UI surface ID,
+// or -1.
+func (h *a2uiSurfaceHost) findByID(surfaceID string) int {
+	for i, id := range h.surfaceIDs {
+		if id == surfaceID && h.surfaceAt(i) != nil {
+			return i
+		}
+	}
+	return -1
+}
+
+// focus grants keyboard focus to the surface at index i and blurs the rest,
+// honoring the a2tea composition contract of at most one focused child.
+func (h *a2uiSurfaceHost) focus(i int) {
+	for j, s := range h.surfaces {
+		if s == nil {
+			continue
+		}
+		if j == i {
+			_ = s.Focus()
+		} else {
+			s.Blur()
+		}
+	}
+}
+
+// blurAll revokes keyboard focus from every live surface.
+func (h *a2uiSurfaceHost) blurAll() {
+	for _, s := range h.surfaces {
+		if s != nil {
+			s.Blur()
+		}
+	}
+}
+
+// --- MCP surface provenance registry ---
+
+// a2uiMCPProvenance maps a rendered A2UI surface ID to the MCP server that
+// served it, so a later interaction event (button press, render failure) can
+// route back to the owning server as an a2ui_action / a2ui_error tool call
+// . Entries live for the process lifetime: surface IDs are
+// server-scoped (typically "default"), so re-rendering a surface from the
+// same server simply overwrites the same key.
+var a2uiMCPProvenance = csync.NewMap[string, string]()
+
+// registerA2UISurfaceProvenance records that surfaceID came from mcpName.
+// An empty surfaceID or mcpName is not registered.
+func registerA2UISurfaceProvenance(surfaceID, mcpName string) {
+	if surfaceID == "" || mcpName == "" {
+		return
+	}
+	a2uiMCPProvenance.Set(surfaceID, mcpName)
+}
+
+// A2UISurfaceProvenance returns the MCP server that served surfaceID, and
+// whether the surface is MCP-owned at all.
+func A2UISurfaceProvenance(surfaceID string) (string, bool) {
+	return a2uiMCPProvenance.Get(surfaceID)
+}

--- a/internal/ui/chat/a2ui_surface_host.go
+++ b/internal/ui/chat/a2ui_surface_host.go
@@ -15,8 +15,8 @@ import (
 // renderable surface hold nil.
 //
 // Assistant surfaces stream and rebuild as deltas arrive, so the assistant
-// item keys its models by source hash and retires them on first submission
-// . MCP tool-result surfaces are long-lived app UIs: they build once
+// item keys its models by source hash and retires them on first
+// submission. MCP tool-result surfaces are long-lived app UIs: they build once
 // from a fixed payload, are never retired on interaction, and feed a button
 // back to the owning server. The host carries the shared state and
 // behavior both kinds need; the items own their lifecycle.
@@ -28,8 +28,33 @@ type a2uiSurfaceHost struct {
 	// part has no renderable surface), so a ButtonClicked event's
 	// SurfaceID can be routed back to the model that emitted it.
 	surfaceIDs []string
+	// surfaceOwners holds the MCP server that served each entry (empty for
+	// chat-scanned surfaces). It is the item-scoped provenance the action
+	// round-trip resolves through, so two servers using the same surface ID
+	// cannot route each other's clicks.
+	surfaceOwners []string
 	// sty themes the surfaces with the crush palette.
 	sty *styles.Styles
+}
+
+// ownerFor returns the MCP server that served the surface at index i, and
+// whether one is known.
+func (h *a2uiSurfaceHost) ownerFor(i int) (string, bool) {
+	if i < 0 || i >= len(h.surfaceOwners) {
+		return "", false
+	}
+	name := h.surfaceOwners[i]
+	return name, name != ""
+}
+
+// drop releases the surface at index i, which the server deleted. The entry
+// is kept (indexes stay parallel to surfaceIDs) but nils out, so hasLive and
+// findByID stop reporting it and it can no longer take focus or keys.
+func (h *a2uiSurfaceHost) drop(i int) {
+	if i < 0 || i >= len(h.surfaces) {
+		return
+	}
+	h.surfaces[i] = nil
 }
 
 // buildSurfaces renders each part's messages into a live a2tea model,
@@ -152,11 +177,14 @@ func (h *a2uiSurfaceHost) blurAll() {
 // --- MCP surface provenance registry ---
 
 // a2uiMCPProvenance maps a rendered A2UI surface ID to the MCP server that
-// served it, so a later interaction event (button press, render failure) can
-// route back to the owning server as an a2ui_action / a2ui_error tool call
-// . Entries live for the process lifetime: surface IDs are
+// served it, so a later interaction event (button press, render failure)
+// can route back to the owning server as an a2ui_action / a2ui_error tool
+// call. Entries live for the process lifetime: surface IDs are
 // server-scoped (typically "default"), so re-rendering a surface from the
-// same server simply overwrites the same key.
+// same server simply overwrites the same key. Two servers emitting the SAME
+// surface ID would clobber each other here — the action round-trip should
+// resolve provenance through the owning item before falling back to this
+// registry.
 var a2uiMCPProvenance = csync.NewMap[string, string]()
 
 // registerA2UISurfaceProvenance records that surfaceID came from mcpName.

--- a/internal/ui/chat/a2ui_test.go
+++ b/internal/ui/chat/a2ui_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
+	"time"
 
 	tea "charm.land/bubbletea/v2"
 	"github.com/charmbracelet/crush/internal/message"
@@ -769,6 +770,30 @@ func TestA2UISurfaceModelStableAcrossRenders(t *testing.T) {
 		"re-renders must reuse the live model — rebuilding would drop interaction state")
 }
 
+// TestA2UIClearCacheDropsSurfacesForRestyle pins the theme-swap path: a
+// style change reaches items as clearCache (applyTheme → refreshStyles →
+// InvalidateRenderCaches → ClearItemCaches), and the surface models baked
+// the old theme's render.Styles in at build time. clearCache must drop them
+// so the next render rebuilds the surfaces with the current theme instead
+// of drawing the previous palette next to newly-themed chat.
+func TestA2UIClearCacheDropsSurfacesForRestyle(t *testing.T) {
+	t.Parallel()
+
+	item := newA2UIFormItem(t)
+	_ = item.RawRender(80)
+	require.True(t, item.hasLiveA2UISurfaces())
+	first := firstLiveA2UISurface(t, item)
+
+	item.clearCache()
+	require.False(t, item.hasLiveA2UISurfaces(),
+		"a style change must drop surface models carrying baked-in styles")
+
+	_ = item.RawRender(80)
+	require.True(t, item.hasLiveA2UISurfaces(), "the next render must rebuild the surfaces")
+	require.NotSame(t, first, firstLiveA2UISurface(t, item),
+		"the rebuilt surface must be a fresh model, not the stale-styled one")
+}
+
 func TestA2UIContentCacheBypassedForLiveSurfaces(t *testing.T) {
 	t.Parallel()
 
@@ -939,4 +964,129 @@ func TestRetireA2UISurfaceUnknownID(t *testing.T) {
 	// The live surface is untouched: it can still be focused.
 	item.SetFocused(true)
 	require.GreaterOrEqual(t, item.focusedA2UISurfaceIndex(), 0)
+}
+
+// --- Single-border + width regression ---
+//
+// A Card surface renders inside exactly one box: a2tea's own CardBorder,
+// themed via render.WithStyles. Crush no longer wraps the surface in an
+// A2UISurface frame. The box must fill exactly `width` with no dangling
+// border fragments.
+
+// TestA2UISurfaceSingleBorder asserts exactly one box is drawn: one top
+// border line and one bottom border line, no nested inner border.
+func TestA2UISurfaceSingleBorder(t *testing.T) {
+	t.Parallel()
+
+	sty := styles.CharmtonePantera()
+	item := &AssistantMessageItem{sty: &sty}
+
+	plain := ansi.Strip(item.renderContentWithA2UI(a2uiSurface, 80, true))
+
+	top := strings.Count(plain, "╭")
+	bottom := strings.Count(plain, "╰")
+	require.Equal(t, 1, top, "expected exactly one top border (single box), got %d\n%s", top, plain)
+	require.Equal(t, 1, bottom, "expected exactly one bottom border (single box), got %d\n%s", bottom, plain)
+}
+
+// TestA2UISurfaceFillsWidth asserts the rendered box spans the full content
+// width — no line narrower than the box and, critically, no dangling border
+// fragment wrapped onto its own line (the double-border overflow symptom).
+func TestA2UISurfaceFillsWidth(t *testing.T) {
+	t.Parallel()
+
+	sty := styles.CharmtonePantera()
+	item := &AssistantMessageItem{sty: &sty}
+
+	for _, width := range []int{80, 60, 41} {
+		plain := ansi.Strip(item.renderContentWithA2UI(a2uiSurface, width, true))
+		lines := strings.Split(plain, "\n")
+
+		var maxW int
+		for _, ln := range lines {
+			if w := ansi.StringWidth(ln); w > maxW {
+				maxW = w
+			}
+		}
+		require.Equal(t, width, maxW, "width=%d: box must fill the full content width\n%s", width, plain)
+
+		// No line may be a lone border fragment (a right border that wrapped
+		// onto its own line), the visible sign of the double-border overflow.
+		for _, ln := range lines {
+			trimmed := strings.TrimSpace(ln)
+			require.NotEqual(t, "╮", trimmed, "width=%d: dangling top-right border fragment\n%s", width, plain)
+			require.NotEqual(t, "╯", trimmed, "width=%d: dangling bottom-right border fragment\n%s", width, plain)
+			require.NotEqual(t, "─╮", trimmed, "width=%d: wrapped border fragment\n%s", width, plain)
+			require.NotEqual(t, "─╯", trimmed, "width=%d: wrapped border fragment\n%s", width, plain)
+		}
+	}
+}
+
+// --- Streaming loading indicator ---
+
+// TestA2UIStreamingLoadingPlaceholder asserts that an unclosed <a2ui-json>
+// tag during streaming renders a magical "Rendering UI…" placeholder instead
+// of raw partial JSON.
+func TestA2UIStreamingLoadingPlaceholder(t *testing.T) {
+	t.Parallel()
+
+	sty := styles.CharmtonePantera()
+	item := &AssistantMessageItem{sty: &sty}
+
+	// Simulate streaming: prose followed by an unclosed <a2ui-json> tag.
+	content := "Here is the trace:\n\n<a2ui-json>{\"version\":\"v0.9\",\"updateComponents\":{\"surfaceId\":\"s\",\"components\":["
+
+	out := ansi.Strip(item.renderContentWithA2UI(content, 80, false))
+
+	require.Contains(t, out, "Here is the trace:", "prose before the unclosed tag should render")
+	require.Contains(t, out, "✨", "loading placeholder should contain the sparkle")
+	require.Contains(t, out, "Rendering UI", "loading placeholder should contain the label")
+	require.NotContains(t, out, `"version"`, "raw partial JSON should not leak into the render")
+	require.NotContains(t, out, `"updateComponents"`, "raw partial JSON should not leak into the render")
+	require.NotContains(t, out, `"surfaceId"`, "raw partial JSON should not leak into the render")
+}
+
+// TestA2UIStreamingLoadingPlaceholderComplete asserts that a complete
+// <a2ui-json> block during streaming renders the surface normally (no
+// loading placeholder).
+func TestA2UIStreamingLoadingPlaceholderComplete(t *testing.T) {
+	t.Parallel()
+
+	sty := styles.CharmtonePantera()
+	item := &AssistantMessageItem{sty: &sty}
+
+	content := "Here you go:\n\n" + a2uiSurface
+
+	out := ansi.Strip(item.renderContentWithA2UI(content, 80, false))
+
+	require.Contains(t, out, "Hello from A2UI", "complete surface should render its content")
+	require.NotContains(t, out, "Rendering UI", "complete surface should not show loading placeholder")
+}
+
+// Regression: a markdown-looking body Text rendered at the surface's
+// un-narrowed width re-enters the shared glamour renderer through the
+// a2uiThemeStyles MarkdownRenderer hook. renderContentWithA2UI used to hold
+// that renderer's lock across model.View(), so the hook's Lock() on the same
+// non-reentrant mutex froze the UI goroutine permanently.
+func TestRenderContentWithA2UIMarkdownBodyNoDeadlock(t *testing.T) {
+	t.Parallel()
+
+	sty := styles.CharmtonePantera()
+	item := &AssistantMessageItem{sty: &sty}
+	// Root-level Text (no Card): a2tea passes the full host width to the
+	// markdown hook, matching the outer renderer's width bucket.
+	content := `<a2ui-json>{"version":"v0.9","updateComponents":{"surfaceId":"s","components":[` +
+		`{"component":"Text","id":"t","text":"This is **bold** markdown"}` +
+		`]}}</a2ui-json>`
+
+	done := make(chan string, 1)
+	go func() {
+		done <- item.renderContentWithA2UI(content, 80, true)
+	}()
+	select {
+	case out := <-done:
+		require.Contains(t, ansi.Strip(out), "bold")
+	case <-time.After(15 * time.Second):
+		t.Fatal("renderContentWithA2UI deadlocked rendering a markdown body Text")
+	}
 }

--- a/internal/ui/chat/a2ui_width.go
+++ b/internal/ui/chat/a2ui_width.go
@@ -1,0 +1,25 @@
+package chat
+
+// a2uiCardChromeWidth is the border+padding chrome a2tea's Card renderer
+// subtracts from its budget (a2tea render/card.go: w := s.width - 4).
+const a2uiCardChromeWidth = 4
+
+// ToolA2UISurfaceWidth returns the interior width, in cells, of a generic
+// tool result's A2UI surface card for a chat viewport of the given width —
+// the number servers pre-rendering bar geometry should size rows to (the
+// ?w= hint read_mcp_resource sends).
+//
+// It mirrors the actual render chain rather than hand-summed constants:
+// the message list reserves one cell for its scrollbar, the tool item and
+// RenderTool each apply cappedMessageWidth, the body is indented by
+// toolBodyLeftPaddingTotal, and a2tea's card chrome takes the rest. Keeping
+// the computation here, next to the constants it depends on, is what stops
+// the hint drifting from the real card interior when the layout changes.
+//
+// Returns 0 (no hint) when the viewport is too small for a meaningful
+// width.
+func ToolA2UISurfaceWidth(chatWidth int) int {
+	listWidth := chatWidth - 1 // scrollbar reservation in model/chat.go SetSize
+	interior := cappedMessageWidth(cappedMessageWidth(listWidth)) - toolBodyLeftPaddingTotal - a2uiCardChromeWidth
+	return max(0, interior)
+}

--- a/internal/ui/chat/a2ui_width_test.go
+++ b/internal/ui/chat/a2ui_width_test.go
@@ -1,0 +1,22 @@
+package chat
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestToolA2UISurfaceWidth(t *testing.T) {
+	t.Parallel()
+
+	// Mirror of the real chain: listWidth = chatWidth-1 (scrollbar), two
+	// cappedMessageWidth passes (-2 each, 120/118 caps), tool body indent
+	// (-2), a2tea card chrome (-4).
+	require.Equal(t, 89, ToolA2UISurfaceWidth(100))
+	// Wide viewports saturate at maxTextWidth: min(...,120)-2-2-4 = 112.
+	require.Equal(t, 112, ToolA2UISurfaceWidth(140))
+	require.Equal(t, 112, ToolA2UISurfaceWidth(500))
+	// Degenerate viewports must yield 0 (no hint), never negative.
+	require.Equal(t, 0, ToolA2UISurfaceWidth(0))
+	require.Equal(t, 0, ToolA2UISurfaceWidth(8))
+}

--- a/internal/ui/chat/assistant.go
+++ b/internal/ui/chat/assistant.go
@@ -710,6 +710,15 @@ func (a *AssistantMessageItem) clearCache() {
 	a.errorSec.reset()
 	a.streamingContent.Reset()
 	a.streamingThinking.Reset()
+	// A2UI surface models bake the theme's render.Styles in at build time
+	// (a2uiThemeStyles), so after a theme swap a kept model would draw the
+	// old palette next to newly-themed chat. Drop them and let the next
+	// render rebuild from the message with the current theme; retirement
+	// marks are keyed by surface ID and survive the rebuild. The cost is
+	// losing in-progress field values on an explicit theme change —
+	// clearCache is only reached via ClearItemCaches (style change) — until
+	// a2tea grows a restyle-in-place.
+	a.dropA2UISurfaces()
 }
 
 // ToggleExpanded advances the F5 thinking view-mode cycle and returns

--- a/internal/ui/chat/generic.go
+++ b/internal/ui/chat/generic.go
@@ -2,10 +2,15 @@ package chat
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
 
+	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/crush/internal/agent/tools"
 	"github.com/charmbracelet/crush/internal/message"
 	"github.com/charmbracelet/crush/internal/ui/styles"
+	"github.com/joestump-agent/a2tea"
+	"github.com/joestump-agent/a2tea/render"
 )
 
 // GenericToolMessageItem is a message item that represents an unknown tool call.
@@ -64,10 +69,169 @@ func (g *GenericToolRenderContext) RenderTool(sty *styles.Styles, width int, opt
 	bodyWidth := cappedWidth - toolBodyLeftPaddingTotal
 
 	if opts.Result.Data != "" && strings.HasPrefix(opts.Result.MIMEType, "image/") {
-		body := sty.Tool.Body.Render(toolOutputImageContent(sty, opts.Result.Data, opts.Result.MIMEType))
-		return joinToolParts(header, body)
+		// toolOutputImageContent applies sty.Tool.Body itself — wrapping it
+		// again here double-indented image results.
+		return joinToolParts(header, toolOutputImageContent(sty, opts.Result.Data, opts.Result.MIMEType))
 	}
 
-	body := renderToolResultTextContent(sty, opts.Result.Content, toolResultContentWidths{Body: bodyWidth, Diff: cappedWidth}, opts.ExpandedContent)
+	widths := toolResultContentWidths{Body: bodyWidth, Diff: cappedWidth}
+
+	// If the tool result carries an A2UI surface (a read_mcp_resource that
+	// returned application/a2ui+json, or an mcp_* tool whose result
+	// embedded one), render it instead of raw text. The payload arrives via
+	// response metadata — the model only sees a placeholder, so it cannot
+	// echo the JSON back and double-render the surface. Live surface models
+	// render interactively; without them (older persisted results)
+	// fall back to the static snapshot. This is what makes
+	// cairn://artifact/{id}/a2ui and similar resource reads render inline.
+	if opts.Result.Metadata != "" {
+		var meta tools.ReadMCPResourceResponseMetadata
+		if err := json.Unmarshal([]byte(opts.Result.Metadata), &meta); err == nil && len(meta.A2UISurfaces) > 0 {
+			return joinToolParts(header, renderToolA2UIResultBody(sty, meta.A2UISurfaces, opts, widths))
+		}
+	}
+	// Pre-change read_mcp_resource results persisted the raw payload in the
+	// content itself — scan for it so old sessions still render as surfaces.
+	// Scoped to this tool (crush_logs and friends share this renderer and
+	// must keep payload-shaped text as text), and gated on contentHasA2UI so
+	// A2UI examples inside markdown code stay code (#6, #96).
+	if opts.ToolCall.Name == tools.ReadMCPResourceToolName && contentHasA2UI(opts.Result.Content) {
+		surf, err := renderToolA2UI(sty, opts.Result.Content, bodyWidth)
+		if err == nil && surf != "" {
+			return joinToolParts(header, sty.Tool.Body.Render(clampToolA2UI(sty, surf, bodyWidth, opts.ExpandedContent)))
+		}
+	}
+
+	body := renderToolResultTextContent(sty, opts.Result.Content, widths, opts.ExpandedContent)
 	return joinToolParts(header, body)
+}
+
+// renderToolA2UIResultBody renders the metadata-delivered surfaces plus any
+// real text content the resource returned alongside them. When the item
+// carries live surface models (opts.LiveSurfaces) they render
+// interactively; otherwise each surface falls back to a static snapshot.
+// When every surface fails to render, an alert replaces the body — the
+// model-facing placeholder claims the user can already see the surface,
+// which would be false here.
+func renderToolA2UIResultBody(sty *styles.Styles, surfaces []string, opts *ToolRenderOpts, widths toolResultContentWidths) string {
+	var b strings.Builder
+	if opts.LiveSurfaces != nil {
+		b.WriteString(opts.LiveSurfaces(widths.Body))
+	} else {
+		failed := 0
+		for _, surf := range surfaces {
+			rendered, err := renderToolA2UI(sty, surf, widths.Body)
+			if err != nil || rendered == "" {
+				failed++
+				continue
+			}
+			if b.Len() > 0 {
+				b.WriteString("\n")
+			}
+			b.WriteString(rendered)
+		}
+
+		var chunks []string
+		if b.Len() > 0 {
+			chunks = append(chunks, sty.Tool.Body.Render(clampToolA2UI(sty, b.String(), widths.Body, opts.ExpandedContent)))
+		}
+		// Alert on ANY failed surface, not only when all fail: a sibling
+		// surface rendering fine must not hide that another one vanished —
+		// the model was told the user can see every one of them.
+		if failed > 0 {
+			chunks = append(chunks, sty.Tool.Body.Render(renderToolA2UIAlert(sty, widths.Body)))
+		}
+		// Show any real text the resource returned alongside its surfaces — the
+		// model-facing placeholder lines are stripped, the rest belongs to the
+		// user just as much as the surfaces do.
+		if text := stripA2UIPlaceholders(opts.Result.Content); text != "" {
+			chunks = append(chunks, renderToolResultTextContent(sty, text, widths, opts.ExpandedContent))
+		}
+		return strings.Join(chunks, "\n")
+	}
+
+	var chunks []string
+	if b.Len() > 0 {
+		chunks = append(chunks, sty.Tool.Body.Render(clampToolA2UI(sty, b.String(), widths.Body, opts.ExpandedContent)))
+	}
+	if text := stripA2UIPlaceholders(opts.Result.Content); text != "" {
+		chunks = append(chunks, renderToolResultTextContent(sty, text, widths, opts.ExpandedContent))
+	}
+	return strings.Join(chunks, "\n")
+}
+
+// stripA2UIPlaceholders removes the model-facing surface placeholder lines
+// from tool content, leaving only text the user should see.
+func stripA2UIPlaceholders(content string) string {
+	var out []string
+	for _, ln := range strings.Split(content, "\n") {
+		if strings.HasPrefix(strings.TrimSpace(ln), tools.A2UISurfacePlaceholderPrefix) {
+			continue
+		}
+		out = append(out, ln)
+	}
+	return strings.TrimSpace(strings.Join(out, "\n"))
+}
+
+// clampToolA2UI applies the collapsed-height budget every other tool body
+// gets from responseContextHeight. The surface is pre-rendered ANSI, so the
+// clamp slices whole lines and appends the standard truncation footer;
+// expanding the tool result restores the full surface.
+func clampToolA2UI(sty *styles.Styles, body string, width int, expanded bool) string {
+	lines := strings.Split(body, "\n")
+	if expanded || len(lines) <= responseContextHeight {
+		return body
+	}
+	out := append([]string{}, lines[:responseContextHeight]...)
+	out = append(out, sty.Tool.ContentTruncation.
+		Width(width).
+		Render(fmt.Sprintf(assistantMessageTruncateFormat, len(lines)-responseContextHeight)))
+	return strings.Join(out, "\n")
+}
+
+// renderToolA2UIAlert mirrors the assistant path's renderA2UIAlert for tool
+// results: the resource advertised A2UI but a2tea could not draw a surface.
+func renderToolA2UIAlert(sty *styles.Styles, width int) string {
+	inner := max(width-2, 1)
+	tag := sty.Messages.ErrorTag.Render("A2UI")
+	title := sty.Messages.ErrorTitle.Render("couldn't render this resource's UI surface")
+	reason := sty.Messages.ErrorDetails.Width(inner).Render(
+		"The A2UI content was malformed or used unsupported components.")
+	return tag + " " + title + "\n\n" + reason
+}
+
+// renderToolA2UI renders a static (non-interactive) A2UI surface from tool
+// result content. Unlike the live surfaces on AssistantMessageItem, this does
+// not support focus/button interaction — it renders a snapshot of the surface
+// using the same themed styles.
+func renderToolA2UI(sty *styles.Styles, content string, width int) (string, error) {
+	parts, err := a2tea.Scan(content)
+	if err != nil {
+		return "", err
+	}
+	var b strings.Builder
+	themedStyles := a2uiThemeStyles(sty)
+	proseStyle := lipgloss.NewStyle().Width(width)
+	for _, p := range parts {
+		// Keep each part's prose, wrapped to the body budget: pre-change
+		// persisted results interleave text with surfaces, and dropping
+		// (or overflowing) it would corrupt content the model saw.
+		if text := strings.TrimSpace(p.Text); text != "" {
+			b.WriteString(proseStyle.Render(text))
+			b.WriteString("\n")
+		}
+		if len(p.Messages) == 0 {
+			continue
+		}
+		model, err := a2tea.Render(p.Messages, render.WithStyles(themedStyles))
+		if err != nil {
+			continue
+		}
+		if rm, ok := model.(render.Model); ok {
+			rm.SetSize(width, 0)
+			b.WriteString(strings.TrimRight(rm.View().Content, "\n"))
+			b.WriteString("\n")
+		}
+	}
+	return strings.TrimRight(b.String(), "\n"), nil
 }

--- a/internal/ui/chat/generic.go
+++ b/internal/ui/chat/generic.go
@@ -115,10 +115,12 @@ func (g *GenericToolRenderContext) RenderTool(sty *styles.Styles, width int, opt
 // which would be false here.
 func renderToolA2UIResultBody(sty *styles.Styles, surfaces []string, opts *ToolRenderOpts, widths toolResultContentWidths) string {
 	var b strings.Builder
+	failed := 0
 	if opts.LiveSurfaces != nil {
-		b.WriteString(opts.LiveSurfaces(widths.Body))
+		rendered, liveFailed := opts.LiveSurfaces(widths.Body)
+		b.WriteString(rendered)
+		failed = liveFailed
 	} else {
-		failed := 0
 		for _, surf := range surfaces {
 			rendered, err := renderToolA2UI(sty, surf, widths.Body)
 			if err != nil || rendered == "" {
@@ -130,30 +132,21 @@ func renderToolA2UIResultBody(sty *styles.Styles, surfaces []string, opts *ToolR
 			}
 			b.WriteString(rendered)
 		}
-
-		var chunks []string
-		if b.Len() > 0 {
-			chunks = append(chunks, sty.Tool.Body.Render(clampToolA2UI(sty, b.String(), widths.Body, opts.ExpandedContent)))
-		}
-		// Alert on ANY failed surface, not only when all fail: a sibling
-		// surface rendering fine must not hide that another one vanished —
-		// the model was told the user can see every one of them.
-		if failed > 0 {
-			chunks = append(chunks, sty.Tool.Body.Render(renderToolA2UIAlert(sty, widths.Body)))
-		}
-		// Show any real text the resource returned alongside its surfaces — the
-		// model-facing placeholder lines are stripped, the rest belongs to the
-		// user just as much as the surfaces do.
-		if text := stripA2UIPlaceholders(opts.Result.Content); text != "" {
-			chunks = append(chunks, renderToolResultTextContent(sty, text, widths, opts.ExpandedContent))
-		}
-		return strings.Join(chunks, "\n")
 	}
 
 	var chunks []string
 	if b.Len() > 0 {
 		chunks = append(chunks, sty.Tool.Body.Render(clampToolA2UI(sty, b.String(), widths.Body, opts.ExpandedContent)))
 	}
+	// Alert on ANY failed surface, not only when all fail: a sibling
+	// surface rendering fine must not hide that another one vanished —
+	// the model was told the user can see every one of them.
+	if failed > 0 {
+		chunks = append(chunks, sty.Tool.Body.Render(renderToolA2UIAlert(sty, widths.Body)))
+	}
+	// Show any real text the resource returned alongside its surfaces — the
+	// model-facing placeholder lines are stripped, the rest belongs to the
+	// user just as much as the surfaces do.
 	if text := stripA2UIPlaceholders(opts.Result.Content); text != "" {
 		chunks = append(chunks, renderToolResultTextContent(sty, text, widths, opts.ExpandedContent))
 	}

--- a/internal/ui/chat/generic_test.go
+++ b/internal/ui/chat/generic_test.go
@@ -1,0 +1,244 @@
+package chat
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/crush/internal/agent/tools"
+	"github.com/charmbracelet/crush/internal/message"
+	"github.com/charmbracelet/crush/internal/ui/styles"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/stretchr/testify/require"
+)
+
+const a2uiTestPlaceholder = tools.A2UISurfacePlaceholderPrefix +
+	"mcp://cairn/run/abc123/a2ui — the user can already see it; do not repeat or echo its JSON payload]"
+
+func genericToolOpts(t *testing.T, result *message.ToolResult) *ToolRenderOpts {
+	t.Helper()
+	return genericToolOptsFor(t, tools.ReadMCPResourceToolName, result)
+}
+
+func genericToolOptsFor(t *testing.T, name string, result *message.ToolResult) *ToolRenderOpts {
+	t.Helper()
+	return &ToolRenderOpts{
+		ToolCall: message.ToolCall{
+			ID:       "call-1",
+			Name:     name,
+			Input:    `{"mcp_name":"cairn","uri":"mcp://cairn/run/abc123/a2ui"}`,
+			Finished: true,
+		},
+		Result: result,
+		Status: ToolStatusSuccess,
+	}
+}
+
+// The A2UI payload lives in result metadata (UI-only), not in the content
+// the model sees — the model only gets a placeholder, so it cannot echo the
+// JSON back and double-render the surface.
+func TestGenericToolRendersA2UIFromMetadata(t *testing.T) {
+	t.Parallel()
+
+	meta, err := json.Marshal(tools.ReadMCPResourceResponseMetadata{
+		A2UISurfaces: []string{a2uiSurface},
+	})
+	require.NoError(t, err)
+
+	sty := styles.CharmtonePantera()
+	ctx := &GenericToolRenderContext{}
+	out := ctx.RenderTool(&sty, 80, genericToolOpts(t, &message.ToolResult{
+		Content:  a2uiTestPlaceholder,
+		Metadata: string(meta),
+	}))
+	plain := ansi.Strip(out)
+
+	require.Contains(t, plain, "Hello from A2UI")
+	require.NotContains(t, plain, "a2ui-json")
+	require.NotContains(t, plain, "updateComponents")
+	// The model-facing placeholder is not shown to the user.
+	require.NotContains(t, plain, "do not repeat")
+}
+
+// A result with no A2UI metadata renders its text content as before.
+func TestGenericToolNoMetadataRendersText(t *testing.T) {
+	t.Parallel()
+
+	sty := styles.CharmtonePantera()
+	ctx := &GenericToolRenderContext{}
+	out := ctx.RenderTool(&sty, 80, genericToolOpts(t, &message.ToolResult{
+		Content: "plain resource text",
+	}))
+	plain := ansi.Strip(out)
+
+	require.Contains(t, plain, "plain resource text")
+}
+
+// A mixed resource read (text/markdown alongside application/a2ui+json)
+// shows both the surface and the real text — only the model-facing
+// placeholder lines are stripped.
+func TestGenericToolMetadataMixedContentShowsText(t *testing.T) {
+	t.Parallel()
+
+	meta, err := json.Marshal(tools.ReadMCPResourceResponseMetadata{
+		A2UISurfaces: []string{a2uiSurface},
+	})
+	require.NoError(t, err)
+
+	sty := styles.CharmtonePantera()
+	ctx := &GenericToolRenderContext{}
+	out := ctx.RenderTool(&sty, 80, genericToolOpts(t, &message.ToolResult{
+		Content:  "the artifact summary text\n" + a2uiTestPlaceholder,
+		Metadata: string(meta),
+	}))
+	plain := ansi.Strip(out)
+
+	require.Contains(t, plain, "Hello from A2UI")
+	require.Contains(t, plain, "the artifact summary text")
+	require.NotContains(t, plain, "do not repeat")
+}
+
+// When every metadata surface fails to render, the user sees an alert — not
+// the model-facing placeholder claiming the surface is already visible.
+func TestGenericToolMetadataAllFailShowsAlert(t *testing.T) {
+	t.Parallel()
+
+	meta, err := json.Marshal(tools.ReadMCPResourceResponseMetadata{
+		A2UISurfaces: []string{"<a2ui-json>{malformed</a2ui-json>"},
+	})
+	require.NoError(t, err)
+
+	sty := styles.CharmtonePantera()
+	ctx := &GenericToolRenderContext{}
+	out := ctx.RenderTool(&sty, 80, genericToolOpts(t, &message.ToolResult{
+		Content:  a2uiTestPlaceholder,
+		Metadata: string(meta),
+	}))
+	plain := ansi.Strip(out)
+
+	require.Contains(t, plain, "couldn't render this resource's UI surface")
+	require.NotContains(t, plain, "do not repeat")
+}
+
+// A failed surface next to a healthy sibling still surfaces an alert — the
+// model was told the user can see every surface.
+func TestGenericToolMetadataPartialFailShowsAlert(t *testing.T) {
+	t.Parallel()
+
+	meta, err := json.Marshal(tools.ReadMCPResourceResponseMetadata{
+		A2UISurfaces: []string{a2uiSurface, "<a2ui-json>{malformed</a2ui-json>"},
+	})
+	require.NoError(t, err)
+
+	sty := styles.CharmtonePantera()
+	ctx := &GenericToolRenderContext{}
+	out := ctx.RenderTool(&sty, 80, genericToolOpts(t, &message.ToolResult{
+		Content:  a2uiTestPlaceholder,
+		Metadata: string(meta),
+	}))
+	plain := ansi.Strip(out)
+
+	require.Contains(t, plain, "Hello from A2UI")
+	require.Contains(t, plain, "couldn't render this resource's UI surface")
+}
+
+// The content-scan fallback exists for pre-change persisted read_mcp_resource
+// results only — other tools sharing the generic renderer must keep
+// payload-shaped text as text.
+func TestGenericToolFallbackScopedToReadMCPResource(t *testing.T) {
+	t.Parallel()
+
+	sty := styles.CharmtonePantera()
+	ctx := &GenericToolRenderContext{}
+	out := ctx.RenderTool(&sty, 80, genericToolOptsFor(t, "crush_logs", &message.ToolResult{
+		Content: "log line before\n" + a2uiSurface + "\nlog line after",
+	}))
+	plain := ansi.Strip(out)
+
+	// Rendered as text (the raw payload stays visible), not as a surface.
+	require.Contains(t, plain, "log line before")
+	require.NotContains(t, plain, "Hello from A2UI")
+}
+
+// A fenced A2UI example inside a read_mcp_resource result is documentation,
+// not live UI (#6, #96) — the masked scan must not extract it.
+func TestGenericToolFallbackIgnoresFencedExample(t *testing.T) {
+	t.Parallel()
+
+	sty := styles.CharmtonePantera()
+	ctx := &GenericToolRenderContext{}
+	out := ctx.RenderTool(&sty, 80, genericToolOpts(t, &message.ToolResult{
+		Content: "Example:\n\n```json\n" + a2uiSurface + "\n```\n\nDone.",
+	}))
+	plain := ansi.Strip(out)
+
+	require.Contains(t, plain, "Example:")
+	require.NotContains(t, plain, "Hello from A2UI")
+}
+
+// Pre-change persisted results interleave prose with tagged surfaces — the
+// fallback render keeps the prose.
+func TestGenericToolFallbackPreservesProse(t *testing.T) {
+	t.Parallel()
+
+	sty := styles.CharmtonePantera()
+	ctx := &GenericToolRenderContext{}
+	out := ctx.RenderTool(&sty, 80, genericToolOpts(t, &message.ToolResult{
+		Content: "intro prose\n" + a2uiSurface + "\nfooter prose",
+	}))
+	plain := ansi.Strip(out)
+
+	require.Contains(t, plain, "Hello from A2UI")
+	require.Contains(t, plain, "intro prose")
+	require.Contains(t, plain, "footer prose")
+}
+
+// tallA2UISurface builds a surface whose rendered height exceeds the
+// collapsed tool-body budget.
+func tallA2UISurface(t *testing.T) string {
+	t.Helper()
+	var comps []string
+	var children []string
+	for i := 0; i < 20; i++ {
+		id := string(rune('a' + i%26))
+		id += string(rune('0' + i/26))
+		children = append(children, `"`+id+`"`)
+		comps = append(comps, `{"component":"Text","id":"`+id+`","text":"row `+id+`"}`)
+	}
+	comps = append([]string{
+		`{"component":"Card","id":"root","child":"col"}`,
+		`{"component":"Column","id":"col","children":[` + strings.Join(children, ",") + `]}`,
+	}, comps...)
+	return `<a2ui-json>{"version":"v0.9","updateComponents":{"surfaceId":"s","components":[` +
+		strings.Join(comps, ",") + `]}}</a2ui-json>`
+}
+
+// A tall surface honors the same collapsed-height budget as every other tool
+// body, and expanding restores the full surface.
+func TestGenericToolA2UICollapse(t *testing.T) {
+	t.Parallel()
+
+	meta, err := json.Marshal(tools.ReadMCPResourceResponseMetadata{
+		A2UISurfaces: []string{tallA2UISurface(t)},
+	})
+	require.NoError(t, err)
+
+	sty := styles.CharmtonePantera()
+	ctx := &GenericToolRenderContext{}
+
+	collapsed := genericToolOpts(t, &message.ToolResult{
+		Content:  a2uiTestPlaceholder,
+		Metadata: string(meta),
+	})
+	out := ansi.Strip(ctx.RenderTool(&sty, 80, collapsed))
+	require.Contains(t, out, "lines hidden")
+
+	expanded := genericToolOpts(t, &message.ToolResult{
+		Content:  a2uiTestPlaceholder,
+		Metadata: string(meta),
+	})
+	expanded.ExpandedContent = true
+	outExpanded := ansi.Strip(ctx.RenderTool(&sty, 80, expanded))
+	require.NotContains(t, outExpanded, "lines hidden")
+	require.Contains(t, outExpanded, "row a0")
+}

--- a/internal/ui/chat/mcp.go
+++ b/internal/ui/chat/mcp.go
@@ -76,10 +76,10 @@ func (b *MCPToolRenderContext) RenderTool(sty *styles.Styles, width int, opts *T
 	bodyWidth := cappedWidth - toolBodyLeftPaddingTotal
 	widths := toolResultContentWidths{Body: bodyWidth, Diff: cappedWidth}
 
-	// An MCP tool result can carry an A2UI surface in its metadata
-	//: the server returned an application/a2ui+json
-	// EmbeddedResource, diverted so the model only sees a placeholder.
-	// Render the live surface (or static fallback) instead of raw text.
+	// An MCP tool result can carry an A2UI surface in its metadata: the
+	// server returned an application/a2ui+json EmbeddedResource, diverted
+	// so the model only sees a placeholder. Render the live surface (or
+	// static fallback) instead of raw text.
 	if opts.Result.Metadata != "" {
 		var meta tools.ReadMCPResourceResponseMetadata
 		if err := json.Unmarshal([]byte(opts.Result.Metadata), &meta); err == nil && len(meta.A2UISurfaces) > 0 {

--- a/internal/ui/chat/mcp.go
+++ b/internal/ui/chat/mcp.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/charmbracelet/crush/internal/agent/tools"
 	"github.com/charmbracelet/crush/internal/message"
 	"github.com/charmbracelet/crush/internal/ui/styles"
 )
@@ -73,6 +74,19 @@ func (b *MCPToolRenderContext) RenderTool(sty *styles.Styles, width int, opts *T
 	}
 
 	bodyWidth := cappedWidth - toolBodyLeftPaddingTotal
-	body := renderToolResultTextContent(sty, opts.Result.Content, toolResultContentWidths{Body: bodyWidth, Diff: cappedWidth}, opts.ExpandedContent)
+	widths := toolResultContentWidths{Body: bodyWidth, Diff: cappedWidth}
+
+	// An MCP tool result can carry an A2UI surface in its metadata
+	//: the server returned an application/a2ui+json
+	// EmbeddedResource, diverted so the model only sees a placeholder.
+	// Render the live surface (or static fallback) instead of raw text.
+	if opts.Result.Metadata != "" {
+		var meta tools.ReadMCPResourceResponseMetadata
+		if err := json.Unmarshal([]byte(opts.Result.Metadata), &meta); err == nil && len(meta.A2UISurfaces) > 0 {
+			return joinToolParts(header, renderToolA2UIResultBody(sty, meta.A2UISurfaces, opts, widths))
+		}
+	}
+
+	body := renderToolResultTextContent(sty, opts.Result.Content, widths, opts.ExpandedContent)
 	return joinToolParts(header, body)
 }

--- a/internal/ui/chat/tool_a2ui.go
+++ b/internal/ui/chat/tool_a2ui.go
@@ -1,0 +1,126 @@
+package chat
+
+import (
+	"encoding/json"
+	"strings"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/crush/internal/agent/tools"
+	"github.com/joestump-agent/a2tea"
+	"github.com/joestump-agent/a2tea/render"
+)
+
+// syncToolA2UISurfaces builds — or reuses — the live a2tea models for the
+// surfaces carried in the tool result's metadata. Models are keyed by
+// a hash of the metadata: a re-render with the same result reuses the live
+// models (preserving focus and edited field values), while a result swap
+// (SetResult) rebuilds them. Each surface's provenance is registered so a
+// later interaction routes back to the owning MCP server.
+func (t *baseToolMessageItem) syncToolA2UISurfaces() {
+	if t.result == nil || t.result.Metadata == "" {
+		t.a2ui.surfaces = nil
+		t.a2ui.surfaceIDs = nil
+		t.surfaceScanned = false
+		return
+	}
+	var meta tools.ReadMCPResourceResponseMetadata
+	if err := json.Unmarshal([]byte(t.result.Metadata), &meta); err != nil || len(meta.A2UISurfaces) == 0 {
+		t.a2ui.surfaces = nil
+		t.a2ui.surfaceIDs = nil
+		t.surfaceScanned = false
+		return
+	}
+	h := fnv64(t.result.Metadata)
+	if t.surfaceScanned && t.surfaceSrcHash == h {
+		return
+	}
+	var surfaces []render.Model
+	var ids []string
+	for i, surfJSON := range meta.A2UISurfaces {
+		parts, err := a2tea.Scan(surfJSON)
+		if err != nil {
+			continue
+		}
+		built, builtIDs := buildA2UISurfaces(t.sty, parts)
+		for j, m := range built {
+			if m == nil {
+				continue
+			}
+			surfaces = append(surfaces, m)
+			id := builtIDs[j]
+			ids = append(ids, id)
+			// Provenance is parallel to A2UISurfaces; a missing or short
+			// slice (older persisted results) means unknown origin.
+			if i < len(meta.MCPSurfaceProvenance) {
+				registerA2UISurfaceProvenance(id, meta.MCPSurfaceProvenance[i])
+			}
+		}
+	}
+	t.a2ui.surfaces = surfaces
+	t.a2ui.surfaceIDs = ids
+	t.surfaceSrcHash = h
+	t.surfaceScanned = true
+	if t.focusableMessageItem.isFocused() {
+		t.focusToolA2UISurfaces()
+	}
+}
+
+// hasToolA2UISurfaces reports whether this item carries live MCP surfaces.
+func (t *baseToolMessageItem) hasToolA2UISurfaces() bool {
+	return t.a2ui.hasLive()
+}
+
+// focusToolA2UISurfaces grants focus to the first live surface and blurs the
+// rest. MCP surfaces are long-lived app UIs — unlike chat-scanned
+// forms they are never retired on submission, so every live surface is
+// focusable.
+func (t *baseToolMessageItem) focusToolA2UISurfaces() {
+	for i, s := range t.a2ui.surfaces {
+		if s != nil {
+			t.a2ui.focus(i)
+			return
+		}
+	}
+}
+
+// blurToolA2UISurfaces revokes keyboard focus from every live surface.
+func (t *baseToolMessageItem) blurToolA2UISurfaces() {
+	t.a2ui.blurAll()
+}
+
+// renderToolA2UISurfaces renders each live surface from its model at the
+// given width, joined by blank lines. Surfaces that fail to produce output
+// are skipped; the alert path in generic.go/mcp.go covers payloads that
+// produced no renderable model at all.
+func (t *baseToolMessageItem) renderToolA2UISurfaces(width int) string {
+	var b strings.Builder
+	for _, s := range t.a2ui.surfaces {
+		if s == nil {
+			continue
+		}
+		s.SetSize(width, 0)
+		rendered := strings.TrimRight(s.View().Content, "\n")
+		if rendered == "" {
+			continue
+		}
+		if b.Len() > 0 {
+			b.WriteString("\n\n")
+		}
+		b.WriteString(rendered)
+	}
+	return b.String()
+}
+
+// HandleKeyEvent routes keys to the focused live MCP surface first
+// — Tab/Shift+Tab cycle its focus ring, Enter activates a button,
+// printable keys edit a focused field (see a2uiSurfaceWantsKey) — then falls
+// through to the copy shortcut. A button activation surfaces as an
+// a2uievent.ButtonClicked tea.Cmd, which the UI model routes per the
+// surface's provenance.
+func (t *baseToolMessageItem) handleA2UIKeyEvent(key tea.KeyMsg) (bool, tea.Cmd) {
+	if idx := t.a2ui.focusedIndex(); idx >= 0 && a2uiSurfaceWantsKey(t.a2ui.surfaces[idx], key) {
+		t.Bump()
+		return true, t.a2ui.update(idx, key)
+	}
+	return false, nil
+}

--- a/internal/ui/chat/tool_a2ui.go
+++ b/internal/ui/chat/tool_a2ui.go
@@ -8,6 +8,7 @@ import (
 	"github.com/charmbracelet/crush/internal/agent/tools"
 	"github.com/joestump-agent/a2tea"
 	"github.com/joestump-agent/a2tea/render"
+	a2ui "github.com/tmc/a2ui"
 )
 
 // syncToolA2UISurfaces builds — or reuses — the live a2tea models for the
@@ -20,6 +21,7 @@ func (t *baseToolMessageItem) syncToolA2UISurfaces() {
 	if t.result == nil || t.result.Metadata == "" {
 		t.a2ui.surfaces = nil
 		t.a2ui.surfaceIDs = nil
+		t.a2ui.surfaceOwners = nil
 		t.surfaceScanned = false
 		return
 	}
@@ -27,6 +29,7 @@ func (t *baseToolMessageItem) syncToolA2UISurfaces() {
 	if err := json.Unmarshal([]byte(t.result.Metadata), &meta); err != nil || len(meta.A2UISurfaces) == 0 {
 		t.a2ui.surfaces = nil
 		t.a2ui.surfaceIDs = nil
+		t.a2ui.surfaceOwners = nil
 		t.surfaceScanned = false
 		return
 	}
@@ -36,38 +39,135 @@ func (t *baseToolMessageItem) syncToolA2UISurfaces() {
 	}
 	var surfaces []render.Model
 	var ids []string
+	var owners []string
+	failed := 0
 	for i, surfJSON := range meta.A2UISurfaces {
 		parts, err := a2tea.Scan(surfJSON)
 		if err != nil {
+			failed++
 			continue
 		}
 		built, builtIDs := buildA2UISurfaces(t.sty, parts)
+		payloadLive := 0
 		for j, m := range built {
 			if m == nil {
 				continue
 			}
+			payloadLive++
 			surfaces = append(surfaces, m)
 			id := builtIDs[j]
 			ids = append(ids, id)
 			// Provenance is parallel to A2UISurfaces; a missing or short
-			// slice (older persisted results) means unknown origin.
+			// slice (older persisted results) means unknown origin. It is
+			// recorded per surface on the item — the round-trip resolves
+			// through that, so two servers sharing a surface ID stay
+			// distinct — and mirrored into the global registry for callers
+			// that only hold an ID.
+			owner := ""
 			if i < len(meta.MCPSurfaceProvenance) {
-				registerA2UISurfaceProvenance(id, meta.MCPSurfaceProvenance[i])
+				owner = meta.MCPSurfaceProvenance[i]
+				registerA2UISurfaceProvenance(id, owner)
 			}
+			owners = append(owners, owner)
+		}
+		// A payload that scanned but drew nothing (unsupported components,
+		// bare data-model update) failed just like a scan error: the model
+		// was told the user can see it.
+		if payloadLive == 0 {
+			failed++
 		}
 	}
 	t.a2ui.surfaces = surfaces
 	t.a2ui.surfaceIDs = ids
+	t.a2ui.surfaceOwners = owners
+	t.surfaceBuildFailed = failed
 	t.surfaceSrcHash = h
 	t.surfaceScanned = true
-	if t.focusableMessageItem.isFocused() {
+	if t.isFocused() {
 		t.focusToolA2UISurfaces()
 	}
+}
+
+// A2UISurfaceItem is implemented by message items that hold live MCP A2UI
+// surfaces (tool message items carrying an MCP-served payload). It lets the
+// UI model locate a surface by ID, read its input values for an a2ui_action
+// context, and feed a server's response back into the surface.
+type A2UISurfaceItem interface {
+	// HasA2UISurface reports whether the item holds the named surface.
+	HasA2UISurface(surfaceID string) bool
+	// A2UISurfaceIsFocused reports whether the item holds the named surface
+	// AND that surface currently has keyboard focus. Surface IDs are only
+	// unique within a server, so two items can hold the same ID; the
+	// focused one is the one the user is actually interacting with.
+	A2UISurfaceIsFocused(surfaceID string) bool
+	// A2UISurfaceOwner returns the MCP server that served the named
+	// surface, and whether one is known.
+	A2UISurfaceOwner(surfaceID string) (string, bool)
+	// ToolA2UIFieldValues reads the named surface's current input values.
+	ToolA2UIFieldValues(surfaceID string) map[string]any
+	// ApplyToolA2UIUpdate feeds server messages back into the named
+	// surface, reporting whether it still has renderable state.
+	ApplyToolA2UIUpdate(surfaceID string, msgs []a2ui.ServerMessage) bool
 }
 
 // hasToolA2UISurfaces reports whether this item carries live MCP surfaces.
 func (t *baseToolMessageItem) hasToolA2UISurfaces() bool {
 	return t.a2ui.hasLive()
+}
+
+// HasA2UISurface reports whether this item holds the named surface.
+func (t *baseToolMessageItem) HasA2UISurface(surfaceID string) bool {
+	return t.a2ui.findByID(surfaceID) >= 0
+}
+
+// A2UISurfaceIsFocused reports whether this item holds the named surface and
+// that surface currently has keyboard focus.
+func (t *baseToolMessageItem) A2UISurfaceIsFocused(surfaceID string) bool {
+	idx := t.a2ui.findByID(surfaceID)
+	return idx >= 0 && idx == t.a2ui.focusedIndex()
+}
+
+// A2UISurfaceOwner returns the MCP server that served the named surface.
+func (t *baseToolMessageItem) A2UISurfaceOwner(surfaceID string) (string, bool) {
+	return t.a2ui.ownerFor(t.a2ui.findByID(surfaceID))
+}
+
+// ToolA2UIFieldValues reads the named surface's current input values, for
+// building an a2ui_action context.
+func (t *baseToolMessageItem) ToolA2UIFieldValues(surfaceID string) map[string]any {
+	idx := t.a2ui.findByID(surfaceID)
+	return t.a2ui.fieldValues(idx)
+}
+
+// ApplyToolA2UIUpdate feeds a batch of A2UI server messages back into the
+// named surface (the response to an a2ui_action round-trip): the surface
+// updates in place rather than being replaced, preserving focus and edited
+// state the server did not touch. It reports whether the surface still has
+// renderable state afterward (false means the server deleted it).
+func (t *baseToolMessageItem) ApplyToolA2UIUpdate(surfaceID string, msgs []a2ui.ServerMessage) bool {
+	idx := t.a2ui.findByID(surfaceID)
+	s := t.a2ui.surfaceAt(idx)
+	if s == nil {
+		return false
+	}
+	applier, ok := s.(interface {
+		Apply([]a2ui.ServerMessage) bool
+	})
+	if !ok {
+		return false
+	}
+	alive := applier.Apply(msgs)
+	if !alive {
+		// The server deleted the surface. Release the model so it stops
+		// claiming focus and swallowing keys for something that draws
+		// nothing, and re-focus whatever is left.
+		t.a2ui.drop(idx)
+		if t.isFocused() {
+			t.focusToolA2UISurfaces()
+		}
+	}
+	t.Bump()
+	return alive
 }
 
 // focusToolA2UISurfaces grants focus to the first live surface and blurs the
@@ -89,11 +189,13 @@ func (t *baseToolMessageItem) blurToolA2UISurfaces() {
 }
 
 // renderToolA2UISurfaces renders each live surface from its model at the
-// given width, joined by blank lines. Surfaces that fail to produce output
-// are skipped; the alert path in generic.go/mcp.go covers payloads that
-// produced no renderable model at all.
-func (t *baseToolMessageItem) renderToolA2UISurfaces(width int) string {
+// given width, joined by blank lines. It also reports how many surfaces
+// failed — payloads that never built a model (surfaceBuildFailed) plus live
+// models that drew nothing — so the renderer can show the same alert the
+// static path shows: the model was told the user can see every surface.
+func (t *baseToolMessageItem) renderToolA2UISurfaces(width int) (string, int) {
 	var b strings.Builder
+	failed := t.surfaceBuildFailed
 	for _, s := range t.a2ui.surfaces {
 		if s == nil {
 			continue
@@ -101,6 +203,7 @@ func (t *baseToolMessageItem) renderToolA2UISurfaces(width int) string {
 		s.SetSize(width, 0)
 		rendered := strings.TrimRight(s.View().Content, "\n")
 		if rendered == "" {
+			failed++
 			continue
 		}
 		if b.Len() > 0 {
@@ -108,7 +211,7 @@ func (t *baseToolMessageItem) renderToolA2UISurfaces(width int) string {
 		}
 		b.WriteString(rendered)
 	}
-	return b.String()
+	return b.String(), failed
 }
 
 // HandleKeyEvent routes keys to the focused live MCP surface first

--- a/internal/ui/chat/tool_a2ui.go
+++ b/internal/ui/chat/tool_a2ui.go
@@ -88,6 +88,31 @@ func (t *baseToolMessageItem) syncToolA2UISurfaces() {
 	}
 }
 
+// dropToolA2UISurfaces discards the live surface models and the scan state
+// that guards rebuilding them, so the next syncToolA2UISurfaces rebuilds
+// from the result metadata. Provenance and retirement live outside these
+// fields and are unaffected.
+func (t *baseToolMessageItem) dropToolA2UISurfaces() {
+	t.a2ui.surfaces = nil
+	t.a2ui.surfaceIDs = nil
+	t.a2ui.surfaceOwners = nil
+	t.surfaceSrcHash = 0
+	t.surfaceScanned = false
+	t.surfaceBuildFailed = 0
+}
+
+// clearCache drops the rendered strings and the A2UI surface models.
+//
+// The surfaces must go with them: buildA2UISurfaces bakes the theme's
+// render.Styles into each model at build time, and the only caller of
+// clearCache is the theme-change path, so a kept model would keep drawing
+// the previous palette beside newly-themed chat. AssistantMessageItem drops
+// its surfaces here for exactly the same reason.
+func (t *baseToolMessageItem) clearCache() {
+	t.cachedMessageItem.clearCache()
+	t.dropToolA2UISurfaces()
+}
+
 // A2UISurfaceItem is implemented by message items that hold live MCP A2UI
 // surfaces (tool message items carrying an MCP-served payload). It lets the
 // UI model locate a surface by ID, read its input values for an a2ui_action

--- a/internal/ui/chat/tool_a2ui_test.go
+++ b/internal/ui/chat/tool_a2ui_test.go
@@ -148,3 +148,58 @@ func TestMCPToolRendersA2UIFromMetadata(t *testing.T) {
 	require.Contains(t, plain, "Recipe Card")
 	require.NotContains(t, plain, "do not repeat")
 }
+
+// TestToolA2UIClearCacheDropsSurfacesForRestyle pins the theme-change path for
+// tool-result surfaces. buildA2UISurfaces bakes the active theme's
+// render.Styles into each a2tea model, and clearCache is only ever called from
+// the theme-change path (applyTheme -> refreshStyles ->
+// InvalidateRenderCaches -> ClearItemCaches), so a surface kept across it goes
+// on drawing the previous palette beside newly-themed chat. The assistant item
+// has had this drop since the surfaces landed; the tool item did not.
+func TestToolA2UIClearCacheDropsSurfacesForRestyle(t *testing.T) {
+	t.Parallel()
+
+	item := newA2UIToolItem(t, []string{a2uiToolSurface}, []string{"recipe"}, "mcp_recipe_card")
+	_ = item.RawRender(100)
+	require.True(t, item.hasToolA2UISurfaces(), "surfaces must build on first render")
+	require.True(t, item.surfaceScanned)
+
+	item.clearCache()
+
+	require.False(t, item.surfaceScanned, "the scan guard must reset so the next render rebuilds")
+	require.Zero(t, item.surfaceSrcHash, "a kept hash would short-circuit the rebuild")
+	require.False(t, item.hasToolA2UISurfaces(), "stale themed models must be dropped")
+
+	// The surfaces come back on the next render, now built from current styles.
+	_ = item.RawRender(100)
+	require.True(t, item.hasToolA2UISurfaces(), "surfaces must rebuild after a restyle")
+}
+
+// TestToolRenderDoesNotCacheLiveSurfaceFrame pins that Render never writes a
+// frame containing a live surface into the prefixed-render cache. The surfaces
+// are built inside RawRender, so the hasToolA2UISurfaces() check that guards
+// the cache is still false when Render first consults it — caching there froze
+// the surface's opening frame, and getCachedPrefixedRender keys on
+// (width, prefix) alone, so once the server deleted the surface the dead frame
+// was served for the rest of the item's life.
+func TestToolRenderDoesNotCacheLiveSurfaceFrame(t *testing.T) {
+	t.Parallel()
+
+	// The tool name must not itself contain the surface's text, or the
+	// rendered header would satisfy the replay assertion below.
+	item := newA2UIToolItem(t, []string{a2uiToolSurface}, []string{"recipe"}, "mcp_recipe_fetch")
+
+	_ = item.Render(100)
+	require.True(t, item.hasToolA2UISurfaces(), "the render must have built a live surface")
+	require.Empty(t, item.prefixedRendered,
+		"a frame holding a live surface must not be cached")
+
+	// Drop the surface the way a server-sent deleteSurface does. With the
+	// frame wrongly cached, the next Render would replay it and keep drawing
+	// the surface that no longer exists.
+	item.dropToolA2UISurfaces()
+	item.result.Metadata = ""
+	out := item.Render(100)
+	require.NotContains(t, ansi.Strip(out), "Recipe Card",
+		"a deleted surface must not be replayed from the cache")
+}

--- a/internal/ui/chat/tool_a2ui_test.go
+++ b/internal/ui/chat/tool_a2ui_test.go
@@ -1,0 +1,131 @@
+package chat
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/charmbracelet/crush/internal/agent/tools"
+	"github.com/charmbracelet/crush/internal/message"
+	"github.com/charmbracelet/crush/internal/ui/styles"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/stretchr/testify/require"
+)
+
+const a2uiToolSurface = `<a2ui-json>{"version":"v0.9","updateComponents":{"surfaceId":"card","components":[` +
+	`{"component":"Card","id":"root","child":"col"},` +
+	`{"component":"Column","id":"col","children":["title"]},` +
+	`{"component":"Text","id":"title","variant":"h2","text":"Recipe Card"}]}}` + `</a2ui-json>`
+
+// newA2UIToolItem builds a base tool item whose result metadata carries the
+// given surfaces and provenance — the shape read_mcp_resource and mcp_* tool
+// results produce.
+func newA2UIToolItem(t *testing.T, surfaces, provenance []string, toolName string) *baseToolMessageItem {
+	t.Helper()
+	meta, err := json.Marshal(tools.ReadMCPResourceResponseMetadata{
+		A2UISurfaces:         surfaces,
+		MCPSurfaceProvenance: provenance,
+	})
+	require.NoError(t, err)
+
+	sty := styles.CharmtonePantera()
+	return newBaseToolMessageItem(&sty, message.ToolCall{
+		ID:       "call-1",
+		Name:     toolName,
+		Input:    `{}`,
+		Finished: true,
+	}, &message.ToolResult{
+		ToolCallID: "call-1",
+		Content:    a2uiTestPlaceholder,
+		Metadata:   string(meta),
+	}, &GenericToolRenderContext{}, false)
+}
+
+func TestToolA2UISurfaces(t *testing.T) {
+	t.Parallel()
+
+	t.Run("metadata surfaces build live models", func(t *testing.T) {
+		t.Parallel()
+		item := newA2UIToolItem(t, []string{a2uiToolSurface}, []string{"cairn"}, tools.ReadMCPResourceToolName)
+		item.syncToolA2UISurfaces()
+
+		require.True(t, item.hasToolA2UISurfaces())
+		require.Len(t, item.a2ui.surfaces, 1)
+		require.Equal(t, "card", item.a2ui.surfaceIDs[0])
+	})
+
+	t.Run("provenance is registered per surface", func(t *testing.T) {
+		t.Parallel()
+		item := newA2UIToolItem(t, []string{a2uiToolSurface}, []string{"cairn"}, tools.ReadMCPResourceToolName)
+		item.syncToolA2UISurfaces()
+
+		server, ok := A2UISurfaceProvenance("card")
+		require.True(t, ok)
+		require.Equal(t, "cairn", server)
+	})
+
+	t.Run("missing provenance means unknown origin", func(t *testing.T) {
+		t.Parallel()
+		item := newA2UIToolItem(t, []string{a2uiToolSurface}, nil, tools.ReadMCPResourceToolName)
+		item.syncToolA2UISurfaces()
+		require.True(t, item.hasToolA2UISurfaces())
+	})
+
+	t.Run("same metadata reuses live models", func(t *testing.T) {
+		t.Parallel()
+		item := newA2UIToolItem(t, []string{a2uiToolSurface}, []string{"cairn"}, tools.ReadMCPResourceToolName)
+		item.syncToolA2UISurfaces()
+		first := item.a2ui.surfaces[0]
+
+		// A re-render with the same result must reuse the model so focus
+		// and edited field values survive.
+		item.syncToolA2UISurfaces()
+		require.Same(t, first, item.a2ui.surfaces[0])
+	})
+
+	t.Run("malformed payload yields no live surface", func(t *testing.T) {
+		t.Parallel()
+		item := newA2UIToolItem(t, []string{"<a2ui-json>{malformed</a2ui-json>"}, []string{"cairn"}, tools.ReadMCPResourceToolName)
+		item.syncToolA2UISurfaces()
+		require.False(t, item.hasToolA2UISurfaces())
+	})
+
+	t.Run("rendering a live surface draws its content", func(t *testing.T) {
+		t.Parallel()
+		item := newA2UIToolItem(t, []string{a2uiToolSurface}, []string{"cairn"}, tools.ReadMCPResourceToolName)
+		item.syncToolA2UISurfaces()
+		out := item.renderToolA2UISurfaces(80)
+		plain := ansi.Strip(out)
+		require.Contains(t, plain, "Recipe Card")
+		require.NotContains(t, plain, "updateComponents")
+	})
+
+	t.Run("RawRender renders the surface instead of the placeholder", func(t *testing.T) {
+		t.Parallel()
+		item := newA2UIToolItem(t, []string{a2uiToolSurface}, []string{"cairn"}, tools.ReadMCPResourceToolName)
+		out := ansi.Strip(item.RawRender(100))
+		require.Contains(t, out, "Recipe Card")
+		require.NotContains(t, out, "do not repeat")
+	})
+}
+
+// The MCP tool renderer (mcp_* tools) renders metadata surfaces too, not
+// just read_mcp_resource.
+func TestMCPToolRendersA2UIFromMetadata(t *testing.T) {
+	t.Parallel()
+
+	meta, err := json.Marshal(tools.ReadMCPResourceResponseMetadata{
+		A2UISurfaces: []string{a2uiToolSurface},
+	})
+	require.NoError(t, err)
+
+	sty := styles.CharmtonePantera()
+	ctx := &MCPToolRenderContext{}
+	out := ctx.RenderTool(&sty, 80, genericToolOptsFor(t, "mcp_recipe_get_recipe_a2ui", &message.ToolResult{
+		Content:  a2uiTestPlaceholder,
+		Metadata: string(meta),
+	}))
+	plain := ansi.Strip(out)
+
+	require.Contains(t, plain, "Recipe Card")
+	require.NotContains(t, plain, "do not repeat")
+}

--- a/internal/ui/chat/tool_a2ui_test.go
+++ b/internal/ui/chat/tool_a2ui_test.go
@@ -93,10 +93,29 @@ func TestToolA2UISurfaces(t *testing.T) {
 		t.Parallel()
 		item := newA2UIToolItem(t, []string{a2uiToolSurface}, []string{"cairn"}, tools.ReadMCPResourceToolName)
 		item.syncToolA2UISurfaces()
-		out := item.renderToolA2UISurfaces(80)
+		out, failed := item.renderToolA2UISurfaces(80)
 		plain := ansi.Strip(out)
 		require.Contains(t, plain, "Recipe Card")
 		require.NotContains(t, plain, "updateComponents")
+		require.Zero(t, failed)
+	})
+
+	t.Run("a failed sibling payload still alerts next to a live surface", func(t *testing.T) {
+		t.Parallel()
+		// One payload renders, one is malformed: the live path must show
+		// the rendered surface AND the alert — the model was told the
+		// user can see both.
+		item := newA2UIToolItem(t,
+			[]string{a2uiToolSurface, "<a2ui-json>{malformed</a2ui-json>"},
+			[]string{"cairn", "cairn"}, tools.ReadMCPResourceToolName)
+		item.syncToolA2UISurfaces()
+		require.True(t, item.hasToolA2UISurfaces())
+		_, failed := item.renderToolA2UISurfaces(80)
+		require.Equal(t, 1, failed)
+
+		out := ansi.Strip(item.RawRender(100))
+		require.Contains(t, out, "Recipe Card")
+		require.Contains(t, out, "couldn't render this resource's UI surface")
 	})
 
 	t.Run("RawRender renders the surface instead of the placeholder", func(t *testing.T) {

--- a/internal/ui/chat/tools.go
+++ b/internal/ui/chat/tools.go
@@ -98,6 +98,12 @@ type ToolRenderOpts struct {
 	Compact         bool
 	IsSpinning      bool
 	Status          ToolStatus
+	// LiveSurfaces renders the item's live MCP A2UI surface models at the
+	// given width. Set only when the result metadata carried
+	// renderable surfaces; nil otherwise, in which case renderers fall
+	// back to the static/text paths. Carried on the opts because the
+	// ToolRenderer interface does not see the owning item.
+	LiveSurfaces func(width int) string
 }
 
 // IsPending returns true if the tool call is still pending (not finished and
@@ -163,6 +169,17 @@ type baseToolMessageItem struct {
 	// output so a plain click on a URL opens it in the browser (see
 	// parseHyperlinkSpans for why the app must handle this itself).
 	hyperlinks []hyperlinkSpan
+
+	// a2ui holds the live surface models for an MCP-served A2UI payload
+	//: a read_mcp_resource or mcp_* tool whose result metadata
+	// carries surfaces. They render interactively and, being long-lived
+	// app UIs, are never retired on interaction. Nil for tools
+	// without surfaces. surfaceSrcHash fingerprints the metadata the
+	// models were built from so a re-render with the same metadata reuses
+	// the live models (and their edited values) instead of rebuilding.
+	a2ui           a2uiSurfaceHost
+	surfaceSrcHash uint64
+	surfaceScanned bool
 }
 
 var _ Expandable = (*baseToolMessageItem)(nil)
@@ -196,6 +213,7 @@ func newBaseToolMessageItem(
 		status:                   status,
 		hasCappedWidth:           hasCappedWidth,
 	}
+	t.a2ui.sty = sty
 	t.anim = anim.New(anim.Settings{
 		ID:          toolCall.ID,
 		Size:        15,
@@ -345,9 +363,20 @@ func (t *baseToolMessageItem) RawRender(width int) string {
 		toolItemWidth = cappedMessageWidth(width)
 	}
 
+	// Build or refresh the live MCP surface models from the result
+	// metadata. While surfaces are live the content cache is
+	// bypassed: a surface's View reflects the current focus ring and
+	// edited values, not a frozen frame.
+	t.syncToolA2UISurfaces()
+	liveSurfaces := t.hasToolA2UISurfaces()
+	var liveRender func(width int) string
+	if liveSurfaces {
+		liveRender = t.renderToolA2UISurfaces
+	}
+
 	content, height, ok := t.getCachedRender(toolItemWidth)
 	// if we are spinning or there is no cache rerender
-	if !ok || t.isSpinning() {
+	if !ok || t.isSpinning() || liveSurfaces {
 		content = t.toolRenderer.RenderTool(t.sty, toolItemWidth, &ToolRenderOpts{
 			ToolCall:        t.toolCall,
 			Result:          t.result,
@@ -356,6 +385,7 @@ func (t *baseToolMessageItem) RawRender(width int) string {
 			Compact:         t.isCompact,
 			IsSpinning:      t.isSpinning(),
 			Status:          t.computeStatus(),
+			LiveSurfaces:    liveRender,
 		})
 
 		// Prepend hook indicator if hooks ran for this tool call.
@@ -366,8 +396,11 @@ func (t *baseToolMessageItem) RawRender(width int) string {
 		}
 
 		height = lipgloss.Height(content)
-		// cache the rendered content
-		t.setCachedRender(content, toolItemWidth, height)
+		// cache the rendered content — but not while surfaces are live:
+		// the next interaction changes the view.
+		if !liveSurfaces {
+			t.setCachedRender(content, toolItemWidth, height)
+		}
 	}
 
 	// Re-index hyperlink spans on every render (cheap relative to the
@@ -382,8 +415,9 @@ func (t *baseToolMessageItem) RawRender(width int) string {
 func (t *baseToolMessageItem) Render(width int) string {
 	// Cache the prefixed output keyed by (width, prefix variant).
 	// Bypass the cache while spinning (RawRender output is
-	// frame-dependent) or while a highlight range is active.
-	useCache := !t.isSpinning() && !t.isHighlighted()
+	// frame-dependent), while a highlight range is active, or while
+	// live MCP surfaces can change between frames.
+	useCache := !t.isSpinning() && !t.isHighlighted() && !t.hasToolA2UISurfaces()
 	var key uint64
 	switch {
 	case t.isCompact:
@@ -432,6 +466,9 @@ func (t *baseToolMessageItem) SetToolCall(tc message.ToolCall) {
 // SetResult sets the tool result associated with this message item.
 func (t *baseToolMessageItem) SetResult(res *message.ToolResult) {
 	t.result = res
+	// New metadata may carry different surfaces; force a rebuild on the
+	// next render while preserving focus/edits when it is unchanged.
+	t.surfaceScanned = false
 	t.clearCache()
 	t.Bump()
 }
@@ -535,13 +572,34 @@ func (t *baseToolMessageItem) HandleMouseClickCmd(btn ansi.MouseButton, x, y int
 	return true, nil
 }
 
-// HandleKeyEvent implements KeyEventHandler.
+// HandleKeyEvent implements KeyEventHandler. A focused live MCP surface
+// gets first claim on the keys it understands — Tab/Shift+Tab cycle
+// its focus ring, Enter activates a button (surfacing an
+// a2uievent.ButtonClicked the UI model routes per provenance) — and
+// every other key falls through, so the copy shortcut keeps working
+// whenever no surface consumes the key.
 func (t *baseToolMessageItem) HandleKeyEvent(key tea.KeyMsg) (bool, tea.Cmd) {
+	if handled, cmd := t.handleA2UIKeyEvent(key); handled {
+		return true, cmd
+	}
 	if k := key.String(); k == "c" || k == "y" {
 		text := t.formatToolForCopy()
 		return true, common.CopyToClipboard(text, "Tool content copied to clipboard")
 	}
 	return false, nil
+}
+
+// SetFocused implements MessageItem. Focus also drives the live MCP
+// surfaces: gaining focus grants it to the first live surface,
+// losing focus blurs them all — so the focus ring only ever lives on the
+// selected item.
+func (t *baseToolMessageItem) SetFocused(focused bool) {
+	t.focusableMessageItem.SetFocused(focused)
+	if focused {
+		t.focusToolA2UISurfaces()
+	} else {
+		t.blurToolA2UISurfaces()
+	}
 }
 
 // pendingTool renders a tool that is still in progress with an animation.

--- a/internal/ui/chat/tools.go
+++ b/internal/ui/chat/tools.go
@@ -421,6 +421,11 @@ func (t *baseToolMessageItem) Render(width int) string {
 	// Bypass the cache while spinning (RawRender output is
 	// frame-dependent), while a highlight range is active, or while
 	// live MCP surfaces can change between frames.
+	//
+	// This decides whether the cache may be READ. It is not sufficient for
+	// the write: the surfaces do not exist yet on the first frame — it is
+	// RawRender below that builds them — so the surface check here is
+	// still false at that point and is re-run after RawRender.
 	useCache := !t.isSpinning() && !t.isHighlighted() && !t.hasToolA2UISurfaces()
 	var key uint64
 	switch {
@@ -449,7 +454,14 @@ func (t *baseToolMessageItem) Render(width int) string {
 		lines[i] = prefix + ln
 	}
 	out := strings.Join(lines, "\n")
-	if useCache {
+	// Re-check now that RawRender has built the surfaces. Caching a frame
+	// that contains a live surface freezes it: getCachedPrefixedRender
+	// keys on (width, prefix) alone and ignores Version(), so once the
+	// server deletes the surface — flipping hasToolA2UISurfaces() back to
+	// false and re-enabling the cache — that first frame would be served
+	// again for the rest of the item's life, still drawing the surface
+	// that no longer exists. RawRender guards its own cache the same way.
+	if useCache && !t.hasToolA2UISurfaces() {
 		t.setCachedPrefixedRender(out, width, key)
 	}
 	return out

--- a/internal/ui/chat/tools.go
+++ b/internal/ui/chat/tools.go
@@ -99,11 +99,12 @@ type ToolRenderOpts struct {
 	IsSpinning      bool
 	Status          ToolStatus
 	// LiveSurfaces renders the item's live MCP A2UI surface models at the
-	// given width. Set only when the result metadata carried
-	// renderable surfaces; nil otherwise, in which case renderers fall
-	// back to the static/text paths. Carried on the opts because the
-	// ToolRenderer interface does not see the owning item.
-	LiveSurfaces func(width int) string
+	// given width, and reports how many of the metadata's surfaces failed
+	// to draw. Set only when the result metadata carried renderable
+	// surfaces; nil otherwise, in which case renderers fall back to the
+	// static/text paths. Carried on the opts because the ToolRenderer
+	// interface does not see the owning item.
+	LiveSurfaces func(width int) (string, int)
 }
 
 // IsPending returns true if the tool call is still pending (not finished and
@@ -170,16 +171,19 @@ type baseToolMessageItem struct {
 	// parseHyperlinkSpans for why the app must handle this itself).
 	hyperlinks []hyperlinkSpan
 
-	// a2ui holds the live surface models for an MCP-served A2UI payload
-	//: a read_mcp_resource or mcp_* tool whose result metadata
-	// carries surfaces. They render interactively and, being long-lived
-	// app UIs, are never retired on interaction. Nil for tools
-	// without surfaces. surfaceSrcHash fingerprints the metadata the
-	// models were built from so a re-render with the same metadata reuses
-	// the live models (and their edited values) instead of rebuilding.
-	a2ui           a2uiSurfaceHost
-	surfaceSrcHash uint64
-	surfaceScanned bool
+	// a2ui holds the live surface models for an MCP-served A2UI payload:
+	// a read_mcp_resource or mcp_* tool whose result metadata carries
+	// surfaces. They render interactively and, being long-lived app UIs,
+	// are never retired on interaction. Nil for tools without surfaces.
+	// surfaceSrcHash fingerprints the metadata the models were built from
+	// so a re-render with the same metadata reuses the live models (and
+	// their edited values) instead of rebuilding; surfaceBuildFailed
+	// counts payloads that never produced a drawable model, so the
+	// renderer can alert on them.
+	a2ui               a2uiSurfaceHost
+	surfaceSrcHash     uint64
+	surfaceScanned     bool
+	surfaceBuildFailed int
 }
 
 var _ Expandable = (*baseToolMessageItem)(nil)
@@ -369,7 +373,7 @@ func (t *baseToolMessageItem) RawRender(width int) string {
 	// edited values, not a frozen frame.
 	t.syncToolA2UISurfaces()
 	liveSurfaces := t.hasToolA2UISurfaces()
-	var liveRender func(width int) string
+	var liveRender func(width int) (string, int)
 	if liveSurfaces {
 		liveRender = t.renderToolA2UISurfaces
 	}

--- a/internal/ui/completions/completions.go
+++ b/internal/ui/completions/completions.go
@@ -428,5 +428,15 @@ func loadMCPResources() []ResourceCompletionValue {
 			})
 		}
 	}
+	for mcpName, mcpTemplates := range mcp.ResourceTemplates() {
+		for _, t := range mcpTemplates {
+			resources = append(resources, ResourceCompletionValue{
+				MCPName:  mcpName,
+				URI:      t.URITemplate,
+				Title:    t.Name,
+				MIMEType: t.MIMEType,
+			})
+		}
+	}
 	return resources
 }

--- a/internal/ui/completions/item.go
+++ b/internal/ui/completions/item.go
@@ -2,6 +2,7 @@ package completions
 
 import (
 	"slices"
+	"strings"
 
 	"charm.land/lipgloss/v2"
 	"github.com/charmbracelet/crush/internal/ui/list"
@@ -21,6 +22,14 @@ type ResourceCompletionValue struct {
 	URI      string
 	Title    string
 	MIMEType string
+}
+
+// IsTemplate reports whether the completion's URI is an unexpanded RFC 6570
+// URI template (it still contains a "{expression}") rather than a concrete,
+// readable resource URI. Templates come from resources/templates/list and
+// cannot be read until their placeholders are filled in.
+func (r ResourceCompletionValue) IsTemplate() bool {
+	return strings.Contains(r.URI, "{")
 }
 
 // CompletionItem represents an item in the completions list.

--- a/internal/ui/completions/item_test.go
+++ b/internal/ui/completions/item_test.go
@@ -1,0 +1,20 @@
+package completions
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestResourceCompletionValueIsTemplate pins the concrete-vs-template
+// distinction the insertion path relies on: a URI still carrying an RFC 6570
+// placeholder must not be read eagerly (the server would see the literal
+// braces), while a concrete URI must keep the auto-attachment read.
+func TestResourceCompletionValueIsTemplate(t *testing.T) {
+	t.Parallel()
+
+	require.True(t, ResourceCompletionValue{URI: "cairn://run/{id}/a2ui"}.IsTemplate())
+	require.True(t, ResourceCompletionValue{URI: "switchboard://queue/{name}"}.IsTemplate())
+	require.False(t, ResourceCompletionValue{URI: "cairn://run/abc123/a2ui"}.IsTemplate())
+	require.False(t, ResourceCompletionValue{URI: ""}.IsTemplate())
+}

--- a/internal/ui/model/a2ui_action_test.go
+++ b/internal/ui/model/a2ui_action_test.go
@@ -1,0 +1,353 @@
+package model
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"charm.land/bubbles/v2/textarea"
+
+	"github.com/charmbracelet/crush/internal/agent/tools"
+	mcptools "github.com/charmbracelet/crush/internal/agent/tools/mcp"
+	"github.com/charmbracelet/crush/internal/config"
+	"github.com/charmbracelet/crush/internal/message"
+	"github.com/charmbracelet/crush/internal/session"
+	"github.com/charmbracelet/crush/internal/ui/chat"
+	"github.com/charmbracelet/crush/internal/ui/common"
+	"github.com/charmbracelet/crush/internal/workspace"
+	"github.com/joestump-agent/a2tea/event"
+	"github.com/stretchr/testify/require"
+	a2ui "github.com/tmc/a2ui"
+)
+
+// a2uiActionWorkspace stubs the workspace calls the A2UI action round-trip
+// touches, recording a2ui_action / a2ui_error calls and serving canned
+// responses.
+type a2uiActionWorkspace struct {
+	workspace.Workspace
+
+	// toolCalls records (name, toolName) pairs in call order.
+	toolCalls [][2]string
+	// lastArgs records the args of the most recent call.
+	lastArgs map[string]any
+	// response is the canned CallMCPTool result.
+	response workspace.MCPToolCallResult
+	// err is returned from CallMCPTool when set.
+	err error
+	// lastPrompt records the content of the most recent AgentRun, so the
+	// fallback path's submission prompt can be asserted on.
+	lastPrompt string
+}
+
+func (w *a2uiActionWorkspace) AgentIsReady() bool     { return true }
+func (w *a2uiActionWorkspace) AgentReadyErr() error   { return nil }
+func (w *a2uiActionWorkspace) Config() *config.Config { return nil }
+
+func (w *a2uiActionWorkspace) AgentRun(_ context.Context, _, content string, _ ...message.Attachment) error {
+	w.lastPrompt = content
+	return nil
+}
+
+func (w *a2uiActionWorkspace) CallMCPTool(_ context.Context, name, toolName string, args map[string]any) (workspace.MCPToolCallResult, error) {
+	w.toolCalls = append(w.toolCalls, [2]string{name, toolName})
+	w.lastArgs = args
+	return w.response, w.err
+}
+
+// a2uiActionForm is an MCP-served surface with a submit button carrying a
+// server-side action, plus a TextField whose value feeds the action context.
+const a2uiActionForm = `{"version":"v0.9","updateComponents":{"surfaceId":"booking","components":[` +
+	`{"component":"Card","id":"root","child":"col"},` +
+	`{"component":"Column","id":"col","children":["start","btn-confirm"]},` +
+	`{"component":"TextField","id":"start","label":"Start","value":"2026-03-20"},` +
+	`{"component":"Button","id":"btn-confirm","child":"btn-confirm-t","action":{"event":{"name":"confirm_booking"}}},` +
+	`{"component":"Text","id":"btn-confirm-t","text":"Confirm"}` +
+	`]}}`
+
+// newA2UIActionUI builds a UI whose chat holds a tool message item carrying
+// an MCP-served A2UI surface with provenance registered to mcpName.
+func newA2UIActionUI(t *testing.T, ws *a2uiActionWorkspace, mcpName string) *UI {
+	t.Helper()
+	m, _ := newA2UIActionUIItem(t, ws, mcpName)
+	return m
+}
+
+// newA2UIActionUIItem is newA2UIActionUI, also handing back the tool item so
+// a test can assert on what the surface actually renders.
+func newA2UIActionUIItem(t *testing.T, ws *a2uiActionWorkspace, mcpName string) (*UI, chat.ToolMessageItem) {
+	t.Helper()
+	com := common.DefaultCommon(ws)
+	m := &UI{
+		com:      com,
+		status:   NewStatus(com, nil),
+		chat:     NewChat(com, config.ScrollbarDefault),
+		textarea: textarea.New(),
+		state:    uiChat,
+		focus:    uiFocusMain,
+		width:    140,
+		height:   45,
+		session:  &session.Session{ID: "sess-1"},
+	}
+
+	meta, err := json.Marshal(tools.ReadMCPResourceResponseMetadata{
+		A2UISurfaces:         []string{"<a2ui-json>" + a2uiActionForm + "</a2ui-json>"},
+		MCPSurfaceProvenance: []string{mcpName},
+	})
+	require.NoError(t, err)
+
+	item := chat.NewMCPToolMessageItem(com.Styles, message.ToolCall{
+		ID:       "call-1",
+		Name:     "mcp_" + mcpName + "_get_form",
+		Input:    `{}`,
+		Finished: true,
+	}, &message.ToolResult{
+		ToolCallID: "call-1",
+		Content:    "form",
+		Metadata:   string(meta),
+	}, false)
+	m.chat.AppendMessages(item)
+	// Render once so the item builds its live surface models and registers
+	// provenance.
+	_ = item.RawRender(100)
+	return m, item
+}
+
+func TestHandleA2UIButtonClickedMCPSurfaceRoundTrips(t *testing.T) {
+	t.Parallel()
+
+	// The MCP tool registry is process-global; a per-test server name keeps
+	// parallel tests from overwriting each other's capabilities.
+	srv := t.Name()
+
+	ws := &a2uiActionWorkspace{
+		response: workspace.MCPToolCallResult{Content: "Booking confirmed"},
+	}
+	m := newA2UIActionUI(t, ws, srv)
+	cleanup := mcptools.SetToolsForTest(srv, "a2ui_action")
+	t.Cleanup(cleanup)
+
+	cmd := m.handleA2UIButtonClicked(event.ButtonClicked{
+		Source: event.Source{ComponentID: "btn-confirm", SurfaceID: "booking"},
+		ID:     "btn-confirm",
+		Action: &a2ui.EventAction{Name: "confirm_booking"},
+	})
+	require.NotNil(t, cmd, "an MCP surface with a2ui_action must round-trip")
+	msg := cmd()
+	result, ok := msg.(a2uiActionResultMsg)
+	require.True(t, ok, "the cmd must produce an a2uiActionResultMsg")
+	require.NoError(t, result.err)
+	require.Equal(t, "booking", result.surfaceID)
+
+	// The server got the action name and the surface's field values as the
+	// context.
+	require.Len(t, ws.toolCalls, 1)
+	require.Equal(t, [2]string{srv, "a2ui_action"}, ws.toolCalls[0])
+	require.Equal(t, "confirm_booking", ws.lastArgs["name"])
+	ctx, ok := ws.lastArgs["context"].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "2026-03-20", ctx["start"])
+
+	// The surface is NOT retired — MCP surfaces are long-lived.
+	_, found := m.chat.A2UISurfaceFieldValues("booking")
+	require.True(t, found, "the surface must stay live after the round-trip")
+}
+
+func TestHandleA2UIButtonClickedMCPSurfaceWithoutActionToolFallsBack(t *testing.T) {
+	t.Parallel()
+
+	// The MCP tool registry is process-global; a per-test server name keeps
+	// parallel tests from overwriting each other's capabilities.
+	srv := t.Name()
+
+	ws := &a2uiActionWorkspace{}
+	m := newA2UIActionUI(t, ws, srv)
+	// Server serves surfaces but NOT a2ui_action.
+	cleanup := mcptools.SetToolsForTest(srv, "some_other_tool")
+	t.Cleanup(cleanup)
+
+	cmd := m.handleA2UIButtonClicked(event.ButtonClicked{
+		Source: event.Source{ComponentID: "btn-confirm", SurfaceID: "booking"},
+		ID:     "btn-confirm",
+		Action: &a2ui.EventAction{Name: "confirm_booking"},
+	})
+	require.NotNil(t, cmd, "fallback must start an agent turn")
+	runCmdTree(cmd)
+
+	require.Empty(t, ws.toolCalls, "no a2ui_action call without the tool")
+
+	// The prompt must carry what the user typed. RetireA2UISurface only
+	// matches assistant items, so an MCP surface's values have to come from
+	// the tool item that holds them — otherwise the whole form is silently
+	// dropped before the agent ever sees it.
+	require.Contains(t, ws.lastPrompt, "2026-03-20",
+		"the fallback submission must carry the surface's field values")
+	require.Contains(t, ws.lastPrompt, "confirm_booking")
+}
+
+func TestHandleA2UIActionResultAppliesSurfacePayload(t *testing.T) {
+	t.Parallel()
+
+	// The MCP tool registry is process-global; a per-test server name keeps
+	// parallel tests from overwriting each other's capabilities.
+	srv := t.Name()
+
+	ws := &a2uiActionWorkspace{}
+	m, item := newA2UIActionUIItem(t, ws, srv)
+	cleanup := mcptools.SetToolsForTest(srv, "a2ui_action")
+	t.Cleanup(cleanup)
+
+	require.Contains(t, item.RawRender(100), "Confirm", "precondition: the original label renders")
+
+	// A response carrying an A2UI payload updates the surface in place.
+	update := `{"version":"v0.9","updateComponents":{"surfaceId":"booking","components":[` +
+		`{"component":"Text","id":"btn-confirm-t","text":"Booked!"}]}}`
+	cmd := m.handleA2UIActionResult(a2uiActionResultMsg{
+		surfaceID: "booking",
+		mcpName:   srv,
+		surfaces:  []string{update},
+	})
+	require.Nil(t, cmd)
+
+	// The update actually reached the live surface — not just "no error".
+	rendered := item.RawRender(100)
+	require.Contains(t, rendered, "Booked!", "the payload must update the surface in place")
+	require.NotContains(t, rendered, "Confirm", "the old label must be replaced")
+
+	// The surface still exists after the in-place update, and the edited
+	// field the server did not touch is preserved.
+	values, found := m.chat.A2UISurfaceFieldValues("booking")
+	require.True(t, found)
+	require.Equal(t, "2026-03-20", values["start"], "untouched field values must survive")
+}
+
+func TestHandleA2UIActionResultInvalidPayloadReportsToServer(t *testing.T) {
+	t.Parallel()
+
+	// The MCP tool registry is process-global; a per-test server name keeps
+	// parallel tests from overwriting each other's capabilities.
+	srv := t.Name()
+
+	ws := &a2uiActionWorkspace{}
+	m := newA2UIActionUI(t, ws, srv)
+	cleanup := mcptools.SetToolsForTest(srv, "a2ui_action", "a2ui_error")
+	t.Cleanup(cleanup)
+
+	// A malformed payload must round-trip an a2ui_error back to the server:
+	// the command reportA2UIError builds has to actually reach Bubble Tea.
+	cmd := m.handleA2UIActionResult(a2uiActionResultMsg{
+		surfaceID: "booking",
+		mcpName:   srv,
+		surfaces:  []string{`{"version":"v0.9","updateComponents":{`},
+	})
+	require.NotNil(t, cmd, "a malformed payload must produce an a2ui_error command")
+	runCmdTree(cmd)
+
+	require.Len(t, ws.toolCalls, 1)
+	require.Equal(t, [2]string{srv, "a2ui_error"}, ws.toolCalls[0])
+	// Truncated JSON scans as prose rather than failing outright, so it
+	// lands as INVALID_PAYLOAD (parsed, but no server messages) rather than
+	// INVALID_JSON. Either way it must not be a silent no-op.
+	require.Equal(t, "INVALID_PAYLOAD", ws.lastArgs["code"])
+	require.Equal(t, "booking", ws.lastArgs["surfaceId"])
+}
+
+func TestHandleA2UIActionResultHonorsPayloadSurfaceID(t *testing.T) {
+	t.Parallel()
+
+	// The MCP tool registry is process-global; a per-test server name keeps
+	// parallel tests from overwriting each other's capabilities.
+	srv := t.Name()
+
+	ws := &a2uiActionWorkspace{}
+	m, item := newA2UIActionUIItem(t, ws, srv)
+	cleanup := mcptools.SetToolsForTest(srv, "a2ui_action", "a2ui_error")
+	t.Cleanup(cleanup)
+
+	// The server answers the "booking" click by targeting a DIFFERENT
+	// surface. That payload must not be forced onto "booking".
+	update := `{"version":"v0.9","updateComponents":{"surfaceId":"receipt","components":[` +
+		`{"component":"Text","id":"btn-confirm-t","text":"Booked!"}]}}`
+	cmd := m.handleA2UIActionResult(a2uiActionResultMsg{
+		surfaceID: "booking",
+		mcpName:   srv,
+		surfaces:  []string{update},
+	})
+	require.NotNil(t, cmd, "a payload for an unheld surface must be reported back")
+	runCmdTree(cmd)
+
+	require.Contains(t, item.RawRender(100), "Confirm",
+		"a payload aimed at another surface must not corrupt the clicked one")
+	require.Len(t, ws.toolCalls, 1)
+	require.Equal(t, [2]string{srv, "a2ui_error"}, ws.toolCalls[0])
+	require.Equal(t, "SURFACE_NOT_FOUND", ws.lastArgs["code"])
+	require.Equal(t, "receipt", ws.lastArgs["surfaceId"])
+}
+
+func TestHandleA2UIActionResultDeletedSurfaceGoesAway(t *testing.T) {
+	t.Parallel()
+
+	// The MCP tool registry is process-global; a per-test server name keeps
+	// parallel tests from overwriting each other's capabilities.
+	srv := t.Name()
+
+	ws := &a2uiActionWorkspace{}
+	m := newA2UIActionUI(t, ws, srv)
+	cleanup := mcptools.SetToolsForTest(srv, "a2ui_action", "a2ui_error")
+	t.Cleanup(cleanup)
+
+	// The server dismisses the form. The surface must be released, not left
+	// behind as a dead widget that still takes focus and swallows keys —
+	// and a delete is not an error worth reporting back.
+	cmd := m.handleA2UIActionResult(a2uiActionResultMsg{
+		surfaceID: "booking",
+		mcpName:   srv,
+		surfaces:  []string{`{"version":"v0.9","deleteSurface":{"surfaceId":"booking"}}`},
+	})
+	runCmdTree(cmd)
+
+	_, found := m.chat.A2UISurfaceFieldValues("booking")
+	require.False(t, found, "a deleted surface must no longer be live")
+	require.Empty(t, ws.toolCalls, "deleting a surface is not an error to report")
+}
+
+func TestHandleA2UIActionResultErrorReports(t *testing.T) {
+	t.Parallel()
+
+	// The MCP tool registry is process-global; a per-test server name keeps
+	// parallel tests from overwriting each other's capabilities.
+	srv := t.Name()
+
+	ws := &a2uiActionWorkspace{}
+	m := newA2UIActionUI(t, ws, srv)
+
+	cmd := m.handleA2UIActionResult(a2uiActionResultMsg{
+		surfaceID: "booking",
+		mcpName:   srv,
+		err:       context.DeadlineExceeded,
+	})
+	require.NotNil(t, cmd, "an error must surface as a note")
+}
+
+func TestReportA2UIErrorCallsErrorTool(t *testing.T) {
+	t.Parallel()
+
+	// The MCP tool registry is process-global; a per-test server name keeps
+	// parallel tests from overwriting each other's capabilities.
+	srv := t.Name()
+
+	ws := &a2uiActionWorkspace{}
+	m := newA2UIActionUI(t, ws, srv)
+	cleanup := mcptools.SetToolsForTest(srv, "a2ui_error")
+	t.Cleanup(cleanup)
+
+	// An empty server name exercises the surface-owner resolution path.
+	cmd := m.reportA2UIError("", "booking", "INVALID_JSON", "bad payload")
+	require.NotNil(t, cmd)
+	msg := cmd()
+	require.Nil(t, msg, "a successful a2ui_error call produces no message")
+
+	require.Len(t, ws.toolCalls, 1)
+	require.Equal(t, [2]string{srv, "a2ui_error"}, ws.toolCalls[0])
+	require.Equal(t, "INVALID_JSON", ws.lastArgs["code"])
+	require.Equal(t, "booking", ws.lastArgs["surfaceId"])
+}

--- a/internal/ui/model/a2ui_action_test.go
+++ b/internal/ui/model/a2ui_action_test.go
@@ -37,6 +37,30 @@ type a2uiActionWorkspace struct {
 	// lastPrompt records the content of the most recent AgentRun, so the
 	// fallback path's submission prompt can be asserted on.
 	lastPrompt string
+	// a2uiTools maps an MCP server name to the a2ui_* tools it exposes,
+	// mirroring what a real workspace publishes in ClientInfo.A2UITools.
+	a2uiTools map[string][]string
+}
+
+// serveA2UITools makes the workspace report that mcpName exposes the given
+// a2ui_* tools, the way a connected server's published state would.
+func (w *a2uiActionWorkspace) serveA2UITools(mcpName string, toolNames ...string) {
+	if w.a2uiTools == nil {
+		w.a2uiTools = map[string][]string{}
+	}
+	w.a2uiTools[mcpName] = toolNames
+}
+
+func (w *a2uiActionWorkspace) MCPGetStates() map[string]mcptools.ClientInfo {
+	out := make(map[string]mcptools.ClientInfo, len(w.a2uiTools))
+	for name, toolNames := range w.a2uiTools {
+		out[name] = mcptools.ClientInfo{
+			Name:      name,
+			State:     mcptools.StateConnected,
+			A2UITools: toolNames,
+		}
+	}
+	return out
 }
 
 func (w *a2uiActionWorkspace) AgentIsReady() bool     { return true }
@@ -115,16 +139,15 @@ func newA2UIActionUIItem(t *testing.T, ws *a2uiActionWorkspace, mcpName string) 
 func TestHandleA2UIButtonClickedMCPSurfaceRoundTrips(t *testing.T) {
 	t.Parallel()
 
-	// The MCP tool registry is process-global; a per-test server name keeps
-	// parallel tests from overwriting each other's capabilities.
+	// Surface provenance is recorded in a process-global registry; a
+	// per-test server name keeps parallel tests from clobbering it.
 	srv := t.Name()
 
 	ws := &a2uiActionWorkspace{
 		response: workspace.MCPToolCallResult{Content: "Booking confirmed"},
 	}
 	m := newA2UIActionUI(t, ws, srv)
-	cleanup := mcptools.SetToolsForTest(srv, "a2ui_action")
-	t.Cleanup(cleanup)
+	ws.serveA2UITools(srv, "a2ui_action")
 
 	cmd := m.handleA2UIButtonClicked(event.ButtonClicked{
 		Source: event.Source{ComponentID: "btn-confirm", SurfaceID: "booking"},
@@ -155,15 +178,14 @@ func TestHandleA2UIButtonClickedMCPSurfaceRoundTrips(t *testing.T) {
 func TestHandleA2UIButtonClickedMCPSurfaceWithoutActionToolFallsBack(t *testing.T) {
 	t.Parallel()
 
-	// The MCP tool registry is process-global; a per-test server name keeps
-	// parallel tests from overwriting each other's capabilities.
+	// Surface provenance is recorded in a process-global registry; a
+	// per-test server name keeps parallel tests from clobbering it.
 	srv := t.Name()
 
 	ws := &a2uiActionWorkspace{}
 	m := newA2UIActionUI(t, ws, srv)
 	// Server serves surfaces but NOT a2ui_action.
-	cleanup := mcptools.SetToolsForTest(srv, "some_other_tool")
-	t.Cleanup(cleanup)
+	ws.serveA2UITools(srv, "some_other_tool")
 
 	cmd := m.handleA2UIButtonClicked(event.ButtonClicked{
 		Source: event.Source{ComponentID: "btn-confirm", SurfaceID: "booking"},
@@ -187,14 +209,13 @@ func TestHandleA2UIButtonClickedMCPSurfaceWithoutActionToolFallsBack(t *testing.
 func TestHandleA2UIActionResultAppliesSurfacePayload(t *testing.T) {
 	t.Parallel()
 
-	// The MCP tool registry is process-global; a per-test server name keeps
-	// parallel tests from overwriting each other's capabilities.
+	// Surface provenance is recorded in a process-global registry; a
+	// per-test server name keeps parallel tests from clobbering it.
 	srv := t.Name()
 
 	ws := &a2uiActionWorkspace{}
 	m, item := newA2UIActionUIItem(t, ws, srv)
-	cleanup := mcptools.SetToolsForTest(srv, "a2ui_action")
-	t.Cleanup(cleanup)
+	ws.serveA2UITools(srv, "a2ui_action")
 
 	require.Contains(t, item.RawRender(100), "Confirm", "precondition: the original label renders")
 
@@ -223,14 +244,13 @@ func TestHandleA2UIActionResultAppliesSurfacePayload(t *testing.T) {
 func TestHandleA2UIActionResultInvalidPayloadReportsToServer(t *testing.T) {
 	t.Parallel()
 
-	// The MCP tool registry is process-global; a per-test server name keeps
-	// parallel tests from overwriting each other's capabilities.
+	// Surface provenance is recorded in a process-global registry; a
+	// per-test server name keeps parallel tests from clobbering it.
 	srv := t.Name()
 
 	ws := &a2uiActionWorkspace{}
 	m := newA2UIActionUI(t, ws, srv)
-	cleanup := mcptools.SetToolsForTest(srv, "a2ui_action", "a2ui_error")
-	t.Cleanup(cleanup)
+	ws.serveA2UITools(srv, "a2ui_action", "a2ui_error")
 
 	// A malformed payload must round-trip an a2ui_error back to the server:
 	// the command reportA2UIError builds has to actually reach Bubble Tea.
@@ -254,14 +274,13 @@ func TestHandleA2UIActionResultInvalidPayloadReportsToServer(t *testing.T) {
 func TestHandleA2UIActionResultHonorsPayloadSurfaceID(t *testing.T) {
 	t.Parallel()
 
-	// The MCP tool registry is process-global; a per-test server name keeps
-	// parallel tests from overwriting each other's capabilities.
+	// Surface provenance is recorded in a process-global registry; a
+	// per-test server name keeps parallel tests from clobbering it.
 	srv := t.Name()
 
 	ws := &a2uiActionWorkspace{}
 	m, item := newA2UIActionUIItem(t, ws, srv)
-	cleanup := mcptools.SetToolsForTest(srv, "a2ui_action", "a2ui_error")
-	t.Cleanup(cleanup)
+	ws.serveA2UITools(srv, "a2ui_action", "a2ui_error")
 
 	// The server answers the "booking" click by targeting a DIFFERENT
 	// surface. That payload must not be forced onto "booking".
@@ -286,14 +305,13 @@ func TestHandleA2UIActionResultHonorsPayloadSurfaceID(t *testing.T) {
 func TestHandleA2UIActionResultDeletedSurfaceGoesAway(t *testing.T) {
 	t.Parallel()
 
-	// The MCP tool registry is process-global; a per-test server name keeps
-	// parallel tests from overwriting each other's capabilities.
+	// Surface provenance is recorded in a process-global registry; a
+	// per-test server name keeps parallel tests from clobbering it.
 	srv := t.Name()
 
 	ws := &a2uiActionWorkspace{}
 	m := newA2UIActionUI(t, ws, srv)
-	cleanup := mcptools.SetToolsForTest(srv, "a2ui_action", "a2ui_error")
-	t.Cleanup(cleanup)
+	ws.serveA2UITools(srv, "a2ui_action", "a2ui_error")
 
 	// The server dismisses the form. The surface must be released, not left
 	// behind as a dead widget that still takes focus and swallows keys —
@@ -313,8 +331,8 @@ func TestHandleA2UIActionResultDeletedSurfaceGoesAway(t *testing.T) {
 func TestHandleA2UIActionResultErrorReports(t *testing.T) {
 	t.Parallel()
 
-	// The MCP tool registry is process-global; a per-test server name keeps
-	// parallel tests from overwriting each other's capabilities.
+	// Surface provenance is recorded in a process-global registry; a
+	// per-test server name keeps parallel tests from clobbering it.
 	srv := t.Name()
 
 	ws := &a2uiActionWorkspace{}
@@ -331,14 +349,13 @@ func TestHandleA2UIActionResultErrorReports(t *testing.T) {
 func TestReportA2UIErrorCallsErrorTool(t *testing.T) {
 	t.Parallel()
 
-	// The MCP tool registry is process-global; a per-test server name keeps
-	// parallel tests from overwriting each other's capabilities.
+	// Surface provenance is recorded in a process-global registry; a
+	// per-test server name keeps parallel tests from clobbering it.
 	srv := t.Name()
 
 	ws := &a2uiActionWorkspace{}
 	m := newA2UIActionUI(t, ws, srv)
-	cleanup := mcptools.SetToolsForTest(srv, "a2ui_error")
-	t.Cleanup(cleanup)
+	ws.serveA2UITools(srv, "a2ui_error")
 
 	// An empty server name exercises the surface-owner resolution path.
 	cmd := m.reportA2UIError("", "booking", "INVALID_JSON", "bad payload")
@@ -350,4 +367,68 @@ func TestReportA2UIErrorCallsErrorTool(t *testing.T) {
 	require.Equal(t, [2]string{srv, "a2ui_error"}, ws.toolCalls[0])
 	require.Equal(t, "INVALID_JSON", ws.lastArgs["code"])
 	require.Equal(t, "booking", ws.lastArgs["surfaceId"])
+}
+
+// assistantCollidingForm is an assistant-authored surface that happens to use
+// the same surface ID as the MCP-served form above. Surface IDs are only
+// unique within whatever authored them, and both the assistant and MCP
+// servers habitually reuse a small set of names ("default", "form"), so the
+// collision is ordinary rather than contrived.
+const assistantCollidingForm = `<a2ui-json>{"version":"v0.9","updateComponents":{"surfaceId":"booking","components":[` +
+	`{"component":"Card","id":"root","child":"col"},` +
+	`{"component":"Column","id":"col","children":["who","btn-go"]},` +
+	`{"component":"TextField","id":"who","label":"Who","value":"Joe"},` +
+	`{"component":"Button","id":"btn-go","child":"btn-go-t","action":{"event":{"name":"go"}}},` +
+	`{"component":"Text","id":"btn-go-t","text":"Go"}` +
+	`]}}</a2ui-json>`
+
+// TestHandleA2UIButtonClickedAssistantSurfaceWinsOverMCPProvenance pins that
+// an assistant-authored surface is never routed to an MCP server, even when
+// its ID collides with one that server owns.
+//
+// Assistant items do not implement chat.A2UISurfaceItem and never appear in
+// the global surfaceID->server registry, so both provenance lookups used to
+// resolve the collision in the MCP server's favour: the user's form values
+// were shipped to that server's a2ui_action tool, the surface was never
+// retired, and no agent turn ever started — the button just looked dead.
+func TestHandleA2UIButtonClickedAssistantSurfaceWinsOverMCPProvenance(t *testing.T) {
+	t.Parallel()
+
+	// Surface provenance is recorded in a process-global registry; a
+	// per-test server name keeps parallel tests from clobbering it.
+	srv := t.Name()
+
+	ws := &a2uiActionWorkspace{
+		response: workspace.MCPToolCallResult{Content: "should never be called"},
+	}
+	// Registers "booking" -> srv in both the item and the global registry.
+	m := newA2UIActionUI(t, ws, srv)
+	ws.serveA2UITools(srv, "a2ui_action")
+
+	// The assistant now emits its own form reusing the same surface ID.
+	msg := &message.Message{
+		ID:   "assistant-form",
+		Role: message.Assistant,
+		Parts: []message.ContentPart{
+			message.TextContent{Text: "Confirm:\n\n" + assistantCollidingForm},
+		},
+	}
+	item, ok := chat.NewAssistantMessageItem(m.com.Styles, msg).(*chat.AssistantMessageItem)
+	require.True(t, ok)
+	m.chat.AppendMessages(item)
+	_ = item.RawRender(80)
+	require.True(t, m.chat.HasAssistantA2UISurface("booking"),
+		"the assistant item must hold a live surface with the colliding ID")
+
+	cmd := m.handleA2UIButtonClicked(event.ButtonClicked{
+		Source: event.Source{ComponentID: "btn-go", SurfaceID: "booking"},
+		ID:     "btn-go",
+		Action: &a2ui.EventAction{Name: "go"},
+	})
+	require.NotNil(t, cmd, "the submission must go somewhere")
+	runCmdTree(cmd)
+
+	require.Empty(t, ws.toolCalls,
+		"an assistant surface must never round-trip to an MCP server")
+	require.NotEmpty(t, ws.lastPrompt, "the submission must start an agent turn")
 }

--- a/internal/ui/model/chat.go
+++ b/internal/ui/model/chat.go
@@ -16,6 +16,7 @@ import (
 	"github.com/charmbracelet/x/ansi"
 	"github.com/clipperhouse/displaywidth"
 	"github.com/clipperhouse/uax29/v2/words"
+	a2ui "github.com/tmc/a2ui"
 )
 
 // Constants for multi-click detection.
@@ -800,6 +801,63 @@ func (m *Chat) RetireA2UISurface(surfaceID string) (map[string]any, bool) {
 		}
 	}
 	return nil, false
+}
+
+// a2uiSurfaceItem locates the chat item holding the named MCP surface.
+// Surface IDs are only unique within a server — invoking the same tool twice
+// appends two items carrying the same ID — so the focused surface wins: that
+// is the one the user is actually interacting with. Only when nothing is
+// focused does it fall back to the first match.
+func (m *Chat) a2uiSurfaceItem(surfaceID string) (chat.A2UISurfaceItem, bool) {
+	var first chat.A2UISurfaceItem
+	for i := range m.list.Len() {
+		item, ok := m.list.ItemAt(i).(chat.A2UISurfaceItem)
+		if !ok || !item.HasA2UISurface(surfaceID) {
+			continue
+		}
+		if item.A2UISurfaceIsFocused(surfaceID) {
+			return item, true
+		}
+		if first == nil {
+			first = item
+		}
+	}
+	return first, first != nil
+}
+
+// A2UISurfaceOwner returns the MCP server that served the named surface,
+// resolved through the item that owns it rather than the global
+// surfaceID-keyed registry, so two servers using the same surface ID cannot
+// route each other's interactions.
+func (m *Chat) A2UISurfaceOwner(surfaceID string) (string, bool) {
+	item, ok := m.a2uiSurfaceItem(surfaceID)
+	if !ok {
+		return "", false
+	}
+	return item.A2UISurfaceOwner(surfaceID)
+}
+
+// A2UISurfaceFieldValues reads the named MCP surface's current input values,
+// for building an a2ui_action context. It reports whether a tool item held
+// the surface.
+func (m *Chat) A2UISurfaceFieldValues(surfaceID string) (map[string]any, bool) {
+	item, ok := m.a2uiSurfaceItem(surfaceID)
+	if !ok {
+		return nil, false
+	}
+	return item.ToolA2UIFieldValues(surfaceID), true
+}
+
+// ApplyA2UISurfaceUpdate feeds a batch of A2UI server messages back into the
+// named MCP surface (the response to an a2ui_action round-trip). It reports
+// whether the surface still has renderable state afterward — false means no
+// item held it, or the server deleted it.
+func (m *Chat) ApplyA2UISurfaceUpdate(surfaceID string, msgs []a2ui.ServerMessage) bool {
+	item, ok := m.a2uiSurfaceItem(surfaceID)
+	if !ok {
+		return false
+	}
+	return item.ApplyToolA2UIUpdate(surfaceID, msgs)
 }
 
 // ToggleExpandedSelectedItem expands the selected message item if it is expandable.

--- a/internal/ui/model/chat.go
+++ b/internal/ui/model/chat.go
@@ -803,6 +803,22 @@ func (m *Chat) RetireA2UISurface(surfaceID string) (map[string]any, bool) {
 	return nil, false
 }
 
+// HasAssistantA2UISurface reports whether a live assistant-authored surface
+// carries the given ID. Assistant items do not implement A2UISurfaceItem and
+// are absent from the MCP provenance registry, so without this check a
+// surface ID an assistant happens to share with an MCP server (both default
+// to "default") resolves as MCP-owned and the user's submission is shipped
+// to that server instead of starting an agent turn.
+func (m *Chat) HasAssistantA2UISurface(surfaceID string) bool {
+	for i := range m.list.Len() {
+		item, ok := m.list.ItemAt(i).(*chat.AssistantMessageItem)
+		if ok && item.HasLiveA2UISurface(surfaceID) {
+			return true
+		}
+	}
+	return false
+}
+
 // a2uiSurfaceItem locates the chat item holding the named MCP surface.
 // Surface IDs are only unique within a server — invoking the same tool twice
 // appends two items carrying the same ID — so the focused surface wins: that

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -796,6 +796,13 @@ func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			cmds = append(cmds, cmd)
 		}
 
+	case a2uiActionResultMsg:
+		// An a2ui_action round-trip returned: update the originating
+		// surface in place (or land plain text) without an agent turn.
+		if cmd := m.handleA2UIActionResult(msg); cmd != nil {
+			cmds = append(cmds, cmd)
+		}
+
 	case userCommandsLoadedMsg:
 		m.customCommands = msg.Commands
 		dia := m.dialog.Dialog(dialog.CommandsID)
@@ -4287,11 +4294,174 @@ func (m *UI) sendMessage(content string, attachments ...message.Attachment) tea.
 // the surface rebuilt without an ID — in which case the submission still
 // goes out with just the button identity rather than being dropped.
 func (m *UI) handleA2UIButtonClicked(clicked a2uievent.ButtonClicked) tea.Cmd {
-	values, _ := m.chat.RetireA2UISurface(clicked.SurfaceID)
+	// A cancel/dismiss button only ever dismisses the surface locally —
+	// it never starts an agent turn nor round-trips to an MCP server.
+	// Checked first, before any provenance branch.
 	if chat.A2UIButtonIsCancel(clicked) {
+		m.chat.RetireA2UISurface(clicked.SurfaceID)
 		return nil
 	}
+	// MCP-served surface: route the interaction back to the owning server
+	// when it speaks the action round-trip, instead of starting an agent
+	// turn. The button press is itself the consent, so the a2ui_action
+	// call is not gated on permission. The surface is long-lived — it is
+	// NOT retired, and a surface payload in the response updates it in
+	// place.
+	// Provenance resolves through the item that owns the surface, falling
+	// back to the global surfaceID-keyed registry only when no live item
+	// claims it: surface IDs are server-scoped (typically "default"), so two
+	// servers would otherwise clobber each other in that registry and route
+	// one another's clicks.
+	mcpName, isMCP := m.chat.A2UISurfaceOwner(clicked.SurfaceID)
+	if !isMCP {
+		mcpName, isMCP = chat.A2UISurfaceProvenance(clicked.SurfaceID)
+	}
+	if isMCP && clicked.Action != nil {
+		if mcp.HasTool(mcpName, "a2ui_action") {
+			return m.runA2UIAction(mcpName, clicked)
+		}
+		// The server serves surfaces but not the action round-trip: keep
+		// today's behavior so a dumb server still works.
+	}
+	// RetireA2UISurface only matches assistant items, so an MCP surface's
+	// values must be read from the tool item that holds it — otherwise the
+	// fallback submits the button identity with everything the user typed
+	// silently dropped.
+	values, ok := m.chat.RetireA2UISurface(clicked.SurfaceID)
+	if !ok {
+		values, _ = m.chat.A2UISurfaceFieldValues(clicked.SurfaceID)
+	}
 	return m.sendMessage(chat.A2UISubmissionPrompt(clicked, values))
+}
+
+// a2uiActionResultMsg carries the outcome of an a2ui_action round-trip back
+// to the UI so the surface updates in place (or a plain-text reply lands as
+// tool output) without an agent turn.
+type a2uiActionResultMsg struct {
+	surfaceID string
+	mcpName   string
+	// surfaces holds any A2UI payloads the response embedded, applied to
+	// the surface in place. content holds plain text from the response.
+	surfaces []string
+	content  string
+	err      error
+}
+
+// runA2UIAction calls the owning server's a2ui_action tool with the
+// button's action name and the surface's resolved input values as the
+// context. The call runs off the UI goroutine; the result returns as an
+// a2uiActionResultMsg.
+func (m *UI) runA2UIAction(mcpName string, clicked a2uievent.ButtonClicked) tea.Cmd {
+	values, _ := m.chat.A2UISurfaceFieldValues(clicked.SurfaceID)
+	if values == nil {
+		values = map[string]any{}
+	}
+	args := map[string]any{
+		"name":    clicked.Action.Name,
+		"context": values,
+	}
+	surfaceID := clicked.SurfaceID
+	return func() tea.Msg {
+		res, err := m.com.Workspace.CallMCPTool(context.Background(), mcpName, "a2ui_action", args)
+		if err != nil {
+			return a2uiActionResultMsg{surfaceID: surfaceID, mcpName: mcpName, err: err}
+		}
+		out := a2uiActionResultMsg{surfaceID: surfaceID, mcpName: mcpName, content: res.Content}
+		for _, s := range res.Surfaces {
+			out.surfaces = append(out.surfaces, s.Payload)
+		}
+		return out
+	}
+}
+
+// handleA2UIActionResult applies an a2ui_action response: any A2UI payload
+// updates the originating surface in place (the surface stays live), and any
+// plain text lands as an informational note. A transport/server error is
+// surfaced as an error note — the surface is left untouched.
+func (m *UI) handleA2UIActionResult(msg a2uiActionResultMsg) tea.Cmd {
+	if msg.err != nil {
+		return util.ReportError(fmt.Errorf("A2UI action failed: %w", msg.err))
+	}
+	var cmds []tea.Cmd
+	for _, payload := range msg.surfaces {
+		if cmd := m.applyA2UIPayloadToSurface(msg.mcpName, msg.surfaceID, payload); cmd != nil {
+			cmds = append(cmds, cmd)
+		}
+	}
+	if msg.content != "" {
+		cmds = append(cmds, util.ReportInfo(msg.content))
+	}
+	if len(cmds) == 0 {
+		return nil
+	}
+	return tea.Batch(cmds...)
+}
+
+// applyA2UIPayloadToSurface scans an A2UI payload and feeds its server
+// messages into the surface the payload targets, which updates in place. A
+// payload that does not scan, or that targets a surface nothing holds, is
+// reported back to the owning server as an a2ui_error when it exposes that
+// tool. clickedID is the surface the interaction came from — the fallback
+// target for a payload that declares no surface of its own — and mcpName is
+// the server that sent it, which is who any error is reported to.
+func (m *UI) applyA2UIPayloadToSurface(mcpName, clickedID, payload string) tea.Cmd {
+	msgs, err := chat.A2UIMessagesFromPayload(payload)
+	if err != nil {
+		return m.reportA2UIError(mcpName, clickedID, "INVALID_JSON",
+			"Failed to parse A2UI payload.")
+	}
+	if len(msgs) == 0 {
+		// The payload parsed but carried no server messages — it scanned
+		// as prose, not A2UI. Applying it would be a silent no-op, which
+		// looks to the user like a dead button.
+		return m.reportA2UIError(mcpName, clickedID, "INVALID_PAYLOAD",
+			"Payload carried no A2UI server messages.")
+	}
+	// Honor the surface the payload itself declares: a server may answer an
+	// action by updating a sibling surface, not the clicked one. Forcing
+	// every payload onto the clicked ID would corrupt that surface instead.
+	target := chat.A2UIMessagesSurfaceID(msgs)
+	if target == "" {
+		target = clickedID
+	}
+	if !m.chat.ApplyA2UISurfaceUpdate(target, msgs) {
+		// Either nothing holds that surface, or the server just deleted
+		// it. A delete is the expected end of a surface's life; a payload
+		// aimed at a surface we never had is a real mismatch worth
+		// reporting back.
+		if !chat.A2UIMessagesDeleteSurface(msgs) {
+			return m.reportA2UIError(mcpName, target, "SURFACE_NOT_FOUND",
+				fmt.Sprintf("No live surface %q to apply the payload to.", target))
+		}
+	}
+	return nil
+}
+
+// reportA2UIError reports a render failure to mcpName via its a2ui_error
+// tool, when it exposes one. Otherwise the failure is only shown to the user
+// (the existing render-failure alert path). mcpName may be empty when the
+// caller only holds a surface ID, in which case the owner is resolved from
+// the surface — item-scoped first, same as the action path, because the
+// global registry is keyed by surface ID alone and two servers sharing an ID
+// clobber each other there.
+func (m *UI) reportA2UIError(mcpName, surfaceID, code, message string) tea.Cmd {
+	ok := mcpName != ""
+	if !ok {
+		if mcpName, ok = m.chat.A2UISurfaceOwner(surfaceID); !ok {
+			mcpName, ok = chat.A2UISurfaceProvenance(surfaceID)
+		}
+	}
+	if !ok || !mcp.HasTool(mcpName, "a2ui_error") {
+		return nil
+	}
+	args := map[string]any{"code": code, "message": message, "surfaceId": surfaceID}
+	return func() tea.Msg {
+		_, err := m.com.Workspace.CallMCPTool(context.Background(), mcpName, "a2ui_error", args)
+		if err != nil {
+			return util.InfoMsg{Type: util.InfoTypeError, Msg: fmt.Sprintf("A2UI error report failed: %v", err)}
+		}
+		return nil
+	}
 }
 
 // handleChannelMessage injects a channel event pushed by an MCP server into a

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -4312,12 +4312,21 @@ func (m *UI) handleA2UIButtonClicked(clicked a2uievent.ButtonClicked) tea.Cmd {
 	// claims it: surface IDs are server-scoped (typically "default"), so two
 	// servers would otherwise clobber each other in that registry and route
 	// one another's clicks.
-	mcpName, isMCP := m.chat.A2UISurfaceOwner(clicked.SurfaceID)
-	if !isMCP {
-		mcpName, isMCP = chat.A2UISurfaceProvenance(clicked.SurfaceID)
+	// An assistant-authored surface is never MCP-owned, whatever the
+	// registries say. It is checked first because assistant items are
+	// invisible to both lookups below — they do not implement
+	// A2UISurfaceItem, and the global registry is keyed by surface ID alone
+	// — so a shared ID would otherwise route this submission to a server
+	// that has nothing to do with it.
+	mcpName, isMCP := "", false
+	if !m.chat.HasAssistantA2UISurface(clicked.SurfaceID) {
+		mcpName, isMCP = m.chat.A2UISurfaceOwner(clicked.SurfaceID)
+		if !isMCP {
+			mcpName, isMCP = chat.A2UISurfaceProvenance(clicked.SurfaceID)
+		}
 	}
 	if isMCP && clicked.Action != nil {
-		if mcp.HasTool(mcpName, "a2ui_action") {
+		if m.mcpServesTool(mcpName, "a2ui_action") {
 			return m.runA2UIAction(mcpName, clicked)
 		}
 		// The server serves surfaces but not the action round-trip: keep
@@ -4332,6 +4341,24 @@ func (m *UI) handleA2UIButtonClicked(clicked a2uievent.ButtonClicked) tea.Cmd {
 		values, _ = m.chat.A2UISurfaceFieldValues(clicked.SurfaceID)
 	}
 	return m.sendMessage(chat.A2UISubmissionPrompt(clicked, values))
+}
+
+// mcpServesTool reports whether the named MCP server exposes toolName.
+//
+// It reads the workspace's published MCP state rather than mcp.HasTool: that
+// registry is only populated in the process that owns the MCP sessions, so
+// in client/server mode it is permanently empty and every HasTool gate is
+// false — which silently disabled the whole A2UI action round-trip on a
+// remote client and left its /mcp/call-tool route unreachable.
+func (m *UI) mcpServesTool(mcpName, toolName string) bool {
+	if mcpName == "" {
+		return false
+	}
+	info, ok := m.com.Workspace.MCPGetStates()[mcpName]
+	if !ok {
+		return false
+	}
+	return info.ServesA2UITool(toolName)
 }
 
 // a2uiActionResultMsg carries the outcome of an a2ui_action round-trip back
@@ -4451,7 +4478,7 @@ func (m *UI) reportA2UIError(mcpName, surfaceID, code, message string) tea.Cmd {
 			mcpName, ok = chat.A2UISurfaceProvenance(surfaceID)
 		}
 	}
-	if !ok || !mcp.HasTool(mcpName, "a2ui_error") {
+	if !ok || !m.mcpServesTool(mcpName, "a2ui_error") {
 		return nil
 	}
 	args := map[string]any{"code": code, "message": message, "surfaceId": surfaceID}

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -27,6 +27,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"charm.land/catwalk/pkg/catwalk"
 	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/crush/internal/agent"
 	"github.com/charmbracelet/crush/internal/agent/hyper"
 	"github.com/charmbracelet/crush/internal/agent/notify"
 	agenttools "github.com/charmbracelet/crush/internal/agent/tools"
@@ -3916,15 +3917,27 @@ func (m *UI) insertFileCompletion(path string) tea.Cmd {
 }
 
 // insertMCPResourceCompletion inserts the selected resource into the textarea,
-// replacing the @query, and adds the resource as an attachment.
+// replacing the @query, and adds the resource as an attachment. An unexpanded
+// resource template is only inserted as text: its URI still carries RFC 6570
+// placeholders ("cairn://run/{id}"), so reading it now would send the literal
+// braces to the server and fail — the read happens once someone (user or
+// agent) has substituted real values.
 func (m *UI) insertMCPResourceCompletion(item completions.ResourceCompletionValue) tea.Cmd {
 	displayText := cmp.Or(item.Title, item.URI)
+	if item.IsTemplate() {
+		// Insert the raw template URI, not the title: the placeholders are
+		// the point — they show what needs filling in.
+		displayText = item.URI
+	}
 
 	prevHeight := m.textarea.Height()
 	if !m.insertCompletionText(displayText) {
 		return nil
 	}
 	heightCmd := m.handleTextareaHeightChange(prevHeight)
+	if item.IsTemplate() {
+		return heightCmd
+	}
 
 	resourceCmd := func() tea.Msg {
 		contents, err := m.com.Workspace.ReadMCPResource(
@@ -4228,6 +4241,12 @@ func (m *UI) sendMessage(content string, attachments ...message.Attachment) tea.
 
 	// Capture session ID to avoid race with main goroutine updating m.session.
 	sessionID := m.session.ID
+	// The turn's content width hint: tools that read width-sensitive remote
+	// content (A2UI surfaces with server-pre-rendered bar geometry) get the
+	// surface card's interior width so the server sizes its rows to fill
+	// the card. The chat package owns the computation — it must track the
+	// real render chain, not constants copied here.
+	contentWidth := chat.ToolA2UISurfaceWidth(m.layout.main.Dx())
 	// Optimistically mark the agent busy: the prompt we are about to submit
 	// either starts a run or is enqueued behind one. This keeps esc pressed
 	// right after enter routing to cancelAgent instead of reading a stale
@@ -4243,7 +4262,7 @@ func (m *UI) sendMessage(content string, attachments ...message.Attachment) tea.
 		// been accepted (HTTP 202) or synchronously with a validation
 		// or transport error. Run failures and cancellation surface
 		// through SSE-derived events, not this return value.
-		err := m.com.Workspace.AgentRun(context.Background(), sessionID, content, attachments...)
+		err := m.com.Workspace.AgentRun(agent.WithContentWidth(context.Background(), contentWidth), sessionID, content, attachments...)
 		if err != nil && !errors.Is(err, context.Canceled) {
 			return util.InfoMsg{
 				Type: util.InfoTypeError,

--- a/internal/workspace/app_workspace.go
+++ b/internal/workspace/app_workspace.go
@@ -2,6 +2,7 @@ package workspace
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -489,6 +490,24 @@ func (w *AppWorkspace) ReadMCPResource(ctx context.Context, name, uri string) ([
 
 func (w *AppWorkspace) ListMCPPrompts(context.Context) ([]commands.MCPPrompt, error) {
 	return commands.LoadMCPPrompts()
+}
+
+// CallMCPTool invokes a tool on a named MCP server and returns its text
+// content plus any A2UI surface payload it embedded.
+func (w *AppWorkspace) CallMCPTool(ctx context.Context, name, toolName string, args map[string]any) (MCPToolCallResult, error) {
+	input, err := json.Marshal(args)
+	if err != nil {
+		return MCPToolCallResult{}, fmt.Errorf("failed to encode tool arguments: %w", err)
+	}
+	res, err := mcptools.RunTool(ctx, w.store, name, toolName, string(input))
+	if err != nil {
+		return MCPToolCallResult{}, err
+	}
+	out := MCPToolCallResult{Content: res.Content}
+	for _, s := range res.Surfaces {
+		out.Surfaces = append(out.Surfaces, MCPToolCallSurface{Payload: s.Payload, URI: s.URI})
+	}
+	return out, nil
 }
 
 func (w *AppWorkspace) GetMCPPrompt(clientID, promptID string, args map[string]string) (string, error) {

--- a/internal/workspace/client_workspace.go
+++ b/internal/workspace/client_workspace.go
@@ -766,6 +766,20 @@ func (w *ClientWorkspace) GetMCPPrompt(clientID, promptID string, args map[strin
 	return w.client.GetMCPPrompt(context.Background(), w.workspaceID(), clientID, promptID, args)
 }
 
+// CallMCPTool invokes a tool on a named MCP server via the server and
+// returns its text content plus any A2UI surface payload it embedded.
+func (w *ClientWorkspace) CallMCPTool(ctx context.Context, name, toolName string, args map[string]any) (MCPToolCallResult, error) {
+	res, err := w.client.CallMCPTool(ctx, w.workspaceID(), name, toolName, args)
+	if err != nil {
+		return MCPToolCallResult{}, err
+	}
+	out := MCPToolCallResult{Content: res.Content}
+	for _, s := range res.Surfaces {
+		out.Surfaces = append(out.Surfaces, MCPToolCallSurface{Payload: s.Payload, URI: s.URI})
+	}
+	return out, nil
+}
+
 func (w *ClientWorkspace) EnableDockerMCP(ctx context.Context) error {
 	return w.client.EnableDockerMCP(ctx, w.workspaceID())
 }

--- a/internal/workspace/client_workspace.go
+++ b/internal/workspace/client_workspace.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/crush/internal/agent"
 	"github.com/charmbracelet/crush/internal/agent/notify"
 	"github.com/charmbracelet/crush/internal/agent/tools/mcp"
 	"github.com/charmbracelet/crush/internal/app"
@@ -236,11 +237,15 @@ func (w *ClientWorkspace) AgentRun(ctx context.Context, sessionID, prompt string
 	// completion detection (it observes message events directly),
 	// so passing an empty RunID is correct here: it skips the
 	// correlator stamping path without functional consequences.
-	return w.client.SendMessage(ctx, w.workspaceID(), sessionID, "", "", prompt, attachments...)
+	//
+	// The content-width hint rides the context locally but cannot cross
+	// the HTTP boundary as a context value, so it is lifted onto the wire
+	// message here and re-attached server-side (backend.runAgent).
+	return w.client.SendMessage(ctx, w.workspaceID(), sessionID, "", "", agent.ContentWidthFromContext(ctx), prompt, attachments...)
 }
 
 func (w *ClientWorkspace) AgentRunChannel(ctx context.Context, channel, sessionID, prompt string, attachments ...message.Attachment) error {
-	return w.client.SendMessage(ctx, w.workspaceID(), sessionID, "", channel, prompt, attachments...)
+	return w.client.SendMessage(ctx, w.workspaceID(), sessionID, "", channel, 0, prompt, attachments...)
 }
 
 func (w *ClientWorkspace) AgentRunShellCommand(ctx context.Context, sessionID, command string, termWidth int, _ func(string), _ bool) (proto.ShellCommandResponse, error) {

--- a/internal/workspace/client_workspace.go
+++ b/internal/workspace/client_workspace.go
@@ -700,6 +700,7 @@ func (w *ClientWorkspace) MCPGetStates() map[string]mcp.ClientInfo {
 			},
 			ConnectedAt: v.ConnectedAt,
 			Channel:     v.Channel,
+			A2UITools:   v.A2UITools,
 		}
 	}
 	return result

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -208,6 +208,12 @@ type Workspace interface {
 	RefreshMCPTools(ctx context.Context, name string)
 	ReadMCPResource(ctx context.Context, name, uri string) ([]MCPResourceContents, error)
 	ListMCPPrompts(ctx context.Context) ([]commands.MCPPrompt, error)
+	// CallMCPTool invokes a tool on a named MCP server and returns its
+	// text content plus any A2UI surface payload it embedded. It backs the
+	// A2UI action round-trip: a button press on an MCP-served surface
+	// routes back to the owning server as an a2ui_action (or a render
+	// failure as an a2ui_error) without an agent turn.
+	CallMCPTool(ctx context.Context, name, toolName string, args map[string]any) (MCPToolCallResult, error)
 	GetMCPPrompt(clientID, promptID string, args map[string]string) (string, error)
 	EnableDockerMCP(ctx context.Context) error
 	DisableDockerMCP() error
@@ -232,4 +238,19 @@ type MCPResourceContents struct {
 	MIMEType string `json:"mime_type,omitempty"`
 	Text     string `json:"text,omitempty"`
 	Blob     []byte `json:"blob,omitempty"`
+}
+
+// MCPToolCallResult holds the model-facing text and any A2UI surface
+// payloads from an MCP tool call.
+type MCPToolCallResult struct {
+	// Content is the result's text (its TextContent, joined).
+	Content string `json:"content"`
+	// Surfaces carries any A2UI surface payloads the result embedded.
+	Surfaces []MCPToolCallSurface `json:"surfaces,omitempty"`
+}
+
+// MCPToolCallSurface is a single A2UI surface payload from a tool call.
+type MCPToolCallSurface struct {
+	Payload string `json:"payload"`
+	URI     string `json:"uri"`
 }


### PR DESCRIPTION
Splits the A2UI/MCP half out of #251 and rebases it linearly onto `main`.

## What changed

- **Resource surfaces render inline.** MCP resource templates are discovered via `resources/templates/list` and fetched eagerly at init; A2UI payloads returned by `read_mcp_resource` render as themed inline surfaces instead of dumping raw JSON at the model. Surfaces are sized to the real chat content width, with the `?w=` hint derived from the render chain and carried across the client/server boundary and into sub-agent runs.
- **Interactions round-trip.** Pressing a button on an MCP-served surface calls that server's `a2ui_action` tool so the surface updates in place, rather than starting a fresh agent turn describing the submission. Render failures report through `a2ui_error`. Audience annotations decide each surface's path.

## Review fixes

A high-effort review of the original branch found six defects here, all fixed in `b8fe823` with reproducing tests:

| Defect | Effect |
|---|---|
| `["user"]`-audience surface dropped when nothing renders it | A channel/headless turn handed the model an **empty tool result** — the agent replied with nothing |
| Assistant surface ID colliding with an MCP one | User's form values shipped to an unrelated server; no agent turn; button looked dead |
| Round-trip gated on `mcp.HasTool` | Permanently false in client/server mode, silently disabling the whole feature and leaving the new `/mcp/call-tool` route unreachable |
| `resources/list` failure swallowed on reconnect | Server showed healthy while all its resources vanished from `@` completions |
| Tool surfaces not dropped on theme change | Kept drawing the previous palette |
| Render cached a live surface's first frame | Deleted surface replayed from cache indefinitely |

Each fix has a test that fails without it — verified by reverting each guard in turn.

## Verification

`go build ./...`, `go test ./...`, `gofumpt -l .`, `go vet ./...` all clean. (`go vet` reports one pre-existing `internal/csync/maps.go` lock-by-value warning that is present on `main` and untouched here.)

## Notes

- This is the first of two PRs; `feat/prompt-skill-completions` stacks on top and should land second.
- The original #251 was a 33-commit branch containing a merge commit; this is a clean linear rebase. The combined tree of both PRs was verified identical to the original merge result apart from one cosmetic struct-field reorder.
- `mcp.HasTool` and `SetToolsForTest` are removed — both became unused once the capability moved onto the published MCP state.

🤖 Posted on behalf of `@joestump` by [`claude-opus-5`](https://openrouter.ai/anthropic/claude-opus-5) using [Claude Code](https://claude.ai).
