### PR TITLE
feat(ui): add /skill completions and @file//skill token highlighting

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -41,6 +41,11 @@ linters:
         text: "SA1019.*interp.ExecHandler"
         linters:
           - staticcheck
+      # Vendored upstream code (bubbles textarea) is kept byte-close to
+      # upstream on purpose; don't restyle it.
+      - path: internal/ui/textarea/
+        linters:
+          - staticcheck
 issues:
   max-issues-per-linter: 0
   max-same-issues: 0

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/PuerkitoBio/goquery v1.12.0
 	github.com/a2aproject/a2a-go/v2 v2.3.1
 	github.com/alecthomas/chroma/v2 v2.27.0
+	github.com/atotto/clipboard v0.1.4
 	github.com/aymanbagabas/go-udiff v0.4.1
 	github.com/bmatcuk/doublestar/v4 v4.10.0
 	github.com/charlievieth/fastwalk v1.0.14
@@ -48,6 +49,7 @@ require (
 	github.com/jordanella/go-ansi-paintbrush v0.0.0-20240728195301-b7ad996ecf3d
 	github.com/lucasb-eyer/go-colorful v1.4.0
 	github.com/mattn/go-isatty v0.0.24
+	github.com/mattn/go-runewidth v0.0.24
 	github.com/modelcontextprotocol/go-sdk v1.7.0-pre.3.0.20260724080706-e761950d9795
 	github.com/nxadm/tail v1.4.11
 	github.com/odvcencio/gotreesitter v0.48.0
@@ -93,7 +95,6 @@ require (
 	github.com/KyleBanks/depth v1.2.1 // indirect
 	github.com/andybalholm/brotli v1.2.2 // indirect
 	github.com/andybalholm/cascadia v1.3.3 // indirect
-	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aws/aws-sdk-go-v2 v1.42.1 // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.14 // indirect
 	github.com/aws/aws-sdk-go-v2/config v1.32.30 // indirect
@@ -158,7 +159,6 @@ require (
 	github.com/klauspost/cpuid/v2 v2.3.0 // indirect
 	github.com/klauspost/pgzip v1.2.6 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
-	github.com/mattn/go-runewidth v0.0.24 // indirect
 	github.com/mfridman/interpolate v0.0.2 // indirect
 	github.com/microcosm-cc/bluemonday v1.0.27 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect

--- a/internal/ui/chat/prompt_tokens.go
+++ b/internal/ui/chat/prompt_tokens.go
@@ -1,0 +1,56 @@
+package chat
+
+import (
+	"strings"
+
+	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/crush/internal/ui/common"
+	"github.com/charmbracelet/crush/internal/ui/styles"
+	"github.com/charmbracelet/x/ansi"
+)
+
+// highlightPromptTokens restyles the @file and /skill tokens in an
+// already-rendered user message so a token keeps the colour it had in the
+// prompt editor after the message is posted.
+//
+// It runs over the rendered output rather than the Markdown source because
+// that output is what the reader sees: Glamour has already wrapped, padded
+// and coloured the text, and re-deriving offsets from the source would not
+// survive any of that. Each line is scanned in its ANSI-stripped form and
+// the token spans are converted to display cells, which is exactly what
+// lipgloss.StyleRanges wants. A token split across a soft wrap highlights
+// on the segment it starts in, which is the same thing the textarea does.
+func highlightPromptTokens(content string, sty *styles.Styles) string {
+	if content == "" {
+		return content
+	}
+
+	lines := strings.Split(content, "\n")
+	changed := false
+	for i, line := range lines {
+		plain := []rune(ansi.Strip(line))
+		tokens := common.ScanPromptTokens(plain)
+		if len(tokens) == 0 {
+			continue
+		}
+
+		ranges := make([]lipgloss.Range, 0, len(tokens))
+		for _, tok := range tokens {
+			// Rune offsets are not cell offsets once wide runes or combining
+			// marks are in play, and StyleRanges counts cells.
+			start := ansi.StringWidth(string(plain[:tok.Start]))
+			end := start + ansi.StringWidth(string(plain[tok.Start:tok.End]))
+			style := sty.Editor.TokenFile
+			if tok.Kind == common.PromptTokenSkill {
+				style = sty.Editor.TokenSkill
+			}
+			ranges = append(ranges, lipgloss.NewRange(start, end, style))
+		}
+		lines[i] = lipgloss.StyleRanges(line, ranges...)
+		changed = true
+	}
+	if !changed {
+		return content
+	}
+	return strings.Join(lines, "\n")
+}

--- a/internal/ui/chat/prompt_tokens_test.go
+++ b/internal/ui/chat/prompt_tokens_test.go
@@ -1,0 +1,102 @@
+package chat
+
+import (
+	"strings"
+	"testing"
+
+	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/crush/internal/ui/common"
+	"github.com/charmbracelet/crush/internal/ui/styles"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/stretchr/testify/require"
+)
+
+// tokenTestStyles returns styles with unmistakable token colours so a test
+// can assert which span picked which one up.
+func tokenTestStyles() *styles.Styles {
+	sty := styles.CharmtonePantera()
+	sty.Editor.TokenFile = lipgloss.NewStyle().Foreground(lipgloss.Color("1"))
+	sty.Editor.TokenSkill = lipgloss.NewStyle().Foreground(lipgloss.Color("2"))
+	return &sty
+}
+
+// styledSpans returns the substrings of an ANSI string rendered under the
+// given SGR foreground parameter.
+func styledSpans(s, sgr string) []string {
+	var out []string
+	for _, part := range strings.Split(s, "\x1b["+sgr+"m")[1:] {
+		if idx := strings.Index(part, "\x1b["); idx >= 0 {
+			part = part[:idx]
+		}
+		out = append(out, part)
+	}
+	return out
+}
+
+func withKnownSkills(t *testing.T, names ...string) {
+	t.Helper()
+	common.SetPromptSkillNames(names)
+	t.Cleanup(func() { common.SetPromptSkillNames(nil) })
+}
+
+func TestHighlightPromptTokensStylesFileAndSkill(t *testing.T) {
+	withKnownSkills(t, "code-review")
+	sty := tokenTestStyles()
+
+	got := highlightPromptTokens("please /code-review @main.go now", sty)
+
+	require.Equal(t, "please /code-review @main.go now", ansi.Strip(got))
+	require.Equal(t, []string{"@main.go"}, styledSpans(got, "31"))
+	require.Equal(t, []string{"/code-review"}, styledSpans(got, "32"))
+}
+
+func TestHighlightPromptTokensLeavesProseAlone(t *testing.T) {
+	withKnownSkills(t, "commit")
+	sty := tokenTestStyles()
+
+	// No word-boundary trigger anywhere: an email-like run, an inline
+	// slash, and an unknown slash-word.
+	const in = "mail me@foo.com or a/b or /bogus"
+	require.Equal(t, in, highlightPromptTokens(in, sty))
+}
+
+func TestHighlightPromptTokensPreservesSurroundingAnsi(t *testing.T) {
+	withKnownSkills(t)
+	sty := tokenTestStyles()
+
+	// Glamour hands us pre-styled text; restyling a token must not eat the
+	// styling around it or change the visible characters.
+	in := lipgloss.NewStyle().Bold(true).Render("see @main.go here")
+	got := highlightPromptTokens(in, sty)
+
+	require.Equal(t, "see @main.go here", ansi.Strip(got))
+	require.Equal(t, []string{"@main.go"}, styledSpans(got, "31"))
+}
+
+func TestHighlightPromptTokensMultiline(t *testing.T) {
+	withKnownSkills(t, "commit")
+	sty := tokenTestStyles()
+
+	got := highlightPromptTokens("@one.go\nplain\n/commit", sty)
+
+	lines := strings.Split(got, "\n")
+	require.Len(t, lines, 3)
+	require.Equal(t, []string{"@one.go"}, styledSpans(lines[0], "31"))
+	require.Equal(t, "plain", lines[1], "untouched lines are returned verbatim")
+	require.Equal(t, []string{"/commit"}, styledSpans(lines[2], "32"))
+}
+
+// TestUserMessageRendersPromptTokens is the end-to-end check: the same
+// colours the prompt editor uses survive into the posted message.
+func TestUserMessageRendersPromptTokens(t *testing.T) {
+	withKnownSkills(t, "code-review")
+
+	item := newTestUserItem("please /code-review @main.go", 0)
+	item.sty = tokenTestStyles()
+
+	out := item.RawRender(80)
+
+	require.Contains(t, ansi.Strip(out), "/code-review")
+	require.Contains(t, styledSpans(out, "31"), "@main.go")
+	require.Contains(t, styledSpans(out, "32"), "/code-review")
+}

--- a/internal/ui/chat/user.go
+++ b/internal/ui/chat/user.go
@@ -105,6 +105,11 @@ func (m *UserMessageItem) RawRender(width int) string {
 				content = strings.TrimSuffix(result, "\n")
 			}
 
+			// Carry the prompt editor's @file / /skill colours into the
+			// posted message, so a token does not lose its highlight the
+			// moment it leaves the editor.
+			content = highlightPromptTokens(content, m.sty)
+
 			if len(m.message.BinaryContent()) > 0 {
 				attachmentsStr := m.renderAttachments(cappedWidth)
 				if content == "" {

--- a/internal/ui/common/prompttokens.go
+++ b/internal/ui/common/prompttokens.go
@@ -1,0 +1,97 @@
+package common
+
+import (
+	"strings"
+	"sync"
+)
+
+// PromptTokenKind distinguishes the two things the prompt marks up.
+type PromptTokenKind int
+
+const (
+	// PromptTokenFile is an "@path" file mention.
+	PromptTokenFile PromptTokenKind = iota
+	// PromptTokenSkill is a "/name" skill reference.
+	PromptTokenSkill
+)
+
+// PromptToken is a highlighted span within a single line, expressed in rune
+// offsets: Start is inclusive, End exclusive.
+type PromptToken struct {
+	Start int
+	End   int
+	Kind  PromptTokenKind
+}
+
+// promptSkills is the set of skill names a "/token" may refer to.
+//
+// It lives here, rather than being threaded through every message-item
+// constructor, because both the prompt editor and the posted-message
+// renderer must agree on it exactly — a token that lights up while you type
+// has to stay lit after you hit enter. The UI event loop is the only
+// writer; renderers read it. This mirrors the package-level discovery-state
+// mirror in internal/skills.
+var promptSkills struct {
+	mu    sync.RWMutex
+	names []string
+}
+
+// SetPromptSkillNames replaces the known-skill set used to validate "/"
+// tokens. Called whenever the effective skill list changes.
+func SetPromptSkillNames(names []string) {
+	promptSkills.mu.Lock()
+	promptSkills.names = names
+	promptSkills.mu.Unlock()
+}
+
+// IsPromptSkillPrefix reports whether name is a prefix of some known skill
+// name. Prefix rather than exact match is deliberate: it is what gives live
+// feedback as a skill name is typed, and using the same rule after the
+// prompt is submitted keeps the highlight from flickering off mid-word.
+func IsPromptSkillPrefix(name string) bool {
+	if name == "" {
+		return false
+	}
+	promptSkills.mu.RLock()
+	defer promptSkills.mu.RUnlock()
+	for _, s := range promptSkills.names {
+		if strings.HasPrefix(s, name) {
+			return true
+		}
+	}
+	return false
+}
+
+// ScanPromptTokens finds the @file and /skill tokens in a single line.
+//
+// Tokens start at a word boundary (start of line or after whitespace) and
+// run to the next whitespace, so they never span lines. An "@" token always
+// counts — the file may not exist yet, and the completions popup is the
+// discovery path — while a "/" token counts only when it matches a known
+// skill, so ordinary prose and absolute paths are left alone.
+func ScanPromptTokens(line []rune) []PromptToken {
+	var tokens []PromptToken
+	i := 0
+	for i < len(line) {
+		atWordStart := i == 0 || isSpaceRune(line[i-1])
+		if atWordStart && (line[i] == '@' || line[i] == '/') && i+1 < len(line) && !isSpaceRune(line[i+1]) {
+			end := i + 1
+			for end < len(line) && !isSpaceRune(line[end]) {
+				end++
+			}
+			if line[i] == '@' {
+				tokens = append(tokens, PromptToken{Start: i, End: end, Kind: PromptTokenFile})
+			} else if IsPromptSkillPrefix(string(line[i+1 : end])) {
+				tokens = append(tokens, PromptToken{Start: i, End: end, Kind: PromptTokenSkill})
+			}
+			i = end
+			continue
+		}
+		i++
+	}
+	return tokens
+}
+
+func isSpaceRune(r rune) bool {
+	return r == ' ' || r == '\t'
+}

--- a/internal/ui/common/prompttokens_test.go
+++ b/internal/ui/common/prompttokens_test.go
@@ -1,0 +1,77 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// scan is a readability helper: it returns each token's literal text
+// alongside its kind, which is what the assertions below actually care
+// about. The known-skill set is process-wide, so these tests are serial.
+func scan(t *testing.T, line string, skills ...string) []string {
+	t.Helper()
+	SetPromptSkillNames(skills)
+	t.Cleanup(func() { SetPromptSkillNames(nil) })
+
+	runes := []rune(line)
+	var out []string
+	for _, tok := range ScanPromptTokens(runes) {
+		kind := "file"
+		if tok.Kind == PromptTokenSkill {
+			kind = "skill"
+		}
+		out = append(out, kind+":"+string(runes[tok.Start:tok.End]))
+	}
+	return out
+}
+
+func TestScanPromptTokensFileMentions(t *testing.T) {
+	require.Equal(t,
+		[]string{"file:@foo.go", "file:@bar.md"},
+		scan(t, "see @foo.go and @bar.md end"),
+	)
+}
+
+func TestScanPromptTokensSkillsMustBeKnown(t *testing.T) {
+	require.Equal(t, []string{"skill:/code-review"},
+		scan(t, "please /code-review this", "code-review", "commit"))
+	require.Empty(t, scan(t, "please /bogus this", "code-review"))
+}
+
+func TestScanPromptTokensSkillPrefixMatches(t *testing.T) {
+	// Prefix matching is what gives live feedback mid-word, and using the
+	// same rule after submit keeps the highlight from flickering.
+	require.Len(t, scan(t, "/cod", "code-review"), 1)
+	require.Empty(t, scan(t, "/codeX", "code-review"))
+}
+
+func TestScanPromptTokensRequireWordBoundary(t *testing.T) {
+	// An email address, a relative path, and a URL are all prose here.
+	require.Empty(t, scan(t, "mail me@foo.go or a/b or x/commit", "commit"))
+	// Tab counts as a boundary.
+	require.Len(t, scan(t, "x\t@foo.go"), 1)
+	// So does start-of-line.
+	require.Len(t, scan(t, "@foo.go trailing"), 1)
+}
+
+func TestScanPromptTokensBareTriggersIgnored(t *testing.T) {
+	require.Empty(t, scan(t, "@ / @", "commit"))
+	require.Empty(t, scan(t, "@"))
+	require.Empty(t, scan(t, ""))
+}
+
+func TestScanPromptTokensAbsolutePathIsNotASkill(t *testing.T) {
+	// "/usr/bin" starts a word but is not a skill, so it stays prose even
+	// when a skill named "usr-something" exists.
+	require.Empty(t, scan(t, "look in /usr/bin", "usr-tools"))
+}
+
+func TestIsPromptSkillPrefixEmptyName(t *testing.T) {
+	SetPromptSkillNames([]string{"commit"})
+	t.Cleanup(func() { SetPromptSkillNames(nil) })
+
+	// A bare "/" has no name to match; it must not match everything.
+	require.False(t, IsPromptSkillPrefix(""))
+	require.True(t, IsPromptSkillPrefix("com"))
+}

--- a/internal/ui/completions/completions.go
+++ b/internal/ui/completions/completions.go
@@ -44,6 +44,19 @@ type CompletionItemsLoadedMsg struct {
 	Resources []ResourceCompletionValue
 }
 
+// Trigger identifies which trigger character opened the completions popup.
+type Trigger rune
+
+const (
+	// TriggerNone means the completions popup is closed.
+	TriggerNone Trigger = 0
+	// TriggerFile is the '@' file-mention trigger.
+	TriggerFile Trigger = '@'
+	// TriggerSkill is the '/' skill trigger (mid-prompt only; at the start
+	// of an empty prompt '/' opens the commands dialog instead).
+	TriggerSkill Trigger = '/'
+)
+
 // Completions represents the completions popup component.
 type Completions struct {
 	// Popup dimensions
@@ -201,6 +214,69 @@ func (c *Completions) SetItems(files []FileCompletionValue, resources []Resource
 	c.updateSize()
 }
 
+// skillDetailSeparator sits between a skill's name and its description in
+// the popup row.
+const skillDetailSeparator = " - "
+
+// minSkillDetailWidth is the smallest description tail worth showing. Below
+// it the row is all ellipsis and the description only costs width, so long
+// skill names simply render bare.
+const minSkillDetailWidth = 12
+
+// SetSkillItems sets skill items and opens the popup. Unlike files, skills
+// are already in memory, so no async load is needed.
+//
+// Each row reads "/name - description", with the description truncated to
+// whatever width the name leaves behind. The description is part of the
+// item's text, so the fuzzy filter matches it too: typing "/pdf" finds a
+// skill described as "extract text from PDFs" even if it is named
+// "document-tools".
+func (c *Completions) SetSkillItems(skills []SkillCompletionValue) {
+	items := make([]list.FilterableItem, 0, len(skills))
+	for _, skill := range skills {
+		name := "/" + skill.Name
+		text := name
+		detailStart := -1
+		if desc := flattenSkillDescription(skill.Description); desc != "" {
+			// maxWidth is the popup's hard cap and renderItem reserves a
+			// cell of padding on each side, so that is the real budget the
+			// name and description share.
+			budget := maxWidth - 2 - ansi.StringWidth(name) - len(skillDetailSeparator)
+			if budget >= minSkillDetailWidth {
+				detailStart = len(name)
+				text = name + skillDetailSeparator + ansi.Truncate(desc, budget, "…")
+			}
+		}
+		item := NewCompletionItem(
+			text,
+			skill,
+			c.normalStyle,
+			c.focusedStyle,
+			c.matchStyle,
+		)
+		if detailStart >= 0 {
+			item = item.withDetail(detailStart, name)
+		}
+		items = append(items, item)
+	}
+
+	c.open = true
+	c.query = ""
+	c.allItems = items
+	c.filtered = append([]list.FilterableItem(nil), items...)
+	c.list.SetItems(c.filtered...)
+	c.list.SetFilter("")
+	c.list.Focus()
+
+	c.width = maxWidth
+	c.height = ordered.Clamp(len(items), int(minHeight), int(maxHeight))
+	c.list.SetSize(c.width, c.height)
+	c.list.SelectFirst()
+	c.list.ScrollToSelected()
+
+	c.updateSize()
+}
+
 // Close closes the completions popup.
 func (c *Completions) Close() {
 	c.open = false
@@ -243,10 +319,28 @@ func (c *Completions) applyNamePriorityFilter(query string) {
 
 	queryLower := strings.ToLower(strings.TrimSpace(query))
 	slices.SortStableFunc(filtered, func(a, b list.FilterableItem) int {
-		return namePriorityTier(a.Filter(), queryLower) - namePriorityTier(b.Filter(), queryLower)
+		return namePriorityTier(tierKey(a), queryLower) - namePriorityTier(tierKey(b), queryLower)
 	})
 	c.filtered = filtered
 	c.list.SetItems(c.filtered...)
+}
+
+// tierKey returns the string namePriorityTier should rank an item on. Items
+// whose display text carries a trailing detail (skills, which append their
+// description) expose the bare name via SortKey; everything else ranks on
+// its filter text, which is the path.
+func tierKey(item list.FilterableItem) string {
+	if s, ok := item.(interface{ SortKey() string }); ok {
+		return s.SortKey()
+	}
+	return item.Filter()
+}
+
+// flattenSkillDescription collapses a SKILL.md description onto one line.
+// Frontmatter descriptions are frequently wrapped across several lines, and
+// a popup row is exactly one.
+func flattenSkillDescription(desc string) string {
+	return strings.Join(strings.Fields(desc), " ")
 }
 
 func namePriorityTier(path, queryLower string) int {
@@ -375,6 +469,11 @@ func (c *Completions) selectCurrent(keepOpen bool) tea.Msg {
 	}
 
 	switch item := item.Value().(type) {
+	case SkillCompletionValue:
+		return SelectionMsg[SkillCompletionValue]{
+			Value:    item,
+			KeepOpen: keepOpen,
+		}
 	case ResourceCompletionValue:
 		return SelectionMsg[ResourceCompletionValue]{
 			Value:    item,

--- a/internal/ui/completions/item.go
+++ b/internal/ui/completions/item.go
@@ -24,6 +24,16 @@ type ResourceCompletionValue struct {
 	MIMEType string
 }
 
+// SkillCompletionValue represents an agent skill completion value. The
+// fields mirror the SKILL.md frontmatter: Description is shown after the
+// name in the popup and folded into the item's filter text, so a skill is
+// findable by what it does and not only by what it is called.
+type SkillCompletionValue struct {
+	Name        string
+	Description string
+	Path        string
+}
+
 // IsTemplate reports whether the completion's URI is an unexpanded RFC 6570
 // URI template (it still contains a "{expression}") rather than a concrete,
 // readable resource URI. Templates come from resources/templates/list and
@@ -42,6 +52,16 @@ type CompletionItem struct {
 	focused bool
 	cache   map[int]string
 
+	// detailStart is the byte offset in text where the secondary detail
+	// (e.g. a skill's description) begins, or -1 when the item is all
+	// primary text. The detail renders dimmed so the name still leads.
+	detailStart int
+
+	// sortKey is what the name-priority tiering ranks on. It defaults to
+	// text, but items whose display text carries a trailing detail set it
+	// to the bare name so the description can't skew the tier.
+	sortKey string
+
 	// Styles
 	normalStyle  lipgloss.Style
 	focusedStyle lipgloss.Style
@@ -54,10 +74,25 @@ func NewCompletionItem(text string, value any, normalStyle, focusedStyle, matchS
 		Versioned:    list.NewVersioned(),
 		text:         text,
 		value:        value,
+		detailStart:  -1,
+		sortKey:      text,
 		normalStyle:  normalStyle,
 		focusedStyle: focusedStyle,
 		matchStyle:   matchStyle,
 	}
+}
+
+// withDetail marks everything from byte offset start onwards as secondary
+// detail text and ranks the item on sortKey instead of its full text.
+func (c *CompletionItem) withDetail(start int, sortKey string) *CompletionItem {
+	c.detailStart = start
+	c.sortKey = sortKey
+	return c
+}
+
+// SortKey returns the string the name-priority tiering ranks on.
+func (c *CompletionItem) SortKey() string {
+	return c.sortKey
 }
 
 // Finished implements list.Item. Completion items render purely from
@@ -123,6 +158,7 @@ func (c *CompletionItem) Render(width int) string {
 		c.focusedStyle,
 		c.matchStyle,
 		c.text,
+		c.detailStart,
 		c.focused,
 		width,
 		c.cache,
@@ -133,6 +169,7 @@ func (c *CompletionItem) Render(width int) string {
 func renderItem(
 	normalStyle, focusedStyle, matchStyle lipgloss.Style,
 	text string,
+	detailStart int,
 	focused bool,
 	width int,
 	cache map[int]string,
@@ -163,6 +200,17 @@ func renderItem(
 
 	// Render full-width text with background.
 	content := style.Padding(0, 1).Width(width).Render(text)
+
+	// Dim the trailing detail (a skill's description) so the name still
+	// leads the row. Applied before the match ranges so a fuzzy hit inside
+	// the description still reads as a match.
+	if detailStart >= 0 {
+		start, _ := bytePosToVisibleCharPos(text, [2]int{detailStart, detailStart})
+		if start+1 < width {
+			detailStyle := style.Faint(true)
+			content = lipgloss.StyleRanges(content, lipgloss.NewRange(start+1, width, detailStyle))
+		}
+	}
 
 	// Apply match highlighting using StyleRanges.
 	if len(match.MatchedIndexes) > 0 {

--- a/internal/ui/completions/skills_test.go
+++ b/internal/ui/completions/skills_test.go
@@ -1,0 +1,158 @@
+package completions
+
+import (
+	"strings"
+	"testing"
+
+	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSetSkillItemsOpensWithSkills(t *testing.T) {
+	t.Parallel()
+
+	c := New(lipgloss.NewStyle(), lipgloss.NewStyle(), lipgloss.NewStyle())
+	require.False(t, c.IsOpen())
+
+	c.SetSkillItems([]SkillCompletionValue{
+		{Name: "code-review", Path: "/skills/code-review/SKILL.md"},
+		{Name: "commit", Path: "/skills/commit/SKILL.md"},
+	})
+
+	require.True(t, c.IsOpen())
+	require.Len(t, c.filtered, 2)
+	first, ok := c.filtered[0].(*CompletionItem)
+	require.True(t, ok)
+	require.Equal(t, "/code-review", first.Text())
+}
+
+func TestSkillCompletionFilter(t *testing.T) {
+	t.Parallel()
+
+	c := New(lipgloss.NewStyle(), lipgloss.NewStyle(), lipgloss.NewStyle())
+	c.SetSkillItems([]SkillCompletionValue{
+		{Name: "code-review"},
+		{Name: "commit"},
+		{Name: "coder"},
+	})
+
+	c.Filter("cod")
+
+	require.NotEmpty(t, c.filtered)
+	first, ok := c.filtered[0].(*CompletionItem)
+	require.True(t, ok)
+	// "coder" is an exact-stem/prefix tier winner over "code-review".
+	require.Equal(t, "/coder", first.Text())
+}
+
+func TestSkillDescriptionShownAndSearchable(t *testing.T) {
+	t.Parallel()
+
+	c := New(lipgloss.NewStyle(), lipgloss.NewStyle(), lipgloss.NewStyle())
+	c.SetSkillItems([]SkillCompletionValue{
+		{Name: "skill-creator", Description: "Use for naming skills\nand writing frontmatter."},
+		{Name: "commit", Description: "Write a conventional commit."},
+	})
+
+	first, ok := c.filtered[0].(*CompletionItem)
+	require.True(t, ok)
+	// The row reads "/name - description", with the frontmatter
+	// description flattened onto one line.
+	require.Equal(t, "/skill-creator - Use for naming skills and writing frontmatter.", first.Text())
+	// The name leads; the description renders as dimmed detail.
+	require.Equal(t, len("/skill-creator"), first.detailStart)
+	require.Equal(t, "/skill-creator", first.SortKey())
+
+	// The description is part of the filter text, so a skill is findable by
+	// what it does and not only by what it is named.
+	c.Filter("frontmatter")
+	require.Len(t, c.filtered, 1)
+	hit, ok := c.filtered[0].(*CompletionItem)
+	require.True(t, ok)
+	require.Equal(t, "skill-creator", hit.Value().(SkillCompletionValue).Name)
+}
+
+func TestSkillDescriptionTruncatedToPopupWidth(t *testing.T) {
+	t.Parallel()
+
+	c := New(lipgloss.NewStyle(), lipgloss.NewStyle(), lipgloss.NewStyle())
+	c.SetSkillItems([]SkillCompletionValue{
+		{Name: "commit", Description: strings.Repeat("long ", 200)},
+	})
+
+	first, ok := c.filtered[0].(*CompletionItem)
+	require.True(t, ok)
+	require.LessOrEqual(t, ansi.StringWidth(first.Text()), maxWidth-2)
+	require.True(t, strings.HasSuffix(first.Text(), "…"), "expected an ellipsis, got %q", first.Text())
+}
+
+func TestSkillDescriptionDroppedWhenNameEatsTheRow(t *testing.T) {
+	t.Parallel()
+
+	// A name long enough to leave no room for a useful description renders
+	// bare rather than as a row of ellipsis.
+	long := strings.Repeat("a", maxWidth)
+	c := New(lipgloss.NewStyle(), lipgloss.NewStyle(), lipgloss.NewStyle())
+	c.SetSkillItems([]SkillCompletionValue{{Name: long, Description: "does things"}})
+
+	first, ok := c.filtered[0].(*CompletionItem)
+	require.True(t, ok)
+	require.Equal(t, "/"+long, first.Text())
+	require.Equal(t, -1, first.detailStart)
+}
+
+func TestSelectCurrentReturnsSkillSelectionMsg(t *testing.T) {
+	t.Parallel()
+
+	c := New(lipgloss.NewStyle(), lipgloss.NewStyle(), lipgloss.NewStyle())
+	c.SetSkillItems([]SkillCompletionValue{
+		{Name: "commit", Path: "/skills/commit/SKILL.md"},
+	})
+
+	msg := c.selectCurrent(false)
+	sel, ok := msg.(SelectionMsg[SkillCompletionValue])
+	require.True(t, ok, "expected SelectionMsg[SkillCompletionValue], got %T", msg)
+	require.Equal(t, "commit", sel.Value.Name)
+	require.Equal(t, "/skills/commit/SKILL.md", sel.Value.Path)
+	require.False(t, sel.KeepOpen)
+	require.False(t, c.IsOpen(), "popup should close on non-keep-open select")
+}
+
+func TestSelectCurrentSkillKeepOpen(t *testing.T) {
+	t.Parallel()
+
+	c := New(lipgloss.NewStyle(), lipgloss.NewStyle(), lipgloss.NewStyle())
+	c.SetSkillItems([]SkillCompletionValue{{Name: "commit"}})
+
+	msg := c.selectCurrent(true)
+	sel, ok := msg.(SelectionMsg[SkillCompletionValue])
+	require.True(t, ok)
+	require.True(t, sel.KeepOpen)
+	require.True(t, c.IsOpen(), "popup should stay open on keep-open select")
+}
+
+func TestSetSkillItemsEmpty(t *testing.T) {
+	t.Parallel()
+
+	c := New(lipgloss.NewStyle(), lipgloss.NewStyle(), lipgloss.NewStyle())
+	c.SetSkillItems(nil)
+
+	require.True(t, c.IsOpen())
+	require.False(t, c.HasItems())
+	require.Nil(t, c.selectCurrent(false))
+}
+
+func TestSkillItemsDoNotAffectFileSelectionDispatch(t *testing.T) {
+	t.Parallel()
+
+	// Regression: file/resource values must still dispatch their own
+	// SelectionMsg types after the skill case was added.
+	c := New(lipgloss.NewStyle(), lipgloss.NewStyle(), lipgloss.NewStyle())
+	c.SetItems([]FileCompletionValue{{Path: "foo.go"}}, nil)
+
+	msg := c.selectCurrent(false)
+	sel, ok := msg.(SelectionMsg[FileCompletionValue])
+	require.True(t, ok, "expected SelectionMsg[FileCompletionValue], got %T", msg)
+	require.Equal(t, "foo.go", sel.Value.Path)
+}

--- a/internal/ui/dialog/question_editor.go
+++ b/internal/ui/dialog/question_editor.go
@@ -5,10 +5,10 @@ import (
 	"strings"
 
 	"charm.land/bubbles/v2/key"
-	"charm.land/bubbles/v2/textarea"
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 	"github.com/charmbracelet/crush/internal/ui/styles"
+	"github.com/charmbracelet/crush/internal/ui/textarea"
 	uv "github.com/charmbracelet/ultraviolet"
 )
 

--- a/internal/ui/dialog/question_freetext.go
+++ b/internal/ui/dialog/question_freetext.go
@@ -5,12 +5,12 @@ import (
 	"strings"
 
 	"charm.land/bubbles/v2/key"
-	"charm.land/bubbles/v2/textarea"
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 	"github.com/charmbracelet/crush/internal/question"
 	"github.com/charmbracelet/crush/internal/ui/common"
 	"github.com/charmbracelet/crush/internal/ui/styles"
+	"github.com/charmbracelet/crush/internal/ui/textarea"
 	uv "github.com/charmbracelet/ultraviolet"
 	"github.com/charmbracelet/x/ansi"
 )

--- a/internal/ui/model/a2ui_action_test.go
+++ b/internal/ui/model/a2ui_action_test.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"charm.land/bubbles/v2/textarea"
+	"github.com/charmbracelet/crush/internal/ui/textarea"
 
 	"github.com/charmbracelet/crush/internal/agent/tools"
 	mcptools "github.com/charmbracelet/crush/internal/agent/tools/mcp"

--- a/internal/ui/model/a2ui_submit_test.go
+++ b/internal/ui/model/a2ui_submit_test.go
@@ -5,8 +5,8 @@ import (
 	"strings"
 	"testing"
 
-	"charm.land/bubbles/v2/textarea"
 	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/crush/internal/ui/textarea"
 
 	"github.com/charmbracelet/crush/internal/config"
 	"github.com/charmbracelet/crush/internal/message"

--- a/internal/ui/model/channel_test.go
+++ b/internal/ui/model/channel_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"charm.land/bubbles/v2/textarea"
+	"github.com/charmbracelet/crush/internal/ui/textarea"
 
 	"github.com/charmbracelet/crush/internal/agent/tools/mcp"
 	"github.com/charmbracelet/crush/internal/config"

--- a/internal/ui/model/completion_backspace_test.go
+++ b/internal/ui/model/completion_backspace_test.go
@@ -3,7 +3,6 @@ package model
 import (
 	"testing"
 
-	"charm.land/bubbles/v2/textarea"
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 
@@ -11,6 +10,7 @@ import (
 	"github.com/charmbracelet/crush/internal/ui/attachments"
 	"github.com/charmbracelet/crush/internal/ui/common"
 	"github.com/charmbracelet/crush/internal/ui/dialog"
+	"github.com/charmbracelet/crush/internal/ui/textarea"
 )
 
 func newCompletionBackspaceUI() *UI {

--- a/internal/ui/model/layout_test.go
+++ b/internal/ui/model/layout_test.go
@@ -5,11 +5,11 @@ import (
 	"strings"
 	"testing"
 
-	"charm.land/bubbles/v2/textarea"
 	"github.com/charmbracelet/crush/internal/config"
 	"github.com/charmbracelet/crush/internal/session"
 	"github.com/charmbracelet/crush/internal/ui/chat"
 	"github.com/charmbracelet/crush/internal/ui/common"
+	"github.com/charmbracelet/crush/internal/ui/textarea"
 )
 
 // testMessageItem is a minimal chat item used to populate the chat list

--- a/internal/ui/model/prompt_highlight_render_test.go
+++ b/internal/ui/model/prompt_highlight_render_test.go
@@ -1,0 +1,74 @@
+package model
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/crush/internal/skills"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRenderEditorViewStylesTokens is the end-to-end check: a prompt
+// containing @file and /skill tokens renders with ANSI styling once the
+// highlighter is wired, and the plain text is unchanged underneath.
+func TestRenderEditorViewStylesTokens(t *testing.T) {
+	m := newSkillCompletionUI()
+	m.promptHighlighter = newTestHighlighter(t, "code-review")
+	m.textarea.SetHighlighter(m.promptHighlighter)
+	m.textarea.SetValue("please /code-review @main.go")
+	m.textarea.SetWidth(120)
+
+	view := m.renderEditorView(120)
+
+	stripped := ansi.Strip(view)
+	require.Contains(t, stripped, "please /code-review @main.go")
+	require.True(t, strings.Contains(view, "\x1b["), "expected styled output, got %q", view)
+}
+
+// TestRenderEditorViewUnknownSkillNotStyled verifies an arbitrary /word in
+// the prompt is left alone.
+func TestRenderEditorViewUnknownSkillNotStyled(t *testing.T) {
+	m := newSkillCompletionUI()
+	m.promptHighlighter = newTestHighlighter(t, "code-review")
+	m.textarea.SetHighlighter(m.promptHighlighter)
+	m.textarea.SetValue("what is /bogus anyway")
+	m.textarea.SetWidth(120)
+
+	before := m.textarea.View()
+	after := func() string {
+		m.promptHighlighter.Rescan(m.textarea.Value())
+		return m.textarea.View()
+	}()
+	require.Equal(t, before, after)
+}
+
+// TestRenderEditorViewBangModeSuppressesTokens verifies shell prompts don't
+// get token styling.
+func TestRenderEditorViewBangModeSuppressesTokens(t *testing.T) {
+	m := newSkillCompletionUI()
+	m.promptHighlighter = newTestHighlighter(t, "ls")
+	m.textarea.SetHighlighter(m.promptHighlighter)
+	m.bangMode = true
+	m.textarea.SetValue("ls /tmp")
+	m.textarea.SetWidth(120)
+
+	before := m.textarea.View()
+	_ = m.renderEditorView(120)
+	after := m.textarea.View()
+
+	require.Equal(t, before, after, "bang mode must not restyle the prompt")
+}
+
+// TestPromptHighlighterSeededFromSkillStates covers the construction-time
+// seeding: names come from skillStates so a /skill typed before the first
+// skills.Event still highlights.
+func TestPromptHighlighterSeededFromSkillStates(t *testing.T) {
+	m := newSkillCompletionUI()
+	m.skillStates = []*skills.SkillState{
+		{Name: "commit", State: skills.StateNormal},
+	}
+	h := newTestHighlighter(t, m.skillNames()...)
+	h.Rescan("/commit")
+	require.Len(t, h.Highlight(0, nil), 1)
+}

--- a/internal/ui/model/prompt_highlighter.go
+++ b/internal/ui/model/prompt_highlighter.go
@@ -30,6 +30,20 @@ func newPromptHighlighter(fileStyle, skillStyle lipgloss.Style) *promptHighlight
 	}
 }
 
+// SetStyles re-pushes the token styles after a theme change.
+//
+// The styles are value copies taken at construction, so without this the
+// editor keeps drawing @file and /skill tokens in the old theme's colours
+// while the posted message — which reads the styles live — draws them in the
+// new one, and the same token appears in two colours above and below the
+// editor. The cached ranges hold offsets only and stay valid.
+func (h *promptHighlighter) SetStyles(fileStyle, skillStyle lipgloss.Style) {
+	h.fileStyle = fileStyle
+	h.skillStyle = skillStyle
+	// The cached ranges carry the old styles, so retokenize on next use.
+	h.lines = nil
+}
+
 // Rescan retokenizes the full prompt value. Called whenever the textarea
 // value changes; cheap (linear scan) and keeps Highlight a pure lookup.
 func (h *promptHighlighter) Rescan(value string) {

--- a/internal/ui/model/prompt_highlighter.go
+++ b/internal/ui/model/prompt_highlighter.go
@@ -1,0 +1,88 @@
+package model
+
+import (
+	"strings"
+
+	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/crush/internal/ui/common"
+	"github.com/charmbracelet/crush/internal/ui/textarea"
+)
+
+// promptHighlighter implements textarea.LineHighlighter for the prompt: it
+// marks @file tokens and /skill tokens as they are typed. Tokenization
+// itself lives in common.ScanPromptTokens, shared with the posted-message
+// renderer so a token looks the same before and after you hit enter; this
+// type only maps tokens onto the editor's styles and caches the result.
+type promptHighlighter struct {
+	fileStyle  lipgloss.Style
+	skillStyle lipgloss.Style
+
+	// lines caches the tokenized logical lines from the last Rescan.
+	lines [][]lipgloss.Range
+}
+
+var _ textarea.LineHighlighter = (*promptHighlighter)(nil)
+
+func newPromptHighlighter(fileStyle, skillStyle lipgloss.Style) *promptHighlighter {
+	return &promptHighlighter{
+		fileStyle:  fileStyle,
+		skillStyle: skillStyle,
+	}
+}
+
+// Rescan retokenizes the full prompt value. Called whenever the textarea
+// value changes; cheap (linear scan) and keeps Highlight a pure lookup.
+func (h *promptHighlighter) Rescan(value string) {
+	rawLines := strings.Split(value, "\n")
+	h.lines = make([][]lipgloss.Range, len(rawLines))
+	for i, line := range rawLines {
+		h.lines[i] = h.scanLine([]rune(line))
+	}
+}
+
+// Highlight implements textarea.LineHighlighter.
+func (h *promptHighlighter) Highlight(lineIdx int, _ []rune) []lipgloss.Range {
+	if lineIdx < 0 || lineIdx >= len(h.lines) {
+		return nil
+	}
+	return h.lines[lineIdx]
+}
+
+// scanLine turns one logical line's tokens into styled rune ranges.
+func (h *promptHighlighter) scanLine(line []rune) []lipgloss.Range {
+	tokens := common.ScanPromptTokens(line)
+	if len(tokens) == 0 {
+		return nil
+	}
+	ranges := make([]lipgloss.Range, 0, len(tokens))
+	for _, tok := range tokens {
+		ranges = append(ranges, lipgloss.NewRange(tok.Start, tok.End, h.tokenStyle(tok.Kind)))
+	}
+	return ranges
+}
+
+func (h *promptHighlighter) tokenStyle(kind common.PromptTokenKind) lipgloss.Style {
+	if kind == common.PromptTokenSkill {
+		return h.skillStyle
+	}
+	return h.fileStyle
+}
+
+// skillNames returns the names of the skills a /token may refer to. It
+// shares skillCompletionValues' source of truth — the effective catalog,
+// falling back to discovery states before the first catalog load — so a
+// token highlights exactly when the popup would have offered it.
+func (m *UI) skillNames() []string {
+	values := m.skillCompletionValues()
+	names := make([]string, 0, len(values))
+	for _, v := range values {
+		names = append(names, v.Name)
+	}
+	return names
+}
+
+// refreshSkillNames re-primes the known-skill set that validates "/" tokens.
+// Called from every path that can change the effective skill list.
+func (m *UI) refreshSkillNames() {
+	common.SetPromptSkillNames(m.skillNames())
+}

--- a/internal/ui/model/prompt_highlighter_test.go
+++ b/internal/ui/model/prompt_highlighter_test.go
@@ -3,8 +3,10 @@ package model
 import (
 	"testing"
 
+	"charm.land/bubbles/v2/spinner"
 	"charm.land/lipgloss/v2"
 	"github.com/charmbracelet/crush/internal/skills"
+	"github.com/charmbracelet/crush/internal/ui/attachments"
 	"github.com/charmbracelet/crush/internal/ui/common"
 	"github.com/stretchr/testify/require"
 )
@@ -142,4 +144,45 @@ func TestSkillNamesFromCatalog(t *testing.T) {
 		},
 	}
 	require.Equal(t, []string{"alpha", "commit"}, m.skillNames())
+}
+
+// TestRefreshStylesRepushesHighlighterStyles pins the highlighter into
+// refreshStyles' invariant: every subcomponent that copies style values at
+// construction gets them re-pushed on a theme change.
+//
+// promptHighlighter is built once in New() from Editor.TokenFile/TokenSkill
+// and holds value copies, so without the re-push the editor kept drawing
+// tokens in the previous theme's colours while the posted message — which
+// reads the styles live — drew them in the new one, leaving the same token
+// two different colours above and below the editor.
+func TestRefreshStylesRepushesHighlighterStyles(t *testing.T) {
+	t.Parallel()
+
+	m := newSkillCompletionUI()
+	m.header = newHeader(m.com)
+	m.todoSpinner = spinner.New()
+	// refreshStyles pushes into every subcomponent, so they all have to be
+	// real for it to run at all.
+	sty := m.com.Styles
+	m.attachments = attachments.New(attachments.NewRenderer(
+		sty.Attachments.Normal,
+		sty.Attachments.Deleting,
+		sty.Attachments.Image,
+		sty.Attachments.Text,
+		sty.Attachments.Skill,
+		sty.Attachments.Remove,
+	), attachments.Keymap{})
+	m.promptHighlighter = newPromptHighlighter(
+		lipgloss.NewStyle().Foreground(lipgloss.Color("1")),
+		lipgloss.NewStyle().Foreground(lipgloss.Color("2")),
+	)
+
+	// Swap in a theme whose token styles differ from the ones above.
+	want := m.com.Styles.Editor.TokenFile
+	m.refreshStyles()
+
+	require.Equal(t, want, m.promptHighlighter.fileStyle,
+		"a theme change must re-push the file-token style")
+	require.Equal(t, m.com.Styles.Editor.TokenSkill, m.promptHighlighter.skillStyle,
+		"a theme change must re-push the skill-token style")
 }

--- a/internal/ui/model/prompt_highlighter_test.go
+++ b/internal/ui/model/prompt_highlighter_test.go
@@ -1,0 +1,145 @@
+package model
+
+import (
+	"testing"
+
+	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/crush/internal/skills"
+	"github.com/charmbracelet/crush/internal/ui/common"
+	"github.com/stretchr/testify/require"
+)
+
+// newTestHighlighter builds a highlighter and primes the known-skill set it
+// validates "/" tokens against. That set is process-wide (see
+// common.SetPromptSkillNames), so these tests do not run in parallel.
+func newTestHighlighter(t *testing.T, skillNames ...string) *promptHighlighter {
+	t.Helper()
+	common.SetPromptSkillNames(skillNames)
+	t.Cleanup(func() { common.SetPromptSkillNames(nil) })
+	return newPromptHighlighter(
+		lipgloss.NewStyle().Foreground(lipgloss.Color("1")),
+		lipgloss.NewStyle().Foreground(lipgloss.Color("2")),
+	)
+}
+
+func TestPromptHighlighterFileTokens(t *testing.T) {
+	h := newTestHighlighter(t)
+	h.Rescan("see @foo.go and @bar.md end")
+
+	line := h.Highlight(0, nil)
+	require.Len(t, line, 2)
+	require.Equal(t, 4, line[0].Start)
+	require.Equal(t, 11, line[0].End) // "@foo.go"
+	require.Equal(t, 16, line[1].Start)
+	require.Equal(t, 23, line[1].End) // "@bar.md"
+}
+
+func TestPromptHighlighterSkillTokens(t *testing.T) {
+	h := newTestHighlighter(t, "code-review", "commit")
+
+	h.Rescan("please /code-review this")
+	line := h.Highlight(0, nil)
+	require.Len(t, line, 1)
+	require.Equal(t, 7, line[0].Start)
+	require.Equal(t, 19, line[0].End) // "/code-review"
+
+	// Unknown slash-words are not styled.
+	h.Rescan("please /bogus this")
+	require.Empty(t, h.Highlight(0, nil))
+}
+
+// TestPromptHighlighterUsesDistinctStyles pins that the two token kinds do
+// not collapse onto one colour.
+func TestPromptHighlighterUsesDistinctStyles(t *testing.T) {
+	h := newTestHighlighter(t, "commit")
+	h.Rescan("@foo.go /commit")
+
+	line := h.Highlight(0, nil)
+	require.Len(t, line, 2)
+	require.Equal(t, h.fileStyle, line[0].Style)
+	require.Equal(t, h.skillStyle, line[1].Style)
+}
+
+func TestPromptHighlighterSkillPrefixWhileTyping(t *testing.T) {
+	h := newTestHighlighter(t, "code-review")
+
+	// Mid-typing prefix of a known skill highlights (live feedback).
+	h.Rescan("/cod")
+	require.Len(t, h.Highlight(0, nil), 1)
+
+	// Diverged from every known skill: no highlight.
+	h.Rescan("/codeX")
+	require.Empty(t, h.Highlight(0, nil))
+}
+
+func TestPromptHighlighterWordBoundary(t *testing.T) {
+	h := newTestHighlighter(t, "commit")
+
+	// Triggers must start a word: email-like and path-like runs don't count.
+	h.Rescan("mail me@foo.go or a/b")
+	require.Empty(t, h.Highlight(0, nil))
+
+	// Tab counts as a boundary too.
+	h.Rescan("x\t@foo.go")
+	require.Len(t, h.Highlight(0, nil), 1)
+}
+
+func TestPromptHighlighterBareTriggerNotStyled(t *testing.T) {
+	h := newTestHighlighter(t)
+	h.Rescan("@ / @")
+	require.Empty(t, h.Highlight(0, nil))
+}
+
+func TestPromptHighlighterMultiline(t *testing.T) {
+	h := newTestHighlighter(t)
+	h.Rescan("first @one.go\nsecond @two.go\nthird plain")
+
+	require.Len(t, h.Highlight(0, nil), 1)
+	require.Len(t, h.Highlight(1, nil), 1)
+	require.Empty(t, h.Highlight(2, nil))
+	// Out of range is safe.
+	require.Nil(t, h.Highlight(3, nil))
+}
+
+func TestPromptHighlighterSkillNamesUpdate(t *testing.T) {
+	h := newTestHighlighter(t)
+	h.Rescan("/commit")
+	require.Empty(t, h.Highlight(0, nil))
+
+	common.SetPromptSkillNames([]string{"commit"})
+	h.Rescan("/commit")
+	require.Len(t, h.Highlight(0, nil), 1)
+}
+
+// TestSkillNamesHelper verifies the UI helper filters to healthy skills.
+func TestSkillNamesHelper(t *testing.T) {
+	t.Parallel()
+
+	m := &UI{
+		skillStates: []*skills.SkillState{
+			{Name: "good", State: skills.StateNormal},
+			{Name: "bad", State: skills.StateError},
+			nil,
+		},
+	}
+	require.Equal(t, []string{"good"}, m.skillNames())
+}
+
+// TestSkillNamesFromCatalog verifies the highlighter validates "/" tokens
+// against the same effective skill set the completions popup offers, so a
+// disabled or overridden skill cannot highlight in one place and be missing
+// from the other.
+func TestSkillNamesFromCatalog(t *testing.T) {
+	t.Parallel()
+
+	m := &UI{
+		skillStates: []*skills.SkillState{
+			{Name: "stale-state-only", State: skills.StateNormal},
+		},
+		skillCatalog: []skills.CatalogEntry{
+			{Name: "commit"},
+			{Name: "alpha"},
+		},
+	}
+	require.Equal(t, []string{"alpha", "commit"}, m.skillNames())
+}

--- a/internal/ui/model/session_busy_test.go
+++ b/internal/ui/model/session_busy_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 	"time"
 
-	"charm.land/bubbles/v2/textarea"
 	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/crush/internal/ui/textarea"
 	"github.com/charmbracelet/x/ansi"
 	"github.com/stretchr/testify/require"
 

--- a/internal/ui/model/sidebar_focus_test.go
+++ b/internal/ui/model/sidebar_focus_test.go
@@ -4,12 +4,12 @@ import (
 	"testing"
 
 	"charm.land/bubbles/v2/key"
-	"charm.land/bubbles/v2/textarea"
 	tea "charm.land/bubbletea/v2"
 	"github.com/charmbracelet/crush/internal/config"
 	"github.com/charmbracelet/crush/internal/ui/common"
 	"github.com/charmbracelet/crush/internal/ui/dialog"
 	"github.com/charmbracelet/crush/internal/ui/styles"
+	"github.com/charmbracelet/crush/internal/ui/textarea"
 	uv "github.com/charmbracelet/ultraviolet"
 	"github.com/stretchr/testify/require"
 )

--- a/internal/ui/model/skill_completion_test.go
+++ b/internal/ui/model/skill_completion_test.go
@@ -1,0 +1,234 @@
+package model
+
+import (
+	"testing"
+
+	"charm.land/bubbles/v2/textarea"
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/charmbracelet/crush/internal/config"
+	"github.com/charmbracelet/crush/internal/skills"
+	"github.com/charmbracelet/crush/internal/ui/attachments"
+	"github.com/charmbracelet/crush/internal/ui/common"
+	"github.com/charmbracelet/crush/internal/ui/completions"
+	"github.com/stretchr/testify/require"
+)
+
+func newSkillCompletionUI() *UI {
+	com := common.DefaultCommon(&slashCommandWorkspace{ready: true})
+	m := &UI{
+		com:      com,
+		status:   NewStatus(com, nil),
+		chat:     NewChat(com, config.ScrollbarDefault),
+		textarea: textarea.New(),
+		state:    uiChat,
+		focus:    uiFocusEditor,
+		width:    140,
+		height:   45,
+	}
+	m.attachments = attachments.New(nil, attachments.Keymap{})
+	m.completions = completions.New(
+		com.Styles.Completions.Normal,
+		com.Styles.Completions.Focused,
+		com.Styles.Completions.Match,
+	)
+	return m
+}
+
+// TestOpenSkillCompletionsPopulatesFromSkillStates verifies the popup opens
+// in skill mode with items built from healthy skill states only.
+func TestOpenSkillCompletionsPopulatesFromSkillStates(t *testing.T) {
+	t.Parallel()
+
+	m := newSkillCompletionUI()
+	m.skillStates = []*skills.SkillState{
+		{Name: "commit", Path: "/skills/commit/SKILL.md", State: skills.StateNormal},
+		{Name: "code-review", Path: "/skills/code-review/SKILL.md", State: skills.StateNormal},
+		{Name: "broken", Path: "/skills/broken/SKILL.md", State: skills.StateError},
+		nil,
+	}
+
+	m.openSkillCompletions(5)
+
+	require.True(t, m.completionsOpen)
+	require.Equal(t, completions.TriggerSkill, m.completionsTrigger)
+	require.Equal(t, 5, m.completionsStartIndex)
+	require.True(t, m.completions.IsOpen())
+	require.True(t, m.completions.HasItems())
+}
+
+// TestSkillCompletionValuesPrefersCatalog verifies the popup is built from
+// the effective skill catalog once it has loaded. The catalog is what
+// carries descriptions, includes builtin skills, and has already resolved
+// user-over-builtin overrides and the disabled-skills list — the raw
+// discovery states do none of that.
+func TestSkillCompletionValuesPrefersCatalog(t *testing.T) {
+	t.Parallel()
+
+	m := newSkillCompletionUI()
+	m.skillStates = []*skills.SkillState{
+		{Name: "only-a-state", Path: "/skills/only-a-state/SKILL.md", State: skills.StateNormal},
+	}
+	m.skillCatalog = []skills.CatalogEntry{
+		{ID: "crush://skills/commit/SKILL.md", Name: "commit", Description: "Write a conventional commit."},
+		{ID: "/skills/alpha/SKILL.md", Name: "alpha", Description: "Go first."},
+		{Name: ""}, // Nameless entries are not selectable; drop them.
+	}
+
+	values := m.skillCompletionValues()
+
+	require.Equal(t, []completions.SkillCompletionValue{
+		{Name: "alpha", Description: "Go first.", Path: "/skills/alpha/SKILL.md"},
+		{Name: "commit", Description: "Write a conventional commit.", Path: "crush://skills/commit/SKILL.md"},
+	}, values)
+}
+
+// TestSkillCompletionValuesFallsBackToStates covers the window between
+// startup and the first catalog load: a name-only list still beats an empty
+// popup. Duplicate names (a user skill shadowing a builtin) collapse to one.
+func TestSkillCompletionValuesFallsBackToStates(t *testing.T) {
+	t.Parallel()
+
+	m := newSkillCompletionUI()
+	m.skillStates = []*skills.SkillState{
+		{Name: "commit", Path: "/user/skills/commit/SKILL.md", State: skills.StateNormal},
+		{Name: "commit", Path: "crush://skills/commit/SKILL.md", State: skills.StateNormal},
+		{Name: "", Path: "/skills/unnamed/SKILL.md", State: skills.StateNormal},
+		{Name: "broken", State: skills.StateError},
+		nil,
+	}
+
+	values := m.skillCompletionValues()
+
+	require.Equal(t, []completions.SkillCompletionValue{
+		{Name: "commit", Path: "/user/skills/commit/SKILL.md"},
+	}, values)
+}
+
+// TestOpenSkillCompletionsNoopWithoutSkills guards the empty-popup trap: an
+// open completions popup consumes enter and the arrow keys, so opening one
+// with nothing in it would leave a user with no skills unable to submit a
+// prompt containing a '/'.
+func TestOpenSkillCompletionsNoopWithoutSkills(t *testing.T) {
+	t.Parallel()
+
+	m := newSkillCompletionUI()
+
+	m.openSkillCompletions(3)
+
+	require.False(t, m.completionsOpen)
+	require.Equal(t, completions.TriggerNone, m.completionsTrigger)
+	require.False(t, m.completions.IsOpen())
+}
+
+// TestOpenSkillCompletionsSortsByName pins alphabetical ordering of the
+// skill popup items: with no query the first selected item should be the
+// alphabetically-first skill.
+func TestOpenSkillCompletionsSortsByName(t *testing.T) {
+	t.Parallel()
+
+	m := newSkillCompletionUI()
+	m.skillStates = []*skills.SkillState{
+		{Name: "zebra", State: skills.StateNormal},
+		{Name: "alpha", State: skills.StateNormal},
+	}
+
+	m.openSkillCompletions(0)
+
+	// Select the first item without filtering: it should be "alpha".
+	msg, handled := m.completions.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	require.True(t, handled)
+	sel, ok := msg.(completions.SelectionMsg[completions.SkillCompletionValue])
+	require.True(t, ok, "expected skill selection, got %T", msg)
+	require.Equal(t, "alpha", sel.Value.Name)
+}
+
+// TestInsertSkillCompletion verifies selecting a skill replaces the /query
+// with "/skill-name" plus a trailing space.
+func TestInsertSkillCompletion(t *testing.T) {
+	t.Parallel()
+
+	m := newSkillCompletionUI()
+	m.textarea.SetValue("hello can you /cod")
+	m.completionsOpen = true
+	m.completionsTrigger = completions.TriggerSkill
+	m.completionsStartIndex = len("hello can you ")
+
+	m.insertSkillCompletion(completions.SkillCompletionValue{Name: "code-review"})
+
+	require.Equal(t, "hello can you /code-review ", m.textarea.Value())
+}
+
+// TestInsertSkillCompletionKeepsSlashRegression guards against the
+// double-slash bug: the replacement span includes the trigger '/', so the
+// inserted text must include exactly one.
+func TestInsertSkillCompletionKeepsSlashRegression(t *testing.T) {
+	t.Parallel()
+
+	m := newSkillCompletionUI()
+	m.textarea.SetValue("/com")
+	m.completionsOpen = true
+	m.completionsTrigger = completions.TriggerSkill
+	m.completionsStartIndex = 0
+
+	m.insertSkillCompletion(completions.SkillCompletionValue{Name: "commit"})
+
+	require.Equal(t, "/commit ", m.textarea.Value())
+}
+
+// TestCloseCompletionsResetsTrigger verifies closing the popup clears the
+// trigger mode so a stale async file load can't clobber a later skill popup.
+func TestCloseCompletionsResetsTrigger(t *testing.T) {
+	t.Parallel()
+
+	m := newSkillCompletionUI()
+	m.completionsOpen = true
+	m.completionsTrigger = completions.TriggerSkill
+	m.completionsQuery = "cod"
+	m.completionsStartIndex = 3
+
+	m.closeCompletions()
+
+	require.False(t, m.completionsOpen)
+	require.Equal(t, completions.TriggerNone, m.completionsTrigger)
+	require.Empty(t, m.completionsQuery)
+	require.Zero(t, m.completionsStartIndex)
+}
+
+// TestCompletionItemsLoadedIgnoredInSkillMode is the regression test for the
+// stale async load: a file-completion load that resolves while the popup is
+// in skill mode must not replace the skill items.
+func TestCompletionItemsLoadedIgnoredInSkillMode(t *testing.T) {
+	t.Parallel()
+
+	m := newSkillCompletionUI()
+	m.skillStates = []*skills.SkillState{{Name: "commit", State: skills.StateNormal}}
+	m.openSkillCompletions(0)
+	require.True(t, m.completions.HasItems())
+
+	// A stale async file load completing while in skill mode must be ignored.
+	m.Update(completions.CompletionItemsLoadedMsg{
+		Files: []completions.FileCompletionValue{{Path: "foo.go"}},
+	})
+
+	// Skill items survive: filtering by skill name still matches.
+	m.completions.Filter("commit")
+	require.True(t, m.completions.HasItems())
+}
+
+// TestCompletionItemsLoadedAppliesInFileMode is the counterpart regression:
+// the async file load must still populate the popup when in file mode.
+func TestCompletionItemsLoadedAppliesInFileMode(t *testing.T) {
+	t.Parallel()
+
+	m := newSkillCompletionUI()
+	m.completionsOpen = true
+	m.completionsTrigger = completions.TriggerFile
+
+	m.Update(completions.CompletionItemsLoadedMsg{
+		Files: []completions.FileCompletionValue{{Path: "foo.go"}},
+	})
+
+	m.completions.Filter("foo")
+	require.True(t, m.completions.HasItems())
+}

--- a/internal/ui/model/skill_completion_test.go
+++ b/internal/ui/model/skill_completion_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/charmbracelet/crush/internal/ui/attachments"
 	"github.com/charmbracelet/crush/internal/ui/common"
 	"github.com/charmbracelet/crush/internal/ui/completions"
+	"github.com/charmbracelet/crush/internal/ui/dialog"
 	"github.com/stretchr/testify/require"
 )
 
@@ -231,4 +232,121 @@ func TestCompletionItemsLoadedAppliesInFileMode(t *testing.T) {
 
 	m.completions.Filter("foo")
 	require.True(t, m.completions.HasItems())
+}
+
+// typeInto drives a literal string through the real key-press path, so the
+// completion trigger and its filter run exactly as they do for a user.
+func typeInto(m *UI, s string) {
+	if m.dialog == nil {
+		m.dialog = dialog.NewOverlay()
+	}
+	m.textarea.Focus()
+	for _, r := range s {
+		code := r
+		if r == ' ' {
+			code = tea.KeySpace
+		}
+		m.handleKeyPressMsg(tea.KeyPressMsg{Code: code, Text: string(r)})
+	}
+}
+
+// TestSkillTriggerIgnoresAbsolutePaths pins that typing an ordinary absolute
+// path does not leave the skill popup holding the prompt hostage.
+//
+// '/' opens both a skill token and every absolute path. The popup used to
+// stay open for the whole path token: with no fuzzy match it drew nothing
+// yet still consumed enter, so the prompt could not be submitted and there
+// was no visible hint as to what was eating the key; with a match, enter
+// replaced the entire path with the skill name.
+func TestSkillTriggerIgnoresAbsolutePaths(t *testing.T) {
+	t.Parallel()
+
+	m := newSkillCompletionUI()
+	m.skillStates = []*skills.SkillState{
+		{Name: "commit", Path: "/skills/commit/SKILL.md", State: skills.StateNormal},
+	}
+
+	typeInto(m, "read /tmp/out.log")
+
+	require.Equal(t, "read /tmp/out.log", m.textarea.Value(),
+		"the path must survive verbatim")
+	require.False(t, m.completionsOpen,
+		"a path token must not leave the skill popup open to swallow enter")
+}
+
+// TestSkillTriggerClosesWhenNothingMatches pins that a '/'-token matching no
+// skill closes the popup rather than sitting open and empty. An open-but-
+// empty popup renders nothing yet still consumes enter and the arrows.
+func TestSkillTriggerClosesWhenNothingMatches(t *testing.T) {
+	t.Parallel()
+
+	m := newSkillCompletionUI()
+	m.skillStates = []*skills.SkillState{
+		{Name: "commit", Path: "/skills/commit/SKILL.md", State: skills.StateNormal},
+	}
+
+	typeInto(m, "do /zzzz")
+
+	require.False(t, m.completionsOpen,
+		"no match must close the popup so enter reaches the prompt")
+}
+
+// TestSkillTriggerOpensOnRealSkillToken is the positive control for the two
+// tests above: the popup must still open and filter for a genuine token.
+func TestSkillTriggerOpensOnRealSkillToken(t *testing.T) {
+	t.Parallel()
+
+	m := newSkillCompletionUI()
+	m.skillStates = []*skills.SkillState{
+		{Name: "commit", Path: "/skills/commit/SKILL.md", State: skills.StateNormal},
+	}
+
+	typeInto(m, "please /com")
+
+	require.True(t, m.completionsOpen, "a real skill token must open the popup")
+	require.Equal(t, completions.TriggerSkill, m.completionsTrigger)
+	require.True(t, m.completions.HasItems())
+}
+
+// TestSkillTriggerSkippedWhenCursorNotAtEnd pins the index invariant.
+//
+// completionsStartIndex is taken from len(value), and insertCompletionText
+// splices there and then MoveToEnd()s, so opening the popup with the cursor
+// elsewhere appended the chosen skill to the end of the prompt and stranded
+// the typed '/' where the cursor actually was.
+func TestSkillTriggerSkippedWhenCursorNotAtEnd(t *testing.T) {
+	t.Parallel()
+
+	m := newSkillCompletionUI()
+	m.skillStates = []*skills.SkillState{
+		{Name: "commit", Path: "/skills/commit/SKILL.md", State: skills.StateNormal},
+	}
+	m.dialog = dialog.NewOverlay()
+	m.textarea.SetValue("review this file ")
+	m.textarea.SetCursorColumn(0)
+	require.NotEqual(t, len(m.textarea.Value()), m.textarea.ByteOffset(),
+		"precondition: the cursor must not be at the end")
+
+	m.handleKeyPressMsg(tea.KeyPressMsg{Code: '/', Text: "/"})
+
+	require.False(t, m.completionsOpen,
+		"the popup must not open when its start index would be wrong")
+}
+
+func TestWordCanBeSkillToken(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		word string
+		want bool
+	}{
+		{"/", true},
+		{"/commit", true},
+		{"/sdd:plan", true}, // plugin skills qualify with a colon
+		{"/tmp/", false},    // a path the moment the second slash lands
+		{"/tmp/out.log", false},
+		{"/usr/local/bin", false},
+	} {
+		require.Equal(t, tc.want, wordCanBeSkillToken(tc.word), "word %q", tc.word)
+	}
 }

--- a/internal/ui/model/skill_completion_test.go
+++ b/internal/ui/model/skill_completion_test.go
@@ -3,8 +3,8 @@ package model
 import (
 	"testing"
 
-	"charm.land/bubbles/v2/textarea"
 	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/crush/internal/ui/textarea"
 
 	"github.com/charmbracelet/crush/internal/config"
 	"github.com/charmbracelet/crush/internal/skills"

--- a/internal/ui/model/slash_command_test.go
+++ b/internal/ui/model/slash_command_test.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"testing"
 
-	"charm.land/bubbles/v2/textarea"
 	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/crush/internal/ui/textarea"
 
 	"github.com/charmbracelet/crush/internal/config"
 	"github.com/charmbracelet/crush/internal/session"

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -136,9 +136,12 @@ type shellStreamMsg struct {
 type (
 	// cancelTimerExpiredMsg is sent when the cancel timer expires.
 	cancelTimerExpiredMsg struct{}
-	// userCommandsLoadedMsg is sent when user commands are loaded.
+	// userCommandsLoadedMsg is sent when user commands are loaded. It also
+	// carries the skill catalog the command list was built from, so the
+	// '/' completions popup gets descriptions off the same single load.
 	userCommandsLoadedMsg struct {
-		Commands []commands.CustomCommand
+		Commands     []commands.CustomCommand
+		SkillEntries []skills.CatalogEntry
 	}
 	// mcpPromptsLoadedMsg is sent when mcp prompts are loaded.
 	mcpPromptsLoadedMsg struct {
@@ -278,9 +281,10 @@ type UI struct {
 	// Completions state
 	completions              *completions.Completions
 	completionsOpen          bool
+	completionsTrigger       completions.Trigger
 	completionsStartIndex    int
 	completionsQuery         string
-	completionsPositionStart image.Point // x,y where user typed '@'
+	completionsPositionStart image.Point // x,y where user typed the trigger
 
 	// lastCompletionEnd tracks the end index of the most recently
 	// inserted completion text so that a single backspace can delete
@@ -309,6 +313,11 @@ type UI struct {
 
 	// skills
 	skillStates []*skills.SkillState
+
+	// skillCatalog is the effective visible skill set (post-override,
+	// post-disable) with frontmatter descriptions, refreshed alongside the
+	// custom commands. It backs the '/' completions popup.
+	skillCatalog []skills.CatalogEntry
 
 	// sidebarLogo keeps a cached version of the sidebar sidebarLogo.
 	sidebarLogo string
@@ -664,7 +673,7 @@ func (m *UI) loadCustomCommands() tea.Cmd {
 			slog.Error("Failed to load skill commands", "error", err)
 		}
 		customCommands = append(customCommands, commands.FromSkillCatalog(skillEntries)...)
-		return userCommandsLoadedMsg{Commands: customCommands}
+		return userCommandsLoadedMsg{Commands: customCommands, SkillEntries: skillEntries}
 	}
 }
 
@@ -805,6 +814,7 @@ func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case userCommandsLoadedMsg:
 		m.customCommands = msg.Commands
+		m.skillCatalog = msg.SkillEntries
 		dia := m.dialog.Dialog(dialog.CommandsID)
 		if dia == nil {
 			break
@@ -937,6 +947,11 @@ func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.lspStates = m.com.Workspace.LSPGetStates()
 	case pubsub.Event[skills.Event]:
 		m.skillStates = msg.Payload.States
+		// Discovery states carry no descriptions and no override/disable
+		// resolution, so re-read the catalog too: a ctrl+r reload in the
+		// skills dialog must move both the command palette and the '/'
+		// completions popup.
+		cmds = append(cmds, m.loadCustomCommands())
 	case pubsub.Event[mcp.Event]:
 		switch msg.Payload.Type {
 		case mcp.EventStateChanged:
@@ -1363,7 +1378,9 @@ func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case util.ClearStatusMsg:
 		m.status.ClearInfoMsg()
 	case completions.CompletionItemsLoadedMsg:
-		if m.completionsOpen {
+		// Guard against a stale async file load landing after the popup
+		// switched to (or was reopened in) skill mode.
+		if m.completionsOpen && m.completionsTrigger == completions.TriggerFile {
 			m.completions.SetItems(msg.Files, msg.Resources)
 		}
 	case uv.KittyGraphicsEvent:
@@ -2485,6 +2502,11 @@ func (m *UI) handleKeyPressMsg(msg tea.KeyPressMsg) tea.Cmd {
 			if m.completionsOpen {
 				if msg, ok := m.completions.Update(msg); ok {
 					switch msg := msg.(type) {
+					case completions.SelectionMsg[completions.SkillCompletionValue]:
+						cmds = append(cmds, m.insertSkillCompletion(msg.Value))
+						if !msg.KeepOpen {
+							m.closeCompletions()
+						}
 					case completions.SelectionMsg[completions.FileCompletionValue]:
 						cmds = append(cmds, m.insertFileCompletion(msg.Value.Path))
 						if !msg.KeepOpen {
@@ -2497,6 +2519,7 @@ func (m *UI) handleKeyPressMsg(msg tea.KeyPressMsg) tea.Cmd {
 						}
 					case completions.ClosedMsg:
 						m.completionsOpen = false
+						m.completionsTrigger = completions.TriggerNone
 					}
 					return tea.Batch(cmds...)
 				}
@@ -2674,20 +2697,32 @@ func (m *UI) handleKeyPressMsg(msg tea.KeyPressMsg) tea.Cmd {
 					m.clearCompletionRange()
 				}
 
-				// Check for @ trigger before passing to textarea.
+				// Check for completion triggers before passing to textarea.
 				curValue := m.textarea.Value()
 				curIdx := len(curValue)
 
-				// Trigger completions on @.
+				// Trigger file completions on @.
 				if msg.String() == "@" && !m.completionsOpen {
 					// Only show if beginning of prompt or after whitespace.
 					if curIdx == 0 || (curIdx > 0 && isWhitespace(curValue[curIdx-1])) {
 						m.completionsOpen = true
+						m.completionsTrigger = completions.TriggerFile
 						m.completionsQuery = ""
 						m.completionsStartIndex = curIdx
 						m.completionsPositionStart = m.completionsPosition()
 						depth, limit := m.com.Config().Options.TUI.Completions.Limits()
 						cmds = append(cmds, m.completions.Open(depth, limit))
+					}
+				}
+
+				// Trigger skill completions on / mid-prompt. At the start of
+				// an empty prompt the commands dialog handles '/' instead
+				// (see the Editor.Commands binding above), so here we only
+				// fire when the textarea already has content and '/' begins
+				// a new word.
+				if msg.String() == "/" && !m.completionsOpen && !m.bangMode {
+					if curIdx > 0 && isWhitespace(curValue[curIdx-1]) {
+						m.openSkillCompletions(curIdx)
 					}
 				}
 
@@ -2731,8 +2766,9 @@ func (m *UI) handleKeyPressMsg(msg tea.KeyPressMsg) tea.Cmd {
 				m.updateHistoryDraft(curValue)
 
 				// After updating textarea, check if we need to filter completions.
-				// Skip filtering on the initial @ keystroke since items are loading async.
-				if m.completionsOpen && msg.String() != "@" {
+				// Skip filtering on the initial trigger keystroke since items
+				// are loading async.
+				if m.completionsOpen && msg.String() != string(m.completionsTrigger) {
 					newValue := m.textarea.Value()
 					newIdx := len(newValue)
 
@@ -2745,7 +2781,7 @@ func (m *UI) handleKeyPressMsg(msg tea.KeyPressMsg) tea.Cmd {
 					} else {
 						// Extract current word and filter.
 						word := m.textareaWord()
-						if strings.HasPrefix(word, "@") {
+						if strings.HasPrefix(word, string(m.completionsTrigger)) {
 							m.completionsQuery = word[1:]
 							m.completions.Filter(m.completionsQuery)
 						} else if m.completionsOpen {
@@ -3835,9 +3871,73 @@ func (m *UI) bangPromptFunc(info textarea.PromptInfo) string {
 // closeCompletions closes the completions popup and resets state.
 func (m *UI) closeCompletions() {
 	m.completionsOpen = false
+	m.completionsTrigger = completions.TriggerNone
 	m.completionsQuery = ""
 	m.completionsStartIndex = 0
 	m.completions.Close()
+}
+
+// skillCompletionValues returns the skills offered by the '/' popup.
+//
+// The catalog is the right source: it is the effective, post-dedup,
+// post-disable set, it includes the builtin skills the raw discovery states
+// omit, and it carries each skill's frontmatter description. The discovery
+// states are only a fallback for the window between startup and the first
+// catalog load, where a name-only list still beats an empty popup.
+func (m *UI) skillCompletionValues() []completions.SkillCompletionValue {
+	var values []completions.SkillCompletionValue
+	if len(m.skillCatalog) > 0 {
+		for _, entry := range m.skillCatalog {
+			if entry.Name == "" {
+				continue
+			}
+			values = append(values, completions.SkillCompletionValue{
+				Name:        entry.Name,
+				Description: entry.Description,
+				Path:        entry.ID,
+			})
+		}
+	} else {
+		seen := make(map[string]struct{}, len(m.skillStates))
+		for _, s := range m.skillStates {
+			if s == nil || s.Name == "" || s.State != skills.StateNormal {
+				continue
+			}
+			if _, dup := seen[s.Name]; dup {
+				continue
+			}
+			seen[s.Name] = struct{}{}
+			values = append(values, completions.SkillCompletionValue{
+				Name: s.Name,
+				Path: s.Path,
+			})
+		}
+	}
+	slices.SortFunc(values, func(a, b completions.SkillCompletionValue) int {
+		return strings.Compare(a.Name, b.Name)
+	})
+	return values
+}
+
+// openSkillCompletions opens the completions popup in skill mode at the
+// given trigger index. Skills are already in memory, so no async load is
+// needed.
+func (m *UI) openSkillCompletions(startIndex int) {
+	values := m.skillCompletionValues()
+	if len(values) == 0 {
+		// An open-but-empty popup still consumes enter and the arrow keys,
+		// so a user with no skills configured could not submit a prompt
+		// containing a '/'. Unlike '@' there is nothing to wait on here —
+		// no skills means no popup.
+		return
+	}
+
+	m.completionsOpen = true
+	m.completionsTrigger = completions.TriggerSkill
+	m.completionsQuery = ""
+	m.completionsStartIndex = startIndex
+	m.completionsPositionStart = m.completionsPosition()
+	m.completions.SetSkillItems(values)
 }
 
 // insertCompletionText replaces the @query in the textarea with the given text.
@@ -3987,6 +4087,17 @@ func (m *UI) insertMCPResourceCompletion(item completions.ResourceCompletionValu
 		}
 	}
 	return tea.Batch(heightCmd, resourceCmd)
+}
+
+// insertSkillCompletion inserts the selected skill name into the textarea,
+// replacing the /query. Unlike files, skills are not attached — the
+// "/skill-name" text in the prompt is the signal to load the skill.
+func (m *UI) insertSkillCompletion(skill completions.SkillCompletionValue) tea.Cmd {
+	prevHeight := m.textarea.Height()
+	if !m.insertCompletionText("/" + skill.Name) {
+		return nil
+	}
+	return m.handleTextareaHeightChange(prevHeight)
 }
 
 // completionsPosition returns the X and Y position for the completions popup.

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -2734,7 +2734,18 @@ func (m *UI) handleKeyPressMsg(msg tea.KeyPressMsg) tea.Cmd {
 				// (see the Editor.Commands binding above), so here we only
 				// fire when the textarea already has content and '/' begins
 				// a new word.
-				if msg.String() == "/" && !m.completionsOpen && !m.bangMode {
+				//
+				// curIdx is the length of the value, not the cursor, and
+				// insertCompletionText splices at completionsStartIndex and
+				// then MoveToEnd()s — so opening the popup with the cursor
+				// anywhere but the end would append the chosen skill to the
+				// end of the prompt and strand the '/' the user typed where
+				// the cursor actually was. Requiring the two to agree keeps
+				// the index honest; the '@' trigger above has the same
+				// end-of-value assumption, and #250's atomic backspace
+				// depends on it as well.
+				if msg.String() == "/" && !m.completionsOpen && !m.bangMode &&
+					m.textarea.ByteOffset() == curIdx {
 					if curIdx > 0 && isWhitespace(curValue[curIdx-1]) {
 						m.openSkillCompletions(curIdx)
 					}
@@ -2795,11 +2806,36 @@ func (m *UI) handleKeyPressMsg(msg tea.KeyPressMsg) tea.Cmd {
 					} else {
 						// Extract current word and filter.
 						word := m.textareaWord()
-						if strings.HasPrefix(word, string(m.completionsTrigger)) {
+						switch {
+						case !strings.HasPrefix(word, string(m.completionsTrigger)):
+							m.closeCompletions()
+						case m.completionsTrigger == completions.TriggerSkill &&
+							!wordCanBeSkillToken(word):
+							// '/' also begins every absolute path, and the
+							// trigger cannot tell the two apart from the
+							// slash alone. A second separator settles it:
+							// skill names never contain one, so the user is
+							// typing a path and the popup must get out of
+							// the way.
+							m.closeCompletions()
+						default:
 							m.completionsQuery = word[1:]
 							m.completions.Filter(m.completionsQuery)
-						} else if m.completionsOpen {
-							m.closeCompletions()
+							// An open popup with nothing in it still swallows
+							// enter and the arrow keys — the prompt cannot be
+							// submitted until the user finds escape. Nothing
+							// is drawn in that state either, so there is no
+							// hint as to what is eating the key.
+							//
+							// Only the skill popup is closed on an empty
+							// filter: its items are installed synchronously
+							// by SetSkillItems, so empty really means "no
+							// match". The file popup loads asynchronously and
+							// is legitimately empty until the walk returns.
+							if m.completionsTrigger == completions.TriggerSkill &&
+								!m.completions.HasItems() {
+								m.closeCompletions()
+							}
 						}
 					}
 				}
@@ -3936,6 +3972,18 @@ func (m *UI) skillCompletionValues() []completions.SkillCompletionValue {
 // openSkillCompletions opens the completions popup in skill mode at the
 // given trigger index. Skills are already in memory, so no async load is
 // needed.
+// wordCanBeSkillToken reports whether word — the token beginning at the '/'
+// that opened the skill popup — can still be a skill reference.
+//
+// '/' opens both a skill token and every absolute path, and at the moment it
+// is typed the two are indistinguishable. They diverge on the next
+// separator: a skill name is a single segment (plugin skills qualify with a
+// colon, as in "sdd:plan"), so a second '/' means the user is typing a path
+// like /tmp/out.log and the popup must stop claiming their keystrokes.
+func wordCanBeSkillToken(word string) bool {
+	return !strings.Contains(strings.TrimPrefix(word, "/"), "/")
+}
+
 func (m *UI) openSkillCompletions(startIndex int) {
 	values := m.skillCompletionValues()
 	if len(values) == 0 {
@@ -4295,6 +4343,12 @@ func (m *UI) refreshStyles() {
 		m.cacheSidebarLogo(m.layout.sidebar.Dx())
 	}
 	m.textarea.SetStyles(t.Editor.Textarea)
+	// The highlighter copies its styles at construction, so it needs the
+	// same re-push every other value-copying subcomponent here gets.
+	if m.promptHighlighter != nil {
+		m.promptHighlighter.SetStyles(t.Editor.TokenFile, t.Editor.TokenSkill)
+		m.promptHighlighter.Rescan(m.textarea.Value())
+	}
 	m.completions.SetStyles(t.Completions.Normal, t.Completions.Focused, t.Completions.Match)
 	m.attachments.Renderer().SetStyles(
 		t.Attachments.Normal,

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -23,7 +23,6 @@ import (
 	"charm.land/bubbles/v2/help"
 	"charm.land/bubbles/v2/key"
 	"charm.land/bubbles/v2/spinner"
-	"charm.land/bubbles/v2/textarea"
 	tea "charm.land/bubbletea/v2"
 	"charm.land/catwalk/pkg/catwalk"
 	"charm.land/lipgloss/v2"
@@ -58,6 +57,7 @@ import (
 	"github.com/charmbracelet/crush/internal/ui/logo"
 	"github.com/charmbracelet/crush/internal/ui/notification"
 	"github.com/charmbracelet/crush/internal/ui/styles"
+	"github.com/charmbracelet/crush/internal/ui/textarea"
 	"github.com/charmbracelet/crush/internal/ui/util"
 	"github.com/charmbracelet/crush/internal/version"
 	"github.com/charmbracelet/crush/internal/workspace"
@@ -297,6 +297,10 @@ type UI struct {
 	lastCompletionEnd   int
 	lastCompletionText  string
 
+	// promptHighlighter styles @file and /skill tokens inline as the user
+	// types. Installed on the textarea via SetHighlighter.
+	promptHighlighter *promptHighlighter
+
 	// Chat components
 	chat *Chat
 
@@ -409,6 +413,12 @@ func New(com *common.Common, initialSessionID string, continueLast bool) *UI {
 	ta.MaxHeight = TextareaMaxHeight
 	ta.Focus()
 
+	promptHL := newPromptHighlighter(
+		com.Styles.Editor.TokenFile,
+		com.Styles.Editor.TokenSkill,
+	)
+	ta.SetHighlighter(promptHL)
+
 	scrollbarMode := config.ScrollbarDefault
 	if cfg := com.Config(); cfg.Options.TUI != nil && cfg.Options.TUI.Scrollbar != "" {
 		scrollbarMode = cfg.Options.TUI.Scrollbar
@@ -458,6 +468,7 @@ func New(com *common.Common, initialSessionID string, continueLast bool) *UI {
 		completions:         comp,
 		attachments:         attachments,
 		todoSpinner:         todoSpinner,
+		promptHighlighter:   promptHL,
 		lspStates:           make(map[string]workspace.LSPClientInfo),
 		mcpStates:           make(map[string]mcp.ClientInfo),
 		notifyBackend:       notification.NoopBackend{},
@@ -466,6 +477,7 @@ func New(com *common.Common, initialSessionID string, continueLast bool) *UI {
 		continueLastSession: continueLast,
 		skillStates:         skills.GetLatestStates(),
 	}
+	ui.refreshSkillNames()
 
 	status := NewStatus(com, ui)
 
@@ -815,6 +827,7 @@ func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case userCommandsLoadedMsg:
 		m.customCommands = msg.Commands
 		m.skillCatalog = msg.SkillEntries
+		m.refreshSkillNames()
 		dia := m.dialog.Dialog(dialog.CommandsID)
 		if dia == nil {
 			break
@@ -947,6 +960,7 @@ func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.lspStates = m.com.Workspace.LSPGetStates()
 	case pubsub.Event[skills.Event]:
 		m.skillStates = msg.Payload.States
+		m.refreshSkillNames()
 		// Discovery states carry no descriptions and no override/disable
 		// resolution, so re-read the catalog too: a ctrl+r reload in the
 		// skills dialog must move both the command palette and the '/'
@@ -4219,6 +4233,19 @@ func (m *UI) renderEditorView(width int) string {
 	var attachmentsView string
 	if len(m.attachments.List()) > 0 {
 		attachmentsView = m.attachments.Render(width)
+	}
+	// Retokenize @file and /skill tokens on every render. The scan is
+	// linear in prompt length and render happens every frame anyway, so
+	// this is the single seam that stays correct for every value-mutation
+	// path (typing, paste, history, completion inserts). Bang mode is a
+	// shell prompt — its slashes are paths, not skills — so tokens are
+	// suppressed there.
+	if m.promptHighlighter != nil {
+		if m.bangMode {
+			m.promptHighlighter.Rescan("")
+		} else {
+			m.promptHighlighter.Rescan(m.textarea.Value())
+		}
 	}
 	return strings.Join([]string{
 		attachmentsView,

--- a/internal/ui/styles/quickstyle.go
+++ b/internal/ui/styles/quickstyle.go
@@ -5,12 +5,12 @@ import (
 
 	"charm.land/bubbles/v2/filepicker"
 	"charm.land/bubbles/v2/help"
-	"charm.land/bubbles/v2/textarea"
 	"charm.land/bubbles/v2/textinput"
 	tea "charm.land/bubbletea/v2"
 	"charm.land/glamour/v2/ansi"
 	"charm.land/lipgloss/v2"
 	"github.com/charmbracelet/crush/internal/ui/diffview"
+	"github.com/charmbracelet/crush/internal/ui/textarea"
 	uv "github.com/charmbracelet/ultraviolet"
 	"github.com/charmbracelet/x/exp/charmtone"
 )
@@ -752,6 +752,12 @@ func quickStyle(o quickStyleOpts) Styles {
 	s.Editor.QuestionRadioOff = lipgloss.NewStyle().Foreground(o.fgSubtle).SetString(RadioOff)
 	s.Editor.QuestionCheckOn = lipgloss.NewStyle().Foreground(o.secondary).SetString(RadioOn)
 	s.Editor.QuestionCheckOff = lipgloss.NewStyle().Foreground(o.fgSubtle).SetString(RadioOff)
+
+	// Inline prompt tokens: @file mentions use the primary accent, /skill
+	// references the secondary, both bolded so they stand apart from prompt
+	// prose.
+	s.Editor.TokenFile = lipgloss.NewStyle().Foreground(o.primary).Bold(true)
+	s.Editor.TokenSkill = lipgloss.NewStyle().Foreground(o.secondary).Bold(true)
 
 	s.Radio.On = lipgloss.NewStyle().Foreground(o.fgSubtle).SetString(RadioOn)
 	s.Radio.Off = lipgloss.NewStyle().Foreground(o.fgSubtle).SetString(RadioOff)

--- a/internal/ui/styles/styles.go
+++ b/internal/ui/styles/styles.go
@@ -8,12 +8,12 @@ import (
 
 	"charm.land/bubbles/v2/filepicker"
 	"charm.land/bubbles/v2/help"
-	"charm.land/bubbles/v2/textarea"
 	"charm.land/bubbles/v2/textinput"
 	"charm.land/glamour/v2/ansi"
 	"charm.land/lipgloss/v2"
 	"github.com/alecthomas/chroma/v2"
 	"github.com/charmbracelet/crush/internal/ui/diffview"
+	"github.com/charmbracelet/crush/internal/ui/textarea"
 	uv "github.com/charmbracelet/ultraviolet"
 )
 
@@ -165,6 +165,11 @@ type Styles struct {
 		QuestionRadioOff   lipgloss.Style // Unselected single-choice radio.
 		QuestionCheckOn    lipgloss.Style // Checked multi-choice indicator.
 		QuestionCheckOff   lipgloss.Style // Unchecked multi-choice indicator.
+
+		// Inline token highlighting in the prompt textarea: @file mentions
+		// and /skill references typed into the prompt.
+		TokenFile  lipgloss.Style
+		TokenSkill lipgloss.Style
 	}
 
 	// Radio

--- a/internal/ui/textarea/highlighter.go
+++ b/internal/ui/textarea/highlighter.go
@@ -2,7 +2,7 @@ package textarea
 
 import (
 	"charm.land/lipgloss/v2"
-	rw "github.com/mattn/go-runewidth"
+	"github.com/charmbracelet/x/ansi"
 )
 
 // LineHighlighter is an optional hook that applies per-token styling to
@@ -103,10 +103,17 @@ func toStyleRanges(seg []rune, ranges []lipgloss.Range, base lipgloss.Style) []l
 }
 
 // runeDisplayWidth returns the total display width of runes.
+//
+// It must measure the same way lipgloss.StyleRanges resolves the cell
+// offsets it is handed — that goes through ansi.Cut, which segments by
+// grapheme cluster. Summing per-rune widths instead disagrees on every
+// cluster built from more than one rune: an emoji with a skin-tone modifier
+// scores 4 rather than 2, a ZWJ family 7 rather than 2, and the token
+// highlight lands that many cells to the right of the token it belongs to.
+// internal/ui/AGENTS.md requires the x/ansi package for exactly this, and
+// the posted-message path (ui/chat/prompt_tokens.go) already uses
+// ansi.StringWidth — measuring differently here made the same text render
+// differently above and below the editor.
 func runeDisplayWidth(r []rune) int {
-	w := 0
-	for _, ru := range r {
-		w += rw.RuneWidth(ru)
-	}
-	return w
+	return ansi.StringWidth(string(r))
 }

--- a/internal/ui/textarea/highlighter.go
+++ b/internal/ui/textarea/highlighter.go
@@ -1,0 +1,112 @@
+package textarea
+
+import (
+	"charm.land/lipgloss/v2"
+	rw "github.com/mattn/go-runewidth"
+)
+
+// LineHighlighter is an optional hook that applies per-token styling to
+// rendered lines. It is consulted once per logical line per render and
+// returns style ranges over the line's runes: range Start (inclusive) and
+// End (exclusive) are rune offsets within the line, and Style is composed
+// with the line's base style by the renderer.
+//
+// The hook runs after wrapping: the textarea asks for ranges on the raw
+// logical line, then intersects those ranges with each wrapped segment at
+// render time. Implementations must therefore return ranges in rune offsets
+// of the logical line they are given — never byte offsets, and never ranges
+// derived from a different string.
+//
+// The cell under the virtual cursor is never styled by ranges: the renderer
+// splits cursor-line content into pre- and post-cursor segments and renders
+// the cursor cell itself separately.
+//
+// Keeping this interface range-based (rather than bubbline's
+// func(string) string ANSI rewriting) means implementations never have to
+// parse or preserve escape sequences, and the textarea's wrap/cursor math
+// always operates on raw runes.
+type LineHighlighter interface {
+	// Highlight returns the style ranges for the given logical line.
+	// lineIdx is the zero-based logical line number; line is the raw rune
+	// content (no trailing newline). Implementations should return nil for
+	// lines with nothing to style.
+	Highlight(lineIdx int, line []rune) []lipgloss.Range
+}
+
+// SetHighlighter installs an optional line highlighter. Pass nil to disable
+// highlighting. The highlighter is consulted at render time only; it does
+// not affect editing, wrapping, or cursor positioning.
+func (m *Model) SetHighlighter(h LineHighlighter) {
+	m.highlighter = h
+}
+
+// highlightRanges returns the highlighter's ranges for a logical line, or
+// nil when no highlighter is installed.
+func (m *Model) highlightRanges(lineIdx int, line []rune) []lipgloss.Range {
+	if m.highlighter == nil {
+		return nil
+	}
+	return m.highlighter.Highlight(lineIdx, line)
+}
+
+// styleSegment renders a wrapped-line segment, applying any highlighter
+// ranges that intersect it. segStart is the rune offset of the segment
+// within its logical line. The cell under the virtual cursor never reaches
+// this function: the renderer splits cursor-line content into pre- and
+// post-cursor segments and renders the cursor cell itself separately, so
+// token styling and cursor styling can never fight over the same cell.
+func styleSegment(
+	base lipgloss.Style,
+	seg []rune,
+	segStart int,
+	lineRanges []lipgloss.Range,
+) string {
+	if len(lineRanges) == 0 || len(seg) == 0 {
+		return base.Render(string(seg))
+	}
+
+	segEnd := segStart + len(seg)
+	var ranges []lipgloss.Range
+	for _, r := range lineRanges {
+		// Intersect the token range with this segment.
+		start := max(r.Start, segStart) - segStart
+		end := min(r.End, segEnd) - segStart
+		if start >= end {
+			continue
+		}
+		ranges = append(ranges, lipgloss.NewRange(start, end, r.Style))
+	}
+
+	if len(ranges) == 0 {
+		return base.Render(string(seg))
+	}
+
+	// StyleRanges composes each range's style over the base-rendered string.
+	// Range offsets are 1-based display cells in lipgloss; map rune offsets
+	// through display widths to stay correct for double-width runes.
+	return lipgloss.StyleRanges(base.Render(string(seg)), toStyleRanges(seg, ranges, base)...)
+}
+
+// toStyleRanges converts rune-offset ranges into the display-cell ranges
+// lipgloss.StyleRanges expects: zero-based and half-open over the cells of
+// the ANSI-stripped string. Each token style inherits the base style's
+// attributes so tokens only override what they set.
+func toStyleRanges(seg []rune, ranges []lipgloss.Range, base lipgloss.Style) []lipgloss.Range {
+	out := make([]lipgloss.Range, 0, len(ranges))
+	for _, r := range ranges {
+		startCell := runeDisplayWidth(seg[:r.Start])
+		endCell := startCell + runeDisplayWidth(seg[r.Start:r.End])
+		style := r.Style.Inherit(base)
+		out = append(out, lipgloss.NewRange(startCell, endCell, style))
+	}
+	return out
+}
+
+// runeDisplayWidth returns the total display width of runes.
+func runeDisplayWidth(r []rune) int {
+	w := 0
+	for _, ru := range r {
+		w += rw.RuneWidth(ru)
+	}
+	return w
+}

--- a/internal/ui/textarea/highlighter_test.go
+++ b/internal/ui/textarea/highlighter_test.go
@@ -174,3 +174,53 @@ func TestViewHighlighterTokenSurvivesWrap(t *testing.T) {
 	}
 	require.True(t, strings.Contains(highlighted, "\x1b["), "expected ANSI styling in output")
 }
+
+// TestRuneDisplayWidthMatchesGraphemeSegmentation pins the measurement
+// contract with lipgloss.StyleRanges.
+//
+// StyleRanges resolves the cell offsets it is handed with ansi.Cut, which
+// segments by grapheme cluster. Summing per-rune widths disagrees on every
+// cluster built from more than one rune, and the highlight then lands that
+// many cells right of its token.
+func TestRuneDisplayWidthMatchesGraphemeSegmentation(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name string
+		in   string
+	}{
+		{"ascii", "hello"},
+		{"cjk double width", "日本語"},
+		{"emoji with skin tone modifier", "👍🏽"},
+		{"zwj family", "👨‍👩‍👧"},
+		{"emoji then token", "👍🏽 @file.go"},
+	} {
+		require.Equal(t, ansi.StringWidth(tc.in), runeDisplayWidth([]rune(tc.in)),
+			"width of %s must match grapheme-cluster segmentation", tc.name)
+	}
+}
+
+// TestHighlightRangesLandOnTokenAfterEmoji is the user-visible form of the
+// bug: with per-rune widths the styled span started two cells past the '@'.
+func TestHighlightRangesLandOnTokenAfterEmoji(t *testing.T) {
+	t.Parallel()
+
+	// "👍🏽 @file.go" — the token starts after a 2-cell grapheme and a space,
+	// so at cell 3. Per-rune summing put it at 5.
+	const line = "👍🏽 @file.go"
+	runes := []rune(line)
+	at := indexOfRune(runes, '@')
+	require.Positive(t, at)
+
+	require.Equal(t, 3, runeDisplayWidth(runes[:at]),
+		"the token must start at the cell ansi.Cut would land on")
+}
+
+func indexOfRune(rs []rune, target rune) int {
+	for i, r := range rs {
+		if r == target {
+			return i
+		}
+	}
+	return -1
+}

--- a/internal/ui/textarea/highlighter_test.go
+++ b/internal/ui/textarea/highlighter_test.go
@@ -1,0 +1,176 @@
+package textarea
+
+import (
+	"strings"
+	"testing"
+
+	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/stretchr/testify/require"
+)
+
+// tokenHighlighter is a test LineHighlighter that marks every "@"-prefixed
+// word with a fixed style.
+type tokenHighlighter struct {
+	style lipgloss.Style
+}
+
+func (h tokenHighlighter) Highlight(_ int, line []rune) []lipgloss.Range {
+	var ranges []lipgloss.Range
+	i := 0
+	for i < len(line) {
+		if line[i] == '@' {
+			end := i + 1
+			for end < len(line) && line[end] != ' ' {
+				end++
+			}
+			ranges = append(ranges, lipgloss.NewRange(i, end, h.style))
+			i = end
+			continue
+		}
+		i++
+	}
+	return ranges
+}
+
+func TestStyleSegmentAppliesRanges(t *testing.T) {
+	t.Parallel()
+
+	base := lipgloss.NewStyle()
+	tokenStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("2"))
+
+	seg := []rune("see @foo.go here")
+	ranges := []lipgloss.Range{lipgloss.NewRange(4, 11, tokenStyle)}
+
+	got := styleSegment(base, seg, 0, ranges)
+
+	// The rendered segment must differ from the plain render and the token
+	// text must survive styling.
+	require.NotEqual(t, base.Render(string(seg)), got)
+	require.Contains(t, ansi.Strip(got), "see @foo.go here")
+}
+
+// TestStyleSegmentStylesExactlyTheToken pins which cells the token style
+// lands on. Regression: the rune-to-cell conversion used to add one, so
+// every token rendered shifted a cell to the right — the trigger character
+// stayed unstyled and the following space picked the style up instead.
+func TestStyleSegmentStylesExactlyTheToken(t *testing.T) {
+	t.Parallel()
+
+	base := lipgloss.NewStyle()
+	tokenStyle := lipgloss.NewStyle().Bold(true)
+
+	seg := []rune("ab @foo cd")
+	got := styleSegment(base, seg, 0, []lipgloss.Range{lipgloss.NewRange(3, 7, tokenStyle)})
+
+	require.Equal(t, "ab \x1b[1m@foo\x1b[m cd", got)
+}
+
+// TestStyleSegmentStylesExactlyTheTokenWideRunes is the same pin with
+// double-width runes ahead of the token, where a rune offset and a cell
+// offset diverge.
+func TestStyleSegmentStylesExactlyTheTokenWideRunes(t *testing.T) {
+	t.Parallel()
+
+	base := lipgloss.NewStyle()
+	tokenStyle := lipgloss.NewStyle().Bold(true)
+
+	// "世界" is two runes but four cells.
+	seg := []rune("世界 @foo")
+	got := styleSegment(base, seg, 0, []lipgloss.Range{lipgloss.NewRange(3, 7, tokenStyle)})
+
+	require.Equal(t, "世界 \x1b[1m@foo\x1b[m", got)
+}
+
+func TestStyleSegmentOffsetsBySegStart(t *testing.T) {
+	t.Parallel()
+	base := lipgloss.NewStyle()
+	tokenStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("2"))
+
+	// Logical line: "see @foo.go here", wrapped segment is "foo.go here"
+	// starting at rune 7. The token range (4,11) intersects as (0,4).
+	seg := []rune("foo.go here")
+	ranges := []lipgloss.Range{lipgloss.NewRange(4, 11, tokenStyle)}
+
+	got := styleSegment(base, seg, 7, ranges)
+	require.Contains(t, ansi.Strip(got), "foo.go here")
+	require.NotEqual(t, base.Render(string(seg)), got)
+}
+
+func TestStyleSegmentNoRangesIsPlainRender(t *testing.T) {
+	t.Parallel()
+
+	base := lipgloss.NewStyle()
+	seg := []rune("plain text")
+
+	require.Equal(t, base.Render(string(seg)), styleSegment(base, seg, 0, nil))
+	require.Equal(t, base.Render(string(seg)), styleSegment(base, seg, 0, []lipgloss.Range{
+		lipgloss.NewRange(50, 60, lipgloss.NewStyle().Bold(true)), // outside segment
+	}))
+}
+
+func TestViewWithHighlighterStylesTokens(t *testing.T) {
+	t.Parallel()
+	m := New()
+	m.SetValue("see @foo.go and @bar.md")
+	m.SetWidth(80)
+	m.SetHighlighter(tokenHighlighter{style: lipgloss.NewStyle().Foreground(lipgloss.Color("2"))})
+
+	plain := New()
+	plain.SetValue("see @foo.go and @bar.md")
+	plain.SetWidth(80)
+
+	highlighted := m.View()
+	require.NotEqual(t, plain.View(), highlighted, "highlighter should change the rendered view")
+	// Content must survive styling: stripping ANSI yields the same text.
+	require.Equal(t, ansi.Strip(plain.View()), ansi.Strip(highlighted))
+}
+
+func TestViewWithoutHighlighterUnchanged(t *testing.T) {
+	t.Parallel()
+
+	m := New()
+	m.SetValue("see @foo.go")
+	m.SetWidth(80)
+
+	before := m.View()
+	m.SetHighlighter(nil)
+	require.Equal(t, before, m.View())
+}
+
+func TestViewHighlighterOnCursorLine(t *testing.T) {
+	t.Parallel()
+	m := New()
+	m.Focus()
+	m.SetValue("go @foo.go now")
+	m.SetWidth(80)
+	m.SetHighlighter(tokenHighlighter{style: lipgloss.NewStyle().Foreground(lipgloss.Color("2"))})
+
+	// Move cursor into the middle of the token to exercise the
+	// pre/post-cursor split paths.
+	m.SetCursorColumn(5)
+
+	highlighted := m.View()
+	// Cursor-line rendering must not corrupt content.
+	require.Contains(t, ansi.Strip(highlighted), "go @foo.go now")
+}
+
+func TestViewHighlighterTokenSurvivesWrap(t *testing.T) {
+	t.Parallel()
+	m := New()
+	// Force a wrap inside the second word region: width 10 wraps
+	// "ab @longtoken cd" into multiple segments.
+	m.SetValue("ab @longtoken cd")
+	m.SetWidth(10)
+	m.SetHeight(6)
+	m.SetHighlighter(tokenHighlighter{style: lipgloss.NewStyle().Foreground(lipgloss.Color("2"))})
+
+	highlighted := m.View()
+	stripped := ansi.Strip(highlighted)
+	// All token characters still render after wrapping + styling (the wrap
+	// splits the token across segments; assert on the wrap chunks).
+	for _, part := range []string{"ab", "@lon", "gtok", "en", "cd"} {
+		require.Contains(t, stripped, part)
+	}
+	require.True(t, strings.Contains(highlighted, "\x1b["), "expected ANSI styling in output")
+}

--- a/internal/ui/textarea/internal/memoization/memoization.go
+++ b/internal/ui/textarea/internal/memoization/memoization.go
@@ -1,0 +1,125 @@
+// Package memoization implement a simple memoization cache. It's designed to
+// improve performance in textarea.
+package memoization
+
+import (
+	"container/list"
+	"crypto/sha256"
+	"fmt"
+	"sync"
+)
+
+// Hasher is an interface that requires a Hash method. The Hash method is
+// expected to return a string representation of the hash of the object.
+type Hasher interface {
+	Hash() string
+}
+
+// entry is a struct that holds a key-value pair. It is used as an element
+// in the evictionList of the MemoCache.
+type entry[T any] struct {
+	key   string
+	value T
+}
+
+// MemoCache is a struct that represents a cache with a set capacity. It
+// uses an LRU (Least Recently Used) eviction policy. It is safe for
+// concurrent use.
+type MemoCache[H Hasher, T any] struct {
+	capacity      int
+	mutex         sync.Mutex
+	cache         map[string]*list.Element // The cache holding the results
+	evictionList  *list.List               // A list to keep track of the order for LRU
+	hashableItems map[string]T             // This map keeps track of the original hashable items (optional)
+}
+
+// NewMemoCache is a function that creates a new MemoCache with a given
+// capacity. It returns a pointer to the created MemoCache.
+func NewMemoCache[H Hasher, T any](capacity int) *MemoCache[H, T] {
+	return &MemoCache[H, T]{
+		capacity:      capacity,
+		cache:         make(map[string]*list.Element),
+		evictionList:  list.New(),
+		hashableItems: make(map[string]T),
+	}
+}
+
+// Capacity is a method that returns the capacity of the MemoCache.
+func (m *MemoCache[H, T]) Capacity() int {
+	return m.capacity
+}
+
+// Size is a method that returns the current size of the MemoCache. It is
+// the number of items currently stored in the cache.
+func (m *MemoCache[H, T]) Size() int {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	return m.evictionList.Len()
+}
+
+// Get is a method that returns the value associated with the given
+// hashable item in the MemoCache. If there is no corresponding value, the
+// method returns nil.
+func (m *MemoCache[H, T]) Get(h H) (T, bool) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	hashedKey := h.Hash()
+	if element, found := m.cache[hashedKey]; found {
+		m.evictionList.MoveToFront(element)
+		return element.Value.(*entry[T]).value, true
+	}
+	var result T
+	return result, false
+}
+
+// Set is a method that sets the value for the given hashable item in the
+// MemoCache. If the cache is at capacity, it evicts the least recently
+// used item before adding the new item.
+func (m *MemoCache[H, T]) Set(h H, value T) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	hashedKey := h.Hash()
+	if element, found := m.cache[hashedKey]; found {
+		m.evictionList.MoveToFront(element)
+		element.Value.(*entry[T]).value = value
+		return
+	}
+
+	// Check if the cache is at capacity
+	if m.evictionList.Len() >= m.capacity {
+		// Evict the least recently used item from the cache
+		toEvict := m.evictionList.Back()
+		if toEvict != nil {
+			evictedEntry := m.evictionList.Remove(toEvict).(*entry[T])
+			delete(m.cache, evictedEntry.key)
+			delete(m.hashableItems, evictedEntry.key) // if you're keeping track of original items
+		}
+	}
+
+	// Add the value to the cache and the evictionList
+	newEntry := &entry[T]{
+		key:   hashedKey,
+		value: value,
+	}
+	element := m.evictionList.PushFront(newEntry)
+	m.cache[hashedKey] = element
+	m.hashableItems[hashedKey] = value // if you're keeping track of original items
+}
+
+// HString is a type that implements the Hasher interface for strings.
+type HString string
+
+// Hash is a method that returns the hash of the string.
+func (h HString) Hash() string {
+	return fmt.Sprintf("%x", sha256.Sum256([]byte(h)))
+}
+
+// HInt is a type that implements the Hasher interface for integers.
+type HInt int
+
+// Hash is a method that returns the hash of the integer.
+func (h HInt) Hash() string {
+	return fmt.Sprintf("%x", sha256.Sum256(fmt.Appendf(nil, "%d", h)))
+}

--- a/internal/ui/textarea/internal/runeutil/runeutil.go
+++ b/internal/ui/textarea/internal/runeutil/runeutil.go
@@ -1,0 +1,102 @@
+// Package runeutil provides utility functions for tidying up incoming runes
+// from Key messages.
+package runeutil
+
+import (
+	"unicode"
+	"unicode/utf8"
+)
+
+// Sanitizer is a helper for bubble widgets that want to process
+// Runes from input key messages.
+type Sanitizer interface {
+	// Sanitize removes control characters from runes in a KeyRunes
+	// message, and optionally replaces newline/carriage return/tabs by a
+	// specified character.
+	//
+	// The rune array is modified in-place if possible. In that case, the
+	// returned slice is the original slice shortened after the control
+	// characters have been removed/translated.
+	Sanitize(runes []rune) []rune
+}
+
+// NewSanitizer constructs a rune sanitizer.
+func NewSanitizer(opts ...Option) Sanitizer {
+	s := sanitizer{
+		replaceNewLine: []rune("\n"),
+		replaceTab:     []rune("    "),
+	}
+	for _, o := range opts {
+		s = o(s)
+	}
+	return &s
+}
+
+// Option is the type of option that can be passed to Sanitize().
+type Option func(sanitizer) sanitizer
+
+// ReplaceTabs replaces tabs by the specified string.
+func ReplaceTabs(tabRepl string) Option {
+	return func(s sanitizer) sanitizer {
+		s.replaceTab = []rune(tabRepl)
+		return s
+	}
+}
+
+// ReplaceNewlines replaces newline characters by the specified string.
+func ReplaceNewlines(nlRepl string) Option {
+	return func(s sanitizer) sanitizer {
+		s.replaceNewLine = []rune(nlRepl)
+		return s
+	}
+}
+
+func (s *sanitizer) Sanitize(runes []rune) []rune {
+	// dstrunes are where we are storing the result.
+	dstrunes := runes[:0:len(runes)]
+	// copied indicates whether dstrunes is an alias of runes
+	// or a copy. We need a copy when dst moves past src.
+	// We use this as an optimization to avoid allocating
+	// a new rune slice in the common case where the output
+	// is smaller or equal to the input.
+	copied := false
+
+	for src := range runes {
+		r := runes[src]
+		switch {
+		case r == utf8.RuneError:
+			// skip
+
+		case r == '\r' || r == '\n':
+			if len(dstrunes)+len(s.replaceNewLine) > src && !copied {
+				dst := len(dstrunes)
+				dstrunes = make([]rune, dst, len(runes)+len(s.replaceNewLine))
+				copy(dstrunes, runes[:dst])
+				copied = true
+			}
+			dstrunes = append(dstrunes, s.replaceNewLine...)
+
+		case r == '\t':
+			if len(dstrunes)+len(s.replaceTab) > src && !copied {
+				dst := len(dstrunes)
+				dstrunes = make([]rune, dst, len(runes)+len(s.replaceTab))
+				copy(dstrunes, runes[:dst])
+				copied = true
+			}
+			dstrunes = append(dstrunes, s.replaceTab...)
+
+		case unicode.IsControl(r):
+			// Other control characters: skip.
+
+		default:
+			// Keep the character.
+			dstrunes = append(dstrunes, runes[src])
+		}
+	}
+	return dstrunes
+}
+
+type sanitizer struct {
+	replaceNewLine []rune
+	replaceTab     []rune
+}

--- a/internal/ui/textarea/textarea.go
+++ b/internal/ui/textarea/textarea.go
@@ -1,0 +1,1923 @@
+// This file is vendored from charm.land/bubbles/v2/textarea (MIT License,
+// Copyright (c) 2020-2026 Charmbracelet, Inc.) with local modifications:
+//
+//   - Internal imports rewritten to the vendored copies under
+//     internal/ui/textarea/internal/.
+//   - Adds an optional line Highlighter hook (see highlighter.go) that lets
+//     callers apply per-token styling (e.g. @file and /skill mentions) to
+//     rendered lines without forking the render loop.
+//
+// Package textarea provides a multi-line text input component for Bubble Tea
+// applications.
+package textarea
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"image/color"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
+	"unicode"
+
+	"charm.land/bubbles/v2/cursor"
+	"charm.land/bubbles/v2/key"
+	"charm.land/bubbles/v2/viewport"
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+	"github.com/atotto/clipboard"
+	"github.com/charmbracelet/crush/internal/ui/textarea/internal/memoization"
+	"github.com/charmbracelet/crush/internal/ui/textarea/internal/runeutil"
+	"github.com/charmbracelet/x/ansi"
+	rw "github.com/mattn/go-runewidth"
+	"github.com/rivo/uniseg"
+)
+
+const (
+	minHeight        = 1
+	defaultHeight    = 6
+	defaultWidth     = 40
+	defaultCharLimit = 0 // no limit
+	defaultMaxHeight = 99
+	defaultMaxWidth  = 500
+
+	// XXX: in v2, make max lines dynamic and default max lines configurable.
+	maxLines = 10000
+)
+
+// Internal messages for clipboard operations.
+type (
+	pasteMsg    string
+	pasteErrMsg struct{ error }
+)
+
+// KeyMap is the key bindings for different actions within the textarea.
+type KeyMap struct {
+	CharacterBackward       key.Binding
+	CharacterForward        key.Binding
+	DeleteAfterCursor       key.Binding
+	DeleteBeforeCursor      key.Binding
+	DeleteCharacterBackward key.Binding
+	DeleteCharacterForward  key.Binding
+	DeleteWordBackward      key.Binding
+	DeleteWordForward       key.Binding
+	InsertNewline           key.Binding
+	LineEnd                 key.Binding
+	LineNext                key.Binding
+	LinePrevious            key.Binding
+	LineStart               key.Binding
+	PageUp                  key.Binding
+	PageDown                key.Binding
+	Paste                   key.Binding
+	WordBackward            key.Binding
+	WordForward             key.Binding
+	InputBegin              key.Binding
+	InputEnd                key.Binding
+
+	UppercaseWordForward  key.Binding
+	LowercaseWordForward  key.Binding
+	CapitalizeWordForward key.Binding
+
+	TransposeCharacterBackward key.Binding
+}
+
+// DefaultKeyMap returns the default set of key bindings for navigating and acting
+// upon the textarea.
+func DefaultKeyMap() KeyMap {
+	return KeyMap{
+		CharacterForward:        key.NewBinding(key.WithKeys("right", "ctrl+f"), key.WithHelp("right", "character forward")),
+		CharacterBackward:       key.NewBinding(key.WithKeys("left", "ctrl+b"), key.WithHelp("left", "character backward")),
+		WordForward:             key.NewBinding(key.WithKeys("alt+right", "alt+f"), key.WithHelp("alt+right", "word forward")),
+		WordBackward:            key.NewBinding(key.WithKeys("alt+left", "alt+b"), key.WithHelp("alt+left", "word backward")),
+		LineNext:                key.NewBinding(key.WithKeys("down", "ctrl+n"), key.WithHelp("down", "next line")),
+		LinePrevious:            key.NewBinding(key.WithKeys("up", "ctrl+p"), key.WithHelp("up", "previous line")),
+		DeleteWordBackward:      key.NewBinding(key.WithKeys("alt+backspace", "ctrl+w"), key.WithHelp("alt+backspace", "delete word backward")),
+		DeleteWordForward:       key.NewBinding(key.WithKeys("alt+delete", "alt+d"), key.WithHelp("alt+delete", "delete word forward")),
+		DeleteAfterCursor:       key.NewBinding(key.WithKeys("ctrl+k"), key.WithHelp("ctrl+k", "delete after cursor")),
+		DeleteBeforeCursor:      key.NewBinding(key.WithKeys("ctrl+u"), key.WithHelp("ctrl+u", "delete before cursor")),
+		InsertNewline:           key.NewBinding(key.WithKeys("enter", "ctrl+m"), key.WithHelp("enter", "insert newline")),
+		DeleteCharacterBackward: key.NewBinding(key.WithKeys("backspace", "ctrl+h"), key.WithHelp("backspace", "delete character backward")),
+		DeleteCharacterForward:  key.NewBinding(key.WithKeys("delete", "ctrl+d"), key.WithHelp("delete", "delete character forward")),
+		LineStart:               key.NewBinding(key.WithKeys("home", "ctrl+a"), key.WithHelp("home", "line start")),
+		LineEnd:                 key.NewBinding(key.WithKeys("end", "ctrl+e"), key.WithHelp("end", "line end")),
+		PageUp:                  key.NewBinding(key.WithKeys("pgup"), key.WithHelp("pgup", "page up")),
+		PageDown:                key.NewBinding(key.WithKeys("pgdown"), key.WithHelp("pgdown", "page down")),
+		Paste:                   key.NewBinding(key.WithKeys("ctrl+v"), key.WithHelp("ctrl+v", "paste")),
+		InputBegin:              key.NewBinding(key.WithKeys("alt+<", "ctrl+home"), key.WithHelp("alt+<", "input begin")),
+		InputEnd:                key.NewBinding(key.WithKeys("alt+>", "ctrl+end"), key.WithHelp("alt+>", "input end")),
+
+		CapitalizeWordForward: key.NewBinding(key.WithKeys("alt+c"), key.WithHelp("alt+c", "capitalize word forward")),
+		LowercaseWordForward:  key.NewBinding(key.WithKeys("alt+l"), key.WithHelp("alt+l", "lowercase word forward")),
+		UppercaseWordForward:  key.NewBinding(key.WithKeys("alt+u"), key.WithHelp("alt+u", "uppercase word forward")),
+
+		TransposeCharacterBackward: key.NewBinding(key.WithKeys("ctrl+t"), key.WithHelp("ctrl+t", "transpose character backward")),
+	}
+}
+
+// LineInfo is a helper for keeping track of line information regarding
+// soft-wrapped lines.
+type LineInfo struct {
+	// Width is the number of columns in the line.
+	Width int
+
+	// CharWidth is the number of characters in the line to account for
+	// double-width runes.
+	CharWidth int
+
+	// Height is the number of rows in the line.
+	Height int
+
+	// StartColumn is the index of the first column of the line.
+	StartColumn int
+
+	// ColumnOffset is the number of columns that the cursor is offset from the
+	// start of the line.
+	ColumnOffset int
+
+	// RowOffset is the number of rows that the cursor is offset from the start
+	// of the line.
+	RowOffset int
+
+	// CharOffset is the number of characters that the cursor is offset
+	// from the start of the line. This will generally be equivalent to
+	// ColumnOffset, but will be different there are double-width runes before
+	// the cursor.
+	CharOffset int
+}
+
+// PromptInfo is a struct that can be used to store information about the
+// prompt.
+type PromptInfo struct {
+	LineNumber int
+	Focused    bool
+}
+
+// CursorStyle is the style for real and virtual cursors.
+type CursorStyle struct {
+	// Style styles the cursor block.
+	//
+	// For real cursors, the foreground color set here will be used as the
+	// cursor color.
+	Color color.Color
+
+	// Shape is the cursor shape. The following shapes are available:
+	//
+	// - tea.CursorBlock
+	// - tea.CursorUnderline
+	// - tea.CursorBar
+	//
+	// This is only used for real cursors.
+	Shape tea.CursorShape
+
+	// CursorBlink determines whether or not the cursor should blink.
+	Blink bool
+
+	// BlinkSpeed is the speed at which the virtual cursor blinks. This has no
+	// effect on real cursors as well as no effect if the cursor is set not to
+	// [CursorBlink].
+	//
+	// By default, the blink speed is set to about 500ms.
+	BlinkSpeed time.Duration
+}
+
+// Styles are the styles for the textarea, separated into focused and blurred
+// states. The appropriate styles will be chosen based on the focus state of
+// the textarea.
+type Styles struct {
+	Focused StyleState
+	Blurred StyleState
+	Cursor  CursorStyle
+}
+
+// StyleState that will be applied to the text area.
+//
+// StyleState can be applied to focused and unfocused states to change the styles
+// depending on the focus state.
+//
+// For an introduction to styling with Lip Gloss see:
+// https://github.com/charmbracelet/lipgloss
+type StyleState struct {
+	Base             lipgloss.Style
+	Text             lipgloss.Style
+	LineNumber       lipgloss.Style
+	CursorLineNumber lipgloss.Style
+	CursorLine       lipgloss.Style
+	EndOfBuffer      lipgloss.Style
+	Placeholder      lipgloss.Style
+	Prompt           lipgloss.Style
+}
+
+func (s StyleState) computedCursorLine() lipgloss.Style {
+	return s.CursorLine.Inherit(s.Base).Inline(true)
+}
+
+func (s StyleState) computedCursorLineNumber() lipgloss.Style {
+	return s.CursorLineNumber.
+		Inherit(s.CursorLine).
+		Inherit(s.Base).
+		Inline(true)
+}
+
+func (s StyleState) computedEndOfBuffer() lipgloss.Style {
+	return s.EndOfBuffer.Inherit(s.Base).Inline(true)
+}
+
+func (s StyleState) computedLineNumber() lipgloss.Style {
+	return s.LineNumber.Inherit(s.Base).Inline(true)
+}
+
+func (s StyleState) computedPlaceholder() lipgloss.Style {
+	return s.Placeholder.Inherit(s.Base).Inline(true)
+}
+
+func (s StyleState) computedPrompt() lipgloss.Style {
+	return s.Prompt.Inherit(s.Base).Inline(true)
+}
+
+func (s StyleState) computedText() lipgloss.Style {
+	return s.Text.Inherit(s.Base).Inline(true)
+}
+
+// line is the input to the text wrapping function. This is stored in a struct
+// so that it can be hashed and memoized.
+type line struct {
+	runes []rune
+	width int
+}
+
+// Hash returns a hash of the line.
+func (w line) Hash() string {
+	v := fmt.Sprintf("%s:%d", string(w.runes), w.width)
+	return fmt.Sprintf("%x", sha256.Sum256([]byte(v)))
+}
+
+// Model is the Bubble Tea model for this text area element.
+type Model struct {
+	Err error
+
+	// General settings.
+	cache *memoization.MemoCache[line, [][]rune]
+
+	// Prompt is printed at the beginning of each line.
+	//
+	// When changing the value of Prompt after the model has been
+	// initialized, ensure that SetWidth() gets called afterwards.
+	//
+	// See also [SetPromptFunc] for a dynamic prompt.
+	Prompt string
+
+	// Placeholder is the text displayed when the user
+	// hasn't entered anything yet.
+	Placeholder string
+
+	// ShowLineNumbers, if enabled, causes line numbers to be printed
+	// after the prompt.
+	ShowLineNumbers bool
+
+	// EndOfBufferCharacter is displayed at the end of the input.
+	EndOfBufferCharacter rune
+
+	// KeyMap encodes the keybindings recognized by the widget.
+	KeyMap KeyMap
+
+	// virtualCursor manages the virtual cursor.
+	virtualCursor cursor.Model
+
+	// CharLimit is the maximum number of characters this input element will
+	// accept. If 0 or less, there's no limit.
+	CharLimit int
+
+	// MaxHeight is the maximum height of the text area in rows. If 0 or less,
+	// there's no limit.
+	MaxHeight int
+
+	// MaxWidth is the maximum width of the text area in columns. If 0 or less,
+	// there's no limit.
+	MaxWidth int
+
+	// DynamicHeight, when true, causes the textarea to automatically grow
+	// and shrink its height to fit the content. The height is clamped between
+	// MinHeight and MaxHeight.
+	DynamicHeight bool
+
+	// MinHeight is the minimum height of the text area in rows when
+	// DynamicHeight is enabled. If 0 or less, defaults to 1.
+	MinHeight int
+
+	// MaxContentHeight is the maximum content height in visual rows
+	// (accounting for soft wraps). When set (> 0), input is blocked once
+	// the total visual lines reach this limit, while MaxHeight controls
+	// only the visible viewport height. When 0, the content guard falls
+	// back to the legacy MaxHeight behavior (blocking at MaxHeight
+	// logical lines) for backward compatibility.
+	MaxContentHeight int
+
+	// Styling. Styles are defined in [Styles]. Use [SetStyles] and [GetStyles]
+	// to work with this value publicly.
+	styles Styles
+
+	// useVirtualCursor determines whether or not to use the virtual cursor.
+	// Use [SetVirtualCursor] and [VirtualCursor] to work with this this
+	// value publicly.
+	useVirtualCursor bool
+
+	// If promptFunc is set, it replaces Prompt as a generator for
+	// prompt strings at the beginning of each line.
+	promptFunc func(PromptInfo) string
+
+	// promptWidth is the width of the prompt.
+	promptWidth int
+
+	// width is the maximum number of characters that can be displayed at once.
+	// If 0 or less this setting is ignored.
+	width int
+
+	// height is the maximum number of lines that can be displayed at once. It
+	// essentially treats the text field like a vertically scrolling viewport
+	// if there are more lines than the permitted height.
+	height int
+
+	// Underlying text value.
+	value [][]rune
+
+	// focus indicates whether user input focus should be on this input
+	// component. When false, ignore keyboard input and hide the cursor.
+	focus bool
+
+	// Cursor column.
+	col int
+
+	// Cursor row.
+	row int
+
+	// Last character offset, used to maintain state when the cursor is moved
+	// vertically such that we can maintain the same navigating position.
+	lastCharOffset int
+
+	// viewport is the vertically-scrollable viewport of the multi-line text
+	// input.
+	viewport *viewport.Model
+
+	// rune sanitizer for input.
+	rsan runeutil.Sanitizer
+
+	// highlighter is the optional per-line token highlighter installed via
+	// SetHighlighter. Consulted at render time only.
+	highlighter LineHighlighter
+}
+
+// New creates a new model with default settings.
+func New() Model {
+	vp := viewport.New()
+	vp.KeyMap = viewport.KeyMap{}
+	cur := cursor.New()
+
+	styles := DefaultDarkStyles()
+
+	m := Model{
+		CharLimit:            defaultCharLimit,
+		MaxHeight:            defaultMaxHeight,
+		MaxWidth:             defaultMaxWidth,
+		Prompt:               lipgloss.ThickBorder().Left + " ",
+		styles:               styles,
+		cache:                memoization.NewMemoCache[line, [][]rune](maxLines),
+		EndOfBufferCharacter: ' ',
+		ShowLineNumbers:      true,
+		useVirtualCursor:     true,
+		virtualCursor:        cur,
+		KeyMap:               DefaultKeyMap(),
+
+		value: make([][]rune, minHeight, maxLines),
+		focus: false,
+		col:   0,
+		row:   0,
+
+		viewport: &vp,
+	}
+
+	m.SetHeight(defaultHeight)
+	m.SetWidth(defaultWidth)
+
+	return m
+}
+
+// DefaultStyles returns the default styles for focused and blurred states for
+// the textarea.
+func DefaultStyles(isDark bool) Styles {
+	lightDark := lipgloss.LightDark(isDark)
+
+	var s Styles
+	s.Focused = StyleState{
+		Base:             lipgloss.NewStyle(),
+		CursorLine:       lipgloss.NewStyle().Background(lightDark(lipgloss.Color("255"), lipgloss.Color("0"))),
+		CursorLineNumber: lipgloss.NewStyle().Foreground(lightDark(lipgloss.Color("240"), lipgloss.Color("240"))),
+		EndOfBuffer:      lipgloss.NewStyle().Foreground(lightDark(lipgloss.Color("254"), lipgloss.Color("0"))),
+		LineNumber:       lipgloss.NewStyle().Foreground(lightDark(lipgloss.Color("249"), lipgloss.Color("7"))),
+		Placeholder:      lipgloss.NewStyle().Foreground(lipgloss.Color("240")),
+		Prompt:           lipgloss.NewStyle().Foreground(lipgloss.Color("7")),
+		Text:             lipgloss.NewStyle(),
+	}
+	s.Blurred = StyleState{
+		Base:             lipgloss.NewStyle(),
+		CursorLine:       lipgloss.NewStyle().Foreground(lightDark(lipgloss.Color("245"), lipgloss.Color("7"))),
+		CursorLineNumber: lipgloss.NewStyle().Foreground(lightDark(lipgloss.Color("249"), lipgloss.Color("7"))),
+		EndOfBuffer:      lipgloss.NewStyle().Foreground(lightDark(lipgloss.Color("254"), lipgloss.Color("0"))),
+		LineNumber:       lipgloss.NewStyle().Foreground(lightDark(lipgloss.Color("249"), lipgloss.Color("7"))),
+		Placeholder:      lipgloss.NewStyle().Foreground(lipgloss.Color("240")),
+		Prompt:           lipgloss.NewStyle().Foreground(lipgloss.Color("7")),
+		Text:             lipgloss.NewStyle().Foreground(lightDark(lipgloss.Color("245"), lipgloss.Color("7"))),
+	}
+	s.Cursor = CursorStyle{
+		Color: lipgloss.Color("7"),
+		Shape: tea.CursorBlock,
+		Blink: true,
+	}
+	return s
+}
+
+// DefaultLightStyles returns the default styles for a light background.
+func DefaultLightStyles() Styles {
+	return DefaultStyles(false)
+}
+
+// DefaultDarkStyles returns the default styles for a dark background.
+func DefaultDarkStyles() Styles {
+	return DefaultStyles(true)
+}
+
+// Styles returns the current styles for the textarea.
+func (m Model) Styles() Styles {
+	return m.styles
+}
+
+// SetStyles updates styling for the textarea.
+func (m *Model) SetStyles(s Styles) {
+	m.styles = s
+	m.updateVirtualCursorStyle()
+}
+
+// VirtualCursor returns whether or not the virtual cursor is enabled.
+func (m Model) VirtualCursor() bool {
+	return m.useVirtualCursor
+}
+
+// SetVirtualCursor sets whether or not to use the virtual cursor.
+func (m *Model) SetVirtualCursor(v bool) {
+	m.useVirtualCursor = v
+	m.updateVirtualCursorStyle()
+}
+
+// updateVirtualCursorStyle sets styling on the virtual cursor based on the
+// textarea's style settings.
+func (m *Model) updateVirtualCursorStyle() {
+	if !m.useVirtualCursor {
+		m.virtualCursor.SetMode(cursor.CursorHide)
+		return
+	}
+
+	m.virtualCursor.Style = lipgloss.NewStyle().Foreground(m.styles.Cursor.Color)
+
+	// By default, the blink speed of the cursor is set to a default
+	// internally.
+	if m.styles.Cursor.Blink {
+		if m.styles.Cursor.BlinkSpeed > 0 {
+			m.virtualCursor.BlinkSpeed = m.styles.Cursor.BlinkSpeed
+		}
+		m.virtualCursor.SetMode(cursor.CursorBlink)
+		return
+	}
+	m.virtualCursor.SetMode(cursor.CursorStatic)
+}
+
+// SetValue sets the value of the text input.
+func (m *Model) SetValue(s string) {
+	m.Reset()
+	m.InsertString(s)
+	m.recalculateHeight()
+}
+
+// InsertString inserts a string at the cursor position.
+func (m *Model) InsertString(s string) {
+	m.insertRunesFromUserInput([]rune(s))
+	m.recalculateHeight()
+}
+
+// InsertRune inserts a rune at the cursor position.
+func (m *Model) InsertRune(r rune) {
+	m.insertRunesFromUserInput([]rune{r})
+	m.recalculateHeight()
+}
+
+// insertRunesFromUserInput inserts runes at the current cursor position.
+func (m *Model) insertRunesFromUserInput(runes []rune) {
+	// Clean up any special characters in the input provided by the
+	// clipboard. This avoids bugs due to e.g. tab characters and
+	// whatnot.
+	runes = m.san().Sanitize(runes)
+
+	if m.CharLimit > 0 {
+		availSpace := m.CharLimit - m.Length()
+		// If the char limit's been reached, cancel.
+		if availSpace <= 0 {
+			return
+		}
+		// If there's not enough space to paste the whole thing cut the pasted
+		// runes down so they'll fit.
+		if availSpace < len(runes) {
+			runes = runes[:availSpace]
+		}
+	}
+
+	// Split the input into lines.
+	var lines [][]rune
+	lstart := 0
+	for i := range runes {
+		if runes[i] == '\n' {
+			// Queue a line to become a new row in the text area below.
+			// Beware to clamp the max capacity of the slice, to ensure no
+			// data from different rows get overwritten when later edits
+			// will modify this line.
+			lines = append(lines, runes[lstart:i:i])
+			lstart = i + 1
+		}
+	}
+	if lstart <= len(runes) {
+		// The last line did not end with a newline character.
+		// Take it now.
+		lines = append(lines, runes[lstart:])
+	}
+
+	// Obey the maximum line limit.
+	if maxLines > 0 && len(m.value)+len(lines)-1 > maxLines {
+		allowedHeight := max(0, maxLines-len(m.value)+1)
+		lines = lines[:allowedHeight]
+	}
+
+	// Obey MaxContentHeight in visual rows when set.
+	if m.MaxContentHeight > 0 {
+		budget := m.MaxContentHeight - m.totalVisualLines()
+		// Trim lines from the end until we fit within the budget.
+		for len(lines) > 1 && m.visualLinesForInsert(lines) > budget {
+			lines = lines[:len(lines)-1]
+		}
+		if m.visualLinesForInsert(lines) > budget {
+			return
+		}
+	}
+
+	if len(lines) == 0 {
+		// Nothing left to insert.
+		return
+	}
+
+	// Save the remainder of the original line at the current
+	// cursor position.
+	tail := make([]rune, len(m.value[m.row][m.col:]))
+	copy(tail, m.value[m.row][m.col:])
+
+	// Paste the first line at the current cursor position.
+	m.value[m.row] = append(m.value[m.row][:m.col], lines[0]...)
+	m.col += len(lines[0])
+
+	if numExtraLines := len(lines) - 1; numExtraLines > 0 {
+		// Add the new lines.
+		// We try to reuse the slice if there's already space.
+		var newGrid [][]rune
+		if cap(m.value) >= len(m.value)+numExtraLines {
+			// Can reuse the extra space.
+			newGrid = m.value[:len(m.value)+numExtraLines]
+		} else {
+			// No space left; need a new slice.
+			newGrid = make([][]rune, len(m.value)+numExtraLines)
+			copy(newGrid, m.value[:m.row+1])
+		}
+		// Add all the rows that were after the cursor in the original
+		// grid at the end of the new grid.
+		copy(newGrid[m.row+1+numExtraLines:], m.value[m.row+1:])
+		m.value = newGrid
+		// Insert all the new lines in the middle.
+		for _, l := range lines[1:] {
+			m.row++
+			m.value[m.row] = l
+			m.col = len(l)
+		}
+	}
+
+	// Finally add the tail at the end of the last line inserted.
+	m.value[m.row] = append(m.value[m.row], tail...)
+
+	m.SetCursorColumn(m.col)
+}
+
+// Value returns the value of the text input.
+func (m Model) Value() string {
+	if m.value == nil {
+		return ""
+	}
+
+	var v strings.Builder
+	for _, l := range m.value {
+		v.WriteString(string(l))
+		v.WriteByte('\n')
+	}
+
+	return strings.TrimSuffix(v.String(), "\n")
+}
+
+// Length returns the number of characters currently in the text input.
+func (m *Model) Length() int {
+	var l int
+	for _, row := range m.value {
+		l += uniseg.StringWidth(string(row))
+	}
+	// We add len(m.value) to include the newline characters.
+	return l + len(m.value) - 1
+}
+
+// LineCount returns the number of lines that are currently in the text input.
+func (m *Model) LineCount() int {
+	return len(m.value)
+}
+
+// Line returns the 0-indexed row position of the cursor.
+func (m Model) Line() int {
+	return m.row
+}
+
+// Column returns the 0-indexed column position of the cursor.
+func (m Model) Column() int {
+	return m.col
+}
+
+// ScrollYOffset returns the Y offset (top row) index of the current view, which
+// can be used to calculate the current scroll position.
+func (m Model) ScrollYOffset() int {
+	return m.viewport.YOffset()
+}
+
+// ScrollPercent returns the amount of the textarea that is currently scrolled
+// through, clamped between 0 and 1.
+func (m Model) ScrollPercent() float64 {
+	return m.viewport.ScrollPercent()
+}
+
+// setCursorLineRelative moves the cursor by the given number of lines. Negative
+// values move the cursor up, positive values move the cursor down.
+func (m *Model) setCursorLineRelative(delta int) {
+	if delta == 0 {
+		return
+	}
+
+	li := m.LineInfo()
+	charOffset := max(m.lastCharOffset, li.CharOffset)
+	m.lastCharOffset = charOffset
+
+	// 2 columns to account for the trailing space wrapping.
+	const trailingSpace = 2
+
+	if delta > 0 { //nolint:nestif
+		// Moving down.
+		for range delta {
+			if li.RowOffset+1 >= li.Height && m.row < len(m.value)-1 {
+				m.row++
+				m.col = 0
+			} else {
+				// Move the cursor to the start of the next virtual line.
+				m.col = min(li.StartColumn+li.Width+trailingSpace, len(m.value[m.row])-1)
+			}
+			li = m.LineInfo()
+		}
+	} else {
+		// Moving up.
+		for range -delta {
+			if li.RowOffset <= 0 && m.row > 0 {
+				m.row--
+				m.col = len(m.value[m.row])
+			} else {
+				// Move the cursor to the end of the previous line.
+				m.col = li.StartColumn - trailingSpace
+			}
+			li = m.LineInfo()
+		}
+	}
+
+	nli := m.LineInfo()
+	m.col = nli.StartColumn
+
+	if nli.Width <= 0 {
+		m.repositionView()
+		return
+	}
+
+	offset := 0
+	for offset < charOffset {
+		if m.row >= len(m.value) || m.col >= len(m.value[m.row]) || offset >= nli.CharWidth-1 {
+			break
+		}
+		offset += rw.RuneWidth(m.value[m.row][m.col])
+		m.col++
+	}
+	m.repositionView()
+}
+
+// CursorDown moves the cursor down by one line.
+func (m *Model) CursorDown() {
+	m.setCursorLineRelative(1)
+}
+
+// CursorUp moves the cursor up by one line.
+func (m *Model) CursorUp() {
+	m.setCursorLineRelative(-1)
+}
+
+// SetCursorColumn moves the cursor to the given position. If the position is
+// out of bounds the cursor will be moved to the start or end accordingly.
+func (m *Model) SetCursorColumn(col int) {
+	m.col = clamp(col, 0, len(m.value[m.row]))
+	// Any time that we move the cursor horizontally we need to reset the last
+	// offset so that the horizontal position when navigating is adjusted.
+	m.lastCharOffset = 0
+}
+
+// CursorStart moves the cursor to the start of the input field.
+func (m *Model) CursorStart() {
+	m.SetCursorColumn(0)
+}
+
+// CursorEnd moves the cursor to the end of the input field.
+func (m *Model) CursorEnd() {
+	m.SetCursorColumn(len(m.value[m.row]))
+}
+
+// Focused returns the focus state on the model.
+func (m Model) Focused() bool {
+	return m.focus
+}
+
+// activeStyle returns the appropriate set of styles to use depending on
+// whether the textarea is focused or blurred.
+func (m Model) activeStyle() *StyleState {
+	if m.focus {
+		return &m.styles.Focused
+	}
+	return &m.styles.Blurred
+}
+
+// Focus sets the focus state on the model. When the model is in focus it can
+// receive keyboard input and the cursor will be hidden.
+func (m *Model) Focus() tea.Cmd {
+	m.focus = true
+	return m.virtualCursor.Focus()
+}
+
+// Blur removes the focus state on the model. When the model is blurred it can
+// not receive keyboard input and the cursor will be hidden.
+func (m *Model) Blur() {
+	m.focus = false
+	m.virtualCursor.Blur()
+}
+
+// Reset sets the input to its default state with no input.
+func (m *Model) Reset() {
+	m.value = make([][]rune, minHeight, maxLines)
+	m.col = 0
+	m.row = 0
+	m.viewport.GotoTop()
+	m.SetCursorColumn(0)
+	m.recalculateHeight()
+}
+
+// Word returns the word at the cursor position.
+// A word is delimited by spaces or line-breaks.
+func (m *Model) Word() string {
+	line := m.value[m.row]
+	col := m.col - 1
+
+	if col < 0 {
+		return ""
+	}
+
+	// If cursor is beyond the line, return empty string
+	if col >= len(line) {
+		return ""
+	}
+
+	// If cursor is on a space, return empty string
+	if unicode.IsSpace(line[col]) {
+		return ""
+	}
+
+	// Find the start of the word by moving left
+	start := col
+	for start > 0 && !unicode.IsSpace(line[start-1]) {
+		start--
+	}
+
+	// Find the end of the word by moving right
+	end := col
+	for end < len(line) && !unicode.IsSpace(line[end]) {
+		end++
+	}
+
+	return string(line[start:end])
+}
+
+// san initializes or retrieves the rune sanitizer.
+func (m *Model) san() runeutil.Sanitizer {
+	if m.rsan == nil {
+		// Textinput has all its input on a single line so collapse
+		// newlines/tabs to single spaces.
+		m.rsan = runeutil.NewSanitizer()
+	}
+	return m.rsan
+}
+
+// deleteBeforeCursor deletes all text before the cursor. Returns whether or
+// not the cursor blink should be reset.
+func (m *Model) deleteBeforeCursor() {
+	m.value[m.row] = m.value[m.row][m.col:]
+	m.SetCursorColumn(0)
+}
+
+// deleteAfterCursor deletes all text after the cursor. Returns whether or not
+// the cursor blink should be reset. If input is masked delete everything after
+// the cursor so as not to reveal word breaks in the masked input.
+func (m *Model) deleteAfterCursor() {
+	m.value[m.row] = m.value[m.row][:m.col]
+	m.SetCursorColumn(len(m.value[m.row]))
+}
+
+// transposeLeft exchanges the runes at the cursor and immediately
+// before. No-op if the cursor is at the beginning of the line.  If
+// the cursor is not at the end of the line yet, moves the cursor to
+// the right.
+func (m *Model) transposeLeft() {
+	if m.col == 0 || len(m.value[m.row]) < 2 {
+		return
+	}
+	if m.col >= len(m.value[m.row]) {
+		m.SetCursorColumn(m.col - 1)
+	}
+	m.value[m.row][m.col-1], m.value[m.row][m.col] = m.value[m.row][m.col], m.value[m.row][m.col-1]
+	if m.col < len(m.value[m.row]) {
+		m.SetCursorColumn(m.col + 1)
+	}
+}
+
+// deleteWordLeft deletes the word left to the cursor. Returns whether or not
+// the cursor blink should be reset.
+func (m *Model) deleteWordLeft() {
+	if m.col == 0 || len(m.value[m.row]) == 0 {
+		return
+	}
+
+	// Linter note: it's critical that we acquire the initial cursor position
+	// here prior to altering it via SetCursor() below. As such, moving this
+	// call into the corresponding if clause does not apply here.
+	oldCol := m.col
+
+	m.SetCursorColumn(m.col - 1)
+	for unicode.IsSpace(m.value[m.row][m.col]) {
+		if m.col <= 0 {
+			break
+		}
+		// ignore series of whitespace before cursor
+		m.SetCursorColumn(m.col - 1)
+	}
+
+	for m.col > 0 {
+		if !unicode.IsSpace(m.value[m.row][m.col]) {
+			m.SetCursorColumn(m.col - 1)
+		} else {
+			if m.col > 0 {
+				// keep the previous space
+				m.SetCursorColumn(m.col + 1)
+			}
+			break
+		}
+	}
+
+	if oldCol > len(m.value[m.row]) {
+		m.value[m.row] = m.value[m.row][:m.col]
+	} else {
+		m.value[m.row] = append(m.value[m.row][:m.col], m.value[m.row][oldCol:]...)
+	}
+}
+
+// deleteWordRight deletes the word right to the cursor.
+func (m *Model) deleteWordRight() {
+	if m.col >= len(m.value[m.row]) || len(m.value[m.row]) == 0 {
+		return
+	}
+
+	oldCol := m.col
+
+	for m.col < len(m.value[m.row]) && unicode.IsSpace(m.value[m.row][m.col]) {
+		// ignore series of whitespace after cursor
+		m.SetCursorColumn(m.col + 1)
+	}
+
+	for m.col < len(m.value[m.row]) {
+		if !unicode.IsSpace(m.value[m.row][m.col]) {
+			m.SetCursorColumn(m.col + 1)
+		} else {
+			break
+		}
+	}
+
+	if m.col > len(m.value[m.row]) {
+		m.value[m.row] = m.value[m.row][:oldCol]
+	} else {
+		m.value[m.row] = append(m.value[m.row][:oldCol], m.value[m.row][m.col:]...)
+	}
+
+	m.SetCursorColumn(oldCol)
+}
+
+// characterRight moves the cursor one character to the right.
+func (m *Model) characterRight() {
+	if m.col < len(m.value[m.row]) {
+		m.SetCursorColumn(m.col + 1)
+	} else {
+		if m.row < len(m.value)-1 {
+			m.row++
+			m.CursorStart()
+		}
+	}
+}
+
+// characterLeft moves the cursor one character to the left.
+// If insideLine is set, the cursor is moved to the last
+// character in the previous line, instead of one past that.
+func (m *Model) characterLeft(insideLine bool) {
+	if m.col == 0 && m.row != 0 {
+		m.row--
+		m.CursorEnd()
+		if !insideLine {
+			return
+		}
+	}
+	if m.col > 0 {
+		m.SetCursorColumn(m.col - 1)
+	}
+}
+
+// wordLeft moves the cursor one word to the left. Returns whether or not the
+// cursor blink should be reset. If input is masked, move input to the start
+// so as not to reveal word breaks in the masked input.
+func (m *Model) wordLeft() {
+	for {
+		m.characterLeft(true /* insideLine */)
+		if m.col < len(m.value[m.row]) && !unicode.IsSpace(m.value[m.row][m.col]) {
+			break
+		}
+	}
+
+	for m.col > 0 {
+		if unicode.IsSpace(m.value[m.row][m.col-1]) {
+			break
+		}
+		m.SetCursorColumn(m.col - 1)
+	}
+}
+
+// wordRight moves the cursor one word to the right. Returns whether or not the
+// cursor blink should be reset. If the input is masked, move input to the end
+// so as not to reveal word breaks in the masked input.
+func (m *Model) wordRight() {
+	m.doWordRight(func(int, int) { /* nothing */ })
+}
+
+func (m *Model) doWordRight(fn func(charIdx int, pos int)) {
+	// Skip spaces forward.
+	for m.col >= len(m.value[m.row]) || unicode.IsSpace(m.value[m.row][m.col]) {
+		if m.row == len(m.value)-1 && m.col == len(m.value[m.row]) {
+			// End of text.
+			break
+		}
+		m.characterRight()
+	}
+
+	charIdx := 0
+	for m.col < len(m.value[m.row]) {
+		if unicode.IsSpace(m.value[m.row][m.col]) {
+			break
+		}
+		fn(charIdx, m.col)
+		m.SetCursorColumn(m.col + 1)
+		charIdx++
+	}
+}
+
+// uppercaseRight changes the word to the right to uppercase.
+func (m *Model) uppercaseRight() {
+	m.doWordRight(func(_ int, i int) {
+		m.value[m.row][i] = unicode.ToUpper(m.value[m.row][i])
+	})
+}
+
+// lowercaseRight changes the word to the right to lowercase.
+func (m *Model) lowercaseRight() {
+	m.doWordRight(func(_ int, i int) {
+		m.value[m.row][i] = unicode.ToLower(m.value[m.row][i])
+	})
+}
+
+// capitalizeRight changes the word to the right to title case.
+func (m *Model) capitalizeRight() {
+	m.doWordRight(func(charIdx int, i int) {
+		if charIdx == 0 {
+			m.value[m.row][i] = unicode.ToTitle(m.value[m.row][i])
+		}
+	})
+}
+
+// LineInfo returns the number of characters from the start of the
+// (soft-wrapped) line and the (soft-wrapped) line width.
+func (m Model) LineInfo() LineInfo {
+	grid := m.memoizedWrap(m.value[m.row], m.width)
+
+	// Find out which line we are currently on. This can be determined by the
+	// m.col and counting the number of runes that we need to skip.
+	var counter int
+	for i, line := range grid {
+		// We've found the line that we are on
+		if counter+len(line) == m.col && i+1 < len(grid) {
+			// We wrap around to the next line if we are at the end of the
+			// previous line so that we can be at the very beginning of the row
+			return LineInfo{
+				CharOffset:   0,
+				ColumnOffset: 0,
+				Height:       len(grid),
+				RowOffset:    i + 1,
+				StartColumn:  m.col,
+				Width:        len(grid[i+1]),
+				CharWidth:    uniseg.StringWidth(string(line)),
+			}
+		}
+
+		if counter+len(line) >= m.col {
+			return LineInfo{
+				CharOffset:   uniseg.StringWidth(string(line[:max(0, m.col-counter)])),
+				ColumnOffset: m.col - counter,
+				Height:       len(grid),
+				RowOffset:    i,
+				StartColumn:  counter,
+				Width:        len(line),
+				CharWidth:    uniseg.StringWidth(string(line)),
+			}
+		}
+
+		counter += len(line)
+	}
+	return LineInfo{}
+}
+
+// repositionView repositions the view of the viewport based on the defined
+// scrolling behavior.
+func (m *Model) repositionView() {
+	minimum := m.viewport.YOffset()
+	maximum := minimum + m.viewport.Height() - 1
+	if row := m.cursorLineNumber(); row < minimum {
+		m.viewport.ScrollUp(minimum - row)
+	} else if row > maximum {
+		m.viewport.ScrollDown(row - maximum)
+	}
+}
+
+// Width returns the width of the textarea.
+func (m Model) Width() int {
+	return m.width
+}
+
+// MoveToBegin moves the cursor to the beginning of the input.
+func (m *Model) MoveToBegin() {
+	m.row = 0
+	m.SetCursorColumn(0)
+	m.repositionView()
+}
+
+// MoveToEnd moves the cursor to the end of the input.
+func (m *Model) MoveToEnd() {
+	m.row = len(m.value) - 1
+	m.SetCursorColumn(len(m.value[m.row]))
+	m.repositionView()
+}
+
+// PageUp moves the cursor up by one page. First call snaps to the first visible
+// line, subsequent calls move up by a full page.
+func (m *Model) PageUp() {
+	// If not on the first visible line, snap to it.
+	if offset := m.viewport.YOffset() - m.cursorLineNumber(); offset < 0 {
+		m.setCursorLineRelative(offset)
+		return
+	}
+
+	// Already on first visible line, move up by a full page.
+	m.setCursorLineRelative(-m.height)
+}
+
+// PageDown moves the cursor down by one page. First call snaps to the last
+// visible line, subsequent calls move down by a full page.
+func (m *Model) PageDown() {
+	// If not on the last visible line, snap to it.
+	if offset := m.cursorLineNumber() - m.viewport.YOffset(); offset < m.height-1 {
+		m.setCursorLineRelative(m.height - 1 - offset)
+		return
+	}
+
+	// Already on last visible line, move down by a full page.
+	m.setCursorLineRelative(m.height)
+}
+
+// SetWidth sets the width of the textarea to fit exactly within the given width.
+// This means that the textarea will account for the width of the prompt and
+// whether or not line numbers are being shown.
+//
+// Ensure that SetWidth is called after setting the Prompt and ShowLineNumbers,
+// It is important that the width of the textarea be exactly the given width
+// and no more.
+func (m *Model) SetWidth(w int) {
+	// Update prompt width only if there is no prompt function as
+	// [SetPromptFunc] updates the prompt width when it is called.
+	if m.promptFunc == nil {
+		// XXX: Do we even need this or can we calculate the prompt width
+		// at render time?
+		m.promptWidth = uniseg.StringWidth(m.Prompt)
+	}
+
+	// Add base style borders and padding to reserved outer width.
+	reservedOuter := m.activeStyle().Base.GetHorizontalFrameSize()
+
+	// Add prompt width to reserved inner width.
+	reservedInner := m.promptWidth
+
+	// Add line number width to reserved inner width.
+	if m.ShowLineNumbers {
+		// XXX: this was originally documented as needing "1 cell" but was,
+		// in practice, effectively hardcoded to 2 cells. We can, and should,
+		// reduce this to one gap and update the tests accordingly.
+		const gap = 2
+
+		// Number of digits plus 1 cell for the margin.
+		reservedInner += numDigits(m.MaxHeight) + gap
+	}
+
+	// Input width must be at least one more than the reserved inner and outer
+	// width. This gives us a minimum input width of 1.
+	minWidth := reservedInner + reservedOuter + 1
+	inputWidth := max(w, minWidth)
+
+	// Input width must be no more than maximum width.
+	if m.MaxWidth > 0 {
+		inputWidth = min(inputWidth, m.MaxWidth)
+	}
+
+	// Since the width of the viewport and input area is dependent on the width of
+	// borders, prompt and line numbers, we need to calculate it by subtracting
+	// the reserved width from them.
+
+	m.viewport.SetWidth(inputWidth - reservedOuter)
+	m.width = inputWidth - reservedOuter - reservedInner
+	m.recalculateHeight()
+}
+
+// SetPromptFunc supersedes the Prompt field and sets a dynamic prompt instead.
+//
+// If the function returns a prompt that is shorter than the specified
+// promptWidth, it will be padded to the left. If it returns a prompt that is
+// longer, display artifacts may occur; the caller is responsible for computing
+// an adequate promptWidth.
+func (m *Model) SetPromptFunc(promptWidth int, fn func(PromptInfo) string) {
+	m.promptFunc = fn
+	m.promptWidth = promptWidth
+}
+
+// Height returns the current height of the textarea.
+func (m Model) Height() int {
+	return m.height
+}
+
+// SetHeight sets the height of the textarea.
+func (m *Model) SetHeight(h int) {
+	if m.MaxHeight > 0 {
+		m.height = clamp(h, minHeight, m.MaxHeight)
+		m.viewport.SetHeight(clamp(h, minHeight, m.MaxHeight))
+	} else {
+		m.height = max(h, minHeight)
+		m.viewport.SetHeight(max(h, minHeight))
+	}
+
+	m.repositionView()
+}
+
+// Update is the Bubble Tea update loop.
+func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
+	if !m.focus {
+		m.virtualCursor.Blur()
+		return m, nil
+	}
+
+	// Used to determine if the cursor should blink.
+	oldRow, oldCol := m.cursorLineNumber(), m.col
+
+	var cmds []tea.Cmd
+
+	if m.value[m.row] == nil {
+		m.value[m.row] = make([]rune, 0)
+	}
+
+	if m.MaxHeight > 0 && m.MaxHeight != m.cache.Capacity() {
+		m.cache = memoization.NewMemoCache[line, [][]rune](m.MaxHeight)
+	}
+
+	switch msg := msg.(type) {
+	case tea.PasteMsg:
+		m.insertRunesFromUserInput([]rune(msg.Content))
+	case tea.KeyPressMsg:
+		switch {
+		case key.Matches(msg, m.KeyMap.DeleteAfterCursor):
+			m.col = clamp(m.col, 0, len(m.value[m.row]))
+			if m.col >= len(m.value[m.row]) {
+				m.mergeLineBelow(m.row)
+				break
+			}
+			m.deleteAfterCursor()
+		case key.Matches(msg, m.KeyMap.DeleteBeforeCursor):
+			m.col = clamp(m.col, 0, len(m.value[m.row]))
+			if m.col <= 0 {
+				m.mergeLineAbove(m.row)
+				break
+			}
+			m.deleteBeforeCursor()
+		case key.Matches(msg, m.KeyMap.DeleteCharacterBackward):
+			m.col = clamp(m.col, 0, len(m.value[m.row]))
+			if m.col <= 0 {
+				m.mergeLineAbove(m.row)
+				break
+			}
+			if len(m.value[m.row]) > 0 {
+				m.value[m.row] = append(m.value[m.row][:max(0, m.col-1)], m.value[m.row][m.col:]...)
+				if m.col > 0 {
+					m.SetCursorColumn(m.col - 1)
+				}
+			}
+		case key.Matches(msg, m.KeyMap.DeleteCharacterForward):
+			if len(m.value[m.row]) > 0 && m.col < len(m.value[m.row]) {
+				m.value[m.row] = slices.Delete(m.value[m.row], m.col, m.col+1)
+			}
+			if m.col >= len(m.value[m.row]) {
+				m.mergeLineBelow(m.row)
+				break
+			}
+		case key.Matches(msg, m.KeyMap.DeleteWordBackward):
+			if m.col <= 0 {
+				m.mergeLineAbove(m.row)
+				break
+			}
+			m.deleteWordLeft()
+		case key.Matches(msg, m.KeyMap.DeleteWordForward):
+			m.col = clamp(m.col, 0, len(m.value[m.row]))
+			if m.col >= len(m.value[m.row]) {
+				m.mergeLineBelow(m.row)
+				break
+			}
+			m.deleteWordRight()
+		case key.Matches(msg, m.KeyMap.InsertNewline):
+			if m.atContentLimit() {
+				return m, nil
+			}
+			m.col = clamp(m.col, 0, len(m.value[m.row]))
+			m.splitLine(m.row, m.col)
+		case key.Matches(msg, m.KeyMap.LineEnd):
+			m.CursorEnd()
+		case key.Matches(msg, m.KeyMap.LineStart):
+			m.CursorStart()
+		case key.Matches(msg, m.KeyMap.CharacterForward):
+			m.characterRight()
+		case key.Matches(msg, m.KeyMap.LineNext):
+			m.CursorDown()
+		case key.Matches(msg, m.KeyMap.WordForward):
+			m.wordRight()
+		case key.Matches(msg, m.KeyMap.Paste):
+			return m, Paste
+		case key.Matches(msg, m.KeyMap.CharacterBackward):
+			m.characterLeft(false /* insideLine */)
+		case key.Matches(msg, m.KeyMap.LinePrevious):
+			m.CursorUp()
+		case key.Matches(msg, m.KeyMap.WordBackward):
+			m.wordLeft()
+		case key.Matches(msg, m.KeyMap.InputBegin):
+			m.MoveToBegin()
+		case key.Matches(msg, m.KeyMap.InputEnd):
+			m.MoveToEnd()
+		case key.Matches(msg, m.KeyMap.PageUp):
+			m.PageUp()
+		case key.Matches(msg, m.KeyMap.PageDown):
+			m.PageDown()
+		case key.Matches(msg, m.KeyMap.LowercaseWordForward):
+			m.lowercaseRight()
+		case key.Matches(msg, m.KeyMap.UppercaseWordForward):
+			m.uppercaseRight()
+		case key.Matches(msg, m.KeyMap.CapitalizeWordForward):
+			m.capitalizeRight()
+		case key.Matches(msg, m.KeyMap.TransposeCharacterBackward):
+			m.transposeLeft()
+
+		default:
+			m.insertRunesFromUserInput([]rune(msg.Text))
+		}
+
+	case pasteMsg:
+		m.insertRunesFromUserInput([]rune(msg))
+
+	case pasteErrMsg:
+		m.Err = msg
+	}
+
+	m.recalculateHeight()
+
+	// Make sure we set the content of the viewport before updating it.
+	view := m.view()
+	m.viewport.SetContent(view)
+	vp, cmd := m.viewport.Update(msg)
+	m.viewport = &vp
+	cmds = append(cmds, cmd)
+
+	if m.useVirtualCursor {
+		m.virtualCursor, cmd = m.virtualCursor.Update(msg)
+
+		// If the cursor has moved, reset the blink state. This is a small UX
+		// nuance that makes cursor movement obvious and feel snappy.
+		newRow, newCol := m.cursorLineNumber(), m.col
+		if (newRow != oldRow || newCol != oldCol) && m.virtualCursor.Mode() == cursor.CursorBlink {
+			m.virtualCursor.IsBlinked = false
+			cmd = m.virtualCursor.Blink()
+		}
+		cmds = append(cmds, cmd)
+	}
+
+	m.repositionView()
+
+	return m, tea.Batch(cmds...)
+}
+
+func (m *Model) view() string {
+	if len(m.Value()) == 0 && m.row == 0 && m.col == 0 && m.Placeholder != "" {
+		return m.placeholderView()
+	}
+	m.virtualCursor.TextStyle = m.activeStyle().computedCursorLine()
+
+	var (
+		s                strings.Builder
+		style            lipgloss.Style
+		newLines         int
+		widestLineNumber int
+		lineInfo         = m.LineInfo()
+		styles           = m.activeStyle()
+	)
+
+	displayLine := 0
+	for l, line := range m.value {
+		wrappedLines := m.memoizedWrap(line, m.width)
+
+		if m.row == l {
+			style = styles.computedCursorLine()
+		} else {
+			style = styles.computedText()
+		}
+
+		// Consult the optional token highlighter once per logical line.
+		// Ranges are rune offsets within the logical line; each wrapped
+		// segment intersects them at render time.
+		var lineRanges []lipgloss.Range
+		if m.highlighter != nil {
+			lineRanges = m.highlightRanges(l, line)
+		}
+
+		segStart := 0
+		for wl, wrappedLine := range wrappedLines {
+			prompt := m.promptView(displayLine)
+			s.WriteString(style.Render(prompt))
+			displayLine++
+
+			var ln string
+			if m.ShowLineNumbers {
+				if wl == 0 { // normal line
+					isCursorLine := m.row == l
+					s.WriteString(m.lineNumberView(l+1, isCursorLine))
+				} else { // soft wrapped line
+					isCursorLine := m.row == l
+					s.WriteString(m.lineNumberView(-1, isCursorLine))
+				}
+			}
+
+			// Note the widest line number for padding purposes later.
+			lnw := uniseg.StringWidth(ln)
+			if lnw > widestLineNumber {
+				widestLineNumber = lnw
+			}
+
+			strwidth := uniseg.StringWidth(string(wrappedLine))
+			padding := m.width - strwidth
+			// SegLen is captured before the trailing-space trim below so
+			// segStart tracking stays aligned with the raw logical line.
+			segLen := len(wrappedLine)
+			// If the trailing space causes the line to be wider than the
+			// width, we should not draw it to the screen since it will result
+			// in an extra space at the end of the line which can look off when
+			// the cursor line is showing.
+			if strwidth > m.width {
+				// The character causing the line to be wider than the width is
+				// guaranteed to be a space since any other character would
+				// have been wrapped.
+				wrappedLine = []rune(strings.TrimSuffix(string(wrappedLine), " "))
+				padding -= m.width - strwidth
+			}
+			if m.row == l && lineInfo.RowOffset == wl {
+				s.WriteString(styleSegment(style, wrappedLine[:lineInfo.ColumnOffset], segStart, lineRanges))
+				if m.col >= len(line) && lineInfo.CharOffset >= m.width {
+					m.virtualCursor.SetChar(" ")
+					s.WriteString(m.virtualCursor.View())
+				} else {
+					m.virtualCursor.SetChar(string(wrappedLine[lineInfo.ColumnOffset]))
+					s.WriteString(style.Render(m.virtualCursor.View()))
+					s.WriteString(styleSegment(style, wrappedLine[lineInfo.ColumnOffset+1:], segStart+lineInfo.ColumnOffset+1, lineRanges))
+				}
+			} else {
+				s.WriteString(styleSegment(style, wrappedLine, segStart, lineRanges))
+			}
+			s.WriteString(style.Render(strings.Repeat(" ", max(0, padding))))
+			s.WriteRune('\n')
+			newLines++
+			segStart += segLen
+		}
+	}
+
+	// Always show at least `m.Height` lines at all times.
+	// To do this we can simply pad out a few extra new lines in the view.
+	for range m.height {
+		s.WriteString(m.promptView(displayLine))
+		displayLine++
+
+		// Write end of buffer content
+		leftGutter := string(m.EndOfBufferCharacter)
+		rightGapWidth := m.Width() - uniseg.StringWidth(leftGutter) + widestLineNumber
+		rightGap := strings.Repeat(" ", max(0, rightGapWidth))
+		s.WriteString(styles.computedEndOfBuffer().Render(leftGutter + rightGap))
+		s.WriteRune('\n')
+	}
+
+	return s.String()
+}
+
+// View renders the text area in its current state.
+func (m Model) View() string {
+	// XXX: This is a workaround for the case where the viewport hasn't
+	// been initialized yet like during the initial render. In that case,
+	// we need to render the view again because Update hasn't been called
+	// yet to set the content of the viewport.
+	m.viewport.SetContent(m.view())
+	view := m.viewport.View()
+	styles := m.activeStyle()
+	return styles.Base.Render(view)
+}
+
+// promptView renders a single line of the prompt.
+func (m Model) promptView(displayLine int) (prompt string) {
+	prompt = m.Prompt
+	if m.promptFunc != nil {
+		prompt = m.promptFunc(PromptInfo{
+			LineNumber: displayLine,
+			Focused:    m.focus,
+		})
+		width := lipgloss.Width(prompt)
+		if width < m.promptWidth {
+			prompt = fmt.Sprintf("%*s%s", m.promptWidth-width, "", prompt)
+		}
+	}
+
+	return m.activeStyle().computedPrompt().Render(prompt)
+}
+
+// lineNumberView renders the line number.
+//
+// If the argument is less than 0, a space styled as a line number is returned
+// instead. Such cases are used for soft-wrapped lines.
+//
+// The second argument indicates whether this line number is for a 'cursorline'
+// line number.
+func (m Model) lineNumberView(n int, isCursorLine bool) (str string) {
+	if !m.ShowLineNumbers {
+		return ""
+	}
+
+	if n <= 0 {
+		str = " "
+	} else {
+		str = strconv.Itoa(n)
+	}
+
+	// XXX: is textStyle really necessary here?
+	textStyle := m.activeStyle().computedText()
+	lineNumberStyle := m.activeStyle().computedLineNumber()
+	if isCursorLine {
+		textStyle = m.activeStyle().computedCursorLine()
+		lineNumberStyle = m.activeStyle().computedCursorLineNumber()
+	}
+
+	// Format line number dynamically based on the maximum number of lines.
+	digits := len(strconv.Itoa(m.MaxHeight))
+	str = fmt.Sprintf(" %*v ", digits, str)
+
+	return textStyle.Render(lineNumberStyle.Render(str))
+}
+
+// placeholderView returns the prompt and placeholder, if any.
+func (m Model) placeholderView() string {
+	var (
+		s      strings.Builder
+		p      = m.Placeholder
+		styles = m.activeStyle()
+	)
+	// word wrap lines
+	pwordwrap := ansi.Wordwrap(p, m.width, "")
+	// hard wrap lines (handles lines that could not be word wrapped)
+	pwrap := ansi.Hardwrap(pwordwrap, m.width, true)
+	// split string by new lines
+	plines := strings.Split(strings.TrimSpace(pwrap), "\n")
+
+	for i := range m.height {
+		isLineNumber := len(plines) > i
+
+		lineStyle := styles.computedPlaceholder()
+		if len(plines) > i {
+			lineStyle = styles.computedCursorLine()
+		}
+
+		// render prompt
+		prompt := m.promptView(i)
+		s.WriteString(lineStyle.Render(prompt))
+
+		// when show line numbers enabled:
+		// - render line number for only the cursor line
+		// - indent other placeholder lines
+		// this is consistent with vim with line numbers enabled
+		if m.ShowLineNumbers {
+			var ln int
+
+			switch {
+			case i == 0:
+				ln = i + 1
+				fallthrough
+			case len(plines) > i:
+				s.WriteString(m.lineNumberView(ln, isLineNumber))
+			default:
+			}
+		}
+
+		switch {
+		// first line
+		case i == 0:
+			// first character of first line as cursor with character
+			m.virtualCursor.TextStyle = styles.computedPlaceholder()
+
+			ch, rest, _, _ := uniseg.FirstGraphemeClusterInString(plines[0], 0)
+			m.virtualCursor.SetChar(ch)
+			s.WriteString(lineStyle.Render(m.virtualCursor.View()))
+
+			// the rest of the first line
+			s.WriteString(lineStyle.Render(styles.computedPlaceholder().Render(rest)))
+
+			// extend the first line with spaces to fill the width, so that
+			// the entire line is filled when cursorline is enabled.
+			gap := strings.Repeat(" ", max(0, m.width-lipgloss.Width(plines[0])))
+			s.WriteString(lineStyle.Render(gap))
+		// remaining lines
+		case len(plines) > i:
+			// current line placeholder text
+			if len(plines) > i {
+				placeholderLine := plines[i]
+				gap := strings.Repeat(" ", max(0, m.width-uniseg.StringWidth(plines[i])))
+				s.WriteString(lineStyle.Render(placeholderLine + gap))
+			}
+		default:
+			// end of line buffer character
+			eob := styles.computedEndOfBuffer().Render(string(m.EndOfBufferCharacter))
+			s.WriteString(eob)
+		}
+
+		// terminate with new line
+		s.WriteRune('\n')
+	}
+
+	m.viewport.SetContent(s.String())
+	return styles.Base.Render(m.viewport.View())
+}
+
+// Blink returns the blink command for the virtual cursor.
+func Blink() tea.Msg {
+	return cursor.Blink()
+}
+
+// Cursor returns a [tea.Cursor] for rendering a real cursor in a Bubble Tea
+// program. This requires that [Model.VirtualCursor] is set to false.
+//
+// Note that you will almost certainly also need to adjust the offset cursor
+// position per the textarea's per the textarea's position in the terminal.
+//
+// Example:
+//
+//	// In your top-level View function:
+//	f := tea.NewFrame(m.textarea.View())
+//	f.Cursor = m.textarea.Cursor()
+//	f.Cursor.Position.X += offsetX
+//	f.Cursor.Position.Y += offsetY
+func (m Model) Cursor() *tea.Cursor {
+	if m.useVirtualCursor || !m.Focused() {
+		return nil
+	}
+
+	lineInfo := m.LineInfo()
+	w := lipgloss.Width
+	baseStyle := m.activeStyle().Base
+
+	xOffset := lineInfo.CharOffset +
+		w(m.promptView(0)) +
+		w(m.lineNumberView(0, false)) +
+		baseStyle.GetMarginLeft() +
+		baseStyle.GetPaddingLeft() +
+		baseStyle.GetBorderLeftSize()
+
+	yOffset := m.cursorLineNumber() -
+		m.viewport.YOffset() +
+		baseStyle.GetMarginTop() +
+		baseStyle.GetPaddingTop() +
+		baseStyle.GetBorderTopSize()
+
+	c := tea.NewCursor(xOffset, yOffset)
+	c.Blink = m.styles.Cursor.Blink
+	c.Color = m.styles.Cursor.Color
+	c.Shape = m.styles.Cursor.Shape
+	return c
+}
+
+func (m Model) memoizedWrap(runes []rune, width int) [][]rune {
+	input := line{runes: runes, width: width}
+	if v, ok := m.cache.Get(input); ok {
+		return v
+	}
+	v := wrap(runes, width)
+	m.cache.Set(input, v)
+	return v
+}
+
+// cursorLineNumber returns the line number that the cursor is on.
+// This accounts for soft wrapped lines.
+func (m Model) cursorLineNumber() int {
+	line := 0
+	for i := range m.row {
+		// Calculate the number of lines that the current line will be split
+		// into.
+		line += len(m.memoizedWrap(m.value[i], m.width))
+	}
+	line += m.LineInfo().RowOffset
+	return line
+}
+
+// totalVisualLines returns the total number of display lines across all
+// logical lines, accounting for soft wraps.
+func (m *Model) totalVisualLines() int {
+	n := 0
+	for _, line := range m.value {
+		n += len(m.memoizedWrap(line, m.width))
+	}
+	return n
+}
+
+// recalculateHeight recomputes and applies the textarea height based on
+// content when DynamicHeight is enabled. It is a no-op otherwise.
+func (m *Model) recalculateHeight() {
+	if !m.DynamicHeight {
+		return
+	}
+	minH := max(m.MinHeight, minHeight)
+	total := m.totalVisualLines()
+	h := max(total, minH)
+	if m.MaxHeight > 0 {
+		h = min(h, m.MaxHeight)
+	}
+	if maxOffset := total - h; m.viewport.YOffset() > maxOffset {
+		m.viewport.SetYOffset(max(0, maxOffset))
+	}
+	m.SetHeight(h)
+}
+
+// atContentLimit reports whether the textarea has reached its content limit.
+// When MaxContentHeight is set (> 0), it checks total visual lines.
+// Otherwise it falls back to the legacy MaxHeight logical-line check for
+// backward compatibility.
+func (m *Model) atContentLimit() bool {
+	if m.MaxContentHeight > 0 {
+		return m.totalVisualLines() >= m.MaxContentHeight
+	}
+	return m.MaxHeight > 0 && len(m.value) >= m.MaxHeight
+}
+
+// visualLinesForInsert estimates how many additional visual lines would result
+// from inserting the given lines at the current cursor position. The first
+// element merges into the current line; subsequent elements become new lines.
+func (m *Model) visualLinesForInsert(lines [][]rune) int {
+	if len(lines) == 0 {
+		return 0
+	}
+
+	// The current row's visual line count before insertion.
+	currentRowVisual := len(m.memoizedWrap(m.value[m.row], m.width))
+
+	// Simulate merging the first paste line into the current row.
+	merged := make([]rune, m.col+len(lines[0]))
+	copy(merged, m.value[m.row][:m.col])
+	copy(merged[m.col:], lines[0])
+	if len(lines) == 1 {
+		merged = append(merged, m.value[m.row][m.col:]...)
+	}
+	delta := len(m.memoizedWrap(merged, m.width)) - currentRowVisual
+
+	// Each additional line is a new logical line.
+	for i, content := range lines {
+		if i == len(lines)-1 {
+			content = append(content, m.value[m.row][m.col:]...)
+		}
+		delta += len(m.memoizedWrap(content, m.width))
+	}
+
+	return delta
+}
+
+// mergeLineBelow merges the current line the cursor is on with the line below.
+func (m *Model) mergeLineBelow(row int) {
+	if row >= len(m.value)-1 {
+		return
+	}
+
+	// To perform a merge, we will need to combine the two lines and then
+	m.value[row] = append(m.value[row], m.value[row+1]...)
+
+	// Shift all lines up by one
+	for i := row + 1; i < len(m.value)-1; i++ {
+		m.value[i] = m.value[i+1]
+	}
+
+	// And, remove the last line
+	if len(m.value) > 0 {
+		m.value = m.value[:len(m.value)-1]
+	}
+}
+
+// mergeLineAbove merges the current line the cursor is on with the line above.
+func (m *Model) mergeLineAbove(row int) {
+	if row <= 0 {
+		return
+	}
+
+	m.col = len(m.value[row-1])
+	m.row = m.row - 1
+
+	// To perform a merge, we will need to combine the two lines and then
+	m.value[row-1] = append(m.value[row-1], m.value[row]...)
+
+	// Shift all lines up by one
+	for i := row; i < len(m.value)-1; i++ {
+		m.value[i] = m.value[i+1]
+	}
+
+	// And, remove the last line
+	if len(m.value) > 0 {
+		m.value = m.value[:len(m.value)-1]
+	}
+}
+
+func (m *Model) splitLine(row, col int) {
+	// To perform a split, take the current line and keep the content before
+	// the cursor, take the content after the cursor and make it the content of
+	// the line underneath, and shift the remaining lines down by one
+	head, tailSrc := m.value[row][:col], m.value[row][col:]
+	tail := make([]rune, len(tailSrc))
+	copy(tail, tailSrc)
+
+	m.value = append(m.value[:row+1], m.value[row:]...)
+
+	m.value[row] = head
+	m.value[row+1] = tail
+
+	m.col = 0
+	m.row++
+}
+
+// Paste is a command for pasting from the clipboard into the text input.
+func Paste() tea.Msg {
+	str, err := clipboard.ReadAll()
+	if err != nil {
+		return pasteErrMsg{err}
+	}
+	return pasteMsg(str)
+}
+
+func wrap(runes []rune, width int) [][]rune {
+	var (
+		lines  = [][]rune{{}}
+		word   = []rune{}
+		row    int
+		spaces int
+	)
+
+	// Word wrap the runes
+	for _, r := range runes {
+		if unicode.IsSpace(r) {
+			spaces++
+		} else {
+			word = append(word, r)
+		}
+
+		if spaces > 0 { //nolint:nestif
+			if uniseg.StringWidth(string(lines[row]))+uniseg.StringWidth(string(word))+spaces > width {
+				row++
+				lines = append(lines, []rune{})
+				lines[row] = append(lines[row], word...)
+				lines[row] = append(lines[row], repeatSpaces(spaces)...)
+				spaces = 0
+				word = nil
+			} else {
+				lines[row] = append(lines[row], word...)
+				lines[row] = append(lines[row], repeatSpaces(spaces)...)
+				spaces = 0
+				word = nil
+			}
+		} else {
+			// If the last character is a double-width rune, then we may not be able to add it to this line
+			// as it might cause us to go past the width.
+			lastCharLen := rw.RuneWidth(word[len(word)-1])
+			if uniseg.StringWidth(string(word))+lastCharLen > width {
+				// If the current line has any content, let's move to the next
+				// line because the current word fills up the entire line.
+				if len(lines[row]) > 0 {
+					row++
+					lines = append(lines, []rune{})
+				}
+				lines[row] = append(lines[row], word...)
+				word = nil
+			}
+		}
+	}
+
+	if uniseg.StringWidth(string(lines[row]))+uniseg.StringWidth(string(word))+spaces >= width {
+		lines = append(lines, []rune{})
+		lines[row+1] = append(lines[row+1], word...)
+		// We add an extra space at the end of the line to account for the
+		// trailing space at the end of the previous soft-wrapped lines so that
+		// behaviour when navigating is consistent and so that we don't need to
+		// continually add edges to handle the last line of the wrapped input.
+		spaces++
+		lines[row+1] = append(lines[row+1], repeatSpaces(spaces)...)
+	} else {
+		lines[row] = append(lines[row], word...)
+		spaces++
+		lines[row] = append(lines[row], repeatSpaces(spaces)...)
+	}
+
+	return lines
+}
+
+func repeatSpaces(n int) []rune {
+	return []rune(strings.Repeat(string(' '), n))
+}
+
+// numDigits returns the number of digits in an integer.
+func numDigits(n int) int {
+	if n == 0 {
+		return 1
+	}
+	count := 0
+	num := abs(n)
+	for num > 0 {
+		count++
+		num /= 10
+	}
+	return count
+}
+
+func clamp(v, low, high int) int {
+	if high < low {
+		low, high = high, low
+	}
+	return min(high, max(low, v))
+}
+
+func abs(n int) int {
+	if n < 0 {
+		return -n
+	}
+	return n
+}

--- a/internal/ui/textarea/textarea.go
+++ b/internal/ui/textarea/textarea.go
@@ -625,6 +625,23 @@ func (m Model) Value() string {
 	return strings.TrimSuffix(v.String(), "\n")
 }
 
+// ByteOffset returns the cursor's position as a byte offset into Value().
+//
+// Callers that slice Value() around the cursor need this rather than
+// Column(), which counts runes within the current row only. Value() joins
+// the rows with "\n", so the offset is every preceding row plus its
+// separator, then the current row up to the cursor.
+func (m Model) ByteOffset() int {
+	var off int
+	for i, row := range m.value {
+		if i == m.row {
+			return off + len(string(row[:min(m.col, len(row))]))
+		}
+		off += len(string(row)) + 1 // +1 for the joining newline
+	}
+	return off
+}
+
 // Length returns the number of characters currently in the text input.
 func (m *Model) Length() int {
 	var l int

--- a/internal/ui/textarea/textarea_test.go
+++ b/internal/ui/textarea/textarea_test.go
@@ -1,0 +1,2431 @@
+package textarea
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"unicode"
+
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+	"github.com/MakeNowJust/heredoc"
+	"github.com/charmbracelet/x/ansi"
+)
+
+func TestVerticalScrolling(t *testing.T) {
+	textarea := newTextArea()
+	textarea.Prompt = ""
+	textarea.ShowLineNumbers = false
+	textarea.SetHeight(1)
+	textarea.SetWidth(20)
+	textarea.CharLimit = 100
+
+	textarea, _ = textarea.Update(nil)
+
+	input := "This is a really long line that should wrap around the text area."
+
+	for _, k := range input {
+		textarea, _ = textarea.Update(keyPress(k))
+	}
+
+	view := textarea.View()
+
+	// The view should contain the end of "line" of the input.
+	if !strings.Contains(view, "the text area.") {
+		t.Log(view)
+		t.Error("Text area did not render the input")
+	}
+
+	// But we should be able to scroll to see the next line.
+	// Let's scroll down for each line to view the full input.
+	lines := []string{
+		"This is a really",
+		"long line that",
+		"should wrap around",
+		"the text area.",
+	}
+	textarea.viewport.GotoTop()
+	for _, line := range lines {
+		view = textarea.View()
+		if !strings.Contains(view, line) {
+			t.Log(view)
+			t.Error("Text area did not render the correct scrolled input")
+		}
+		textarea.viewport.ScrollDown(1)
+	}
+}
+
+func TestWordWrapOverflowing(t *testing.T) {
+	// An interesting edge case is when the user enters many words that fill up
+	// the text area and then goes back up and inserts a few words which causes
+	// a cascading wrap and causes an overflow of the last line.
+	//
+	// In this case, we should not let the user insert more words if, after the
+	// entire wrap is complete, the last line is overflowing.
+	textarea := newTextArea()
+
+	textarea.SetHeight(3)
+	textarea.SetWidth(20)
+	textarea.CharLimit = 500
+
+	textarea, _ = textarea.Update(nil)
+
+	input := "Testing Testing Testing Testing Testing Testing Testing Testing"
+
+	for _, k := range input {
+		textarea, _ = textarea.Update(keyPress(k))
+		textarea.View()
+	}
+
+	// We have essentially filled the text area with input.
+	// Let's see if we can cause wrapping to overflow the last line.
+	textarea.row = 0
+	textarea.col = 0
+
+	input = "Testing"
+
+	for _, k := range input {
+		textarea, _ = textarea.Update(keyPress(k))
+		textarea.View()
+	}
+
+	lastLineWidth := textarea.LineInfo().Width
+	if lastLineWidth > 20 {
+		t.Log(lastLineWidth)
+		t.Log(textarea.View())
+		t.Fail()
+	}
+}
+
+func TestValueSoftWrap(t *testing.T) {
+	textarea := newTextArea()
+	textarea.SetWidth(16)
+	textarea.SetHeight(10)
+	textarea.CharLimit = 500
+
+	textarea, _ = textarea.Update(nil)
+
+	input := "Testing Testing Testing Testing Testing Testing Testing Testing"
+
+	for _, k := range []rune(input) {
+		textarea, _ = textarea.Update(keyPress(k))
+		textarea.View()
+	}
+
+	value := textarea.Value()
+	if value != input {
+		t.Log(value)
+		t.Log(input)
+		t.Fatal("The text area does not have the correct value")
+	}
+}
+
+func TestSetValue(t *testing.T) {
+	textarea := newTextArea()
+	textarea.SetValue(strings.Join([]string{"Foo", "Bar", "Baz"}, "\n"))
+
+	if textarea.row != 2 && textarea.col != 3 {
+		t.Log(textarea.row, textarea.col)
+		t.Fatal("Cursor Should be on row 2 column 3 after inserting 2 new lines")
+	}
+
+	value := textarea.Value()
+	if value != "Foo\nBar\nBaz" {
+		t.Fatal("Value should be Foo\nBar\nBaz")
+	}
+
+	// SetValue should reset text area
+	textarea.SetValue("Test")
+	value = textarea.Value()
+	if value != "Test" {
+		t.Log(value)
+		t.Fatal("Text area was not reset when SetValue() was called")
+	}
+}
+
+func TestInsertString(t *testing.T) {
+	textarea := newTextArea()
+
+	// Insert some text
+	input := "foo baz"
+
+	for _, k := range []rune(input) {
+		textarea, _ = textarea.Update(keyPress(k))
+	}
+
+	// Put cursor in the middle of the text
+	textarea.col = 4
+
+	textarea.InsertString("bar ")
+
+	value := textarea.Value()
+	if value != "foo bar baz" {
+		t.Log(value)
+		t.Fatal("Expected insert string to insert bar between foo and baz")
+	}
+}
+
+func TestCanHandleEmoji(t *testing.T) {
+	textarea := newTextArea()
+	input := "🧋"
+
+	for _, k := range []rune(input) {
+		textarea, _ = textarea.Update(keyPress(k))
+	}
+
+	value := textarea.Value()
+	if value != input {
+		t.Log(value)
+		t.Fatal("Expected emoji to be inserted")
+	}
+
+	input = "🧋🧋🧋"
+
+	textarea.SetValue(input)
+
+	value = textarea.Value()
+	if value != input {
+		t.Log(value)
+		t.Fatal("Expected emoji to be inserted")
+	}
+
+	if textarea.col != 3 {
+		t.Log(textarea.col)
+		t.Fatal("Expected cursor to be on the third character")
+	}
+
+	if charOffset := textarea.LineInfo().CharOffset; charOffset != 6 {
+		t.Log(charOffset)
+		t.Fatal("Expected cursor to be on the sixth character")
+	}
+}
+
+func TestVerticalNavigationKeepsCursorHorizontalPosition(t *testing.T) {
+	textarea := newTextArea()
+	textarea.SetWidth(20)
+
+	textarea.SetValue(strings.Join([]string{"你好你好", "Hello"}, "\n"))
+
+	textarea.row = 0
+	textarea.col = 2
+
+	// 你好|你好
+	// Hell|o
+	// 1234|
+
+	// Let's imagine our cursor is on the first line where the pipe is.
+	// We press the down arrow to get to the next line.
+	// The issue is that if we keep the cursor on the same column, the cursor will jump to after the `e`.
+	//
+	// 你好|你好
+	// He|llo
+	//
+	// But this is wrong because visually we were at the 4th character due to
+	// the first line containing double-width runes.
+	// We want to keep the cursor on the same visual column.
+	//
+	// 你好|你好
+	// Hell|o
+	//
+	// This test ensures that the cursor is kept on the same visual column by
+	// ensuring that the column offset goes from 2 -> 4.
+
+	lineInfo := textarea.LineInfo()
+	if lineInfo.CharOffset != 4 || lineInfo.ColumnOffset != 2 {
+		t.Log(lineInfo.CharOffset)
+		t.Log(lineInfo.ColumnOffset)
+		t.Fatal("Expected cursor to be on the fourth character because there are two double width runes on the first line.")
+	}
+
+	downMsg := tea.KeyPressMsg{Code: tea.KeyDown}
+	textarea, _ = textarea.Update(downMsg)
+
+	lineInfo = textarea.LineInfo()
+	if lineInfo.CharOffset != 4 || lineInfo.ColumnOffset != 4 {
+		t.Log(lineInfo.CharOffset)
+		t.Log(lineInfo.ColumnOffset)
+		t.Fatal("Expected cursor to be on the fourth character because we came down from the first line.")
+	}
+}
+
+func TestVerticalNavigationShouldRememberPositionWhileTraversing(t *testing.T) {
+	textarea := newTextArea()
+	textarea.SetWidth(40)
+
+	// Let's imagine we have a text area with the following content:
+	//
+	// Hello
+	// World
+	// This is a long line.
+	//
+	// If we are at the end of the last line and go up, we should be at the end
+	// of the second line.
+	// And, if we go up again we should be at the end of the first line.
+	// But, if we go back down twice, we should be at the end of the last line
+	// again and not the fifth (length of second line) character of the last line.
+	//
+	// In other words, we should remember the last horizontal position while
+	// traversing vertically.
+
+	textarea.SetValue(strings.Join([]string{"Hello", "World", "This is a long line."}, "\n"))
+
+	// We are at the end of the last line.
+	if textarea.col != 20 || textarea.row != 2 {
+		t.Log(textarea.col)
+		t.Fatal("Expected cursor to be on the 20th character of the last line")
+	}
+
+	// Let's go up.
+	upMsg := tea.KeyPressMsg{Code: tea.KeyUp}
+	textarea, _ = textarea.Update(upMsg)
+
+	// We should be at the end of the second line.
+	if textarea.col != 5 || textarea.row != 1 {
+		t.Log(textarea.col)
+		t.Fatal("Expected cursor to be on the 5th character of the second line")
+	}
+
+	// And, again.
+	textarea, _ = textarea.Update(upMsg)
+
+	// We should be at the end of the first line.
+	if textarea.col != 5 || textarea.row != 0 {
+		t.Log(textarea.col)
+		t.Fatal("Expected cursor to be on the 5th character of the first line")
+	}
+
+	// Let's go down, twice.
+	downMsg := tea.KeyPressMsg{Code: tea.KeyDown}
+	textarea, _ = textarea.Update(downMsg)
+	textarea, _ = textarea.Update(downMsg)
+
+	// We should be at the end of the last line.
+	if textarea.col != 20 || textarea.row != 2 {
+		t.Log(textarea.col)
+		t.Fatal("Expected cursor to be on the 20th character of the last line")
+	}
+
+	// Now, for correct behavior, if we move right or left, we should forget
+	// (reset) the saved horizontal position. Since we assume the user wants to
+	// keep the cursor where it is horizontally. This is how most text areas
+	// work.
+
+	textarea, _ = textarea.Update(upMsg)
+	leftMsg := tea.KeyPressMsg{Code: tea.KeyLeft}
+	textarea, _ = textarea.Update(leftMsg)
+
+	if textarea.col != 4 || textarea.row != 1 {
+		t.Log(textarea.col)
+		t.Fatal("Expected cursor to be on the 5th character of the second line")
+	}
+
+	// Going down now should keep us at the 4th column since we moved left and
+	// reset the horizontal position saved state.
+	textarea, _ = textarea.Update(downMsg)
+	if textarea.col != 4 || textarea.row != 2 {
+		t.Log(textarea.col)
+		t.Fatal("Expected cursor to be on the 4th character of the last line")
+	}
+}
+
+func TestView(t *testing.T) {
+	t.Parallel()
+
+	type want struct {
+		view      string
+		cursorRow int
+		cursorCol int
+	}
+
+	tests := []struct {
+		name      string
+		modelFunc func(Model) Model
+		want      want
+	}{
+		{
+			name: "placeholder",
+			want: want{
+				view: heredoc.Doc(`
+					>   1 Hello, World!
+					>
+					>
+					>
+					>
+					>
+				`),
+			},
+		},
+		{
+			name: "single line",
+			modelFunc: func(m Model) Model {
+				m.SetValue("the first line")
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					>   1 the first line
+					>
+					>
+					>
+					>
+					>
+				`),
+				cursorRow: 0,
+				cursorCol: 14,
+			},
+		},
+		{
+			name: "multiple lines",
+			modelFunc: func(m Model) Model {
+				m.SetValue("the first line\nthe second line\nthe third line")
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					>   1 the first line
+					>   2 the second line
+					>   3 the third line
+					>
+					>
+					>
+				`),
+				cursorRow: 2,
+				cursorCol: 14,
+			},
+		},
+		{
+			name: "single line without line numbers",
+			modelFunc: func(m Model) Model {
+				m.SetValue("the first line")
+				m.ShowLineNumbers = false
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					> the first line
+					>
+					>
+					>
+					>
+					>
+				`),
+				cursorRow: 0,
+				cursorCol: 14,
+			},
+		},
+		{
+			name: "multipline lines without line numbers",
+			modelFunc: func(m Model) Model {
+				m.SetValue("the first line\nthe second line\nthe third line")
+				m.ShowLineNumbers = false
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					> the first line
+					> the second line
+					> the third line
+					>
+					>
+					>
+				`),
+				cursorRow: 2,
+				cursorCol: 14,
+			},
+		},
+		{
+			name: "single line and custom end of buffer character",
+			modelFunc: func(m Model) Model {
+				m.SetValue("the first line")
+				m.EndOfBufferCharacter = '*'
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					>   1 the first line
+					> *
+					> *
+					> *
+					> *
+					> *
+				`),
+				cursorRow: 0,
+				cursorCol: 14,
+			},
+		},
+		{
+			name: "multiple lines and custom end of buffer character",
+			modelFunc: func(m Model) Model {
+				m.SetValue("the first line\nthe second line\nthe third line")
+				m.EndOfBufferCharacter = '*'
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					>   1 the first line
+					>   2 the second line
+					>   3 the third line
+					> *
+					> *
+					> *
+				`),
+				cursorRow: 2,
+				cursorCol: 14,
+			},
+		},
+		{
+			name: "single line without line numbers and custom end of buffer character",
+			modelFunc: func(m Model) Model {
+				m.SetValue("the first line")
+				m.ShowLineNumbers = false
+				m.EndOfBufferCharacter = '*'
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					> the first line
+					> *
+					> *
+					> *
+					> *
+					> *
+				`),
+				cursorRow: 0,
+				cursorCol: 14,
+			},
+		},
+		{
+			name: "multiple lines without line numbers and custom end of buffer character",
+			modelFunc: func(m Model) Model {
+				m.SetValue("the first line\nthe second line\nthe third line")
+				m.ShowLineNumbers = false
+				m.EndOfBufferCharacter = '*'
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					> the first line
+					> the second line
+					> the third line
+					> *
+					> *
+					> *
+				`),
+				cursorRow: 2,
+				cursorCol: 14,
+			},
+		},
+		{
+			name: "single line and custom prompt",
+			modelFunc: func(m Model) Model {
+				m.SetValue("the first line")
+				m.Prompt = "* "
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					*   1 the first line
+					*
+					*
+					*
+					*
+					*
+				`),
+				cursorRow: 0,
+				cursorCol: 14,
+			},
+		},
+		{
+			name: "multiple lines and custom prompt",
+			modelFunc: func(m Model) Model {
+				m.SetValue("the first line\nthe second line\nthe third line")
+				m.Prompt = "* "
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					*   1 the first line
+					*   2 the second line
+					*   3 the third line
+					*
+					*
+					*
+				`),
+				cursorRow: 2,
+				cursorCol: 14,
+			},
+		},
+		{
+			name: "type single line",
+			modelFunc: func(m Model) Model {
+				input := "foo"
+				m = sendString(m, input)
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					>   1 foo
+					>
+					>
+					>
+					>
+					>
+				`),
+				cursorRow: 0,
+				cursorCol: 3,
+			},
+		},
+		{
+			name: "type multiple lines",
+			modelFunc: func(m Model) Model {
+				input := "foo\nbar\nbaz"
+				m = sendString(m, input)
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					>   1 foo
+					>   2 bar
+					>   3 baz
+					>
+					>
+					>
+				`),
+				cursorRow: 2,
+				cursorCol: 3,
+			},
+		},
+		{
+			name: "softwrap",
+			modelFunc: func(m Model) Model {
+				m.ShowLineNumbers = false
+				m.Prompt = ""
+				m.SetWidth(5)
+
+				input := "foo bar baz"
+				m = sendString(m, input)
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					foo
+					bar
+					baz
+
+
+
+				`),
+				cursorRow: 2,
+				cursorCol: 3,
+			},
+		},
+		{
+			name: "single line character limit",
+			modelFunc: func(m Model) Model {
+				m.CharLimit = 7
+
+				input := "foo bar baz"
+				m = sendString(m, input)
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					>   1 foo bar
+					>
+					>
+					>
+					>
+					>
+				`),
+				cursorRow: 0,
+				cursorCol: 7,
+			},
+		},
+		{
+			name: "multiple lines character limit",
+			modelFunc: func(m Model) Model {
+				m.CharLimit = 19
+
+				input := "foo bar baz\nfoo bar baz"
+				m = sendString(m, input)
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					>   1 foo bar baz
+					>   2 foo bar
+					>
+					>
+					>
+					>
+				`),
+				cursorRow: 1,
+				cursorCol: 7,
+			},
+		},
+		{
+			name: "set width",
+			modelFunc: func(m Model) Model {
+				m.SetWidth(10)
+
+				input := "12"
+				m = sendString(m, input)
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					>   1 12
+					>
+					>
+					>
+					>
+					>
+				`),
+				cursorRow: 0,
+				cursorCol: 2,
+			},
+		},
+		{
+			name: "set width max length text minus one",
+			modelFunc: func(m Model) Model {
+				m.SetWidth(10)
+
+				input := "123"
+				m = sendString(m, input)
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					>   1 123
+					>
+					>
+					>
+					>
+					>
+				`),
+				cursorRow: 0,
+				cursorCol: 3,
+			},
+		},
+		{
+			name: "set width max length text",
+			modelFunc: func(m Model) Model {
+				m.SetWidth(10)
+
+				input := "1234"
+				m = sendString(m, input)
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					>   1 1234
+					>
+					>
+					>
+					>
+					>
+				`),
+				cursorRow: 1,
+				cursorCol: 0,
+			},
+		},
+		{
+			name: "set width max length text plus one",
+			modelFunc: func(m Model) Model {
+				m.SetWidth(10)
+
+				input := "12345"
+				m = sendString(m, input)
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					>   1 1234
+					>     5
+					>
+					>
+					>
+					>
+				`),
+				cursorRow: 1,
+				cursorCol: 1,
+			},
+		},
+		{
+			name: "set width set max width minus one",
+			modelFunc: func(m Model) Model {
+				m.MaxWidth = 10
+				m.SetWidth(11)
+
+				input := "123"
+				m = sendString(m, input)
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					>   1 123
+					>
+					>
+					>
+					>
+					>
+				`),
+				cursorRow: 0,
+				cursorCol: 3,
+			},
+		},
+		{
+			name: "set width set max width",
+			modelFunc: func(m Model) Model {
+				m.MaxWidth = 10
+				m.SetWidth(11)
+
+				input := "1234"
+				m = sendString(m, input)
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					>   1 1234
+					>
+					>
+					>
+					>
+					>
+				`),
+				cursorRow: 1,
+				cursorCol: 0,
+			},
+		},
+		{
+			name: "set width set max width plus one",
+			modelFunc: func(m Model) Model {
+				m.MaxWidth = 10
+				m.SetWidth(11)
+
+				input := "12345"
+				m = sendString(m, input)
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					>   1 1234
+					>     5
+					>
+					>
+					>
+					>
+				`),
+				cursorRow: 1,
+				cursorCol: 1,
+			},
+		},
+		{
+			name: "set width min width minus one",
+			modelFunc: func(m Model) Model {
+				m.SetWidth(6)
+
+				input := "123"
+				m = sendString(m, input)
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					>   1 1
+					>     2
+					>     3
+					>
+					>
+					>
+				`),
+				cursorRow: 3,
+				cursorCol: 0,
+			},
+		},
+		{
+			name: "set width min width",
+			modelFunc: func(m Model) Model {
+				m.SetWidth(7)
+
+				input := "123"
+				m = sendString(m, input)
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					>   1 1
+					>     2
+					>     3
+					>
+					>
+					>
+				`),
+				cursorRow: 3,
+				cursorCol: 0,
+			},
+		},
+		{
+			name: "set width min width no line numbers",
+			modelFunc: func(m Model) Model {
+				m.ShowLineNumbers = false
+				m.SetWidth(0)
+
+				input := "123"
+				m = sendString(m, input)
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					> 1
+					> 2
+					> 3
+					>
+					>
+					>
+				`),
+				cursorRow: 3,
+				cursorCol: 0,
+			},
+		},
+		{
+			name: "set width min width no line numbers no prompt",
+			modelFunc: func(m Model) Model {
+				m.ShowLineNumbers = false
+				m.Prompt = ""
+				m.SetWidth(0)
+
+				input := "123"
+				m = sendString(m, input)
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					1
+					2
+					3
+
+
+
+				`),
+				cursorRow: 3,
+				cursorCol: 0,
+			},
+		},
+		{
+			name: "set width min width plus one",
+			modelFunc: func(m Model) Model {
+				m.SetWidth(8)
+
+				input := "123"
+				m = sendString(m, input)
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					>   1 12
+					>     3
+					>
+					>
+					>
+					>
+				`),
+				cursorRow: 1,
+				cursorCol: 1,
+			},
+		},
+		{
+			name: "set width without line numbers max length text minus one",
+			modelFunc: func(m Model) Model {
+				m.ShowLineNumbers = false
+				m.SetWidth(6)
+
+				input := "123"
+				m = sendString(m, input)
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					> 123
+					>
+					>
+					>
+					>
+					>
+				`),
+				cursorRow: 0,
+				cursorCol: 3,
+			},
+		},
+		{
+			name: "set width without line numbers max length text",
+			modelFunc: func(m Model) Model {
+				m.ShowLineNumbers = false
+				m.SetWidth(6)
+
+				input := "1234"
+				m = sendString(m, input)
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					> 1234
+					>
+					>
+					>
+					>
+					>
+				`),
+				cursorRow: 1,
+				cursorCol: 0,
+			},
+		},
+		{
+			name: "set width without line numbers max length text plus one",
+			modelFunc: func(m Model) Model {
+				m.ShowLineNumbers = false
+				m.SetWidth(6)
+
+				input := "12345"
+				m = sendString(m, input)
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					> 1234
+					> 5
+					>
+					>
+					>
+					>
+				`),
+				cursorRow: 1,
+				cursorCol: 1,
+			},
+		},
+		{
+			name: "set width with style",
+			modelFunc: func(m Model) Model {
+				s := m.Styles()
+				s.Focused.Base = lipgloss.NewStyle().Border(lipgloss.NormalBorder())
+				m.SetStyles(s)
+				m.Focus()
+
+				m.SetWidth(12)
+
+				input := "1"
+				m = sendString(m, input)
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					┌──────────┐
+					│>   1 1   │
+					│>         │
+					│>         │
+					│>         │
+					│>         │
+					│>         │
+					└──────────┘
+				`),
+				cursorRow: 0,
+				cursorCol: 1,
+			},
+		},
+		{
+			name: "set width with style max width minus one",
+			modelFunc: func(m Model) Model {
+				s := m.Styles()
+				s.Focused.Base = lipgloss.NewStyle().Border(lipgloss.NormalBorder())
+				m.SetStyles(s)
+				m.Focus()
+
+				m.SetWidth(12)
+
+				input := "123"
+				m = sendString(m, input)
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					┌──────────┐
+					│>   1 123 │
+					│>         │
+					│>         │
+					│>         │
+					│>         │
+					│>         │
+					└──────────┘
+				`),
+				cursorRow: 0,
+				cursorCol: 3,
+			},
+		},
+		{
+			name: "set width with style max width",
+			modelFunc: func(m Model) Model {
+				s := m.Styles()
+				s.Focused.Base = lipgloss.NewStyle().Border(lipgloss.NormalBorder())
+				m.SetStyles(s)
+				m.Focus()
+
+				m.SetWidth(12)
+
+				input := "1234"
+				m = sendString(m, input)
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					┌──────────┐
+					│>   1 1234│
+					│>         │
+					│>         │
+					│>         │
+					│>         │
+					│>         │
+					└──────────┘
+				`),
+				cursorRow: 1,
+				cursorCol: 0,
+			},
+		},
+		{
+			name: "set width with style max width plus one",
+			modelFunc: func(m Model) Model {
+				s := m.Styles()
+				s.Focused.Base = lipgloss.NewStyle().Border(lipgloss.NormalBorder())
+				m.SetStyles(s)
+				m.Focus()
+
+				m.SetWidth(12)
+
+				input := "12345"
+				m = sendString(m, input)
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					┌──────────┐
+					│>   1 1234│
+					│>     5   │
+					│>         │
+					│>         │
+					│>         │
+					│>         │
+					└──────────┘
+				`),
+				cursorRow: 1,
+				cursorCol: 1,
+			},
+		},
+		{
+			name: "set width without line numbers with style",
+			modelFunc: func(m Model) Model {
+				s := m.Styles()
+				s.Focused.Base = lipgloss.NewStyle().Border(lipgloss.NormalBorder())
+				m.SetStyles(s)
+				m.Focus()
+
+				m.ShowLineNumbers = false
+				m.SetWidth(12)
+
+				input := "123456"
+				m = sendString(m, input)
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					┌──────────┐
+					│> 123456  │
+					│>         │
+					│>         │
+					│>         │
+					│>         │
+					│>         │
+					└──────────┘
+				`),
+				cursorRow: 0,
+				cursorCol: 6,
+			},
+		},
+		{
+			name: "set width without line numbers with style max width minus one",
+			modelFunc: func(m Model) Model {
+				s := m.Styles()
+				s.Focused.Base = lipgloss.NewStyle().Border(lipgloss.NormalBorder())
+				m.SetStyles(s)
+				m.Focus()
+
+				m.ShowLineNumbers = false
+				m.SetWidth(12)
+
+				input := "1234567"
+				m = sendString(m, input)
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					┌──────────┐
+					│> 1234567 │
+					│>         │
+					│>         │
+					│>         │
+					│>         │
+					│>         │
+					└──────────┘
+				`),
+				cursorRow: 0,
+				cursorCol: 7,
+			},
+		},
+		{
+			name: "set width without line numbers with style max width",
+			modelFunc: func(m Model) Model {
+				s := m.Styles()
+				s.Focused.Base = lipgloss.NewStyle().Border(lipgloss.NormalBorder())
+				m.SetStyles(s)
+				m.Focus()
+
+				m.ShowLineNumbers = false
+				m.SetWidth(12)
+
+				input := "12345678"
+				m = sendString(m, input)
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					┌──────────┐
+					│> 12345678│
+					│>         │
+					│>         │
+					│>         │
+					│>         │
+					│>         │
+					└──────────┘
+				`),
+				cursorRow: 1,
+				cursorCol: 0,
+			},
+		},
+		{
+			name: "set width without line numbers with style max width plus one",
+			modelFunc: func(m Model) Model {
+				s := m.Styles()
+				s.Focused.Base = lipgloss.NewStyle().Border(lipgloss.NormalBorder())
+				m.SetStyles(s)
+				m.Focus()
+
+				m.ShowLineNumbers = false
+				m.SetWidth(12)
+
+				input := "123456789"
+				m = sendString(m, input)
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					┌──────────┐
+					│> 12345678│
+					│> 9       │
+					│>         │
+					│>         │
+					│>         │
+					│>         │
+					└──────────┘
+				`),
+				cursorRow: 1,
+				cursorCol: 1,
+			},
+		},
+		{
+			name: "placeholder min width",
+			modelFunc: func(m Model) Model {
+				m.SetWidth(0)
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					>   1 H
+					>     e
+					>     l
+					>     l
+					>     o
+					>     ,
+				`),
+			},
+		},
+		{
+			name: "placeholder single line",
+			modelFunc: func(m Model) Model {
+				m.Placeholder = "placeholder the first line"
+				m.ShowLineNumbers = false
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					> placeholder the first line
+					>
+					>
+					>
+					>
+					>
+					`),
+			},
+		},
+		{
+			name: "placeholder multiple lines",
+			modelFunc: func(m Model) Model {
+				m.Placeholder = "placeholder the first line\nplaceholder the second line\nplaceholder the third line"
+				m.ShowLineNumbers = false
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					> placeholder the first line
+					> placeholder the second line
+					> placeholder the third line
+					>
+					>
+					>
+				`),
+			},
+		},
+		{
+			name: "placeholder single line with line numbers",
+			modelFunc: func(m Model) Model {
+				m.Placeholder = "placeholder the first line"
+				m.ShowLineNumbers = true
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					>   1 placeholder the first line
+					>
+					>
+					>
+					>
+					>
+				`),
+			},
+		},
+		{
+			name: "placeholder multiple lines with line numbers",
+			modelFunc: func(m Model) Model {
+				m.Placeholder = "placeholder the first line\nplaceholder the second line\nplaceholder the third line"
+				m.ShowLineNumbers = true
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					>   1 placeholder the first line
+					>     placeholder the second line
+					>     placeholder the third line
+					>
+					>
+					>
+				`),
+			},
+		},
+		{
+			name: "placeholder single line with end of buffer character",
+			modelFunc: func(m Model) Model {
+				m.Placeholder = "placeholder the first line"
+				m.ShowLineNumbers = false
+				m.EndOfBufferCharacter = '*'
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					> placeholder the first line
+					> *
+					> *
+					> *
+					> *
+					> *
+				`),
+			},
+		},
+		{
+			name: "placeholder multiple lines with with end of buffer character",
+			modelFunc: func(m Model) Model {
+				m.Placeholder = "placeholder the first line\nplaceholder the second line\nplaceholder the third line"
+				m.ShowLineNumbers = false
+				m.EndOfBufferCharacter = '*'
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					> placeholder the first line
+					> placeholder the second line
+					> placeholder the third line
+					> *
+					> *
+					> *
+				`),
+			},
+		},
+		{
+			name: "placeholder single line with line numbers and end of buffer character",
+			modelFunc: func(m Model) Model {
+				m.Placeholder = "placeholder the first line"
+				m.ShowLineNumbers = true
+				m.EndOfBufferCharacter = '*'
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					>   1 placeholder the first line
+					> *
+					> *
+					> *
+					> *
+					> *
+				`),
+			},
+		},
+		{
+			name: "placeholder multiple lines with line numbers and end of buffer character",
+			modelFunc: func(m Model) Model {
+				m.Placeholder = "placeholder the first line\nplaceholder the second line\nplaceholder the third line"
+				m.ShowLineNumbers = true
+				m.EndOfBufferCharacter = '*'
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					>   1 placeholder the first line
+					>     placeholder the second line
+					>     placeholder the third line
+					> *
+					> *
+					> *
+				`),
+			},
+		},
+		{
+			name: "placeholder single line that is longer than max width",
+			modelFunc: func(m Model) Model {
+				m.Placeholder = "placeholder the first line that is longer than the max width"
+				m.SetWidth(40)
+				m.ShowLineNumbers = false
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					> placeholder the first line that is
+					> longer than the max width
+					>
+					>
+					>
+					>
+				`),
+			},
+		},
+		{
+			name: "placeholder multiple lines that are longer than max width",
+			modelFunc: func(m Model) Model {
+				m.Placeholder = "placeholder the first line that is longer than the max width\nplaceholder the second line that is longer than the max width"
+				m.ShowLineNumbers = false
+				m.SetWidth(40)
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					> placeholder the first line that is
+					> longer than the max width
+					> placeholder the second line that is
+					> longer than the max width
+					>
+					>
+				`),
+			},
+		},
+		{
+			name: "placeholder single line that is longer than max width with line numbers",
+			modelFunc: func(m Model) Model {
+				m.Placeholder = "placeholder the first line that is longer than the max width"
+				m.ShowLineNumbers = true
+				m.SetWidth(40)
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					>   1 placeholder the first line that is
+					>     longer than the max width
+					>
+					>
+					>
+					>
+				`),
+			},
+		},
+		{
+			name: "placeholder multiple lines that are longer than max width with line numbers",
+			modelFunc: func(m Model) Model {
+				m.Placeholder = "placeholder the first line that is longer than the max width\nplaceholder the second line that is longer than the max width"
+				m.ShowLineNumbers = true
+				m.SetWidth(40)
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					>   1 placeholder the first line that is
+					>     longer than the max width
+					>     placeholder the second line that
+					>     is longer than the max width
+					>
+					>
+				`),
+			},
+		},
+		{
+			name: "placeholder single line that is longer than max width at limit",
+			modelFunc: func(m Model) Model {
+				m.Placeholder = "123456789012345678"
+				m.ShowLineNumbers = false
+				m.SetWidth(20)
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					> 123456789012345678
+					>
+					>
+					>
+					>
+					>
+				`),
+			},
+		},
+		{
+			name: "placeholder single line that is longer than max width at limit plus one",
+			modelFunc: func(m Model) Model {
+				m.Placeholder = "1234567890123456789"
+				m.ShowLineNumbers = false
+				m.SetWidth(20)
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					> 123456789012345678
+					> 9
+					>
+					>
+					>
+					>
+				`),
+			},
+		},
+		{
+			name: "placeholder single line that is longer than max width with line numbers at limit",
+			modelFunc: func(m Model) Model {
+				m.Placeholder = "12345678901234"
+				m.ShowLineNumbers = true
+				m.SetWidth(20)
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					>   1 12345678901234
+					>
+					>
+					>
+					>
+					>
+				`),
+			},
+		},
+		{
+			name: "placeholder single line that is longer than max width with line numbers at limit plus one",
+			modelFunc: func(m Model) Model {
+				m.Placeholder = "123456789012345"
+				m.ShowLineNumbers = true
+				m.SetWidth(20)
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					>   1 12345678901234
+					>     5
+					>
+					>
+					>
+					>
+				`),
+			},
+		},
+		{
+			name: "placeholder multiple lines that are longer than max width at limit",
+			modelFunc: func(m Model) Model {
+				m.Placeholder = "123456789012345678\n123456789012345678"
+				m.ShowLineNumbers = false
+				m.SetWidth(20)
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					> 123456789012345678
+					> 123456789012345678
+					>
+					>
+					>
+					>
+				`),
+			},
+		},
+		{
+			name: "placeholder multiple lines that are longer than max width at limit plus one",
+			modelFunc: func(m Model) Model {
+				m.Placeholder = "1234567890123456789\n1234567890123456789"
+				m.ShowLineNumbers = false
+				m.SetWidth(20)
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					> 123456789012345678
+					> 9
+					> 123456789012345678
+					> 9
+					>
+					>
+				`),
+			},
+		},
+		{
+			name: "placeholder multiple lines that are longer than max width with line numbers at limit",
+			modelFunc: func(m Model) Model {
+				m.Placeholder = "12345678901234\n12345678901234"
+				m.ShowLineNumbers = true
+				m.SetWidth(20)
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					>   1 12345678901234
+					>     12345678901234
+					>
+					>
+					>
+					>
+				`),
+			},
+		},
+		{
+			name: "placeholder multiple lines that are longer than max width with line numbers at limit plus one",
+			modelFunc: func(m Model) Model {
+				m.Placeholder = "123456789012345\n123456789012345"
+				m.ShowLineNumbers = true
+				m.SetWidth(20)
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					>   1 12345678901234
+					>     5
+					>     12345678901234
+					>     5
+					>
+					>
+				`),
+			},
+		},
+		{
+			name: "placeholder chinese character",
+			modelFunc: func(m Model) Model {
+				m.Placeholder = "输入消息..."
+				m.ShowLineNumbers = true
+				m.SetWidth(20)
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					>   1 输入消息...
+					>
+					>
+					>
+					>
+					>
+
+				`),
+			},
+		},
+		{
+			name: "page up moves to beginning when near top",
+			modelFunc: func(m Model) Model {
+				m.ShowLineNumbers = true
+				m.SetHeight(4)
+				m.SetWidth(20)
+
+				lines := make([]string, 10)
+				for i := range 10 {
+					lines[i] = fmt.Sprintf("Line %d", i+1)
+				}
+				m.SetValue(strings.Join(lines, "\n"))
+				m.viewport.SetContent(m.view()) // force setting of viewport content.
+
+				m.row = 3
+				m.col = 0
+				m.viewport.SetYOffset(0)
+				m.PageUp()
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					>   1 Line 1
+					>   2 Line 2
+					>   3 Line 3
+					>   4 Line 4
+				`),
+				cursorRow: 0,
+			},
+		},
+		{
+			name: "page up snaps to first visible line when not on it",
+			modelFunc: func(m Model) Model {
+				m.ShowLineNumbers = true
+				m.SetHeight(4)
+				m.SetWidth(20)
+
+				lines := make([]string, 10)
+				for i := range 10 {
+					lines[i] = fmt.Sprintf("Line %d", i+1)
+				}
+				m.SetValue(strings.Join(lines, "\n"))
+				m.viewport.SetContent(m.view()) // force setting of viewport content.
+
+				m.row = 5
+				m.col = 0
+				m.viewport.SetYOffset(3)
+				m.PageUp()
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					>   4 Line 4
+					>   5 Line 5
+					>   6 Line 6
+					>   7 Line 7
+				`),
+				cursorRow: 3,
+			},
+		},
+		{
+			name: "page up moves up by full page when on first visible line",
+			modelFunc: func(m Model) Model {
+				m.ShowLineNumbers = true
+				m.SetHeight(3)
+				m.SetWidth(20)
+
+				lines := make([]string, 10)
+				for i := range 10 {
+					lines[i] = fmt.Sprintf("Line %d", i+1)
+				}
+				m.SetValue(strings.Join(lines, "\n"))
+				m.viewport.SetContent(m.view()) // force setting of viewport content.
+
+				m.row = 5
+				m.col = 0
+				m.viewport.SetYOffset(5)
+				m.PageUp()
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					>   3 Line 3
+					>   4 Line 4
+					>   5 Line 5
+				`),
+				cursorRow: 2,
+			},
+		},
+		{
+			name: "page down moves to end when near bottom",
+			modelFunc: func(m Model) Model {
+				m.SetHeight(3)
+				m.SetWidth(20)
+
+				lines := make([]string, 10)
+				for i := range 10 {
+					lines[i] = fmt.Sprintf("Line %d", i+1)
+				}
+				m.SetValue(strings.Join(lines, "\n"))
+				m.viewport.SetContent(m.view()) // force setting of viewport content.
+
+				m.row = 8
+				m.col = 0
+				m.viewport.SetYOffset(7)
+				m.PageDown()
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					>   8 Line 8
+					>   9 Line 9
+					>  10 Line 10
+				`),
+				cursorRow: 9,
+			},
+		},
+		{
+			name: "page down snaps to last visible line when not on it",
+			modelFunc: func(m Model) Model {
+				m.SetHeight(3)
+				m.SetWidth(20)
+
+				lines := make([]string, 10)
+				for i := range 10 {
+					lines[i] = fmt.Sprintf("Line %d", i+1)
+				}
+				m.SetValue(strings.Join(lines, "\n"))
+				m.viewport.SetContent(m.view()) // force setting of viewport content.
+
+				m.row = 3
+				m.col = 0
+				m.viewport.SetYOffset(3)
+				m.PageDown()
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					>   4 Line 4
+					>   5 Line 5
+					>   6 Line 6
+				`),
+				cursorRow: 5,
+			},
+		},
+		{
+			name: "page down moves down by full page when on last visible line",
+			modelFunc: func(m Model) Model {
+				m.SetHeight(3)
+				m.SetWidth(20)
+
+				lines := make([]string, 10)
+				for i := range 10 {
+					lines[i] = fmt.Sprintf("Line %d", i+1)
+				}
+				m.SetValue(strings.Join(lines, "\n"))
+				m.viewport.SetContent(m.view()) // force setting of viewport content.
+
+				m.row = 4
+				m.col = 0
+				m.viewport.SetYOffset(2)
+				m.PageDown()
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					>   6 Line 6
+					>   7 Line 7
+					>   8 Line 8
+				`),
+				cursorRow: 7,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			textarea := newTextArea()
+
+			if tt.modelFunc != nil {
+				textarea = tt.modelFunc(textarea)
+			}
+
+			view := stripString(textarea.View())
+			wantView := stripString(tt.want.view)
+
+			if view != wantView {
+				t.Fatalf("Want:\n%v\nGot:\n%v\n", wantView, view)
+			}
+
+			cursorRow := textarea.cursorLineNumber()
+			cursorCol := textarea.LineInfo().ColumnOffset
+			if tt.want.cursorRow != cursorRow || tt.want.cursorCol != cursorCol {
+				format := "Want cursor at row: %v, col: %v Got: row: %v col: %v\n"
+				t.Fatalf(format, tt.want.cursorRow, tt.want.cursorCol, cursorRow, cursorCol)
+			}
+		})
+	}
+}
+
+func TestWord(t *testing.T) {
+	textarea := newTextArea()
+
+	textarea.SetHeight(3)
+	textarea.SetWidth(20)
+	textarea.CharLimit = 500
+
+	textarea, _ = textarea.Update(nil)
+
+	t.Run("regular input", func(t *testing.T) {
+		input := "Word1 Word2 Word3 Word4"
+		for _, k := range input {
+			textarea, _ = textarea.Update(keyPress(k))
+			textarea.View()
+		}
+
+		expect := "Word4"
+		if word := textarea.Word(); word != expect {
+			t.Fatalf("Expected last word to be '%s', got '%s'", expect, word)
+		}
+	})
+
+	t.Run("navigate", func(t *testing.T) {
+		for _, k := range []tea.KeyPressMsg{
+			{Code: tea.KeyLeft, Mod: tea.ModAlt, Text: "alt+left"},
+			{Code: tea.KeyLeft, Mod: tea.ModAlt, Text: "alt+left"},
+			{Code: tea.KeyRight, Text: "right"},
+		} {
+			textarea, _ = textarea.Update(k)
+			textarea.View()
+		}
+
+		expect := "Word3"
+		if word := textarea.Word(); word != expect {
+			t.Fatalf("Expected last word to be '%s', got '%s'", expect, word)
+		}
+	})
+
+	t.Run("delete", func(t *testing.T) {
+		for _, k := range []tea.KeyPressMsg{
+			{Code: tea.KeyEnd, Text: "end"},
+			{Code: tea.KeyBackspace, Mod: tea.ModAlt, Text: "alt+backspace"},
+			{Code: tea.KeyBackspace, Mod: tea.ModAlt, Text: "alt+backspace"},
+			{Code: tea.KeyBackspace, Text: "backspace"},
+		} {
+			textarea, _ = textarea.Update(k)
+			textarea.View()
+		}
+
+		expect := "Word2"
+		if word := textarea.Word(); word != expect {
+			t.Fatalf("Expected last word to be '%s', got '%s'", expect, word)
+		}
+	})
+}
+
+func newDynamicTextArea(minH, maxH int) Model {
+	ta := New()
+	ta.Prompt = ""
+	ta.ShowLineNumbers = false
+	ta.DynamicHeight = true
+	ta.MinHeight = minH
+	ta.MaxHeight = maxH
+	ta.SetWidth(20)
+	ta.Focus()
+	ta, _ = ta.Update(nil)
+	return ta
+}
+
+func TestDynamicHeight_DefaultUnchanged(t *testing.T) {
+	ta := newTextArea()
+	ta.SetHeight(6)
+	ta.SetWidth(40)
+
+	for _, k := range "hello\nworld\n" {
+		ta, _ = ta.Update(keyPress(k))
+	}
+
+	if ta.Height() != 6 {
+		t.Errorf("expected static height 6, got %d", ta.Height())
+	}
+}
+
+func TestDynamicHeight_GrowsOnNewline(t *testing.T) {
+	ta := newDynamicTextArea(1, 20)
+
+	ta, _ = ta.Update(keyPress('a'))
+	if ta.Height() != 1 {
+		t.Errorf("expected height 1 after single char, got %d", ta.Height())
+	}
+
+	enter := tea.KeyPressMsg{Code: tea.KeyEnter}
+	ta, _ = ta.Update(enter)
+	if ta.Height() != 2 {
+		t.Errorf("expected height 2 after first newline, got %d", ta.Height())
+	}
+
+	ta, _ = ta.Update(enter)
+	if ta.Height() != 3 {
+		t.Errorf("expected height 3 after second newline, got %d", ta.Height())
+	}
+}
+
+func TestDynamicHeight_GrowsOnSoftWrap(t *testing.T) {
+	ta := newDynamicTextArea(1, 20)
+	// width=20, so typing >20 chars should cause a soft wrap
+	input := "abcdefghijklmnopqrstuvwxyz"
+	for _, k := range input {
+		ta, _ = ta.Update(keyPress(k))
+	}
+
+	if ta.Height() < 2 {
+		t.Errorf("expected height >= 2 after soft wrap, got %d", ta.Height())
+	}
+}
+
+func TestDynamicHeight_ShrinksOnLineDeletion(t *testing.T) {
+	ta := newDynamicTextArea(1, 20)
+
+	enter := tea.KeyPressMsg{Code: tea.KeyEnter}
+	ta, _ = ta.Update(keyPress('a'))
+	ta, _ = ta.Update(enter)
+	ta, _ = ta.Update(keyPress('b'))
+	ta, _ = ta.Update(enter)
+	ta, _ = ta.Update(keyPress('c'))
+
+	if ta.Height() != 3 {
+		t.Fatalf("expected height 3 before deletion, got %d", ta.Height())
+	}
+
+	// Backspace at start of line 3 merges with line 2
+	ta.CursorStart()
+	backspace := tea.KeyPressMsg{Code: tea.KeyBackspace}
+	ta, _ = ta.Update(backspace)
+
+	if ta.Height() != 2 {
+		t.Errorf("expected height 2 after line merge, got %d", ta.Height())
+	}
+}
+
+func TestDynamicHeight_RespectsMinHeight(t *testing.T) {
+	ta := newDynamicTextArea(5, 20)
+
+	ta, _ = ta.Update(keyPress('a'))
+
+	if ta.Height() != 5 {
+		t.Errorf("expected min height 5, got %d", ta.Height())
+	}
+}
+
+func TestDynamicHeight_RespectsMaxHeight(t *testing.T) {
+	ta := newDynamicTextArea(1, 5)
+
+	enter := tea.KeyPressMsg{Code: tea.KeyEnter}
+	for range 10 {
+		ta, _ = ta.Update(keyPress('x'))
+		ta, _ = ta.Update(enter)
+	}
+
+	if ta.Height() != 5 {
+		t.Errorf("expected max height 5, got %d", ta.Height())
+	}
+}
+
+func TestDynamicHeight_GrowsOnPaste(t *testing.T) {
+	ta := newDynamicTextArea(1, 20)
+
+	paste := tea.PasteMsg{Content: "line1\nline2\nline3\nline4\nline5"}
+	ta, _ = ta.Update(paste)
+
+	if ta.Height() != 5 {
+		t.Errorf("expected height 5 after pasting 5 lines, got %d", ta.Height())
+	}
+}
+
+func TestDynamicHeight_RecalculatesOnSetWidth(t *testing.T) {
+	ta := newDynamicTextArea(1, 50)
+	ta.SetWidth(40)
+
+	// Insert a line that fits in 40 cols but wraps in 10 cols
+	ta.SetValue("abcdefghijklmnopqrstuvwxyz")
+
+	if ta.Height() != 1 {
+		t.Fatalf("expected height 1 at width 40, got %d", ta.Height())
+	}
+
+	ta.SetWidth(10)
+
+	if ta.Height() < 3 {
+		t.Errorf("expected height >= 3 after narrowing to width 10, got %d", ta.Height())
+	}
+}
+
+func TestDynamicHeight_RecalculatesOnSetValue(t *testing.T) {
+	ta := newDynamicTextArea(1, 20)
+
+	ta.SetValue("a\nb\nc\nd\ne")
+
+	if ta.Height() != 5 {
+		t.Errorf("expected height 5 after SetValue with 5 lines, got %d", ta.Height())
+	}
+}
+
+func TestDynamicHeight_CursorPositionAfterGrow(t *testing.T) {
+	ta := newDynamicTextArea(1, 20)
+
+	enter := tea.KeyPressMsg{Code: tea.KeyEnter}
+	for i := range 5 {
+		ta, _ = ta.Update(keyPress(rune('a' + i)))
+		ta, _ = ta.Update(enter)
+	}
+	ta, _ = ta.Update(keyPress('f'))
+
+	// Cursor should be on the last line (row 5, 0-indexed)
+	if ta.Line() != 5 {
+		t.Errorf("expected cursor on row 5, got %d", ta.Line())
+	}
+
+	// Cursor visual line should be within the viewport
+	cursorLine := ta.cursorLineNumber()
+	minVisible := ta.viewport.YOffset()
+	maxVisible := minVisible + ta.viewport.Height() - 1
+	if cursorLine < minVisible || cursorLine > maxVisible {
+		t.Errorf("cursor line %d outside viewport [%d, %d]", cursorLine, minVisible, maxVisible)
+	}
+}
+
+func TestDynamicHeight_CursorPositionAfterShrink(t *testing.T) {
+	ta := newDynamicTextArea(1, 20)
+
+	enter := tea.KeyPressMsg{Code: tea.KeyEnter}
+	for i := range 5 {
+		ta, _ = ta.Update(keyPress(rune('a' + i)))
+		ta, _ = ta.Update(enter)
+	}
+	ta, _ = ta.Update(keyPress('f'))
+
+	if ta.Height() != 6 {
+		t.Fatalf("expected height 6 before shrink, got %d", ta.Height())
+	}
+
+	// Delete lines by backspacing
+	backspace := tea.KeyPressMsg{Code: tea.KeyBackspace}
+	ta, _ = ta.Update(backspace) // delete 'f'
+	ta, _ = ta.Update(backspace) // merge line 5 into 4
+	ta, _ = ta.Update(backspace) // delete 'e'
+	ta, _ = ta.Update(backspace) // merge line 4 into 3
+
+	cursorLine := ta.cursorLineNumber()
+	minVisible := ta.viewport.YOffset()
+	maxVisible := minVisible + ta.viewport.Height() - 1
+	if cursorLine < minVisible || cursorLine > maxVisible {
+		t.Errorf("cursor line %d outside viewport [%d, %d] after shrink", cursorLine, minVisible, maxVisible)
+	}
+}
+
+func TestDynamicHeight_CursorPositionAfterPaste(t *testing.T) {
+	ta := newDynamicTextArea(1, 20)
+
+	paste := tea.PasteMsg{Content: "line1\nline2\nline3\nline4\nline5"}
+	ta, _ = ta.Update(paste)
+
+	// Cursor should be at the end of the last pasted line
+	if ta.Line() != 4 {
+		t.Errorf("expected cursor on row 4, got %d", ta.Line())
+	}
+
+	cursorLine := ta.cursorLineNumber()
+	minVisible := ta.viewport.YOffset()
+	maxVisible := minVisible + ta.viewport.Height() - 1
+	if cursorLine < minVisible || cursorLine > maxVisible {
+		t.Errorf("cursor line %d outside viewport [%d, %d] after paste", cursorLine, minVisible, maxVisible)
+	}
+}
+
+func TestMaxContentHeight_ScrollsBeyondMaxHeight(t *testing.T) {
+	ta := newDynamicTextArea(1, 5)
+	ta.MaxContentHeight = 10
+
+	enter := tea.KeyPressMsg{Code: tea.KeyEnter}
+	for range 8 {
+		ta, _ = ta.Update(keyPress('x'))
+		ta, _ = ta.Update(enter)
+	}
+
+	if ta.Height() != 5 {
+		t.Errorf("expected visible height capped at 5, got %d", ta.Height())
+	}
+
+	if ta.LineCount() != 9 {
+		t.Errorf("expected 9 logical lines, got %d", ta.LineCount())
+	}
+}
+
+func TestMaxContentHeight_BlocksAtLimit(t *testing.T) {
+	ta := New()
+	ta.Prompt = ""
+	ta.ShowLineNumbers = false
+	ta.MaxContentHeight = 5
+	ta.SetWidth(20)
+	ta.Focus()
+	ta, _ = ta.Update(nil)
+
+	enter := tea.KeyPressMsg{Code: tea.KeyEnter}
+	for range 10 {
+		ta, _ = ta.Update(keyPress('x'))
+		ta, _ = ta.Update(enter)
+	}
+
+	if ta.totalVisualLines() > 5 {
+		t.Errorf("expected total visual lines <= 5, got %d", ta.totalVisualLines())
+	}
+}
+
+func TestMaxContentHeight_BackwardCompat(t *testing.T) {
+	ta := New()
+	ta.Prompt = ""
+	ta.ShowLineNumbers = false
+	ta.MaxHeight = 10
+	ta.SetWidth(20)
+	ta.Focus()
+	ta, _ = ta.Update(nil)
+
+	enter := tea.KeyPressMsg{Code: tea.KeyEnter}
+	for range 15 {
+		ta, _ = ta.Update(keyPress('x'))
+		ta, _ = ta.Update(enter)
+	}
+
+	if ta.LineCount() > 10 {
+		t.Errorf("expected logical line count <= 10 (legacy behavior), got %d", ta.LineCount())
+	}
+}
+
+func TestMaxContentHeight_WithoutDynamicHeight(t *testing.T) {
+	ta := New()
+	ta.Prompt = ""
+	ta.ShowLineNumbers = false
+	ta.MaxContentHeight = 5
+	ta.SetHeight(3)
+	ta.SetWidth(20)
+	ta.Focus()
+	ta, _ = ta.Update(nil)
+
+	enter := tea.KeyPressMsg{Code: tea.KeyEnter}
+	for range 10 {
+		ta, _ = ta.Update(keyPress('x'))
+		ta, _ = ta.Update(enter)
+	}
+
+	if ta.Height() != 3 {
+		t.Errorf("expected fixed height 3, got %d", ta.Height())
+	}
+
+	if ta.totalVisualLines() > 5 {
+		t.Errorf("expected content capped at 5 visual lines, got %d", ta.totalVisualLines())
+	}
+}
+
+func TestMaxContentHeight_CursorVisibleWhileScrolling(t *testing.T) {
+	ta := newDynamicTextArea(1, 5)
+	ta.MaxContentHeight = 10
+
+	enter := tea.KeyPressMsg{Code: tea.KeyEnter}
+	for range 8 {
+		ta, _ = ta.Update(keyPress('x'))
+		ta, _ = ta.Update(enter)
+	}
+	ta, _ = ta.Update(keyPress('y'))
+
+	cursorLine := ta.cursorLineNumber()
+	minVisible := ta.viewport.YOffset()
+	maxVisible := minVisible + ta.viewport.Height() - 1
+	if cursorLine < minVisible || cursorLine > maxVisible {
+		t.Errorf("cursor line %d outside viewport [%d, %d] while scrolling", cursorLine, minVisible, maxVisible)
+	}
+}
+
+func TestMaxContentHeight_PasteCapped(t *testing.T) {
+	ta := New()
+	ta.Prompt = ""
+	ta.ShowLineNumbers = false
+	ta.MaxContentHeight = 5
+	ta.SetWidth(20)
+	ta.Focus()
+	ta, _ = ta.Update(nil)
+
+	paste := tea.PasteMsg{Content: "1\n2\n3\n4\n5\n6\n7\n8\n9\n10"}
+	ta, _ = ta.Update(paste)
+
+	if ta.totalVisualLines() > 5 {
+		t.Errorf("expected paste capped at 5 visual lines, got %d", ta.totalVisualLines())
+	}
+}
+
+func TestDynamicHeight_ShrinksWhenScrolledAndLinesDeleted(t *testing.T) {
+	ta := newDynamicTextArea(1, 5)
+	ta.MaxContentHeight = 10
+
+	enter := tea.KeyPressMsg{Code: tea.KeyEnter}
+	// Type 8 lines so we exceed MaxHeight (5) and start scrolling
+	for range 7 {
+		ta, _ = ta.Update(keyPress('x'))
+		ta, _ = ta.Update(enter)
+	}
+	ta, _ = ta.Update(keyPress('x'))
+
+	if ta.Height() != 5 {
+		t.Fatalf("expected height 5 (capped at MaxHeight), got %d", ta.Height())
+	}
+	if ta.LineCount() != 8 {
+		t.Fatalf("expected 8 lines, got %d", ta.LineCount())
+	}
+
+	// Now delete lines from the bottom by selecting all on current line and backspacing
+	backspace := tea.KeyPressMsg{Code: tea.KeyBackspace}
+	for ta.LineCount() > 4 {
+		ta.CursorEnd()
+		for len(ta.value[ta.row]) > 0 {
+			ta, _ = ta.Update(backspace)
+		}
+		ta, _ = ta.Update(backspace) // merge with previous line
+	}
+
+	// Now we have 4 lines, which is less than MaxHeight (5).
+	// Height should shrink to 4.
+	if ta.Height() != 4 {
+		t.Errorf("expected height to shrink to 4 (matching content), got %d", ta.Height())
+	}
+	if ta.viewport.YOffset() != 0 {
+		t.Errorf("expected yOffset 0 after shrinking, got %d", ta.viewport.YOffset())
+	}
+}
+
+func TestDynamicHeight_ShrinksWhenScrolledNoMaxContent(t *testing.T) {
+	// DynamicHeight with MaxHeight but no MaxContentHeight
+	ta := newDynamicTextArea(1, 99)
+
+	enter := tea.KeyPressMsg{Code: tea.KeyEnter}
+	// Type 8 lines
+	for range 7 {
+		ta, _ = ta.Update(keyPress('x'))
+		ta, _ = ta.Update(enter)
+	}
+	ta, _ = ta.Update(keyPress('x'))
+
+	if ta.Height() != 8 {
+		t.Fatalf("expected height 8, got %d", ta.Height())
+	}
+
+	// Manually set a smaller MaxHeight to simulate scrolling scenario
+	ta.MaxHeight = 5
+	ta, _ = ta.Update(nil)
+
+	// Now delete lines from the bottom
+	backspace := tea.KeyPressMsg{Code: tea.KeyBackspace}
+	for ta.LineCount() > 3 {
+		ta.CursorEnd()
+		for len(ta.value[ta.row]) > 0 {
+			ta, _ = ta.Update(backspace)
+		}
+		ta, _ = ta.Update(backspace)
+	}
+
+	if ta.Height() != 3 {
+		t.Errorf("expected height to shrink to 3 (matching content), got %d", ta.Height())
+	}
+	if ta.viewport.YOffset() != 0 {
+		t.Errorf("expected yOffset 0 after shrinking, got %d", ta.viewport.YOffset())
+	}
+}
+
+func newTextArea() Model {
+	textarea := New()
+
+	textarea.Prompt = "> "
+	textarea.Placeholder = "Hello, World!"
+
+	textarea.Focus()
+
+	textarea, _ = textarea.Update(nil)
+
+	return textarea
+}
+
+func keyPress(key rune) tea.Msg {
+	return tea.KeyPressMsg{Code: key, Text: string(key)}
+}
+
+func sendString(m Model, str string) Model {
+	for _, k := range []rune(str) {
+		m, _ = m.Update(keyPress(k))
+	}
+
+	return m
+}
+
+func stripString(str string) string {
+	s := ansi.Strip(str)
+	ss := strings.Split(s, "\n")
+
+	var lines []string
+	for _, l := range ss {
+		trim := strings.TrimRightFunc(l, unicode.IsSpace)
+		if trim != "" {
+			lines = append(lines, trim)
+		}
+	}
+
+	return strings.Join(lines, "\n")
+}


### PR DESCRIPTION
Splits the prompt-editor half out of #251. **Stacked on #252** — merge that first, then this rebases onto `main` cleanly.

## What changed

- **`/skill` completions popup.** Typing `/` mid-prompt opens an inline popup listing available skills, searchable by name and description. At the start of an empty prompt `/` still opens the commands dialog, so the two triggers do not collide. The popup is built from the effective skill catalog — the resolved set the agent actually sees — so a shadowed or disabled skill never appears.
- **Token highlighting.** `@file` and `/skill` tokens are styled inline as you type and keep that styling in the posted message, so a token looks the same above and below the editor. This vendors the bubbles textarea into `internal/ui/textarea` so it can accept a highlighter hook.

## Review fixes

A high-effort review found four defects here, all fixed in `61dee3c` with reproducing tests:

| Defect | Effect |
|---|---|
| `/` trigger fired on absolute paths | `read /tmp/out.log` opened the skill popup; with no match it drew **nothing but still ate every Enter** — the prompt could not be submitted and nothing on screen explained why. With a match, Enter replaced the whole path with a skill name |
| Trigger index taken from `len(value)`, not the cursor | Typing `/` mid-prompt appended the skill to the **end** of the prompt and stranded the typed `/` where the cursor was |
| Per-rune width math in the highlighter | `lipgloss.StyleRanges` segments by grapheme cluster, so any emoji with a modifier or ZWJ pushed highlights off their token — 2 cells for a skin tone, 4 for a ZWJ family |
| `refreshStyles` never re-pushed highlighter styles | After a theme change the editor drew tokens in the old palette while the posted message used the new one |

Each fix has a test that fails without it — verified by reverting each guard in turn.

Two API additions came out of this: `textarea.ByteOffset()` (cursor position as a byte offset into `Value()`, so callers slicing around the cursor stop guessing) and `promptHighlighter.SetStyles`.

## Verification

`go build ./...`, `go test ./...`, `gofumpt -l .`, `go vet ./...` all clean. (`go vet` reports one pre-existing `internal/csync/maps.go` lock-by-value warning present on `main` and untouched here.)

## Notes

- The `/` trigger deliberately does **not** open when the cursor is not at the end of the value. `insertCompletionText` splices at `completionsStartIndex` then `MoveToEnd()`s, and #250's atomic backspace depends on the completion sitting at the end — so mid-prompt insertion is a larger change than this PR should carry. The `@` trigger has the same existing limitation; declining to open is strictly better than mangling the prompt.
- `internal/ui/textarea/textarea.go` and its `internal/` subpackages are a straight lift of the upstream bubbles component plus the `SetHighlighter` hook and `ByteOffset`; they were excluded from review scope as vendored code.

🤖 Posted on behalf of `@joestump` by [`claude-opus-5`](https://openrouter.ai/anthropic/claude-opus-5) using [Claude Code](https://claude.ai).
