### PR TITLE
fix(ui): preserve @file highlighting and remove attachment on atomic backspace

### DIFF
--- a/internal/ui/attachments/attachments.go
+++ b/internal/ui/attachments/attachments.go
@@ -39,6 +39,18 @@ type Attachments struct {
 func (m *Attachments) List() []message.Attachment { return m.list }
 func (m *Attachments) Reset()                     { m.list = nil }
 
+// RemoveByFilePath removes the first attachment whose FilePath matches path.
+// Used when an atomic backspace deletes a @file mention from the prompt so
+// the corresponding attachment chip is removed alongside it.
+func (m *Attachments) RemoveByFilePath(path string) {
+	for i, att := range m.list {
+		if att.FilePath == path {
+			m.list = slices.Delete(m.list, i, i+1)
+			return
+		}
+	}
+}
+
 func (m *Attachments) Update(msg tea.Msg) bool {
 	switch msg := msg.(type) {
 	case message.Attachment:

--- a/internal/ui/attachments/attachments_test.go
+++ b/internal/ui/attachments/attachments_test.go
@@ -388,3 +388,63 @@ func TestHandleClick_EmptyListIgnored(t *testing.T) {
 	handled := m.HandleClick(5)
 	require.False(t, handled)
 }
+
+// TestRemoveByFilePath pins the semantics the atomic-backspace caller in
+// internal/ui/model depends on: exactly one attachment goes, chosen by path,
+// and anything else on the toolbar is left alone.
+func TestRemoveByFilePath(t *testing.T) {
+	t.Parallel()
+
+	newList := func(paths ...string) *Attachments {
+		a := New(nil, Keymap{})
+		for _, p := range paths {
+			a.list = append(a.list, message.Attachment{FilePath: p, FileName: p})
+		}
+		return a
+	}
+	paths := func(a *Attachments) []string {
+		var out []string
+		for _, at := range a.List() {
+			out = append(out, at.FilePath)
+		}
+		return out
+	}
+
+	t.Run("removes the matching attachment", func(t *testing.T) {
+		t.Parallel()
+		a := newList("a.go", "b.go", "c.go")
+		a.RemoveByFilePath("b.go")
+		require.Equal(t, []string{"a.go", "c.go"}, paths(a))
+	})
+
+	t.Run("no match leaves the list untouched", func(t *testing.T) {
+		t.Parallel()
+		a := newList("a.go", "b.go")
+		a.RemoveByFilePath("nope.go")
+		require.Equal(t, []string{"a.go", "b.go"}, paths(a))
+	})
+
+	t.Run("removes only the first of duplicate paths", func(t *testing.T) {
+		t.Parallel()
+		// Duplicates should not arise from the completion path (fileCmd
+		// dedupes), but the method is exported: removing every match would
+		// silently drop an attachment the caller still expects to hold.
+		a := newList("dup.go", "dup.go")
+		a.RemoveByFilePath("dup.go")
+		require.Equal(t, []string{"dup.go"}, paths(a))
+	})
+
+	t.Run("empty path matches nothing on a normal list", func(t *testing.T) {
+		t.Parallel()
+		a := newList("a.go")
+		a.RemoveByFilePath("")
+		require.Equal(t, []string{"a.go"}, paths(a))
+	})
+
+	t.Run("empty list is a no-op", func(t *testing.T) {
+		t.Parallel()
+		a := newList()
+		a.RemoveByFilePath("a.go")
+		require.Empty(t, a.List())
+	})
+}

--- a/internal/ui/model/completion_backspace_test.go
+++ b/internal/ui/model/completion_backspace_test.go
@@ -1,6 +1,8 @@
 package model
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -14,6 +16,7 @@ import (
 	"github.com/charmbracelet/crush/internal/ui/completions"
 	"github.com/charmbracelet/crush/internal/ui/dialog"
 	"github.com/charmbracelet/crush/internal/ui/textarea"
+	"github.com/stretchr/testify/require"
 )
 
 func newCompletionBackspaceUI() *UI {
@@ -233,4 +236,129 @@ func TestAtomicBackspaceIgnoresStaleRangeOfEqualLength(t *testing.T) {
 	if m.lastCompletionEnd != 0 {
 		t.Fatal("expected the stale range to be cleared")
 	}
+}
+
+// runInsertCmd runs the tea.Cmd an insert* returned and feeds any produced
+// attachment into the toolbar, so a test exercises the real fileCmd instead
+// of fabricating an attachment whose FilePath happens to match. Nothing else
+// pins fileCmd's FilePath to what the backspace path looks up, so a test that
+// hand-builds the attachment stays green even if the two drift apart.
+func runInsertCmd(t *testing.T, m *UI, cmd tea.Cmd) {
+	t.Helper()
+	if cmd == nil {
+		return
+	}
+	var run func(tea.Cmd)
+	run = func(c tea.Cmd) {
+		if c == nil {
+			return
+		}
+		msg := c()
+		if batch, ok := msg.(tea.BatchMsg); ok {
+			for _, sub := range batch {
+				run(sub)
+			}
+			return
+		}
+		if att, ok := msg.(message.Attachment); ok {
+			m.attachments.Update(att)
+		}
+	}
+	run(cmd)
+}
+
+// TestAtomicBackspaceKeepsAttachmentForRemainingMention pins the duplicate
+// mention case.
+//
+// fileCmd dedupes on sessionFileReads, so mentioning one file twice produces
+// a single attachment that both mentions share. Removing it whenever any
+// mention is backspaced deleted the chip while an earlier @mention was still
+// in the prompt — the file was then silently never sent to the model, which
+// is worse than the orphan chip this PR set out to fix.
+func TestAtomicBackspaceKeepsAttachmentForRemainingMention(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "dup.go")
+	require.NoError(t, os.WriteFile(path, []byte("package main\n"), 0o644))
+
+	m := newCompletionBackspaceUI()
+	m.textarea.SetValue("compare @")
+	m.completionsStartIndex = len("compare ")
+	runInsertCmd(t, m, m.insertFileCompletion(path))
+	require.Len(t, m.attachments.List(), 1, "the first mention attaches the file")
+
+	// Mention the same file again; the dedupe means no second attachment.
+	base := m.textarea.Value()
+	m.textarea.SetValue(base + "@")
+	m.completionsStartIndex = len(base)
+	runInsertCmd(t, m, m.insertFileCompletion(path))
+	require.Len(t, m.attachments.List(), 1, "the repeat mention reuses one attachment")
+
+	m.Update(tea.KeyPressMsg{Code: tea.KeyBackspace})
+
+	require.Contains(t, m.textarea.Value(), "@"+path,
+		"the first mention must survive the backspace")
+	require.Len(t, m.attachments.List(), 1,
+		"the attachment belongs to the mention still in the prompt")
+}
+
+// TestAtomicBackspaceAllowsReMention pins the dedupe rollback.
+//
+// insertFileCompletion records the file in sessionFileReads so a repeat
+// mention does not attach twice. Removing the attachment on backspace without
+// clearing that record made the file un-attachable for the rest of the
+// session: re-mentioning it produced a mention with no chip and no warning,
+// and the model never saw the contents.
+func TestAtomicBackspaceAllowsReMention(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "again.go")
+	require.NoError(t, os.WriteFile(path, []byte("package main\n"), 0o644))
+
+	m := newCompletionBackspaceUI()
+	m.textarea.SetValue("read @")
+	m.completionsStartIndex = len("read ")
+	runInsertCmd(t, m, m.insertFileCompletion(path))
+	require.Len(t, m.attachments.List(), 1)
+
+	m.Update(tea.KeyPressMsg{Code: tea.KeyBackspace})
+	require.Empty(t, m.attachments.List(), "backspace removes the chip with the text")
+
+	// Mention it again: it must attach, exactly as it did the first time.
+	m.textarea.SetValue("read @")
+	m.completionsStartIndex = len("read ")
+	runInsertCmd(t, m, m.insertFileCompletion(path))
+	require.Len(t, m.attachments.List(), 1,
+		"a re-mentioned file must attach again after its chip was removed")
+}
+
+// TestSkillInsertDoesNotInheritFileAttachment pins that the attached-path
+// record belongs to the completion that set it. It used to survive into the
+// next completion, so inserting @file.go and then /skill left the file's path
+// attached to the skill's range and backspacing the skill removed the
+// unrelated file's chip.
+func TestSkillInsertDoesNotInheritFileAttachment(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "keep.go")
+	require.NoError(t, os.WriteFile(path, []byte("package main\n"), 0o644))
+
+	m := newCompletionBackspaceUI()
+	m.textarea.SetValue("read @")
+	m.completionsStartIndex = len("read ")
+	runInsertCmd(t, m, m.insertFileCompletion(path))
+	require.Len(t, m.attachments.List(), 1)
+
+	base := m.textarea.Value()
+	m.textarea.SetValue(base + "/")
+	m.completionsStartIndex = len(base)
+	m.insertSkillCompletion(completions.SkillCompletionValue{Name: "code-review"})
+
+	m.Update(tea.KeyPressMsg{Code: tea.KeyBackspace})
+
+	require.Len(t, m.attachments.List(), 1,
+		"backspacing a skill must not remove a file's attachment")
 }

--- a/internal/ui/model/completion_backspace_test.go
+++ b/internal/ui/model/completion_backspace_test.go
@@ -1,14 +1,17 @@
 package model
 
 import (
+	"strings"
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 
 	"github.com/charmbracelet/crush/internal/config"
+	"github.com/charmbracelet/crush/internal/message"
 	"github.com/charmbracelet/crush/internal/ui/attachments"
 	"github.com/charmbracelet/crush/internal/ui/common"
+	"github.com/charmbracelet/crush/internal/ui/completions"
 	"github.com/charmbracelet/crush/internal/ui/dialog"
 	"github.com/charmbracelet/crush/internal/ui/textarea"
 )
@@ -118,6 +121,88 @@ func insertTestCompletion(t *testing.T, m *UI, prefix, text string) {
 	}
 	if got, want := m.textarea.Value(), prefix+text+" "; got != want {
 		t.Fatalf("setup produced %q, want %q", got, want)
+	}
+}
+
+// TestFileCompletionPreservesAtPrefix verifies that inserting a file
+// completion keeps the @ prefix so the token highlights in the editor.
+func TestFileCompletionPreservesAtPrefix(t *testing.T) {
+	t.Parallel()
+
+	m := newCompletionBackspaceUI()
+	m.textarea.SetValue("read ")
+	m.completionsStartIndex = len("read ")
+	// Simulate the @ trigger being in the textarea already.
+	m.textarea.SetValue("read @")
+	m.completionsStartIndex = len("read ")
+
+	cmd := m.insertFileCompletion("main.go")
+	_ = cmd // attachment command not relevant here
+
+	got := m.textarea.Value()
+	if !strings.Contains(got, "@main.go") {
+		t.Fatalf("expected @main.go in prompt, got %q", got)
+	}
+}
+
+// TestAtomicBackspaceRemovesFileAttachment verifies that deleting a
+// @file mention via atomic backspace also removes the corresponding
+// attachment chip.
+func TestAtomicBackspaceRemovesFileAttachment(t *testing.T) {
+	t.Parallel()
+
+	m := newCompletionBackspaceUI()
+	m.textarea.SetValue("read @")
+	m.completionsStartIndex = len("read ")
+
+	m.insertFileCompletion("main.go")
+
+	// Simulate the attachment being added (normally done via tea.Cmd).
+	m.attachments.Update(message.Attachment{
+		FilePath: "main.go",
+		FileName: "main.go",
+		MimeType: "text/plain",
+	})
+	if len(m.attachments.List()) != 1 {
+		t.Fatalf("expected 1 attachment, got %d", len(m.attachments.List()))
+	}
+
+	// Press backspace — should delete the entire completion AND the attachment.
+	m.Update(tea.KeyPressMsg{Code: tea.KeyBackspace})
+
+	if got := m.textarea.Value(); got != "read " {
+		t.Fatalf("expected %q after atomic backspace, got %q", "read ", got)
+	}
+	if len(m.attachments.List()) != 0 {
+		t.Fatalf("expected 0 attachments after atomic backspace, got %d", len(m.attachments.List()))
+	}
+}
+
+// TestSkillAtomicBackspaceDeletesEntireToken verifies that pressing
+// backspace immediately after a skill completion deletes the entire
+// /skill-name token at once.
+func TestSkillAtomicBackspaceDeletesEntireToken(t *testing.T) {
+	t.Parallel()
+
+	m := newCompletionBackspaceUI()
+	m.textarea.SetValue("please ")
+	m.completionsStartIndex = len("please ")
+	// Simulate the / trigger being in the textarea.
+	m.textarea.SetValue("please /")
+	m.completionsStartIndex = len("please ")
+
+	m.insertSkillCompletion(completions.SkillCompletionValue{Name: "code-review"})
+
+	got := m.textarea.Value()
+	if got != "please /code-review " {
+		t.Fatalf("expected %q after skill insertion, got %q", "please /code-review ", got)
+	}
+
+	// Press backspace — should delete the entire skill token.
+	m.Update(tea.KeyPressMsg{Code: tea.KeyBackspace})
+
+	if got := m.textarea.Value(); got != "please " {
+		t.Fatalf("expected %q after atomic backspace, got %q", "please ", got)
 	}
 }
 

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -2690,9 +2690,7 @@ func (m *UI) handleKeyPressMsg(msg tea.KeyPressMsg) tea.Cmd {
 						// Remove the attachment that was added alongside
 						// this @file mention, so the chip disappears with
 						// the text.
-						if m.lastCompletionFilePath != "" {
-							m.attachments.RemoveByFilePath(m.lastCompletionFilePath)
-						}
+						m.dropCompletionAttachment(val[:m.lastCompletionStart])
 						m.clearCompletionRange()
 						// Deleting a wrapped completion changes the editor's
 						// height, and the deletion is a draft edit like any
@@ -2723,7 +2721,20 @@ func (m *UI) handleKeyPressMsg(msg tea.KeyPressMsg) tea.Cmd {
 				curIdx := len(curValue)
 
 				// Trigger file completions on @.
-				if msg.String() == "@" && !m.completionsOpen {
+				//
+				// Bang mode is excluded for the same reason the '/' trigger
+				// and the highlighter exclude it: the line is a shell
+				// command, and a mention inserts a literal '@' the shell
+				// would pass through to the program (`cat @main.go`).
+				//
+				// The cursor must also be at the end of the value, because
+				// curIdx above is the value length rather than the cursor and
+				// insertCompletionText splices at completionsStartIndex then
+				// MoveToEnd()s — opening the popup with the cursor elsewhere
+				// strands the typed '@' and appends the mention at the end.
+				// Same guard the '/' trigger uses below.
+				if msg.String() == "@" && !m.completionsOpen && !m.bangMode &&
+					m.textarea.ByteOffset() == curIdx {
 					// Only show if beginning of prompt or after whitespace.
 					if curIdx == 0 || (curIdx > 0 && isWhitespace(curValue[curIdx-1])) {
 						m.completionsOpen = true
@@ -4030,7 +4041,68 @@ func (m *UI) insertCompletionText(text string) bool {
 	m.lastCompletionText = text + " "
 	m.lastCompletionStart = m.completionsStartIndex
 	m.lastCompletionEnd = m.completionsStartIndex + len(m.lastCompletionText)
+	// The attached path belongs to the run recorded above, so it is reset
+	// here with the rest of the range and re-set by the callers that
+	// actually attach something. Without this it survives into the next
+	// completion: inserting @file.go and then /skill left the file's path
+	// attached to the skill's range, so backspacing the skill removed the
+	// unrelated file's chip.
+	m.lastCompletionFilePath = ""
 	return true
+}
+
+// dropCompletionAttachment removes the attachment that the just-deleted
+// completion put on the prompt, given the prompt text that survives the
+// deletion.
+//
+// Two guards make this safe, both of which the naive "remove by path" version
+// got wrong:
+//
+// Repeat mentions share one attachment. insertFileCompletion's fileCmd
+// dedupes on sessionFileReads, so mentioning the same file twice creates a
+// single attachment owned, in effect, by the first mention. Removing on the
+// second backspace deleted that shared attachment while its first mention was
+// still sitting in the prompt — the chip vanished and the file was silently
+// never sent. So the attachment only goes when nothing left in the prompt
+// still mentions it.
+//
+// Removing it must also roll back the dedupe entry, or the file becomes
+// un-attachable: re-mentioning it hits sessionFileReads, returns nil, and the
+// user gets a mention with no attachment and no indication anything is wrong.
+func (m *UI) dropCompletionAttachment(remaining string) {
+	path := m.lastCompletionFilePath
+	if path == "" {
+		return
+	}
+	if promptMentions(remaining, path) {
+		return
+	}
+	m.attachments.RemoveByFilePath(path)
+	if absPath, err := filepath.Abs(path); err == nil {
+		m.sessionFileReads = slices.DeleteFunc(m.sessionFileReads, func(p string) bool {
+			return p == absPath
+		})
+	}
+}
+
+// promptMentions reports whether value still carries an "@target" token.
+// Matching goes through the same tokenizer that highlights mentions, so what
+// counts as a live mention here is exactly what the user sees highlighted.
+func promptMentions(value, target string) bool {
+	// ScanPromptTokens works a line at a time and reports rune offsets, so
+	// slice the rune view of each line rather than the byte string.
+	for _, line := range strings.Split(value, "\n") {
+		runes := []rune(line)
+		for _, tok := range common.ScanPromptTokens(runes) {
+			if tok.Kind != common.PromptTokenFile {
+				continue
+			}
+			if string(runes[tok.Start+1:tok.End]) == target {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // clearCompletionRange forgets the last inserted completion, so a later
@@ -4109,13 +4181,29 @@ func (m *UI) insertMCPResourceCompletion(item completions.ResourceCompletionValu
 	}
 
 	prevHeight := m.textarea.Height()
-	if !m.insertCompletionText("@" + displayText) {
+	// Only prefix '@' when the text can actually read back as one mention.
+	// ScanPromptTokens ends a token at the first space, so "@Daily Report
+	// 2026" highlights as a mention of a file called "Daily" followed by
+	// loose prose, and the model sees the same. A template URI is not a
+	// path at all — "@cairn://run/{id}" invites the model to resolve
+	// something that does not exist. Both keep the bare text they had
+	// before mentions were prefixed.
+	insertText := displayText
+	if !item.IsTemplate() && !strings.ContainsAny(displayText, " \t") {
+		insertText = "@" + displayText
+	}
+	if !m.insertCompletionText(insertText) {
 		return nil
 	}
 	heightCmd := m.handleTextareaHeightChange(prevHeight)
 	if item.IsTemplate() {
 		return heightCmd
 	}
+	// The attachment this completion is about to add is keyed by the
+	// resource URI, so record that — not displayText, which may be the
+	// human-readable title. Without it, backspacing an MCP resource mention
+	// removed the text and left the chip behind.
+	m.lastCompletionFilePath = item.URI
 
 	resourceCmd := func() tea.Msg {
 		contents, err := m.com.Workspace.ReadMCPResource(

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -293,9 +293,10 @@ type UI struct {
 	// is only honoured while the textarea still holds it, so a whole-value
 	// replacement (history recall, paste) cannot make a stale range point
 	// at unrelated text that happens to be the same length.
-	lastCompletionStart int
-	lastCompletionEnd   int
-	lastCompletionText  string
+	lastCompletionStart    int
+	lastCompletionEnd      int
+	lastCompletionText     string
+	lastCompletionFilePath string // non-empty when the last completion attached a file
 
 	// promptHighlighter styles @file and /skill tokens inline as the user
 	// types. Installed on the textarea via SetHighlighter.
@@ -2686,6 +2687,12 @@ func (m *UI) handleKeyPressMsg(msg tea.KeyPressMsg) tea.Cmd {
 						prevHeight := m.textarea.Height()
 						m.textarea.SetValue(val[:m.lastCompletionStart])
 						m.textarea.MoveToEnd()
+						// Remove the attachment that was added alongside
+						// this @file mention, so the chip disappears with
+						// the text.
+						if m.lastCompletionFilePath != "" {
+							m.attachments.RemoveByFilePath(m.lastCompletionFilePath)
+						}
 						m.clearCompletionRange()
 						// Deleting a wrapped completion changes the editor's
 						// height, and the deletion is a draft edit like any
@@ -4032,15 +4039,17 @@ func (m *UI) clearCompletionRange() {
 	m.lastCompletionStart = 0
 	m.lastCompletionEnd = 0
 	m.lastCompletionText = ""
+	m.lastCompletionFilePath = ""
 }
 
 // insertFileCompletion inserts the selected file path into the textarea,
 // replacing the @query, and adds the file as an attachment.
 func (m *UI) insertFileCompletion(path string) tea.Cmd {
 	prevHeight := m.textarea.Height()
-	if !m.insertCompletionText(path) {
+	if !m.insertCompletionText("@" + path) {
 		return nil
 	}
+	m.lastCompletionFilePath = path
 	heightCmd := m.handleTextareaHeightChange(prevHeight)
 
 	fileCmd := func() tea.Msg {
@@ -4100,7 +4109,7 @@ func (m *UI) insertMCPResourceCompletion(item completions.ResourceCompletionValu
 	}
 
 	prevHeight := m.textarea.Height()
-	if !m.insertCompletionText(displayText) {
+	if !m.insertCompletionText("@" + displayText) {
 		return nil
 	}
 	heightCmd := m.handleTextareaHeightChange(prevHeight)


### PR DESCRIPTION
Three fixes for prompt editor completion behavior:

- **File mentions not highlighted**: `insertFileCompletion` inserted bare paths without the `@` prefix, so `ScanPromptTokens` never matched them. Now prepends `@` for both file and MCP resource completions.
- **Backspace doesn't remove attachment chip**: Atomic backspace deleted the text but left the attachment. Added `lastCompletionFilePath` tracking and `Attachments.RemoveByFilePath()` so the chip disappears with the mention.
- **Skill atomic backspace regression test**: Already worked correctly through `insertCompletionText`; added a test to prevent future regressions.

Tests cover all three fixes in `completion_backspace_test.go`.

💘 Generated with Crush