### PR TITLE
fix(ui): load MCP prompts at startup

### DIFF
--- a/internal/ui/model/mcp_prompts_init_test.go
+++ b/internal/ui/model/mcp_prompts_init_test.go
@@ -1,0 +1,124 @@
+package model
+
+import (
+	"context"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+
+	mcptools "github.com/charmbracelet/crush/internal/agent/tools/mcp"
+	"github.com/charmbracelet/crush/internal/commands"
+	"github.com/charmbracelet/crush/internal/config"
+	"github.com/charmbracelet/crush/internal/ui/common"
+	"github.com/charmbracelet/crush/internal/ui/textarea"
+	"github.com/charmbracelet/crush/internal/workspace"
+	"github.com/stretchr/testify/require"
+)
+
+// mcpPromptWorkspace serves a fixed set of MCP prompts, standing in for
+// connected servers that advertise them.
+type mcpPromptWorkspace struct {
+	workspace.Workspace
+	prompts []commands.MCPPrompt
+	dataDir string
+	calls   int
+}
+
+func (w *mcpPromptWorkspace) AgentIsReady() bool   { return true }
+func (w *mcpPromptWorkspace) AgentReadyErr() error { return nil }
+
+// Init fans out to the other loaders too, and loadCustomCommands reads
+// Options.DataDirectory, so this has to be a real (if empty) config.
+func (w *mcpPromptWorkspace) Config() *config.Config {
+	return &config.Config{Options: &config.Options{DataDirectory: w.dataDir}}
+}
+
+func (w *mcpPromptWorkspace) ListMCPPrompts(context.Context) ([]commands.MCPPrompt, error) {
+	w.calls++
+	return w.prompts, nil
+}
+
+// The rest of what Init touches, stubbed to their empty results.
+func (w *mcpPromptWorkspace) LSPGetStates() map[string]workspace.LSPClientInfo {
+	return nil
+}
+
+func (w *mcpPromptWorkspace) MCPGetStates() map[string]mcptools.ClientInfo {
+	return nil
+}
+
+// TestInitLoadsMCPPrompts pins MCP prompt loading into startup.
+//
+// m.mcpPrompts used to be populated from exactly one place — the
+// mcp.EventStateChanged branch of the pubsub handler. Servers publish that
+// event as they connect, which normally happens before this model is
+// subscribed to the bus, so the event was missed and the field stayed nil for
+// the entire session. The commands dialog then hid its MCP Prompts category
+// outright, because commandsRadioView renders an empty string when there are
+// no user commands and no prompts, and every server's prompts were
+// unreachable from the UI even though the whole pipeline behind them worked.
+func TestInitLoadsMCPPrompts(t *testing.T) {
+	t.Parallel()
+
+	ws := &mcpPromptWorkspace{
+		dataDir: t.TempDir(),
+		prompts: []commands.MCPPrompt{
+			{ID: "cairn:run_capture", PromptID: "run_capture", ClientID: "cairn"},
+			{ID: "gitea:review", PromptID: "review", ClientID: "gitea"},
+		},
+	}
+	com := common.DefaultCommon(ws)
+	m := &UI{
+		com:      com,
+		status:   NewStatus(com, nil),
+		chat:     NewChat(com, config.ScrollbarDefault),
+		textarea: textarea.New(),
+		state:    uiChat,
+		focus:    uiFocusEditor,
+		width:    140,
+		height:   45,
+	}
+
+	require.Empty(t, m.mcpPrompts, "precondition: nothing loaded before Init")
+
+	// Init must schedule the load without depending on any MCP event.
+	runInitCmds(t, m, m.Init())
+
+	require.Positive(t, ws.calls, "Init must ask the workspace for MCP prompts")
+	require.Len(t, m.mcpPrompts, 2,
+		"prompts must be available without waiting for an mcp.EventStateChanged")
+}
+
+// runInitCmds executes the commands Init returned and feeds any
+// mcpPromptsLoadedMsg back through Update, mirroring the runtime loop.
+func runInitCmds(t *testing.T, m *UI, cmd tea.Cmd) {
+	t.Helper()
+	if cmd == nil {
+		return
+	}
+	var run func(tea.Cmd)
+	run = func(c tea.Cmd) {
+		if c == nil {
+			return
+		}
+		// Init fans out to every startup loader, and the others want a far
+		// fuller workspace than this fixture builds. Isolate each command so
+		// a sibling's missing stub cannot mask the one assertion here —
+		// which is that Init asks for MCP prompts at all.
+		var msg tea.Msg
+		func() {
+			defer func() { _ = recover() }()
+			msg = c()
+		}()
+		if batch, ok := msg.(tea.BatchMsg); ok {
+			for _, sub := range batch {
+				run(sub)
+			}
+			return
+		}
+		if loaded, ok := msg.(mcpPromptsLoadedMsg); ok {
+			m.mcpPrompts = loaded.Prompts
+		}
+	}
+	run(cmd)
+}

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -534,6 +534,14 @@ func (m *UI) Init() tea.Cmd {
 	}
 	// load the user commands async
 	cmds = append(cmds, m.loadCustomCommands())
+	// Load MCP prompts async. Without this they are only ever picked up
+	// from an mcp.EventStateChanged, which servers publish as they connect
+	// — normally before this model is subscribed to the bus. The event is
+	// then missed and m.mcpPrompts stays nil for the whole session, so the
+	// commands dialog hides its MCP Prompts category outright
+	// (commandsRadioView renders nothing when there are no user commands
+	// and no prompts) and every server's prompts are unreachable.
+	cmds = append(cmds, m.loadMCPrompts)
 	// load prompt history async
 	cmds = append(cmds, m.loadPromptHistory())
 	// load initial LSP state


### PR DESCRIPTION
MCP prompts have never been reachable from the TUI. Every server's prompts were invisible, including servers that clearly advertise them.

## Root cause

`m.mcpPrompts` was populated from exactly one place — the `mcp.EventStateChanged` branch of the pubsub handler (`ui.go:970-975`). Servers publish that event **as they connect**, which normally happens before the UI model is subscribed to the bus. The event is missed, and the field stays `nil` for the entire session.

The failure is then silent rather than merely empty: `commandsRadioView` (`dialog/commands.go:286`) returns an empty string when there are no user commands *and* no MCP prompts, so the commands dialog doesn't show an empty "MCP Prompts" category — it hides the category selector outright. Typing `/` on an empty prompt looks completely normal, just with no way to reach any prompt.

## The fix

One line: schedule `loadMCPrompts` from `Init()` alongside the other startup loaders.

Everything else on the path was already built and correct — `getPrompts` → `updatePrompts` on connect, `mcp.Prompts()` → `LoadMCPPrompts()` → `ListMCPPrompts`, the dialog's prompts category, and the arguments dialog for prompts that declare arguments. Only the initial load was missing.

## Verification

`TestInitLoadsMCPPrompts` asserts `Init()` asks the workspace for prompts without any MCP event being delivered. Confirmed to fail when the added line is removed:

```
--- FAIL: TestInitLoadsMCPPrompts
    Error: "0" is not positive
    Messages: Init must ask the workspace for MCP prompts
```

The test isolates each command in `Init()`'s batch, because the other startup loaders want a much fuller workspace fixture than this test builds — that way a sibling's missing stub can't mask the one thing being asserted.

`go build ./...`, `go test ./...`, `gofumpt -l .` all clean.

## Note

Found while investigating why `/` showed no Cairn prompts. Reported symptom: 12 configured MCP servers, several advertising prompts, and nothing prompt-related anywhere in the `/` menu.

🤖 Posted on behalf of `@joestump` by [`claude-opus-5`](https://openrouter.ai/anthropic/claude-opus-5) using [Claude Code](https://claude.ai).
