### PR TITLE
feat(ui): offer MCP prompts in the inline / completions

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1559,7 +1559,7 @@ func (a *sessionAgent) createUserMessage(ctx context.Context, call SessionAgentC
 	parts := []message.ContentPart{message.TextContent{Text: call.Prompt}}
 	var attachmentParts []message.ContentPart
 	for _, attachment := range call.Attachments {
-		attachmentParts = append(attachmentParts, message.BinaryContent{Path: attachment.FilePath, MIMEType: attachment.MimeType, Data: attachment.Content})
+		attachmentParts = append(attachmentParts, message.BinaryContent{Path: attachment.FilePath, MIMEType: attachment.MimeType, Data: attachment.Content, Kind: attachment.Kind, PromptArgCount: attachment.PromptArgCount})
 	}
 	parts = append(parts, attachmentParts...)
 	msg, err := a.messages.Create(ctx, call.SessionID, message.CreateMessageParams{

--- a/internal/message/attachment.go
+++ b/internal/message/attachment.go
@@ -5,11 +5,40 @@ import (
 	"strings"
 )
 
+// AttachmentKind names what an attachment came from, for presentation.
+//
+// It exists because MIME type cannot answer the question: an MCP prompt's
+// content is text that must reach the model intact, so it necessarily shares
+// a MIME type with skills and other text attachments while needing its own
+// icon and label rule. Sniffing harder only makes the coupling more brittle.
+//
+// The zero value is [AttachmentKindFile], so attachments built before this
+// field existed — and every call site that does not care — keep the previous
+// behavior, which derives presentation from the MIME type.
+type AttachmentKind string
+
+const (
+	// AttachmentKindFile is a file or MCP resource pulled in by an @mention,
+	// or anything else that is fundamentally file-shaped. Presentation falls
+	// back to MIME sniffing for these.
+	AttachmentKindFile AttachmentKind = ""
+	// AttachmentKindMCPPrompt is a resolved MCP prompt, attached by the
+	// inline "/server:prompt" completion.
+	AttachmentKindMCPPrompt AttachmentKind = "mcp_prompt"
+)
+
 type Attachment struct {
 	FilePath string
 	FileName string
 	MimeType string
 	Content  []byte
+	// Kind distinguishes attachments whose presentation cannot be derived
+	// from MimeType. See [AttachmentKind].
+	Kind AttachmentKind
+	// PromptArgCount is the number of arguments a resolved MCP prompt was
+	// invoked with, shown on its chip. Only meaningful for
+	// [AttachmentKindMCPPrompt].
+	PromptArgCount int
 }
 
 // textMimePrefixes are MIME type prefixes that should be treated as text.

--- a/internal/message/content.go
+++ b/internal/message/content.go
@@ -87,6 +87,14 @@ type BinaryContent struct {
 	Path     string
 	MIMEType string
 	Data     []byte
+	// Kind and PromptArgCount carry an attachment's presentation identity
+	// across the message boundary. Without them a chip loses what it is the
+	// moment the message is sent: the transcript rebuilds attachments from
+	// these parts, and MIMEType alone cannot distinguish an MCP prompt from
+	// any other text attachment. Both are omitempty and zero-valued for
+	// ordinary files, so existing persisted messages decode unchanged.
+	Kind           AttachmentKind `json:",omitempty"`
+	PromptArgCount int            `json:",omitempty"`
 }
 
 func (bc BinaryContent) String(p catwalk.InferenceProvider) string {

--- a/internal/proto/message.go
+++ b/internal/proto/message.go
@@ -638,15 +638,22 @@ type Attachment struct {
 	FileName string `json:"file_name"`
 	MimeType string `json:"mime_type"`
 	Content  []byte `json:"content"`
+	// Kind and PromptArgCount carry presentation identity that MimeType
+	// cannot express; see [message.AttachmentKind]. Both are omitempty so
+	// an ordinary file attachment serializes exactly as it did before.
+	Kind           string `json:"kind,omitempty"`
+	PromptArgCount int    `json:"prompt_arg_count,omitempty"`
 }
 
 // ToMessage converts a proto Attachment to a [message.Attachment].
 func (a Attachment) ToMessage() message.Attachment {
 	return message.Attachment{
-		FilePath: a.FilePath,
-		FileName: a.FileName,
-		MimeType: a.MimeType,
-		Content:  a.Content,
+		FilePath:       a.FilePath,
+		FileName:       a.FileName,
+		MimeType:       a.MimeType,
+		Content:        a.Content,
+		Kind:           message.AttachmentKind(a.Kind),
+		PromptArgCount: a.PromptArgCount,
 	}
 }
 
@@ -654,10 +661,12 @@ func (a Attachment) ToMessage() message.Attachment {
 // Attachment.
 func AttachmentFromMessage(a message.Attachment) Attachment {
 	return Attachment{
-		FilePath: a.FilePath,
-		FileName: a.FileName,
-		MimeType: a.MimeType,
-		Content:  a.Content,
+		FilePath:       a.FilePath,
+		FileName:       a.FileName,
+		MimeType:       a.MimeType,
+		Content:        a.Content,
+		Kind:           string(a.Kind),
+		PromptArgCount: a.PromptArgCount,
 	}
 }
 

--- a/internal/ui/attachments/attachments.go
+++ b/internal/ui/attachments/attachments.go
@@ -271,31 +271,54 @@ type chipSpec struct {
 	label string
 }
 
-// chipSpecFor decides how an attachment presents. Adding a chip type means
-// adding a case here and a label rule — nothing else in this file changes.
+// chipRenderer turns one attachment into the chip that represents it.
+type chipRenderer func(*Renderer, message.Attachment) chipSpec
+
+// chipRenderers is the registry of chip presentations, keyed by attachment
+// kind. Adding a chip type means adding an entry here and the function it
+// points at — nothing in the layout, the fit math, or the hit-testing needs
+// to know the kind exists.
+//
+// A kind with no entry falls back to fileChip, so an attachment produced by
+// an older client, or by code that never set Kind, still renders sensibly
+// rather than blank.
+var chipRenderers = map[message.AttachmentKind]chipRenderer{
+	message.AttachmentKindFile:      fileChip,
+	message.AttachmentKindMCPPrompt: mcpPromptChip,
+}
+
 func (r *Renderer) chipSpecFor(a message.Attachment) chipSpec {
-	switch a.Kind {
-	case message.AttachmentKindMCPPrompt:
-		// The full prompt name is the point of the chip — "/gitea:foo…"
-		// would leave two prompts from the same server indistinguishable —
-		// so it is never truncated. The argument values live in the prompt
-		// token in the editor, where there is room; the chip carries only
-		// how many there are.
-		label := a.FileName
-		if a.PromptArgCount > 0 {
-			label = fmt.Sprintf("%s (%d %s)", label, a.PromptArgCount,
-				plural(a.PromptArgCount, "arg", "args"))
-		}
-		return chipSpec{icon: r.promptStyle, label: label}
-	default:
-		// File-shaped attachments keep the historical rule: basename only,
-		// truncated to a uniform budget so a row of them stays tidy.
-		label := filepath.Base(a.FileName)
-		if ansi.StringWidth(label) > maxFilename {
-			label = ansi.Truncate(label, maxFilename, "…")
-		}
-		return chipSpec{icon: r.icon(a), label: label}
+	render, ok := chipRenderers[a.Kind]
+	if !ok {
+		render = fileChip
 	}
+	return render(r, a)
+}
+
+// fileChip presents anything file-shaped: the basename only, truncated to a
+// uniform budget so a row of them stays tidy, with the icon chosen by MIME
+// type. MIME sniffing lives here rather than in the dispatch above, because
+// it can only distinguish file-ish things from each other.
+func fileChip(r *Renderer, a message.Attachment) chipSpec {
+	label := filepath.Base(a.FileName)
+	if ansi.StringWidth(label) > maxFilename {
+		label = ansi.Truncate(label, maxFilename, "…")
+	}
+	return chipSpec{icon: r.icon(a), label: label}
+}
+
+// mcpPromptChip presents a resolved MCP prompt. The full prompt name is the
+// point — "/gitea:foo…" would leave two prompts from the same server
+// indistinguishable — so it is never truncated. Argument values live in the
+// token in the editor, where there is room; the chip carries only how many
+// there are.
+func mcpPromptChip(r *Renderer, a message.Attachment) chipSpec {
+	label := a.FileName
+	if a.PromptArgCount > 0 {
+		label = fmt.Sprintf("%s (%d %s)", label, a.PromptArgCount,
+			plural(a.PromptArgCount, "arg", "args"))
+	}
+	return chipSpec{icon: r.promptStyle, label: label}
 }
 
 func plural(n int, one, many string) string {

--- a/internal/ui/attachments/attachments.go
+++ b/internal/ui/attachments/attachments.go
@@ -2,7 +2,6 @@ package attachments
 
 import (
 	"fmt"
-	"math"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -111,29 +110,31 @@ func (m *Attachments) Render(width int) string {
 // styles in place.
 func (m *Attachments) Renderer() *Renderer { return m.renderer }
 
-func NewRenderer(normalStyle, deletingStyle, imageStyle, textStyle, skillStyle, removeStyle lipgloss.Style) *Renderer {
+func NewRenderer(normalStyle, deletingStyle, imageStyle, textStyle, skillStyle, promptStyle, removeStyle lipgloss.Style) *Renderer {
 	return &Renderer{
 		normalStyle:   normalStyle,
 		textStyle:     textStyle,
 		imageStyle:    imageStyle,
 		skillStyle:    skillStyle,
+		promptStyle:   promptStyle,
 		removeStyle:   removeStyle,
 		deletingStyle: deletingStyle,
 	}
 }
 
 // SetStyles updates the renderer styles in place.
-func (r *Renderer) SetStyles(normalStyle, deletingStyle, imageStyle, textStyle, skillStyle, removeStyle lipgloss.Style) {
+func (r *Renderer) SetStyles(normalStyle, deletingStyle, imageStyle, textStyle, skillStyle, promptStyle, removeStyle lipgloss.Style) {
 	r.normalStyle = normalStyle
 	r.textStyle = textStyle
 	r.imageStyle = imageStyle
 	r.skillStyle = skillStyle
+	r.promptStyle = promptStyle
 	r.removeStyle = removeStyle
 	r.deletingStyle = deletingStyle
 }
 
 type Renderer struct {
-	normalStyle, textStyle, imageStyle, skillStyle, removeStyle, deletingStyle lipgloss.Style
+	normalStyle, textStyle, imageStyle, skillStyle, promptStyle, removeStyle, deletingStyle lipgloss.Style
 	// bounds stores the X-coordinate ranges of each chip's remove
 	// button from the most recent Render call, for mouse hit-testing.
 	bounds []chipBounds
@@ -162,18 +163,19 @@ func (r *Renderer) Render(attachments []message.Attachment, deleting, showRemove
 	if showRemove {
 		removeReserve = removeStr
 	}
+	// A nominal chip width, used only to size the trailing "N more…" marker
+	// and to reserve room for it. Individual chips are measured as they are
+	// built: chip labels are no longer a uniform width (a prompt chip shows
+	// its full name plus an argument count), so a single width cannot decide
+	// how many fit.
 	maxItemWidth := lipgloss.Width(r.imageStyle.String() + r.normalStyle.Render(strings.Repeat("x", maxFilename)) + removeReserve)
-	fits := int(math.Floor(float64(width)/float64(maxItemWidth))) - 1
 
 	var offset int
 	for i, att := range attachments {
-		filename := filepath.Base(att.FileName)
-		// Truncate if needed.
-		if ansi.StringWidth(filename) > maxFilename {
-			filename = ansi.Truncate(filename, maxFilename, "…")
-		}
+		spec := r.chipSpecFor(att)
+		filename := spec.label
 
-		iconStr := r.icon(att).String()
+		iconStr := spec.icon.String()
 		nameStyle := r.normalStyle
 		if !showRemove {
 			// Without a remove button there is nothing to carry the
@@ -185,8 +187,31 @@ func (r *Renderer) Render(attachments []message.Attachment, deleting, showRemove
 		}
 		nameStr := nameStyle.Render(filename)
 
-		chips = append(chips, iconStr, nameStr)
 		chipW := lipgloss.Width(iconStr) + lipgloss.Width(nameStr)
+
+		// Measure the whole chip, trailing element included, before
+		// committing to it. Chip widths vary by kind now, so the only
+		// reliable cutoff is a running total. Reserve room for the
+		// "N more…" marker whenever anything would be left over, and always
+		// emit at least one chip however narrow the editor is.
+		trailW := 0
+		switch {
+		case deleting:
+			trailW = lipgloss.Width(r.deletingStyle.Render(fmt.Sprintf("%d", i)))
+		case showRemove:
+			trailW = lipgloss.Width(removeStr)
+		}
+		reserve := 0
+		if i < len(attachments)-1 {
+			reserve = maxItemWidth
+		}
+		if i > 0 && offset+chipW+trailW+reserve > width {
+			chips = append(chips, lipgloss.NewStyle().Width(maxItemWidth).
+				Render(fmt.Sprintf("%d more…", len(attachments)-i)))
+			break
+		}
+
+		chips = append(chips, iconStr, nameStr)
 
 		switch {
 		case deleting:
@@ -210,14 +235,19 @@ func (r *Renderer) Render(attachments []message.Attachment, deleting, showRemove
 		default:
 			offset += chipW
 		}
-
-		if i == fits && len(attachments) > i {
-			chips = append(chips, lipgloss.NewStyle().Width(maxItemWidth).Render(fmt.Sprintf("%d more…", len(attachments)-fits)))
-			break
-		}
 	}
 
-	return lipgloss.JoinHorizontal(lipgloss.Left, chips...)
+	out := lipgloss.JoinHorizontal(lipgloss.Left, chips...)
+	// Final guarantee. At least one chip is always drawn, however narrow the
+	// editor, and a prompt chip's label is deliberately not truncated to the
+	// filename budget — so a single wide chip in a narrow editor can still
+	// exceed the space, and the caller lays this row out expecting it not to.
+	// Truncating here bounds that case without imposing a budget on labels
+	// in the ordinary case, where the running total above already fits them.
+	if lipgloss.Width(out) > width {
+		out = ansi.Truncate(out, width, "…")
+	}
+	return out
 }
 
 // HitTestRemove returns the index of the attachment whose remove button
@@ -229,6 +259,50 @@ func (r *Renderer) HitTestRemove(_ []message.Attachment, x int) int {
 		}
 	}
 	return -1
+}
+
+// chipSpec is what one chip shows, decoupled from how it is laid out.
+// Building a spec is the only thing a new attachment kind has to define: the
+// layout below measures whatever label it produces, so a kind is free to be
+// wider or narrower than a filename without the fit math or the remove-button
+// hit regions going wrong.
+type chipSpec struct {
+	icon  lipgloss.Style
+	label string
+}
+
+// chipSpecFor decides how an attachment presents. Adding a chip type means
+// adding a case here and a label rule — nothing else in this file changes.
+func (r *Renderer) chipSpecFor(a message.Attachment) chipSpec {
+	switch a.Kind {
+	case message.AttachmentKindMCPPrompt:
+		// The full prompt name is the point of the chip — "/gitea:foo…"
+		// would leave two prompts from the same server indistinguishable —
+		// so it is never truncated. The argument values live in the prompt
+		// token in the editor, where there is room; the chip carries only
+		// how many there are.
+		label := a.FileName
+		if a.PromptArgCount > 0 {
+			label = fmt.Sprintf("%s (%d %s)", label, a.PromptArgCount,
+				plural(a.PromptArgCount, "arg", "args"))
+		}
+		return chipSpec{icon: r.promptStyle, label: label}
+	default:
+		// File-shaped attachments keep the historical rule: basename only,
+		// truncated to a uniform budget so a row of them stays tidy.
+		label := filepath.Base(a.FileName)
+		if ansi.StringWidth(label) > maxFilename {
+			label = ansi.Truncate(label, maxFilename, "…")
+		}
+		return chipSpec{icon: r.icon(a), label: label}
+	}
+}
+
+func plural(n int, one, many string) string {
+	if n == 1 {
+		return one
+	}
+	return many
 }
 
 func (r *Renderer) icon(a message.Attachment) lipgloss.Style {

--- a/internal/ui/attachments/attachments.go
+++ b/internal/ui/attachments/attachments.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"slices"
+	"strconv"
 	"strings"
 
 	"charm.land/bubbles/v2/key"
@@ -185,6 +186,15 @@ func (r *Renderer) Render(attachments []message.Attachment, deleting, showRemove
 			// attachments render with their chip backgrounds touching.
 			nameStyle = nameStyle.MarginRight(1)
 		}
+		// Bound the label to the room actually left. Prompt labels are
+		// deliberately not capped at maxFilename, so without this a single
+		// long one overruns the row and the trailing ✕ — and the overflow
+		// marker — get eaten by the row-level truncation below, leaving
+		// click regions pointing at cells that no longer show a button.
+		budget := width - offset - lipgloss.Width(iconStr) - trailWidth(r, deleting, showRemove, removeStr, i)
+		if budget > 0 && ansi.StringWidth(filename) > budget {
+			filename = ansi.Truncate(filename, budget, "…")
+		}
 		nameStr := nameStyle.Render(filename)
 
 		chipW := lipgloss.Width(iconStr) + lipgloss.Width(nameStr)
@@ -194,20 +204,18 @@ func (r *Renderer) Render(attachments []message.Attachment, deleting, showRemove
 		// reliable cutoff is a running total. Reserve room for the
 		// "N more…" marker whenever anything would be left over, and always
 		// emit at least one chip however narrow the editor is.
-		trailW := 0
-		switch {
-		case deleting:
-			trailW = lipgloss.Width(r.deletingStyle.Render(fmt.Sprintf("%d", i)))
-		case showRemove:
-			trailW = lipgloss.Width(removeStr)
-		}
+		trailW := trailWidth(r, deleting, showRemove, removeStr, i)
 		reserve := 0
 		if i < len(attachments)-1 {
 			reserve = maxItemWidth
 		}
-		if i > 0 && offset+chipW+trailW+reserve > width {
-			chips = append(chips, lipgloss.NewStyle().Width(maxItemWidth).
-				Render(fmt.Sprintf("%d more…", len(attachments)-i)))
+		if offset+chipW+trailW+reserve > width {
+			// Nothing more fits. Report the remainder if there is room for
+			// the marker; otherwise stop silently rather than overflow.
+			if offset+maxItemWidth <= width {
+				chips = append(chips, lipgloss.NewStyle().Width(maxItemWidth).
+					Render(fmt.Sprintf("%d more…", len(attachments)-i)))
+			}
 			break
 		}
 
@@ -248,6 +256,19 @@ func (r *Renderer) Render(attachments []message.Attachment, deleting, showRemove
 		out = ansi.Truncate(out, width, "…")
 	}
 	return out
+}
+
+// trailWidth is the width of whatever follows a chip's label: the delete-mode
+// numeral, the remove button, or nothing.
+func trailWidth(r *Renderer, deleting, showRemove bool, removeStr string, i int) int {
+	switch {
+	case deleting:
+		return lipgloss.Width(r.deletingStyle.Render(fmt.Sprintf("%d", i)))
+	case showRemove:
+		return lipgloss.Width(removeStr)
+	default:
+		return 0
+	}
 }
 
 // HitTestRemove returns the index of the attachment whose remove button
@@ -313,12 +334,31 @@ func fileChip(r *Renderer, a message.Attachment) chipSpec {
 // token in the editor, where there is room; the chip carries only how many
 // there are.
 func mcpPromptChip(r *Renderer, a message.Attachment) chipSpec {
-	label := a.FileName
+	label := promptChipName(a.FileName)
 	if a.PromptArgCount > 0 {
 		label = fmt.Sprintf("%s (%d %s)", label, a.PromptArgCount,
 			plural(a.PromptArgCount, "arg", "args"))
 	}
 	return chipSpec{icon: r.promptStyle, label: label}
+}
+
+// promptChipName normalizes what the chip shows for a prompt.
+//
+// In the composer the label is already "/server:prompt". A posted message
+// rebuilds its attachments from the stored part, which carries only the
+// removal key — "server:prompt#3", made unique per insertion — so the
+// trailing counter comes off and the leading slash goes back on. Doing it
+// here keeps every prompt-specific presentation rule in one place.
+func promptChipName(name string) string {
+	if i := strings.LastIndexByte(name, '#'); i > 0 {
+		if _, err := strconv.Atoi(name[i+1:]); err == nil {
+			name = name[:i]
+		}
+	}
+	if !strings.HasPrefix(name, "/") {
+		name = "/" + name
+	}
+	return name
 }
 
 func plural(n int, one, many string) string {

--- a/internal/ui/attachments/attachments_test.go
+++ b/internal/ui/attachments/attachments_test.go
@@ -557,3 +557,64 @@ func TestRenderVariableWidthChipsDoNotOverflow(t *testing.T) {
 			"a prompt name must survive intact when there is room")
 	})
 }
+
+// TestRenderNarrowRowKeepsRemoveButtonAndBounds pins the two failures the
+// untruncated prompt label introduced.
+//
+// Prompt labels are deliberately not capped at maxFilename, so a long one
+// could overrun the row: the trailing ✕ was truncated away by the row-level
+// backstop while r.bounds still claimed a hit region there, and clicking the
+// resulting blank space silently deleted an attachment. The overflow marker
+// disappeared the same way, so extra attachments went unreported.
+func TestRenderNarrowRowKeepsRemoveButtonAndBounds(t *testing.T) {
+	t.Parallel()
+
+	atts := []message.Attachment{
+		{
+			Kind:           message.AttachmentKindMCPPrompt,
+			FileName:       "/stumpcloud-ansible:deploy_production_playbook",
+			PromptArgCount: 3,
+		},
+		{FileName: "main.go", MimeType: "text/plain"},
+	}
+
+	for _, width := range []int{20, 27, 28, 30, 40, 60} {
+		r := newTestRenderer()
+		out := r.Render(atts, false, true, width)
+		stripped := ansi.Strip(out)
+
+		require.LessOrEqual(t, lipgloss.Width(out), width,
+			"width %d: row must not overflow", width)
+
+		// Every recorded hit region must sit inside what was actually drawn,
+		// or a click lands on a button that is not there.
+		for _, b := range r.bounds {
+			require.LessOrEqual(t, b.removeEnd, lipgloss.Width(out),
+				"width %d: hit region %v extends past the drawn row %q",
+				width, b, stripped)
+		}
+	}
+}
+
+// TestHitTestRemoveDoesNotMatchTruncatedButton is the click-level form of the
+// same bug: no hit region may survive for a button the user cannot see.
+func TestHitTestRemoveDoesNotMatchTruncatedButton(t *testing.T) {
+	t.Parallel()
+
+	atts := []message.Attachment{{
+		Kind:           message.AttachmentKindMCPPrompt,
+		FileName:       "/gitea:review",
+		PromptArgCount: 1,
+	}}
+
+	for _, width := range []int{27, 28} {
+		r := newTestRenderer()
+		out := r.Render(atts, false, true, width)
+		drawn := lipgloss.Width(out)
+		for x := drawn; x < drawn+4; x++ {
+			require.Equal(t, -1, r.HitTestRemove(atts, x),
+				"width %d: x=%d is past the drawn row but hit-tests as a remove button",
+				width, x)
+		}
+	}
+}

--- a/internal/ui/attachments/attachments_test.go
+++ b/internal/ui/attachments/attachments_test.go
@@ -8,6 +8,7 @@ import (
 	"charm.land/lipgloss/v2"
 	"github.com/charmbracelet/crush/internal/message"
 	"github.com/charmbracelet/crush/internal/ui/styles"
+	"github.com/charmbracelet/x/ansi"
 	"github.com/stretchr/testify/require"
 )
 
@@ -19,6 +20,7 @@ func newTestRenderer() *Renderer {
 		sty.Attachments.Image,
 		sty.Attachments.Text,
 		sty.Attachments.Skill,
+		sty.Attachments.Prompt,
 		sty.Attachments.Remove,
 	)
 }
@@ -446,5 +448,112 @@ func TestRemoveByFilePath(t *testing.T) {
 		a := newList()
 		a.RemoveByFilePath("a.go")
 		require.Empty(t, a.List())
+	})
+}
+
+// TestChipSpecForMCPPrompt pins the prompt chip's label rule: the full prompt
+// name, never truncated, plus how many arguments it carries. The name is what
+// distinguishes two prompts from the same server, so truncating it the way
+// filenames are truncated would make them ambiguous.
+func TestChipSpecForMCPPrompt(t *testing.T) {
+	t.Parallel()
+
+	r := newTestRenderer()
+
+	t.Run("full name is kept past the filename budget", func(t *testing.T) {
+		t.Parallel()
+		spec := r.chipSpecFor(message.Attachment{
+			Kind:           message.AttachmentKindMCPPrompt,
+			FileName:       "/gitea:some-very-long-prompt-name",
+			PromptArgCount: 2,
+		})
+		require.Equal(t, "/gitea:some-very-long-prompt-name (2 args)", spec.label)
+		require.NotContains(t, spec.label, "…", "a prompt name must not be truncated")
+	})
+
+	t.Run("singular for one argument", func(t *testing.T) {
+		t.Parallel()
+		spec := r.chipSpecFor(message.Attachment{
+			Kind:           message.AttachmentKindMCPPrompt,
+			FileName:       "/cairn:run",
+			PromptArgCount: 1,
+		})
+		require.Equal(t, "/cairn:run (1 arg)", spec.label)
+	})
+
+	t.Run("no suffix when the prompt takes no arguments", func(t *testing.T) {
+		t.Parallel()
+		spec := r.chipSpecFor(message.Attachment{
+			Kind:     message.AttachmentKindMCPPrompt,
+			FileName: "/cairn:run",
+		})
+		require.Equal(t, "/cairn:run", spec.label)
+	})
+
+	t.Run("a path-shaped argument value is not eaten by filepath.Base", func(t *testing.T) {
+		t.Parallel()
+		// File chips call filepath.Base, which would cut "gitea:review" out
+		// of a label ending in a slash-bearing value. Prompt labels must not
+		// go through it.
+		spec := r.chipSpecFor(message.Attachment{
+			Kind:           message.AttachmentKindMCPPrompt,
+			FileName:       "/gitea:review",
+			PromptArgCount: 1,
+		})
+		require.Equal(t, "/gitea:review (1 arg)", spec.label)
+	})
+}
+
+// TestChipSpecForFileKeepsTruncation pins that the file rule is unchanged:
+// basename only, truncated to the shared budget.
+func TestChipSpecForFileKeepsTruncation(t *testing.T) {
+	t.Parallel()
+
+	r := newTestRenderer()
+	spec := r.chipSpecFor(message.Attachment{
+		FileName: "/some/deep/path/a-very-long-file-name.go",
+		MimeType: "text/plain",
+	})
+	require.Contains(t, spec.label, "…")
+	require.NotContains(t, spec.label, "/", "file chips show the basename only")
+}
+
+// TestRenderVariableWidthChipsDoNotOverflow pins the layout change. The fit
+// cutoff used to divide the available width by one nominal chip width, which
+// silently assumed every chip was the same size; a prompt chip is not.
+func TestRenderVariableWidthChipsDoNotOverflow(t *testing.T) {
+	t.Parallel()
+
+	atts := []message.Attachment{
+		{Kind: message.AttachmentKindMCPPrompt, FileName: "/gitea:a-long-prompt-name", PromptArgCount: 3},
+		{Kind: message.AttachmentKindMCPPrompt, FileName: "/cairn:another-long-one", PromptArgCount: 2},
+		{FileName: "main.go", MimeType: "text/plain"},
+		{FileName: "other.go", MimeType: "text/plain"},
+	}
+
+	t.Run("row never exceeds the width it was given", func(t *testing.T) {
+		t.Parallel()
+		// Sweep widths, including ones too narrow for even the first chip.
+		for _, width := range []int{10, 20, 40, 60, 80, 120, 200} {
+			out := newTestRenderer().Render(atts, false, true, width)
+			require.LessOrEqual(t, lipgloss.Width(out), width,
+				"width %d: the chip row must not render wider than its space", width)
+		}
+	})
+
+	t.Run("chips that do not fit are reported, not dropped", func(t *testing.T) {
+		t.Parallel()
+		// Wide enough for some but not all of them.
+		out := newTestRenderer().Render(atts, false, true, 80)
+		require.Contains(t, ansi.Strip(out), "more…")
+	})
+
+	t.Run("everything fits when there is room", func(t *testing.T) {
+		t.Parallel()
+		out := newTestRenderer().Render(atts, false, true, 300)
+		stripped := ansi.Strip(out)
+		require.NotContains(t, stripped, "more…")
+		require.Contains(t, stripped, "/gitea:a-long-prompt-name (3 args)",
+			"a prompt name must survive intact when there is room")
 	})
 }

--- a/internal/ui/chat/messages.go
+++ b/internal/ui/chat/messages.go
@@ -502,6 +502,7 @@ func ExtractMessageItems(sty *styles.Styles, msg *message.Message, toolResults m
 			sty.Attachments.Image,
 			sty.Attachments.Text,
 			sty.Attachments.Skill,
+			sty.Attachments.Prompt,
 			sty.Attachments.Remove,
 		)
 		items = []MessageItem{NewUserMessageItem(sty, msg, r)}

--- a/internal/ui/chat/prefix_cache_test.go
+++ b/internal/ui/chat/prefix_cache_test.go
@@ -117,6 +117,7 @@ func TestUserMessageItemRender_PrefixCacheFocusBlur(t *testing.T) {
 		sty.Attachments.Image,
 		sty.Attachments.Text,
 		sty.Attachments.Skill,
+		sty.Attachments.Prompt,
 		sty.Attachments.Remove,
 	)
 	item := NewUserMessageItem(&sty, msg, r).(*UserMessageItem)

--- a/internal/ui/chat/user.go
+++ b/internal/ui/chat/user.go
@@ -267,8 +267,10 @@ func (m *UserMessageItem) renderAttachments(width int) string {
 	var attachments []message.Attachment
 	for _, at := range m.message.BinaryContent() {
 		attachments = append(attachments, message.Attachment{
-			FileName: at.Path,
-			MimeType: at.MIMEType,
+			FileName:       at.Path,
+			MimeType:       at.MIMEType,
+			Kind:           at.Kind,
+			PromptArgCount: at.PromptArgCount,
 		})
 	}
 	// This message is already posted, so the attachment can't be removed;

--- a/internal/ui/chat/user_test.go
+++ b/internal/ui/chat/user_test.go
@@ -26,6 +26,7 @@ func newTestUserItem(text string, createdAt int64) *UserMessageItem {
 		sty.Attachments.Image,
 		sty.Attachments.Text,
 		sty.Attachments.Skill,
+		sty.Attachments.Prompt,
 		sty.Attachments.Remove,
 	)
 	return NewUserMessageItem(&sty, msg, r).(*UserMessageItem)

--- a/internal/ui/chat/version_bump_test.go
+++ b/internal/ui/chat/version_bump_test.go
@@ -84,6 +84,7 @@ func TestUserMessageItem_MutatorsBumpVersion(t *testing.T) {
 		sty.Attachments.Image,
 		sty.Attachments.Text,
 		sty.Attachments.Skill,
+		sty.Attachments.Prompt,
 		sty.Attachments.Remove,
 	)
 	msg := &message.Message{
@@ -256,6 +257,7 @@ func TestUserMessageItem_FinishedAlwaysTrue(t *testing.T) {
 		sty.Attachments.Image,
 		sty.Attachments.Text,
 		sty.Attachments.Skill,
+		sty.Attachments.Prompt,
 		sty.Attachments.Remove,
 	)
 	msg := &message.Message{

--- a/internal/ui/common/prompttokens.go
+++ b/internal/ui/common/prompttokens.go
@@ -62,6 +62,20 @@ func IsPromptSkillPrefix(name string) bool {
 	return false
 }
 
+// promptTokenName reduces a "/" token's body to the name to validate.
+//
+// An MCP prompt carries its arguments in the token itself —
+// "/gitea:review(id=42)" — so the parenthesised tail has to come off before
+// matching. Without this the argument-bearing form never validates:
+// IsPromptSkillPrefix asks whether the token is a prefix of a known name, and
+// a name with arguments appended is longer than the name, not a prefix of it.
+func promptTokenName(body string) string {
+	if i := strings.IndexByte(body, '('); i >= 0 {
+		return body[:i]
+	}
+	return body
+}
+
 // ScanPromptTokens finds the @file and /skill tokens in a single line.
 //
 // Tokens start at a word boundary (start of line or after whitespace) and
@@ -81,7 +95,7 @@ func ScanPromptTokens(line []rune) []PromptToken {
 			}
 			if line[i] == '@' {
 				tokens = append(tokens, PromptToken{Start: i, End: end, Kind: PromptTokenFile})
-			} else if IsPromptSkillPrefix(string(line[i+1 : end])) {
+			} else if IsPromptSkillPrefix(promptTokenName(string(line[i+1 : end]))) {
 				tokens = append(tokens, PromptToken{Start: i, End: end, Kind: PromptTokenSkill})
 			}
 			i = end

--- a/internal/ui/common/prompttokens_test.go
+++ b/internal/ui/common/prompttokens_test.go
@@ -75,3 +75,44 @@ func TestIsPromptSkillPrefixEmptyName(t *testing.T) {
 	require.False(t, IsPromptSkillPrefix(""))
 	require.True(t, IsPromptSkillPrefix("com"))
 }
+
+// TestScanPromptTokensPromptWithArguments pins that an MCP prompt token
+// highlights with its arguments attached.
+//
+// The token carries its arguments inline — "/gitea:review(id=42)" — and
+// IsPromptSkillPrefix asks whether the token is a prefix of a known name. A
+// name with arguments appended is longer than the name, so without stripping
+// the parenthesised tail the argument-bearing form never validates and the
+// whole token renders as unstyled prose.
+func TestScanPromptTokensPromptWithArguments(t *testing.T) {
+	SetPromptSkillNames([]string{"gitea:review", "code-review"})
+	t.Cleanup(func() { SetPromptSkillNames(nil) })
+
+	for _, tc := range []struct {
+		name string
+		line string
+		want bool
+	}{
+		{"bare prompt name", "do /gitea:review", true},
+		{"with one argument", "do /gitea:review(id=42)", true},
+		{"argument value containing a slash", "do /gitea:review(repo=stump.wtf/crush)", true},
+		{"several arguments", "do /gitea:review(id=42,repo=a/b)", true},
+		{"partially typed", "do /gitea:rev", true},
+		{"unknown prompt is left alone", "do /nope:thing(id=1)", false},
+		{"an ordinary path is left alone", "read /tmp/out.log", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			toks := ScanPromptTokens([]rune(tc.line))
+			var gotSkill bool
+			for _, tok := range toks {
+				if tok.Kind == PromptTokenSkill {
+					gotSkill = true
+					// The whole token, arguments included, is one span.
+					require.Equal(t, len([]rune(tc.line)), tok.End,
+						"the token must run to the end of the word")
+				}
+			}
+			require.Equal(t, tc.want, gotSkill)
+		})
+	}
+}

--- a/internal/ui/completions/completions.go
+++ b/internal/ui/completions/completions.go
@@ -231,33 +231,15 @@ const minSkillDetailWidth = 12
 // item's text, so the fuzzy filter matches it too: typing "/pdf" finds a
 // skill described as "extract text from PDFs" even if it is named
 // "document-tools".
-func (c *Completions) SetSkillItems(skills []SkillCompletionValue) {
-	items := make([]list.FilterableItem, 0, len(skills))
+func (c *Completions) SetSkillItems(skills []SkillCompletionValue, prompts []PromptCompletionValue) {
+	items := make([]list.FilterableItem, 0, len(skills)+len(prompts))
+	// Prompts lead: they are server-qualified, so they cannot collide with a
+	// skill name, and a user who typed "/gitea:" wants them first.
+	for _, prompt := range prompts {
+		items = append(items, c.completionRow("/"+prompt.Name, prompt.Description, prompt))
+	}
 	for _, skill := range skills {
-		name := "/" + skill.Name
-		text := name
-		detailStart := -1
-		if desc := flattenSkillDescription(skill.Description); desc != "" {
-			// maxWidth is the popup's hard cap and renderItem reserves a
-			// cell of padding on each side, so that is the real budget the
-			// name and description share.
-			budget := maxWidth - 2 - ansi.StringWidth(name) - len(skillDetailSeparator)
-			if budget >= minSkillDetailWidth {
-				detailStart = len(name)
-				text = name + skillDetailSeparator + ansi.Truncate(desc, budget, "…")
-			}
-		}
-		item := NewCompletionItem(
-			text,
-			skill,
-			c.normalStyle,
-			c.focusedStyle,
-			c.matchStyle,
-		)
-		if detailStart >= 0 {
-			item = item.withDetail(detailStart, name)
-		}
-		items = append(items, item)
+		items = append(items, c.completionRow("/"+skill.Name, skill.Description, skill))
 	}
 
 	c.open = true
@@ -275,6 +257,30 @@ func (c *Completions) SetSkillItems(skills []SkillCompletionValue) {
 	c.list.ScrollToSelected()
 
 	c.updateSize()
+}
+
+// completionRow builds one "/name - description" row. The description is
+// part of the item's text so the fuzzy filter matches it too: typing "/pdf"
+// finds a skill described as "extract text from PDFs" even if it is named
+// "document-tools", and the same holds for an MCP prompt's description.
+func (c *Completions) completionRow(name, description string, value any) list.FilterableItem {
+	text := name
+	detailStart := -1
+	if desc := flattenSkillDescription(description); desc != "" {
+		// maxWidth is the popup's hard cap and renderItem reserves a cell of
+		// padding on each side, so that is the real budget the name and
+		// description share.
+		budget := maxWidth - 2 - ansi.StringWidth(name) - len(skillDetailSeparator)
+		if budget >= minSkillDetailWidth {
+			detailStart = len(name)
+			text = name + skillDetailSeparator + ansi.Truncate(desc, budget, "…")
+		}
+	}
+	item := NewCompletionItem(text, value, c.normalStyle, c.focusedStyle, c.matchStyle)
+	if detailStart >= 0 {
+		item = item.withDetail(detailStart, name)
+	}
+	return item
 }
 
 // Close closes the completions popup.

--- a/internal/ui/completions/completions.go
+++ b/internal/ui/completions/completions.go
@@ -490,6 +490,11 @@ func (c *Completions) selectCurrent(keepOpen bool) tea.Msg {
 			Value:    item,
 			KeepOpen: keepOpen,
 		}
+	case PromptCompletionValue:
+		return SelectionMsg[PromptCompletionValue]{
+			Value:    item,
+			KeepOpen: keepOpen,
+		}
 	default:
 		return nil
 	}

--- a/internal/ui/completions/item.go
+++ b/internal/ui/completions/item.go
@@ -34,6 +34,31 @@ type SkillCompletionValue struct {
 	Path        string
 }
 
+// PromptCompletionValue represents an MCP prompt offered by the "/" popup
+// alongside skills.
+//
+// Name is the server-qualified "server:prompt" form. Prompt names are only
+// unique within a server, so the qualifier is the name as far as the editor
+// is concerned — two servers may both expose "review".
+type PromptCompletionValue struct {
+	Name        string
+	Description string
+	// MCPName and PromptID are the unqualified halves, for the call that
+	// resolves the prompt.
+	MCPName  string
+	PromptID string
+	// Arguments the prompt declares, in the order the server listed them.
+	Arguments []PromptArgument
+}
+
+// PromptArgument mirrors the argument metadata an MCP prompt declares.
+type PromptArgument struct {
+	ID          string
+	Title       string
+	Description string
+	Required    bool
+}
+
 // IsTemplate reports whether the completion's URI is an unexpanded RFC 6570
 // URI template (it still contains a "{expression}") rather than a concrete,
 // readable resource URI. Templates come from resources/templates/list and

--- a/internal/ui/completions/skills_test.go
+++ b/internal/ui/completions/skills_test.go
@@ -18,7 +18,7 @@ func TestSetSkillItemsOpensWithSkills(t *testing.T) {
 	c.SetSkillItems([]SkillCompletionValue{
 		{Name: "code-review", Path: "/skills/code-review/SKILL.md"},
 		{Name: "commit", Path: "/skills/commit/SKILL.md"},
-	})
+	}, nil)
 
 	require.True(t, c.IsOpen())
 	require.Len(t, c.filtered, 2)
@@ -35,7 +35,7 @@ func TestSkillCompletionFilter(t *testing.T) {
 		{Name: "code-review"},
 		{Name: "commit"},
 		{Name: "coder"},
-	})
+	}, nil)
 
 	c.Filter("cod")
 
@@ -53,7 +53,7 @@ func TestSkillDescriptionShownAndSearchable(t *testing.T) {
 	c.SetSkillItems([]SkillCompletionValue{
 		{Name: "skill-creator", Description: "Use for naming skills\nand writing frontmatter."},
 		{Name: "commit", Description: "Write a conventional commit."},
-	})
+	}, nil)
 
 	first, ok := c.filtered[0].(*CompletionItem)
 	require.True(t, ok)
@@ -79,7 +79,7 @@ func TestSkillDescriptionTruncatedToPopupWidth(t *testing.T) {
 	c := New(lipgloss.NewStyle(), lipgloss.NewStyle(), lipgloss.NewStyle())
 	c.SetSkillItems([]SkillCompletionValue{
 		{Name: "commit", Description: strings.Repeat("long ", 200)},
-	})
+	}, nil)
 
 	first, ok := c.filtered[0].(*CompletionItem)
 	require.True(t, ok)
@@ -94,7 +94,7 @@ func TestSkillDescriptionDroppedWhenNameEatsTheRow(t *testing.T) {
 	// bare rather than as a row of ellipsis.
 	long := strings.Repeat("a", maxWidth)
 	c := New(lipgloss.NewStyle(), lipgloss.NewStyle(), lipgloss.NewStyle())
-	c.SetSkillItems([]SkillCompletionValue{{Name: long, Description: "does things"}})
+	c.SetSkillItems([]SkillCompletionValue{{Name: long, Description: "does things"}}, nil)
 
 	first, ok := c.filtered[0].(*CompletionItem)
 	require.True(t, ok)
@@ -108,7 +108,7 @@ func TestSelectCurrentReturnsSkillSelectionMsg(t *testing.T) {
 	c := New(lipgloss.NewStyle(), lipgloss.NewStyle(), lipgloss.NewStyle())
 	c.SetSkillItems([]SkillCompletionValue{
 		{Name: "commit", Path: "/skills/commit/SKILL.md"},
-	})
+	}, nil)
 
 	msg := c.selectCurrent(false)
 	sel, ok := msg.(SelectionMsg[SkillCompletionValue])
@@ -123,7 +123,7 @@ func TestSelectCurrentSkillKeepOpen(t *testing.T) {
 	t.Parallel()
 
 	c := New(lipgloss.NewStyle(), lipgloss.NewStyle(), lipgloss.NewStyle())
-	c.SetSkillItems([]SkillCompletionValue{{Name: "commit"}})
+	c.SetSkillItems([]SkillCompletionValue{{Name: "commit"}}, nil)
 
 	msg := c.selectCurrent(true)
 	sel, ok := msg.(SelectionMsg[SkillCompletionValue])
@@ -136,7 +136,7 @@ func TestSetSkillItemsEmpty(t *testing.T) {
 	t.Parallel()
 
 	c := New(lipgloss.NewStyle(), lipgloss.NewStyle(), lipgloss.NewStyle())
-	c.SetSkillItems(nil)
+	c.SetSkillItems(nil, nil)
 
 	require.True(t, c.IsOpen())
 	require.False(t, c.HasItems())
@@ -155,4 +155,46 @@ func TestSkillItemsDoNotAffectFileSelectionDispatch(t *testing.T) {
 	sel, ok := msg.(SelectionMsg[FileCompletionValue])
 	require.True(t, ok, "expected SelectionMsg[FileCompletionValue], got %T", msg)
 	require.Equal(t, "foo.go", sel.Value.Path)
+}
+
+// TestSetSkillItemsIncludesPrompts pins that MCP prompts share the "/" popup
+// with skills and are findable by name and description, the same way skills
+// are.
+func TestSetSkillItemsIncludesPrompts(t *testing.T) {
+	t.Parallel()
+
+	c := New(lipgloss.NewStyle(), lipgloss.NewStyle(), lipgloss.NewStyle())
+	c.SetSkillItems(
+		[]SkillCompletionValue{{Name: "code-review", Description: "Review a diff."}},
+		[]PromptCompletionValue{
+			{Name: "gitea:review", Description: "Review a pull request.", MCPName: "gitea", PromptID: "review"},
+			{Name: "cairn:run_capture", Description: "Capture a run.", MCPName: "cairn", PromptID: "run_capture"},
+		},
+	)
+	require.True(t, c.HasItems())
+
+	// Server-qualified, so a server name narrows to that server's prompts.
+	c.Filter("gitea:")
+	require.True(t, c.HasItems(), "a server prefix must match its prompts")
+
+	// Descriptions are part of the filter text for prompts too.
+	c.Filter("capture")
+	require.True(t, c.HasItems(), "a prompt must be findable by its description")
+
+	// Skills still work alongside them.
+	c.Filter("code-rev")
+	require.True(t, c.HasItems(), "skills must remain in the popup")
+}
+
+// TestSetSkillItemsPromptsOnly covers a config with MCP prompts but no
+// skills: the popup must still open rather than treating "no skills" as
+// "nothing to offer".
+func TestSetSkillItemsPromptsOnly(t *testing.T) {
+	t.Parallel()
+
+	c := New(lipgloss.NewStyle(), lipgloss.NewStyle(), lipgloss.NewStyle())
+	c.SetSkillItems(nil, []PromptCompletionValue{
+		{Name: "gitea:review", MCPName: "gitea", PromptID: "review"},
+	})
+	require.True(t, c.HasItems())
 }

--- a/internal/ui/completions/skills_test.go
+++ b/internal/ui/completions/skills_test.go
@@ -198,3 +198,38 @@ func TestSetSkillItemsPromptsOnly(t *testing.T) {
 	})
 	require.True(t, c.HasItems())
 }
+
+// TestSelectCurrentReturnsPromptSelection is the test whose absence let the
+// whole feature ship inert: selectCurrent had no PromptCompletionValue case,
+// so pressing enter on a prompt row returned nil, the model's type switch
+// matched nothing, and the insertion path was dead code. Every other test
+// stopped at SetSkillItems/Filter and never pressed enter.
+func TestSelectCurrentReturnsPromptSelection(t *testing.T) {
+	t.Parallel()
+
+	c := New(lipgloss.NewStyle(), lipgloss.NewStyle(), lipgloss.NewStyle())
+	c.SetSkillItems(nil, []PromptCompletionValue{
+		{Name: "gitea:review", MCPName: "gitea", PromptID: "review"},
+	})
+
+	msg := c.selectCurrent(false)
+	sel, ok := msg.(SelectionMsg[PromptCompletionValue])
+	require.True(t, ok, "selecting a prompt must produce a prompt selection, got %T", msg)
+	require.Equal(t, "gitea:review", sel.Value.Name)
+	require.Equal(t, "gitea", sel.Value.MCPName)
+	require.Equal(t, "review", sel.Value.PromptID)
+}
+
+// TestSelectCurrentStillReturnsSkillSelection is the control: adding prompts
+// must not have displaced skills from the same popup.
+func TestSelectCurrentStillReturnsSkillSelection(t *testing.T) {
+	t.Parallel()
+
+	c := New(lipgloss.NewStyle(), lipgloss.NewStyle(), lipgloss.NewStyle())
+	c.SetSkillItems([]SkillCompletionValue{{Name: "code-review"}}, nil)
+
+	msg := c.selectCurrent(false)
+	sel, ok := msg.(SelectionMsg[SkillCompletionValue])
+	require.True(t, ok, "got %T", msg)
+	require.Equal(t, "code-review", sel.Value.Name)
+}

--- a/internal/ui/dialog/actions.go
+++ b/internal/ui/dialog/actions.go
@@ -181,6 +181,20 @@ type (
 
 // ActionCmd represents an action that carries a [tea.Cmd] to be passed to the
 // Bubble Tea program loop.
+// ActionInsertMCPPrompt is a message to attach an MCP prompt to the prompt
+// currently being composed, rather than running it as a whole turn the way
+// ActionRunMCPPrompt does. It is produced by the inline "/" completion, where
+// the user is mid-sentence and the prompt is one ingredient of their message.
+type ActionInsertMCPPrompt struct {
+	// Name is the server-qualified "server:prompt" form shown in the editor.
+	Name     string
+	MCPName  string
+	PromptID string
+	// Arguments the prompt declares; Args is what the user supplied.
+	Arguments []commands.Argument
+	Args      map[string]string
+}
+
 type ActionCmd struct {
 	Cmd tea.Cmd
 }

--- a/internal/ui/dialog/actions.go
+++ b/internal/ui/dialog/actions.go
@@ -193,6 +193,11 @@ type ActionInsertMCPPrompt struct {
 	// Arguments the prompt declares; Args is what the user supplied.
 	Arguments []commands.Argument
 	Args      map[string]string
+	// StartIndex is where the token replaces the trigger text in the
+	// editor. It travels on the action because the completions popup — and
+	// with it the model's own start index — is closed before this dialog
+	// opens.
+	StartIndex int
 }
 
 type ActionCmd struct {

--- a/internal/ui/dialog/arguments.go
+++ b/internal/ui/dialog/arguments.go
@@ -218,6 +218,9 @@ func (a *Arguments) HandleMsg(msg tea.Msg) Action {
 				case ActionRunMCPPrompt:
 					action.Args = args
 					return action
+				case ActionInsertMCPPrompt:
+					action.Args = args
+					return action
 				}
 			}
 			a.focusInput(a.focused + 1)

--- a/internal/ui/model/attachments_mouse_test.go
+++ b/internal/ui/model/attachments_mouse_test.go
@@ -31,6 +31,7 @@ func newAttachmentClickTestUI(t *testing.T) (*UI, int) {
 		sty.Image,
 		sty.Text,
 		sty.Skill,
+		sty.Prompt,
 		sty.Remove,
 	)
 	u.attachments = attachments.New(renderer, attachments.Keymap{})

--- a/internal/ui/model/completion_backspace_test.go
+++ b/internal/ui/model/completion_backspace_test.go
@@ -16,11 +16,18 @@ import (
 	"github.com/charmbracelet/crush/internal/ui/completions"
 	"github.com/charmbracelet/crush/internal/ui/dialog"
 	"github.com/charmbracelet/crush/internal/ui/textarea"
+	"github.com/charmbracelet/crush/internal/workspace"
 	"github.com/stretchr/testify/require"
 )
 
 func newCompletionBackspaceUI() *UI {
-	com := common.DefaultCommon(&slashCommandWorkspace{ready: true})
+	return newCompletionBackspaceUIWith(&slashCommandWorkspace{ready: true})
+}
+
+// newCompletionBackspaceUIWith is newCompletionBackspaceUI over a caller-
+// supplied workspace, for tests that need to observe workspace calls.
+func newCompletionBackspaceUIWith(ws workspace.Workspace) *UI {
+	com := common.DefaultCommon(ws)
 	ta := textarea.New()
 	ta.Focus()
 	return &UI{

--- a/internal/ui/model/completion_backspace_test.go
+++ b/internal/ui/model/completion_backspace_test.go
@@ -34,6 +34,7 @@ func newCompletionBackspaceUI() *UI {
 				lipgloss.NewStyle(), lipgloss.NewStyle(),
 				lipgloss.NewStyle(), lipgloss.NewStyle(),
 				lipgloss.NewStyle(), lipgloss.NewStyle(),
+				lipgloss.NewStyle(),
 			),
 			attachments.Keymap{},
 		),

--- a/internal/ui/model/mcp_prompt_completion_test.go
+++ b/internal/ui/model/mcp_prompt_completion_test.go
@@ -101,3 +101,27 @@ func TestAttachMCPPromptWithArguments(t *testing.T) {
 	require.Equal(t, 2, m.attachments.List()[0].PromptArgCount,
 		"the chip needs the argument count")
 }
+
+// TestAtomicBackspaceRemovesPromptChip pins that the prompt token behaves
+// like an @file mention on backspace: deleting the token takes its chip with
+// it, so the resolved body stops being sent along with a message that no
+// longer refers to it.
+func TestAtomicBackspaceRemovesPromptChip(t *testing.T) {
+	t.Parallel()
+
+	ws := &promptWorkspace{body: "body"}
+	ws.ready = true
+	m := newCompletionBackspaceUIWith(ws)
+	m.textarea.SetValue("do /")
+	m.completionsStartIndex = len("do ")
+
+	runPromptCmd(t, m, m.attachMCPPrompt("gitea:review", "gitea", "review",
+		map[string]string{"id": "42"}))
+	require.Len(t, m.attachments.List(), 1)
+
+	m.Update(tea.KeyPressMsg{Code: tea.KeyBackspace})
+
+	require.Equal(t, "do ", m.textarea.Value(), "the whole token goes at once")
+	require.Empty(t, m.attachments.List(),
+		"the chip must go with the token that referenced it")
+}

--- a/internal/ui/model/mcp_prompt_completion_test.go
+++ b/internal/ui/model/mcp_prompt_completion_test.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"errors"
 	"strings"
 	"testing"
 
@@ -14,6 +15,7 @@ import (
 type promptWorkspace struct {
 	slashCommandWorkspace
 	body     string
+	err      error
 	gotArgs  map[string]string
 	gotName  string
 	gotPromp string
@@ -21,7 +23,7 @@ type promptWorkspace struct {
 
 func (w *promptWorkspace) GetMCPPrompt(clientID, promptID string, args map[string]string) (string, error) {
 	w.gotName, w.gotPromp, w.gotArgs = clientID, promptID, args
-	return w.body, nil
+	return w.body, w.err
 }
 
 func runPromptCmd(t *testing.T, m *UI, cmd tea.Cmd) {
@@ -65,7 +67,9 @@ func TestAttachMCPPromptWithoutArguments(t *testing.T) {
 	att := m.attachments.List()[0]
 	require.Equal(t, message.AttachmentKindMCPPrompt, att.Kind)
 	require.Equal(t, "/cairn:run_capture", att.FileName)
-	require.Equal(t, "cairn:run_capture", att.FilePath)
+	// FilePath is the removal key, made unique per insertion so two
+	// insertions of one prompt are independently removable.
+	require.Equal(t, "cairn:run_capture#1", att.FilePath)
 	require.Equal(t, ws.body, string(att.Content), "the model must receive the body")
 	require.Zero(t, att.PromptArgCount)
 }
@@ -124,4 +128,98 @@ func TestAtomicBackspaceRemovesPromptChip(t *testing.T) {
 	require.Equal(t, "do ", m.textarea.Value(), "the whole token goes at once")
 	require.Empty(t, m.attachments.List(),
 		"the chip must go with the token that referenced it")
+}
+
+// TestAttachMCPPromptDropsBlankArguments pins that a blank optional argument
+// is "not supplied": absent from the token, absent from the chip's count, and
+// never sent to the server. The arguments dialog returns every declared
+// argument, blank ones included, so without filtering the chip claimed
+// "(3 args)" beside a token showing one, and the server was handed
+// empty-string values it never asked for.
+func TestAttachMCPPromptDropsBlankArguments(t *testing.T) {
+	t.Parallel()
+
+	ws := &promptWorkspace{body: "body"}
+	ws.ready = true
+	m := newCompletionBackspaceUIWith(ws)
+	m.textarea.SetValue("go /")
+	m.completionsStartIndex = len("go ")
+
+	runPromptCmd(t, m, m.attachMCPPrompt("gitea:review", "gitea", "review",
+		map[string]string{"id": "42", "title": "", "body": "   "}))
+
+	require.Equal(t, "go /gitea:review(id=42) ", m.textarea.Value())
+	require.Equal(t, map[string]string{"id": "42"}, ws.gotArgs,
+		"blank arguments must not reach the server")
+	require.Len(t, m.attachments.List(), 1)
+	require.Equal(t, 1, m.attachments.List()[0].PromptArgCount,
+		"the count must match what the token shows")
+}
+
+// TestAttachMCPPromptEncodesWhitespaceInValues pins the token grammar against
+// free-text argument values. ScanPromptTokens ends a token at the first
+// space, so an unescaped value like "fix the bug" split the token in half —
+// the exact failure the design claims to prevent.
+func TestAttachMCPPromptEncodesWhitespaceInValues(t *testing.T) {
+	t.Parallel()
+
+	ws := &promptWorkspace{body: "body"}
+	ws.ready = true
+	m := newCompletionBackspaceUIWith(ws)
+	m.textarea.SetValue("go /")
+	m.completionsStartIndex = len("go ")
+
+	runPromptCmd(t, m, m.attachMCPPrompt("gitea:review", "gitea", "review",
+		map[string]string{"title": "fix the bug"}))
+
+	got := m.textarea.Value()
+	token := strings.TrimSpace(got[strings.Index(got, "/"):])
+	require.NotContains(t, token, " ", "the token must survive a spaced value")
+	require.Contains(t, token, "%20")
+	// The server still gets the real value, not the encoded one.
+	require.Equal(t, map[string]string{"title": "fix the bug"}, ws.gotArgs)
+}
+
+// TestAttachMCPPromptRollsBackOnResolveFailure pins that a prompt whose body
+// cannot be resolved does not leave its token stranded in the editor. A
+// stranded token is sent to the model as literal prose with none of the
+// prompt behind it — a silently degraded turn rather than a blocked one.
+func TestAttachMCPPromptRollsBackOnResolveFailure(t *testing.T) {
+	t.Parallel()
+
+	ws := &promptWorkspace{err: errors.New("server unavailable")}
+	ws.ready = true
+	m := newCompletionBackspaceUIWith(ws)
+	m.textarea.SetValue("please /")
+	m.completionsStartIndex = len("please ")
+
+	cmd := m.attachMCPPrompt("gitea:review", "gitea", "review", nil)
+	require.Equal(t, "please /gitea:review ", m.textarea.Value(),
+		"the token is inserted optimistically")
+
+	// Drain the command and feed the failure back through Update.
+	var failure tea.Msg
+	var run func(tea.Cmd)
+	run = func(c tea.Cmd) {
+		if c == nil {
+			return
+		}
+		msg := c()
+		if batch, ok := msg.(tea.BatchMsg); ok {
+			for _, sub := range batch {
+				run(sub)
+			}
+			return
+		}
+		if f, ok := msg.(promptResolveFailedMsg); ok {
+			failure = f
+		}
+	}
+	run(cmd)
+	require.NotNil(t, failure, "a failed resolve must report back")
+	m.Update(failure)
+
+	require.Equal(t, "please ", m.textarea.Value(),
+		"the token must be rolled back when its body never arrives")
+	require.Empty(t, m.attachments.List())
 }

--- a/internal/ui/model/mcp_prompt_completion_test.go
+++ b/internal/ui/model/mcp_prompt_completion_test.go
@@ -1,0 +1,103 @@
+package model
+
+import (
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/charmbracelet/crush/internal/message"
+	"github.com/stretchr/testify/require"
+)
+
+// promptWorkspace resolves MCP prompts to a canned body.
+type promptWorkspace struct {
+	slashCommandWorkspace
+	body     string
+	gotArgs  map[string]string
+	gotName  string
+	gotPromp string
+}
+
+func (w *promptWorkspace) GetMCPPrompt(clientID, promptID string, args map[string]string) (string, error) {
+	w.gotName, w.gotPromp, w.gotArgs = clientID, promptID, args
+	return w.body, nil
+}
+
+func runPromptCmd(t *testing.T, m *UI, cmd tea.Cmd) {
+	t.Helper()
+	var run func(tea.Cmd)
+	run = func(c tea.Cmd) {
+		if c == nil {
+			return
+		}
+		msg := c()
+		if batch, ok := msg.(tea.BatchMsg); ok {
+			for _, sub := range batch {
+				run(sub)
+			}
+			return
+		}
+		if att, ok := msg.(message.Attachment); ok {
+			m.attachments.Update(att)
+		}
+	}
+	run(cmd)
+}
+
+// TestAttachMCPPromptWithoutArguments pins the no-argument path: a compact
+// token in the editor and the resolved body as an attachment, rather than the
+// body being spliced into the prompt where it would bury what the user wrote.
+func TestAttachMCPPromptWithoutArguments(t *testing.T) {
+	t.Parallel()
+
+	ws := &promptWorkspace{body: "Resolved prompt body, potentially very long."}
+	ws.ready = true
+	m := newCompletionBackspaceUIWith(ws)
+	m.textarea.SetValue("please /")
+	m.completionsStartIndex = len("please ")
+
+	runPromptCmd(t, m, m.attachMCPPrompt("cairn:run_capture", "cairn", "run_capture", nil))
+
+	require.Equal(t, "please /cairn:run_capture ", m.textarea.Value(),
+		"the editor keeps a compact token, not the body")
+	require.Len(t, m.attachments.List(), 1)
+	att := m.attachments.List()[0]
+	require.Equal(t, message.AttachmentKindMCPPrompt, att.Kind)
+	require.Equal(t, "/cairn:run_capture", att.FileName)
+	require.Equal(t, "cairn:run_capture", att.FilePath)
+	require.Equal(t, ws.body, string(att.Content), "the model must receive the body")
+	require.Zero(t, att.PromptArgCount)
+}
+
+// TestAttachMCPPromptWithArguments pins the token's argument form. It has to
+// be space-free: ScanPromptTokens ends a token at the first space, so a
+// spaced form would highlight only the name and leave the arguments rendering
+// as loose prose, and one atomic backspace would no longer remove the whole
+// thing.
+func TestAttachMCPPromptWithArguments(t *testing.T) {
+	t.Parallel()
+
+	ws := &promptWorkspace{body: "body"}
+	ws.ready = true
+	m := newCompletionBackspaceUIWith(ws)
+	m.textarea.SetValue("do /")
+	m.completionsStartIndex = len("do ")
+
+	runPromptCmd(t, m, m.attachMCPPrompt("gitea:review", "gitea", "review",
+		map[string]string{"repo": "stump.wtf/crush", "id": "42"}))
+
+	got := m.textarea.Value()
+	require.Equal(t, "do /gitea:review(id=42,repo=stump.wtf/crush) ", got)
+	token := strings.TrimSpace(got[strings.Index(got, "/"):])
+	require.NotContains(t, token, " ",
+		"the token itself must contain no spaces, or ScanPromptTokens ends it early")
+
+	require.Equal(t, "gitea", ws.gotName)
+	require.Equal(t, "review", ws.gotPromp)
+	require.Equal(t, map[string]string{"repo": "stump.wtf/crush", "id": "42"}, ws.gotArgs)
+
+	require.Len(t, m.attachments.List(), 1)
+	require.Equal(t, 2, m.attachments.List()[0].PromptArgCount,
+		"the chip needs the argument count")
+}

--- a/internal/ui/model/prompt_highlighter.go
+++ b/internal/ui/model/prompt_highlighter.go
@@ -82,14 +82,20 @@ func (h *promptHighlighter) tokenStyle(kind common.PromptTokenKind) lipgloss.Sty
 	return h.fileStyle
 }
 
-// skillNames returns the names of the skills a /token may refer to. It
-// shares skillCompletionValues' source of truth — the effective catalog,
-// falling back to discovery states before the first catalog load — so a
-// token highlights exactly when the popup would have offered it.
+// skillNames returns the names a /token may refer to: skills and MCP
+// prompts alike. It shares the popup's sources of truth — the effective
+// skill catalog and the loaded MCP prompts — so a token highlights exactly
+// when the popup would have offered it. A prompt that is offered but not
+// registered here renders as unstyled prose, which reads as "this did not
+// take" even though the attachment went through.
 func (m *UI) skillNames() []string {
-	values := m.skillCompletionValues()
-	names := make([]string, 0, len(values))
-	for _, v := range values {
+	skills := m.skillCompletionValues()
+	prompts := m.promptCompletionValues()
+	names := make([]string, 0, len(skills)+len(prompts))
+	for _, v := range skills {
+		names = append(names, v.Name)
+	}
+	for _, v := range prompts {
 		names = append(names, v.Name)
 	}
 	return names

--- a/internal/ui/model/prompt_highlighter_test.go
+++ b/internal/ui/model/prompt_highlighter_test.go
@@ -170,6 +170,7 @@ func TestRefreshStylesRepushesHighlighterStyles(t *testing.T) {
 		sty.Attachments.Image,
 		sty.Attachments.Text,
 		sty.Attachments.Skill,
+		sty.Attachments.Prompt,
 		sty.Attachments.Remove,
 	), attachments.Keymap{})
 	m.promptHighlighter = newPromptHighlighter(

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -4377,6 +4377,10 @@ func (m *UI) attachMCPPrompt(name, mcpName, promptID string, args map[string]str
 	if !m.insertCompletionText(token) {
 		return nil
 	}
+	// Key the attachment by the qualified name — what the attachment's
+	// FilePath is set to below — so backspacing the token takes this chip
+	// with it and no other.
+	m.lastCompletionFilePath = name
 	heightCmd := m.handleTextareaHeightChange(prevHeight)
 
 	argCount := len(args)

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -297,6 +297,18 @@ type UI struct {
 	lastCompletionEnd      int
 	lastCompletionText     string
 	lastCompletionFilePath string // non-empty when the last completion attached a file
+	// promptAttachSeq makes each MCP prompt attachment's key unique, so
+	// inserting one prompt twice yields two independently removable chips.
+	promptAttachSeq int
+	// pendingPromptTrigger is the "/query" text still sitting in the editor
+	// while the arguments dialog is open. Cancelling the dialog takes it
+	// back out; without that the query lingers and — since prompt names
+	// validate "/" tokens — renders as a perfectly good prompt token with
+	// no body behind it.
+	pendingPromptTrigger struct {
+		start int
+		text  string
+	}
 
 	// promptHighlighter styles @file and /skill tokens inline as the user
 	// types. Installed on the textarea via SetHighlighter.
@@ -853,6 +865,12 @@ func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Auto-open the MCP auth dialog if any servers need authentication.
 		if cmd := m.openMCPAuthDialog(); cmd != nil {
 			cmds = append(cmds, cmd)
+		}
+	case promptResolveFailedMsg:
+		m.removePromptToken(msg.start, msg.text)
+		if msg.err != nil {
+			cmds = append(cmds, util.ReportError(fmt.Errorf(
+				"could not resolve /%s: %w", msg.name, msg.err)))
 		}
 	case mcpPromptsLoadedMsg:
 		m.mcpPrompts = msg.Prompts
@@ -1880,6 +1898,14 @@ func (m *UI) handleDialogMsg(msg tea.Msg) tea.Cmd {
 
 		m.dialog.CloseFrontDialog()
 
+		// A cancelled prompt-arguments dialog leaves the "/query" the user
+		// typed behind. Nothing was attached, so take it back out rather
+		// than leave a token that looks resolved.
+		if m.pendingPromptTrigger.text != "" {
+			m.removePromptToken(m.pendingPromptTrigger.start, m.pendingPromptTrigger.text)
+			m.pendingPromptTrigger.text = ""
+		}
+
 		if isOnboarding {
 			if cmd := m.openModelsDialog(); cmd != nil {
 				cmds = append(cmds, cmd)
@@ -2157,6 +2183,10 @@ func (m *UI) handleDialogMsg(msg tea.Msg) tea.Cmd {
 		cmds = append(cmds, m.attachSkill(msg.ID, msg.Name))
 	case dialog.ActionInsertMCPPrompt:
 		m.dialog.CloseFrontDialog()
+		// Restore the splice point the popup was closed with; the insertion
+		// replaces the trigger text, so it is no longer pending.
+		m.completionsStartIndex = msg.StartIndex
+		m.pendingPromptTrigger.text = ""
 		cmds = append(cmds, m.attachMCPPrompt(msg.Name, msg.MCPName, msg.PromptID, msg.Args))
 	case dialog.ActionRunMCPPrompt:
 		if len(msg.Arguments) > 0 && msg.Args == nil {
@@ -4334,15 +4364,49 @@ func (m *UI) insertMCPPromptCompletion(p completions.PromptCompletionValue) tea.
 			Required:    a.Required,
 		})
 	}
+	// Capture the splice point before the popup closes: closeCompletions
+	// zeroes completionsStartIndex, and the insertion does not happen until
+	// the dialog resolves. Without carrying it on the action, the token was
+	// spliced at index 0 and ate everything before the trigger.
+	startIndex := m.completionsStartIndex
+	m.pendingPromptTrigger.start = startIndex
+	m.pendingPromptTrigger.text = m.textareaWord()
 	m.closeCompletions()
 	m.dialog.OpenDialog(dialog.NewArguments(m.com, "/"+p.Name, p.Description, args,
 		dialog.ActionInsertMCPPrompt{
-			Name:      p.Name,
-			MCPName:   p.MCPName,
-			PromptID:  p.PromptID,
-			Arguments: args,
+			Name:       p.Name,
+			MCPName:    p.MCPName,
+			PromptID:   p.PromptID,
+			Arguments:  args,
+			StartIndex: startIndex,
 		}))
 	return nil
+}
+
+// promptTokenValue renders one argument value for the inline token.
+//
+// Values come from free-text dialog inputs, so they can contain anything.
+// Whitespace is the one thing the token grammar cannot carry —
+// ScanPromptTokens ends a token at the first space — so it is percent-encoded
+// rather than dropped: the value stays readable and the token stays a single
+// highlighted, atomically-deletable unit.
+func promptTokenValue(v string) string {
+	var b strings.Builder
+	for _, r := range v {
+		switch r {
+		case ' ':
+			b.WriteString("%20")
+		case '\t':
+			b.WriteString("%09")
+		case '\n':
+			b.WriteString("%0A")
+		case '\r':
+			b.WriteString("%0D")
+		default:
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
 }
 
 // attachMCPPrompt resolves the prompt against its server and attaches the
@@ -4355,52 +4419,64 @@ func (m *UI) insertMCPPromptCompletion(p completions.PromptCompletionValue) tea.
 // unit and one atomic backspace removes it — while the body rides along as an
 // attachment the model receives, exactly like an @file mention.
 func (m *UI) attachMCPPrompt(name, mcpName, promptID string, args map[string]string) tea.Cmd {
+	// The dialog returns every declared argument, blank ones included. A
+	// blank optional is "not supplied": it must not reach the server, must
+	// not appear in the token, and must not be counted on the chip.
+	supplied := make(map[string]string, len(args))
+	for k, v := range args {
+		if strings.TrimSpace(v) != "" {
+			supplied[k] = v
+		}
+	}
+
 	token := "/" + name
-	if len(args) > 0 {
-		keys := make([]string, 0, len(args))
-		for k := range args {
+	if len(supplied) > 0 {
+		keys := make([]string, 0, len(supplied))
+		for k := range supplied {
 			keys = append(keys, k)
 		}
 		slices.Sort(keys)
 		parts := make([]string, 0, len(keys))
 		for _, k := range keys {
-			if args[k] != "" {
-				parts = append(parts, k+"="+args[k])
-			}
+			parts = append(parts, k+"="+promptTokenValue(supplied[k]))
 		}
-		if len(parts) > 0 {
-			// No spaces: ScanPromptTokens ends a token at the first one, so a
-			// spaced form would highlight only the name and leave the
-			// arguments rendering as loose prose.
-			token += "(" + strings.Join(parts, ",") + ")"
-		}
+		token += "(" + strings.Join(parts, ",") + ")"
 	}
 
 	prevHeight := m.textarea.Height()
 	if !m.insertCompletionText(token) {
 		return nil
 	}
-	// Key the attachment by the qualified name — what the attachment's
-	// FilePath is set to below — so backspacing the token takes this chip
-	// with it and no other.
-	m.lastCompletionFilePath = name
+	// Key the attachment uniquely per insertion. Keying by the prompt name
+	// alone made RemoveByFilePath's first-match delete remove the wrong
+	// entry when the same prompt was inserted twice — dropping one body
+	// while its token was still in the editor.
+	m.promptAttachSeq++
+	attachKey := fmt.Sprintf("%s#%d", name, m.promptAttachSeq)
+	m.lastCompletionFilePath = attachKey
 	heightCmd := m.handleTextareaHeightChange(prevHeight)
 
-	argCount := len(args)
+	argCount := len(supplied)
+	insertedText := m.lastCompletionText
+	insertedStart := m.lastCompletionStart
 	promptCmd := func() tea.Msg {
-		body, err := m.com.Workspace.GetMCPPrompt(mcpName, promptID, args)
-		if err != nil {
-			slog.Warn("Failed to resolve MCP prompt", "prompt", name, "error", err)
-			return util.InfoMsg{
-				Type: util.InfoTypeError,
-				Msg:  fmt.Sprintf("Could not resolve /%s: %v", name, err),
+		body, err := m.com.Workspace.GetMCPPrompt(mcpName, promptID, supplied)
+		if err != nil || body == "" {
+			if err != nil {
+				slog.Warn("Failed to resolve MCP prompt", "prompt", name, "error", err)
+			}
+			// Roll the token back. Leaving it stranded would send the model
+			// the literal "/server:prompt(...)" text with none of the body
+			// behind it — a silently degraded turn rather than a blocked one.
+			return promptResolveFailedMsg{
+				name:  name,
+				start: insertedStart,
+				text:  insertedText,
+				err:   err,
 			}
 		}
-		if body == "" {
-			return nil
-		}
 		return message.Attachment{
-			FilePath:       name,
+			FilePath:       attachKey,
 			FileName:       "/" + name,
 			MimeType:       "text/markdown",
 			Content:        []byte(body),
@@ -4409,6 +4485,30 @@ func (m *UI) attachMCPPrompt(name, mcpName, promptID string, args map[string]str
 		}
 	}
 	return tea.Batch(heightCmd, promptCmd)
+}
+
+// promptResolveFailedMsg asks the editor to take back a prompt token whose
+// body could not be resolved.
+type promptResolveFailedMsg struct {
+	name  string
+	start int
+	text  string
+	err   error
+}
+
+// removePromptToken deletes a previously inserted prompt token, provided the
+// editor still holds exactly that run at exactly that offset. Anything else
+// means the user has since edited around it, and silently cutting text out of
+// the middle of their prompt would be worse than leaving the token.
+func (m *UI) removePromptToken(start int, text string) {
+	value := m.textarea.Value()
+	end := start + len(text)
+	if start < 0 || end > len(value) || value[start:end] != text {
+		return
+	}
+	m.textarea.SetValue(value[:start] + value[end:])
+	m.textarea.MoveToEnd()
+	m.clearCompletionRange()
 }
 
 // completionsPosition returns the X and Y position for the completions popup.

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -2152,6 +2152,9 @@ func (m *UI) handleDialogMsg(msg tea.Msg) tea.Cmd {
 	case dialog.ActionAttachSkill:
 		m.dialog.CloseFrontDialog()
 		cmds = append(cmds, m.attachSkill(msg.ID, msg.Name))
+	case dialog.ActionInsertMCPPrompt:
+		m.dialog.CloseFrontDialog()
+		cmds = append(cmds, m.attachMCPPrompt(msg.Name, msg.MCPName, msg.PromptID, msg.Args))
 	case dialog.ActionRunMCPPrompt:
 		if len(msg.Arguments) > 0 && msg.Args == nil {
 			m.dialog.CloseFrontDialog()
@@ -2528,6 +2531,11 @@ func (m *UI) handleKeyPressMsg(msg tea.KeyPressMsg) tea.Cmd {
 					switch msg := msg.(type) {
 					case completions.SelectionMsg[completions.SkillCompletionValue]:
 						cmds = append(cmds, m.insertSkillCompletion(msg.Value))
+						if !msg.KeepOpen {
+							m.closeCompletions()
+						}
+					case completions.SelectionMsg[completions.PromptCompletionValue]:
+						cmds = append(cmds, m.insertMCPPromptCompletion(msg.Value))
 						if !msg.KeepOpen {
 							m.closeCompletions()
 						}
@@ -4013,11 +4021,12 @@ func wordCanBeSkillToken(word string) bool {
 
 func (m *UI) openSkillCompletions(startIndex int) {
 	values := m.skillCompletionValues()
-	if len(values) == 0 {
+	prompts := m.promptCompletionValues()
+	if len(values) == 0 && len(prompts) == 0 {
 		// An open-but-empty popup still consumes enter and the arrow keys,
-		// so a user with no skills configured could not submit a prompt
+		// so a user with nothing configured could not submit a prompt
 		// containing a '/'. Unlike '@' there is nothing to wait on here —
-		// no skills means no popup.
+		// nothing to offer means no popup.
 		return
 	}
 
@@ -4026,7 +4035,44 @@ func (m *UI) openSkillCompletions(startIndex int) {
 	m.completionsQuery = ""
 	m.completionsStartIndex = startIndex
 	m.completionsPositionStart = m.completionsPosition()
-	m.completions.SetSkillItems(values)
+	m.completions.SetSkillItems(values, prompts)
+}
+
+// promptCompletionValues turns the loaded MCP prompts into popup items.
+//
+// Names are server-qualified ("gitea:review"), which is both how
+// commands.LoadMCPPrompts already keys them and the only form that can be
+// unambiguous: prompt names are unique per server, so two servers may each
+// expose "review". Skills are not qualified — Crush skill names come
+// straight from SKILL.md frontmatter and there is no namespace to qualify
+// them with.
+func (m *UI) promptCompletionValues() []completions.PromptCompletionValue {
+	values := make([]completions.PromptCompletionValue, 0, len(m.mcpPrompts))
+	for _, p := range m.mcpPrompts {
+		if p.ClientID == "" || p.PromptID == "" {
+			continue
+		}
+		args := make([]completions.PromptArgument, 0, len(p.Arguments))
+		for _, a := range p.Arguments {
+			args = append(args, completions.PromptArgument{
+				ID:          a.ID,
+				Title:       a.Title,
+				Description: a.Description,
+				Required:    a.Required,
+			})
+		}
+		values = append(values, completions.PromptCompletionValue{
+			Name:        p.ClientID + ":" + p.PromptID,
+			Description: cmp.Or(p.Description, p.Title),
+			MCPName:     p.ClientID,
+			PromptID:    p.PromptID,
+			Arguments:   args,
+		})
+	}
+	slices.SortFunc(values, func(a, b completions.PromptCompletionValue) int {
+		return strings.Compare(a.Name, b.Name)
+	})
+	return values
 }
 
 // insertCompletionText replaces the @query in the textarea with the given text.
@@ -4266,6 +4312,96 @@ func (m *UI) insertSkillCompletion(skill completions.SkillCompletionValue) tea.C
 		return nil
 	}
 	return m.handleTextareaHeightChange(prevHeight)
+}
+
+// insertMCPPromptCompletion handles picking an MCP prompt from the "/" popup.
+//
+// Prompts that declare arguments open the arguments dialog first; the
+// insertion happens once the values come back, via promptArgsResolvedMsg.
+func (m *UI) insertMCPPromptCompletion(p completions.PromptCompletionValue) tea.Cmd {
+	if len(p.Arguments) == 0 {
+		return m.attachMCPPrompt(p.Name, p.MCPName, p.PromptID, nil)
+	}
+	args := make([]commands.Argument, 0, len(p.Arguments))
+	for _, a := range p.Arguments {
+		args = append(args, commands.Argument{
+			ID:          a.ID,
+			Title:       cmp.Or(a.Title, a.ID),
+			Description: a.Description,
+			Required:    a.Required,
+		})
+	}
+	m.closeCompletions()
+	m.dialog.OpenDialog(dialog.NewArguments(m.com, "/"+p.Name, p.Description, args,
+		dialog.ActionInsertMCPPrompt{
+			Name:      p.Name,
+			MCPName:   p.MCPName,
+			PromptID:  p.PromptID,
+			Arguments: args,
+		}))
+	return nil
+}
+
+// attachMCPPrompt resolves the prompt against its server and attaches the
+// result.
+//
+// The resolved body becomes an attachment rather than text spliced into the
+// editor: prompt templates run long, and dropping one into the prompt area
+// would bury whatever the user was writing. The editor keeps a compact
+// "/server:prompt(arg=value)" token — space-free, so it stays one highlighted
+// unit and one atomic backspace removes it — while the body rides along as an
+// attachment the model receives, exactly like an @file mention.
+func (m *UI) attachMCPPrompt(name, mcpName, promptID string, args map[string]string) tea.Cmd {
+	token := "/" + name
+	if len(args) > 0 {
+		keys := make([]string, 0, len(args))
+		for k := range args {
+			keys = append(keys, k)
+		}
+		slices.Sort(keys)
+		parts := make([]string, 0, len(keys))
+		for _, k := range keys {
+			if args[k] != "" {
+				parts = append(parts, k+"="+args[k])
+			}
+		}
+		if len(parts) > 0 {
+			// No spaces: ScanPromptTokens ends a token at the first one, so a
+			// spaced form would highlight only the name and leave the
+			// arguments rendering as loose prose.
+			token += "(" + strings.Join(parts, ",") + ")"
+		}
+	}
+
+	prevHeight := m.textarea.Height()
+	if !m.insertCompletionText(token) {
+		return nil
+	}
+	heightCmd := m.handleTextareaHeightChange(prevHeight)
+
+	argCount := len(args)
+	promptCmd := func() tea.Msg {
+		body, err := m.com.Workspace.GetMCPPrompt(mcpName, promptID, args)
+		if err != nil {
+			slog.Warn("Failed to resolve MCP prompt", "prompt", name, "error", err)
+			return util.InfoMsg{
+				Type: util.InfoTypeError,
+				Msg:  fmt.Sprintf("Could not resolve /%s: %v", name, err),
+			}
+		}
+		if body == "" {
+			return nil
+		}
+		return message.Attachment{
+			FilePath:       name,
+			FileName:       "/" + name,
+			MimeType:       "text/markdown",
+			Content:        []byte(body),
+			Kind:           message.AttachmentKindMCPPrompt,
+			PromptArgCount: argCount,
+		}
+	}
+	return tea.Batch(heightCmd, promptCmd)
 }
 
 // completionsPosition returns the X and Y position for the completions popup.

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -856,6 +856,9 @@ func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 	case mcpPromptsLoadedMsg:
 		m.mcpPrompts = msg.Prompts
+		// Prompt names validate "/" tokens in the editor just as skill names
+		// do, so the known-name set has to move when the prompts do.
+		m.refreshSkillNames()
 		dia := m.dialog.Dialog(dialog.CommandsID)
 		if dia == nil {
 			break

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -448,6 +448,7 @@ func New(com *common.Common, initialSessionID string, continueLast bool) *UI {
 			com.Styles.Attachments.Image,
 			com.Styles.Attachments.Text,
 			com.Styles.Attachments.Skill,
+			com.Styles.Attachments.Prompt,
 			com.Styles.Attachments.Remove,
 		),
 		attachments.Keymap{
@@ -4461,6 +4462,7 @@ func (m *UI) refreshStyles() {
 		t.Attachments.Image,
 		t.Attachments.Text,
 		t.Attachments.Skill,
+		t.Attachments.Prompt,
 		t.Attachments.Remove,
 	)
 	m.todoSpinner.Style = t.Pills.TodoSpinner

--- a/internal/ui/styles/quickstyle.go
+++ b/internal/ui/styles/quickstyle.go
@@ -1060,6 +1060,7 @@ func quickStyle(o quickStyleOpts) Styles {
 	s.Attachments.Image = attachmentIconStyle.SetString(ImageIcon)
 	s.Attachments.Text = attachmentIconStyle.SetString(TextIcon)
 	s.Attachments.Skill = attachmentIconStyle.SetString(SkillIcon)
+	s.Attachments.Prompt = attachmentIconStyle.SetString(PromptIcon)
 	s.Attachments.Normal = base.Padding(0, 1).Background(o.fgMoreSubtle).Foreground(o.fgBase)
 	// Remove and Deleting share the same slot on the right side of a chip
 	// and must keep the same geometry so toggling delete-mode doesn't

--- a/internal/ui/styles/styles.go
+++ b/internal/ui/styles/styles.go
@@ -46,9 +46,13 @@ const (
 	CronOneShotIcon   string = "•"
 	CronDeletedIcon   string = "✕"
 
-	ImageIcon  string = "▣"
-	TextIcon   string = "≡"
-	SkillIcon  string = "▲"
+	ImageIcon string = "▣"
+	TextIcon  string = "≡"
+	SkillIcon string = "▲"
+	// PromptIcon marks a resolved MCP prompt. Single-width and geometric to
+	// match the icons above: an emoji here would be double-width and
+	// colour-rendered, breaking both the row's look and its width math.
+	PromptIcon string = "◈"
 	RemoveIcon string = "✕"
 
 	ScrollbarThumb string = "┃"
@@ -601,6 +605,7 @@ type Styles struct {
 		Image    lipgloss.Style
 		Text     lipgloss.Style
 		Skill    lipgloss.Style
+		Prompt   lipgloss.Style
 		Remove   lipgloss.Style
 		Deleting lipgloss.Style
 	}


### PR DESCRIPTION
Adds MCP prompts to the inline `/` completions popup, alongside skills.

## Why

Prompts were reachable only from the commands dialog, which runs one as an **entire turn** via `sendMessageMsg` — whatever you had typed is discarded. That makes a prompt unusable as one ingredient of a sentence, and it's why `/gitea:some-prompt` mid-prompt had no coherent meaning before this.

## What it does

Selecting a prompt inserts a compact token and attaches the resolved body:

```
review this and /gitea:review(id=42,repo=stump.wtf/crush)
                ◈ /gitea:review (2 args)
```

- **Names are server-qualified** (`gitea:review`) — the form `commands.LoadMCPPrompts` already keys on, and the only unambiguous one, since prompt names are unique only within a server. Skill names stay bare; they come from `SKILL.md` frontmatter and there is no namespace to qualify them with.
- **Arguments open the existing arguments dialog** first, via a new `ActionInsertMCPPrompt` that attaches rather than firing a turn.
- **The body becomes an attachment, not inline text.** Prompt templates run long; expanding one into the editor would bury the sentence being written. The model receives it exactly as it receives an `@file` mention.
- **The token is deliberately space-free.** `ScanPromptTokens` ends a token at the first space, so a spaced form would highlight only the name, leave the arguments as loose prose, and break atomic backspace.
- **The chip shows the full prompt name plus an argument count.** The name is never truncated — `/gitea:foo…` would leave two prompts from one server indistinguishable.

## Chip rendering is now an API

The renderer derived a chip's icon by sniffing MIME type and assumed every chip was the same width. Neither survives a second kind of chip: a prompt's content is text that must reach the model intact, so it necessarily shares a MIME type with skills while needing its own icon and label.

Chips are now a registry:

```go
var chipRenderers = map[message.AttachmentKind]chipRenderer{
	message.AttachmentKindFile:      fileChip,
	message.AttachmentKindMCPPrompt: mcpPromptChip,
}
```

Adding a chip type is one entry plus the function it points at. MIME sniffing survives *inside* `fileChip`, where it can only distinguish file-ish things from each other, rather than being the dispatch. Unknown kinds fall back to `fileChip`, so an attachment from an older client still renders.

The layout stopped assuming uniform widths — it used to compute how many chips fit by dividing the row by one nominal width. It now measures each chip, reserves room for the `N more…` marker, and truncates the finished row as a backstop for a single chip too wide for a narrow editor.

`message.Attachment` gains `Kind` and `PromptArgCount`, both `omitempty` on the proto twin, so an ordinary file attachment serializes exactly as before.

## Verification

`go build ./...`, `go test ./...`, `go vet ./...`, `gofumpt -l .` all clean.

New tests cover the popup carrying prompts (findable by server prefix and by description), the prompts-only case, the token's space-free argument form, the attachment's kind/content/arg-count, chip labels including a path-shaped argument value that `filepath.Base` would otherwise eat, and a width sweep asserting the chip row never overflows.

## Known gap

Backspacing a prompt token does not yet remove its chip. That path keys on `lastCompletionFilePath`, which is introduced by #255 and hasn't landed — this branch is off `main`. Once #255 merges, wiring it is a one-line addition (`m.lastCompletionFilePath = name` in `attachMCPPrompt`, where the attachment's `FilePath` is already the qualified name for exactly this purpose).

🤖 Posted on behalf of `@joestump` by [`claude-opus-5`](https://openrouter.ai/anthropic/claude-opus-5) using [Claude Code](https://claude.ai).
