### PR TITLE
fix(ui): drop argument values from the MCP prompt token

### DIFF
--- a/internal/ui/common/prompttokens.go
+++ b/internal/ui/common/prompttokens.go
@@ -64,11 +64,13 @@ func IsPromptSkillPrefix(name string) bool {
 
 // promptTokenName reduces a "/" token's body to the name to validate.
 //
-// An MCP prompt carries its arguments in the token itself —
-// "/gitea:review(id=42)" — so the parenthesised tail has to come off before
+// Older drafts of the MCP prompt completion carried the arguments in the
+// token itself — "/gitea:review(id=42)" — and a posted message from one of
+// those drafts still does, so the parenthesised tail has to come off before
 // matching. Without this the argument-bearing form never validates:
-// IsPromptSkillPrefix asks whether the token is a prefix of a known name, and
-// a name with arguments appended is longer than the name, not a prefix of it.
+// IsPromptSkillPrefix asks whether the token is a prefix of a known name,
+// and a name with arguments appended is longer than the name, not a prefix
+// of it.
 func promptTokenName(body string) string {
 	if i := strings.IndexByte(body, '('); i >= 0 {
 		return body[:i]

--- a/internal/ui/model/mcp_prompt_completion_test.go
+++ b/internal/ui/model/mcp_prompt_completion_test.go
@@ -74,11 +74,11 @@ func TestAttachMCPPromptWithoutArguments(t *testing.T) {
 	require.Zero(t, att.PromptArgCount)
 }
 
-// TestAttachMCPPromptWithArguments pins the token's argument form. It has to
-// be space-free: ScanPromptTokens ends a token at the first space, so a
-// spaced form would highlight only the name and leave the arguments rendering
-// as loose prose, and one atomic backspace would no longer remove the whole
-// thing.
+// TestAttachMCPPromptWithArguments pins the token's argument-free form.
+// Argument values stay out of the editor text: a long or whitespace-bearing
+// value would wrap the token across lines or force an escaping scheme into
+// what the user reads. The chip under the composer reports the count, and
+// the values themselves go to the server out of band.
 func TestAttachMCPPromptWithArguments(t *testing.T) {
 	t.Parallel()
 
@@ -92,7 +92,7 @@ func TestAttachMCPPromptWithArguments(t *testing.T) {
 		map[string]string{"repo": "stump.wtf/crush", "id": "42"}))
 
 	got := m.textarea.Value()
-	require.Equal(t, "do /gitea:review(id=42,repo=stump.wtf/crush) ", got)
+	require.Equal(t, "do /gitea:review ", got)
 	token := strings.TrimSpace(got[strings.Index(got, "/"):])
 	require.NotContains(t, token, " ",
 		"the token itself must contain no spaces, or ScanPromptTokens ends it early")
@@ -131,11 +131,11 @@ func TestAtomicBackspaceRemovesPromptChip(t *testing.T) {
 }
 
 // TestAttachMCPPromptDropsBlankArguments pins that a blank optional argument
-// is "not supplied": absent from the token, absent from the chip's count, and
-// never sent to the server. The arguments dialog returns every declared
-// argument, blank ones included, so without filtering the chip claimed
-// "(3 args)" beside a token showing one, and the server was handed
-// empty-string values it never asked for.
+// is "not supplied": absent from the chip's count and never sent to the
+// server. The arguments dialog returns every declared argument, blank ones
+// included, so without filtering the chip claimed "(3 args)" beside a token
+// that took one, and the server was handed empty-string values it never
+// asked for.
 func TestAttachMCPPromptDropsBlankArguments(t *testing.T) {
 	t.Parallel()
 
@@ -148,19 +148,21 @@ func TestAttachMCPPromptDropsBlankArguments(t *testing.T) {
 	runPromptCmd(t, m, m.attachMCPPrompt("gitea:review", "gitea", "review",
 		map[string]string{"id": "42", "title": "", "body": "   "}))
 
-	require.Equal(t, "go /gitea:review(id=42) ", m.textarea.Value())
+	require.Equal(t, "go /gitea:review ", m.textarea.Value())
 	require.Equal(t, map[string]string{"id": "42"}, ws.gotArgs,
 		"blank arguments must not reach the server")
 	require.Len(t, m.attachments.List(), 1)
 	require.Equal(t, 1, m.attachments.List()[0].PromptArgCount,
-		"the count must match what the token shows")
+		"the count must match what the server received")
 }
 
-// TestAttachMCPPromptEncodesWhitespaceInValues pins the token grammar against
-// free-text argument values. ScanPromptTokens ends a token at the first
-// space, so an unescaped value like "fix the bug" split the token in half —
-// the exact failure the design claims to prevent.
-func TestAttachMCPPromptEncodesWhitespaceInValues(t *testing.T) {
+// TestAttachMCPPromptKeepsValuesOutOfTheToken pins that a whitespace-bearing
+// argument value does not leak into the editor text. The token must remain
+// "/server:prompt" with no encoded form of the value: percent-encoding kept
+// the grammar intact but leaked "%20" into what the user read, and any
+// inlined value is one long argument away from wrapping the token across
+// lines.
+func TestAttachMCPPromptKeepsValuesOutOfTheToken(t *testing.T) {
 	t.Parallel()
 
 	ws := &promptWorkspace{body: "body"}
@@ -172,12 +174,10 @@ func TestAttachMCPPromptEncodesWhitespaceInValues(t *testing.T) {
 	runPromptCmd(t, m, m.attachMCPPrompt("gitea:review", "gitea", "review",
 		map[string]string{"title": "fix the bug"}))
 
-	got := m.textarea.Value()
-	token := strings.TrimSpace(got[strings.Index(got, "/"):])
-	require.NotContains(t, token, " ", "the token must survive a spaced value")
-	require.Contains(t, token, "%20")
-	// The server still gets the real value, not the encoded one.
-	require.Equal(t, map[string]string{"title": "fix the bug"}, ws.gotArgs)
+	require.Equal(t, "go /gitea:review ", m.textarea.Value(),
+		"no part of the value — encoded or otherwise — belongs in the token")
+	require.Equal(t, map[string]string{"title": "fix the bug"}, ws.gotArgs,
+		"the server still gets the real value")
 }
 
 // TestAttachMCPPromptRollsBackOnResolveFailure pins that a prompt whose body
@@ -222,4 +222,44 @@ func TestAttachMCPPromptRollsBackOnResolveFailure(t *testing.T) {
 	require.Equal(t, "please ", m.textarea.Value(),
 		"the token must be rolled back when its body never arrives")
 	require.Empty(t, m.attachments.List())
+}
+
+// TestAttachMCPPromptTwiceTracksEachInsertion pins that two insertions of
+// the same prompt are independently removable. With argument values no
+// longer inline, both tokens are the same text, so the mention tracker must
+// hold one attachment key per occurrence rather than letting the second
+// insert overwrite the first.
+func TestAttachMCPPromptTwiceTracksEachInsertion(t *testing.T) {
+	t.Parallel()
+
+	ws := &promptWorkspace{body: "body"}
+	ws.ready = true
+	m := newCompletionBackspaceUIWith(ws)
+	m.textarea.SetValue("do /")
+	m.completionsStartIndex = len("do ")
+
+	runPromptCmd(t, m, m.attachMCPPrompt("gitea:review", "gitea", "review",
+		map[string]string{"id": "42"}))
+	require.Equal(t, "do /gitea:review ", m.textarea.Value())
+	require.Len(t, m.attachments.List(), 1)
+
+	// Move past the inserted trailing space, then trigger and resolve the
+	// same prompt a second time.
+	m.textarea.InsertRune('x')
+	m.textarea.InsertRune(' ')
+	m.completionsStartIndex = len("do /gitea:review x ")
+	m.textarea.SetValue("do /gitea:review x /")
+	runPromptCmd(t, m, m.attachMCPPrompt("gitea:review", "gitea", "review",
+		map[string]string{"id": "43"}))
+
+	require.Equal(t, "do /gitea:review x /gitea:review ", m.textarea.Value())
+	require.Len(t, m.attachments.List(), 2,
+		"each insertion must own its own attachment")
+
+	// Backspacing the second token drops only its chip; the first must stay.
+	m.Update(tea.KeyPressMsg{Code: tea.KeyBackspace})
+	require.Equal(t, "do /gitea:review x ", m.textarea.Value())
+	require.Len(t, m.attachments.List(), 1,
+		"the surviving token's chip must survive its twin's deletion")
+	require.Equal(t, "gitea:review#1", m.attachments.List()[0].FilePath)
 }

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -297,11 +297,14 @@ type UI struct {
 	lastCompletionEnd      int
 	lastCompletionText     string
 	lastCompletionFilePath string // non-empty when the last completion attached a file
-	// mentionAttachments maps a token in the prompt to the attachment it
-	// owns, so deleting the token can take the attachment with it. Only
-	// tokens put entries here, so a pasted image or a dropped file — which
-	// has no token — is never touched.
-	mentionAttachments map[string]string
+	// mentionAttachments maps a token in the prompt to the attachments it
+	// owns, so deleting the token can take the attachment with it. The
+	// value is a list because the same token text can appear more than
+	// once: two insertions of "/server:prompt" differ only in their
+	// resolved bodies, so each gets its own entry here and a backspace
+	// pops exactly one. Only tokens put entries here, so a pasted image
+	// or a dropped file — which has no token — is never touched.
+	mentionAttachments map[string][]string
 	// discardedMentions holds attachment keys whose token was deleted before
 	// the (asynchronous) read that produces the attachment came back. The
 	// attachment is dropped on arrival rather than landing as an orphan chip
@@ -4246,12 +4249,15 @@ func promptMentions(value, target string) bool {
 }
 
 // trackMentionAttachment records which attachment a token in the prompt owns,
-// so deleting that token can take the attachment with it.
+// so deleting that token can take the attachment with it. A token that
+// already has an entry (the same prompt inserted twice, the same file
+// mentioned twice) appends rather than overwrites, so each occurrence can be
+// removed independently.
 func (m *UI) trackMentionAttachment(key, token string) {
 	if m.mentionAttachments == nil {
-		m.mentionAttachments = map[string]string{}
+		m.mentionAttachments = map[string][]string{}
 	}
-	m.mentionAttachments[token] = key
+	m.mentionAttachments[token] = append(m.mentionAttachments[token], key)
 }
 
 // dropMentionAttachment removes the attachment owned by a token that has just
@@ -4261,10 +4267,10 @@ func (m *UI) trackMentionAttachment(key, token string) {
 // prompt after every keystroke. Reconciling looks more thorough and is much
 // worse: an attachment's identity would have to be recoverable from the
 // prompt text, and it often is not. A path or resource title containing a
-// space does not tokenize back to what was inserted, editing an MCP prompt's
-// arguments changes the token, and the tokenizer's known-name set is re-primed
-// asynchronously when MCP servers reload — each of which made a live
-// attachment disappear mid-composition while its mention sat on screen.
+// space does not tokenize back to what was inserted, and the tokenizer's
+// known-name set is re-primed asynchronously when MCP servers reload — each
+// of which made a live attachment disappear mid-composition while its
+// mention sat on screen.
 // Acting only where the token is known to have gone can miss a removal, which
 // is a visible chip the user can delete; the alternative silently drops data
 // the user believes they attached.
@@ -4272,8 +4278,8 @@ func (m *UI) dropMentionAttachment(token string) {
 	if token == "" {
 		return
 	}
-	key, ok := m.mentionAttachments[token]
-	if !ok {
+	keys, ok := m.mentionAttachments[token]
+	if !ok || len(keys) == 0 {
 		return
 	}
 	// A repeat mention shares one attachment (fileCmd dedupes), so it only
@@ -4281,8 +4287,18 @@ func (m *UI) dropMentionAttachment(token string) {
 	if slices.Contains(m.promptTokenTexts(), token) {
 		return
 	}
+	// The token is gone. Drop one tracking entry and remove its attachment;
+	// if more entries remain (a duplicate token was deleted earlier and the
+	// rest of the prompt was edited away in the meantime), they go too, so
+	// no orphan chip survives its token.
+	key := keys[len(keys)-1]
+	keys = keys[:len(keys)-1]
+	if len(keys) == 0 {
+		delete(m.mentionAttachments, token)
+	} else {
+		m.mentionAttachments[token] = keys
+	}
 	m.attachments.RemoveByFilePath(key)
-	delete(m.mentionAttachments, token)
 	// A late-arriving read for a mention that is already gone would land as
 	// an orphan chip with nothing referring to it.
 	if m.discardedMentions == nil {
@@ -4557,45 +4573,22 @@ func (m *UI) insertMCPPromptCompletion(p completions.PromptCompletionValue) tea.
 	return nil
 }
 
-// promptTokenValue renders one argument value for the inline token.
-//
-// Values come from free-text dialog inputs, so they can contain anything.
-// Whitespace is the one thing the token grammar cannot carry —
-// ScanPromptTokens ends a token at the first space — so it is percent-encoded
-// rather than dropped: the value stays readable and the token stays a single
-// highlighted, atomically-deletable unit.
-func promptTokenValue(v string) string {
-	var b strings.Builder
-	for _, r := range v {
-		switch r {
-		case ' ':
-			b.WriteString("%20")
-		case '\t':
-			b.WriteString("%09")
-		case '\n':
-			b.WriteString("%0A")
-		case '\r':
-			b.WriteString("%0D")
-		default:
-			b.WriteRune(r)
-		}
-	}
-	return b.String()
-}
-
 // attachMCPPrompt resolves the prompt against its server and attaches the
 // result.
 //
 // The resolved body becomes an attachment rather than text spliced into the
 // editor: prompt templates run long, and dropping one into the prompt area
 // would bury whatever the user was writing. The editor keeps a compact
-// "/server:prompt(arg=value)" token — space-free, so it stays one highlighted
-// unit and one atomic backspace removes it — while the body rides along as an
-// attachment the model receives, exactly like an @file mention.
+// "/server:prompt" token — argument values stay out of it, so a long value
+// cannot wrap the token across lines and no escaping scheme leaks into what
+// the user reads — while the body rides along as an attachment the model
+// receives, exactly like an @file mention. The chip under the composer
+// carries the argument count, which is the only piece of argument
+// information the composer needs to show.
 func (m *UI) attachMCPPrompt(name, mcpName, promptID string, args map[string]string) tea.Cmd {
 	// The dialog returns every declared argument, blank ones included. A
-	// blank optional is "not supplied": it must not reach the server, must
-	// not appear in the token, and must not be counted on the chip.
+	// blank optional is "not supplied": it must not reach the server and
+	// must not be counted on the chip.
 	supplied := make(map[string]string, len(args))
 	for k, v := range args {
 		if strings.TrimSpace(v) != "" {
@@ -4604,18 +4597,6 @@ func (m *UI) attachMCPPrompt(name, mcpName, promptID string, args map[string]str
 	}
 
 	token := "/" + name
-	if len(supplied) > 0 {
-		keys := make([]string, 0, len(supplied))
-		for k := range supplied {
-			keys = append(keys, k)
-		}
-		slices.Sort(keys)
-		parts := make([]string, 0, len(keys))
-		for _, k := range keys {
-			parts = append(parts, k+"="+promptTokenValue(supplied[k]))
-		}
-		token += "(" + strings.Join(parts, ",") + ")"
-	}
 
 	prevHeight := m.textarea.Height()
 	if !m.insertCompletionText(token) {


### PR DESCRIPTION
## Why

The screenshot in the linked chat showed the inline composer token as

```
/cairn:run_capture(task=Please%20pull%20directly%20from%20Crush's%20SQLite%20DB%20for%20this%20session%20going%20back%20no%20more%20than%20an%20hour.)
```

— percent-encoded whitespace leaking into what the user reads, and a single long value wrapping the token across two lines. The chip under the composer already carries the count (`/cairn:run_capture (1 arg)`), and the resolved prompt body reaches the model as an attachment, so the inline argument form was redundant as well as ugly.

## What changed

- `attachMCPPrompt` no longer splices `arg=value` into the editor token. The token is now just `/server:prompt`, matching the chip label exactly.
- The percent-encoder (`promptTokenValue`) is gone; nothing else consumed it.
- `mentionAttachments` became `map[string][]string` so two insertions of the same prompt (which now produce identical token text) are tracked as two entries and backspacing removes exactly one.
- `promptTokenName` still strips a `(...)` tail so messages posted before this change keep their highlight.

## Verification

- `go test ./internal/ui/...` — all green, including the updated prompt-completion tests and a new `TestAttachMCPPromptTwiceTracksEachInsertion` covering the two-instance backspace case.
- `go build ./...`, `go vet ./internal/ui/...`, `gofumpt -l` — clean.