### PR TITLE
fix(ui): expand every pills section on ctrl+t

### DIFF
--- a/internal/ui/dialog/commands.go
+++ b/internal/ui/dialog/commands.go
@@ -63,6 +63,7 @@ type Commands struct {
 	hasSession bool
 	hasTodos   bool
 	hasQueue   bool
+	hasCron    bool
 	selected   CommandType
 
 	spinner spinner.Model
@@ -87,7 +88,7 @@ type Commands struct {
 var _ Dialog = (*Commands)(nil)
 
 // NewCommands creates a new commands dialog.
-func NewCommands(com *common.Common, sessionID string, hasSession, hasTodos, hasQueue bool, customCommands []commands.CustomCommand, mcpPrompts []commands.MCPPrompt) (*Commands, error) {
+func NewCommands(com *common.Common, sessionID string, hasSession, hasTodos, hasQueue, hasCron bool, customCommands []commands.CustomCommand, mcpPrompts []commands.MCPPrompt) (*Commands, error) {
 	c := &Commands{
 		com:            com,
 		selected:       SystemCommands,
@@ -95,6 +96,7 @@ func NewCommands(com *common.Common, sessionID string, hasSession, hasTodos, has
 		hasSession:     hasSession,
 		hasTodos:       hasTodos,
 		hasQueue:       hasQueue,
+		hasCron:        hasCron,
 		customCommands: customCommands,
 		mcpPrompts:     mcpPrompts,
 	}
@@ -608,16 +610,20 @@ func (c *Commands) defaultCommands() []*CommandItem {
 		commands = append(commands, NewCommandItem(c.com.Styles, "disable_docker_mcp", "Disable Docker MCP Catalog", "", ActionDisableDockerMCP{}))
 	}
 
-	if c.hasTodos || c.hasQueue {
-		var label string
-		switch {
-		case c.hasTodos && c.hasQueue:
-			label = "Toggle To-Dos/Queue"
-		case c.hasQueue:
-			label = "Toggle Queue"
-		default:
-			label = "Toggle To-Dos"
+	// ctrl+t expands every section that has content, so the label names all of
+	// them rather than just the first.
+	if c.hasTodos || c.hasQueue || c.hasCron {
+		var sections []string
+		if c.hasTodos {
+			sections = append(sections, "To-Dos")
 		}
+		if c.hasQueue {
+			sections = append(sections, "Queue")
+		}
+		if c.hasCron {
+			sections = append(sections, "Scheduled")
+		}
+		label := "Toggle " + strings.Join(sections, "/")
 		commands = append(commands, NewCommandItem(c.com.Styles, "toggle_pills", label, "ctrl+t", ActionTogglePills{}))
 	}
 

--- a/internal/ui/dialog/commands_test.go
+++ b/internal/ui/dialog/commands_test.go
@@ -31,7 +31,7 @@ func newTestCommands(t *testing.T) *Commands {
 		Workspace: &testCommandsWorkspace{cfg: cfg},
 		Styles:    &s,
 	}
-	c, err := NewCommands(com, "", false, false, false, nil, nil)
+	c, err := NewCommands(com, "", false, false, false, false, nil, nil)
 	require.NoError(t, err)
 	return c
 }

--- a/internal/ui/model/keys.go
+++ b/internal/ui/model/keys.go
@@ -29,8 +29,6 @@ type KeyMap struct {
 		Tab            key.Binding
 		Details        key.Binding
 		TogglePills    key.Binding
-		PillLeft       key.Binding
-		PillRight      key.Binding
 		Down           key.Binding
 		Up             key.Binding
 		UpDown         key.Binding
@@ -179,14 +177,6 @@ func DefaultKeyMap() KeyMap {
 	km.Chat.TogglePills = key.NewBinding(
 		key.WithKeys("ctrl+t", "ctrl+space"),
 		key.WithHelp("ctrl+t", "toggle tasks"),
-	)
-	km.Chat.PillLeft = key.NewBinding(
-		key.WithKeys("left"),
-		key.WithHelp("←/→", "switch section"),
-	)
-	km.Chat.PillRight = key.NewBinding(
-		key.WithKeys("right"),
-		key.WithHelp("←/→", "switch section"),
 	)
 
 	km.Chat.Down = key.NewBinding(

--- a/internal/ui/model/layout_test.go
+++ b/internal/ui/model/layout_test.go
@@ -139,9 +139,6 @@ func TestAutoExpandPillsIfReasonable(t *testing.T) {
 		if !u.pillsExpanded {
 			t.Fatal("expected pillsExpanded to be true")
 		}
-		if u.focusedPillSection != pillSectionTodos {
-			t.Fatalf("expected focusedPillSection to be pillSectionTodos, got %d", u.focusedPillSection)
-		}
 	})
 
 	t.Run("does not expand when terminal is too short", func(t *testing.T) {
@@ -206,9 +203,6 @@ func TestAutoExpandPillsIfReasonable(t *testing.T) {
 
 		if !u.pillsExpanded {
 			t.Fatal("expected pillsExpanded to be true for prompt queue")
-		}
-		if u.focusedPillSection != pillSectionQueue {
-			t.Fatalf("expected focusedPillSection to be pillSectionQueue, got %d", u.focusedPillSection)
 		}
 	})
 

--- a/internal/ui/model/pill_border_test.go
+++ b/internal/ui/model/pill_border_test.go
@@ -3,7 +3,9 @@ package model
 import (
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/charmbracelet/crush/internal/scheduler"
 	"github.com/charmbracelet/crush/internal/session"
 )
 
@@ -33,23 +35,20 @@ func queuePillHasBorder(view string) bool {
 }
 
 // TestQueuePillAlwaysHasBorder guards CHARM-1678: the queued-prompts pill must
-// render with its rounded border regardless of panel expansion or which pill
-// section is nominally focused.
+// render with its rounded border regardless of panel expansion.
 func TestQueuePillAlwaysHasBorder(t *testing.T) {
 	incompleteTodos := []session.Todo{{Content: "a", Status: session.TodoStatusPending}}
 
 	cases := []struct {
-		name           string
-		expanded       bool
-		focusedSection pillSection
-		todos          []session.Todo
-		queue          int
+		name     string
+		expanded bool
+		todos    []session.Todo
+		queue    int
 	}{
-		{"collapsed only queue", false, pillSectionTodos, nil, 2},
-		{"collapsed queue+todos", false, pillSectionTodos, incompleteTodos, 2},
-		{"expanded queue focused", true, pillSectionQueue, nil, 2},
-		{"expanded stale todos focus only queue", true, pillSectionTodos, nil, 2},
-		{"expanded todos focused queue+todos", true, pillSectionTodos, incompleteTodos, 2},
+		{"collapsed only queue", false, nil, 2},
+		{"collapsed queue+todos", false, incompleteTodos, 2},
+		{"expanded only queue", true, nil, 2},
+		{"expanded queue+todos", true, incompleteTodos, 2},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -57,7 +56,6 @@ func TestQueuePillAlwaysHasBorder(t *testing.T) {
 			u.session = &session.Session{ID: "s1", Todos: tc.todos}
 			u.promptQueue = tc.queue
 			u.pillsExpanded = tc.expanded
-			u.focusedPillSection = tc.focusedSection
 			u.updateLayoutAndSize()
 			u.renderPills()
 
@@ -71,31 +69,52 @@ func TestQueuePillAlwaysHasBorder(t *testing.T) {
 	}
 }
 
-// TestEffectiveFocusedSectionFallsThrough verifies that a stale focused section
-// (pointing at a section with no content) resolves to the section that still
-// has content, so the expanded list stays populated.
-func TestEffectiveFocusedSectionFallsThrough(t *testing.T) {
-	cases := []struct {
-		name     string
-		stored   pillSection
-		todos    []session.Todo
-		queue    int
-		expected pillSection
-	}{
-		{"todos focus but only queue", pillSectionTodos, nil, 2, pillSectionQueue},
-		{"queue focus but only todos", pillSectionQueue, []session.Todo{{Content: "a", Status: session.TodoStatusPending}}, 0, pillSectionTodos},
-		{"todos focus with todos", pillSectionTodos, []session.Todo{{Content: "a", Status: session.TodoStatusPending}}, 2, pillSectionTodos},
-		{"queue focus with queue", pillSectionQueue, nil, 2, pillSectionQueue},
+// TestExpandedPillsShowEverySection verifies that expanding the panel lists
+// every section that has content, not just one of them: with todos, queued
+// prompts and scheduled tasks all present, ctrl+t must reveal all three lists.
+func TestExpandedPillsShowEverySection(t *testing.T) {
+	u := newTestUI()
+	u.session = &session.Session{ID: "s1", Todos: []session.Todo{
+		{Content: "write the todo", Status: session.TodoStatusPending},
+	}}
+	u.promptQueue = 1
+	u.promptQueueItems = []string{"queued prompt"}
+	u.cronTasks = []scheduler.Task{{
+		ID:        "abc12345",
+		Prompt:    "scheduled prompt",
+		NextRunAt: time.Now().Add(time.Hour),
+	}}
+	u.pillsExpanded = true
+	u.updateLayoutAndSize()
+	u.renderPills()
+
+	for _, want := range []string{"write the todo", "queued prompt", "scheduled prompt"} {
+		if !strings.Contains(u.pillsView, want) {
+			t.Fatalf("expected expanded pills to contain %q:\n%s", want, u.pillsView)
+		}
 	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			u := newTestUI()
-			u.session = &session.Session{ID: "s1", Todos: tc.todos}
-			u.promptQueue = tc.queue
-			u.focusedPillSection = tc.stored
-			if got := u.effectiveFocusedSection(); got != tc.expected {
-				t.Fatalf("effectiveFocusedSection() = %d, want %d", got, tc.expected)
-			}
-		})
+}
+
+// TestPillsAreaHeightSumsExpandedSections verifies the reserved height accounts
+// for every expanded list, so the stacked sections are not clipped.
+func TestPillsAreaHeightSumsExpandedSections(t *testing.T) {
+	u := newTestUI()
+	u.session = &session.Session{ID: "s1", Todos: []session.Todo{
+		{Content: "a", Status: session.TodoStatusPending},
+		{Content: "b", Status: session.TodoStatusPending},
+	}}
+	u.promptQueue = 3
+	u.cronTasks = []scheduler.Task{
+		{ID: "t1", NextRunAt: time.Now()},
+		{ID: "t2", NextRunAt: time.Now()},
+	}
+
+	if got, want := u.pillsAreaHeight(), pillHeightWithBorder; got != want {
+		t.Fatalf("collapsed pillsAreaHeight() = %d, want %d", got, want)
+	}
+
+	u.pillsExpanded = true
+	if got, want := u.pillsAreaHeight(), pillHeightWithBorder+2+3+2; got != want {
+		t.Fatalf("expanded pillsAreaHeight() = %d, want %d", got, want)
 	}
 }

--- a/internal/ui/model/pills.go
+++ b/internal/ui/model/pills.go
@@ -23,15 +23,6 @@ const (
 	maxQueueDisplayLength = 60
 )
 
-// pillSection represents which section of the pills panel is focused.
-type pillSection int
-
-const (
-	pillSectionTodos pillSection = iota
-	pillSectionQueue
-	pillSectionCron
-)
-
 // hasIncompleteTodos returns true if there are any non-completed todos.
 func hasIncompleteTodos(todos []session.Todo) bool {
 	return session.HasIncompleteTodos(todos)
@@ -65,7 +56,9 @@ func queuePill(queue int, t *styles.Styles) string {
 }
 
 // todoPill renders the todo progress pill with optional spinner and task name.
-func todoPill(todos []session.Todo, spinnerView string, panelFocused bool, t *styles.Styles) string {
+// When the panel is expanded the current task is omitted from the pill, since
+// the list below already shows it.
+func todoPill(todos []session.Todo, spinnerView string, expanded bool, t *styles.Styles) string {
 	if !hasIncompleteTodos(todos) {
 		return ""
 	}
@@ -89,7 +82,7 @@ func todoPill(todos []session.Todo, spinnerView string, panelFocused bool, t *st
 	progress := t.Pills.TodoProgress.Render(fmt.Sprintf("%d/%d", completed, total))
 
 	var content string
-	if panelFocused {
+	if expanded {
 		content = fmt.Sprintf("%s %s", label, progress)
 	} else if currentTodo != nil {
 		taskText := currentTodo.Content
@@ -164,7 +157,9 @@ func cronList(tasks []scheduler.Task, t *styles.Styles) string {
 			recurring = " ↻"
 		}
 		text := fmt.Sprintf("%s %s%s — %s", task.ID, nextRun, recurring, prompt)
-		prefix := t.Pills.QueueItemPrefix.Render() + " "
+		// A clock prefix keeps scheduled tasks distinct from the queued-prompt
+		// list directly above them when both sections are expanded.
+		prefix := t.Pills.CronItemPrefix.Render() + " "
 		lines = append(lines, prefix+t.Pills.QueueItemText.Render(text))
 	}
 
@@ -199,13 +194,6 @@ func (m *UI) autoExpandPillsIfReasonable() tea.Cmd {
 	}
 	m.pillsExpanded = true
 	m.pillsAutoExpanded = true
-	if hasIncompleteTodos(m.session.Todos) {
-		m.focusedPillSection = pillSectionTodos
-	} else if m.promptQueue > 0 {
-		m.focusedPillSection = pillSectionQueue
-	} else {
-		m.focusedPillSection = pillSectionCron
-	}
 	m.updateLayoutAndSize()
 	if m.chat.Follow() {
 		m.chat.ScrollToBottom()
@@ -223,15 +211,6 @@ func (m *UI) togglePillsExpanded() tea.Cmd {
 		return nil
 	}
 	m.pillsExpanded = !m.pillsExpanded
-	if m.pillsExpanded {
-		if hasIncompleteTodos(m.session.Todos) {
-			m.focusedPillSection = pillSectionTodos
-		} else if m.promptQueue > 0 {
-			m.focusedPillSection = pillSectionQueue
-		} else {
-			m.focusedPillSection = pillSectionCron
-		}
-	}
 	m.updateLayoutAndSize()
 
 	// Make sure to follow scroll if follow is enabled when toggling pills.
@@ -242,88 +221,6 @@ func (m *UI) togglePillsExpanded() tea.Cmd {
 	}
 
 	return nil
-}
-
-// switchPillSection changes focus between todo, queue, and cron sections.
-func (m *UI) switchPillSection(dir int) tea.Cmd {
-	if !m.pillsExpanded || !m.hasSession() {
-		return nil
-	}
-	hasIncompleteTodos := hasIncompleteTodos(m.session.Todos)
-	hasQueue := m.promptQueue > 0
-	hasCron := len(m.cronTasks) > 0
-
-	// Build the ordered list of sections that have content.
-	var sections []pillSection
-	if hasIncompleteTodos {
-		sections = append(sections, pillSectionTodos)
-	}
-	if hasQueue {
-		sections = append(sections, pillSectionQueue)
-	}
-	if hasCron {
-		sections = append(sections, pillSectionCron)
-	}
-	if len(sections) < 2 {
-		return nil
-	}
-
-	// Find the current section in the list and move by dir.
-	current := m.effectiveFocusedSection()
-	for i, s := range sections {
-		if s == current {
-			next := (i + dir + len(sections)) % len(sections)
-			m.focusedPillSection = sections[next]
-			m.updateLayoutAndSize()
-			return nil
-		}
-	}
-	return nil
-}
-
-// effectiveFocusedSection returns the pill section that should be treated as
-// focused for rendering. The stored focusedPillSection can go stale when its
-// section loses all content (for example todos complete while the panel is open,
-// or it defaults to todos before any todos exist). In that case we fall through
-// to whichever section still has content so the expanded list stays populated.
-func (m *UI) effectiveFocusedSection() pillSection {
-	hasIncomplete := hasIncompleteTodos(m.session.Todos)
-	hasQueue := m.promptQueue > 0
-	hasCron := len(m.cronTasks) > 0
-
-	switch m.focusedPillSection {
-	case pillSectionCron:
-		if hasCron {
-			return pillSectionCron
-		}
-		if hasIncomplete {
-			return pillSectionTodos
-		}
-		if hasQueue {
-			return pillSectionQueue
-		}
-	case pillSectionQueue:
-		if hasQueue {
-			return pillSectionQueue
-		}
-		if hasIncomplete {
-			return pillSectionTodos
-		}
-		if hasCron {
-			return pillSectionCron
-		}
-	default: // pillSectionTodos
-		if hasIncomplete {
-			return pillSectionTodos
-		}
-		if hasQueue {
-			return pillSectionQueue
-		}
-		if hasCron {
-			return pillSectionCron
-		}
-	}
-	return m.focusedPillSection
 }
 
 // pillsAreaHeight calculates the total height needed for the pills area.
@@ -346,19 +243,16 @@ func (m *UI) pillsAreaHeight() int {
 
 	pillsAreaHeight := pillHeightWithBorder
 	if m.pillsExpanded {
-		switch m.effectiveFocusedSection() {
-		case pillSectionTodos:
-			if hasIncomplete {
-				pillsAreaHeight += len(m.session.Todos)
-			}
-		case pillSectionQueue:
-			if hasQueue {
-				pillsAreaHeight += m.promptQueue
-			}
-		case pillSectionCron:
-			if hasCron {
-				pillsAreaHeight += len(m.cronTasks)
-			}
+		// Every section with content expands, so the panel needs room for all
+		// of their lists stacked, not just one.
+		if hasIncomplete {
+			pillsAreaHeight += len(m.session.Todos)
+		}
+		if hasQueue {
+			pillsAreaHeight += m.promptQueue
+		}
+		if hasCron {
+			pillsAreaHeight += len(m.cronTasks)
 		}
 	}
 	return pillsAreaHeight
@@ -392,10 +286,6 @@ func (m *UI) renderPills() {
 	}
 
 	t := m.com.Styles
-	effective := m.effectiveFocusedSection()
-	todosFocused := m.pillsExpanded && effective == pillSectionTodos
-	queueFocused := m.pillsExpanded && effective == pillSectionQueue
-	cronFocused := m.pillsExpanded && effective == pillSectionCron
 
 	inProgressIcon := t.Tool.TodoInProgressIcon.Render(styles.SpinnerIcon)
 	if m.todoIsSpinning {
@@ -415,21 +305,24 @@ func (m *UI) renderPills() {
 		pills = append(pills, cronPill(m.cronTasks, t))
 	}
 
-	var expandedList string
+	// Expanding shows every section that has content, stacked in the same order
+	// as the pills above them, so the panel matches what the pills advertise.
+	var expandedSections []string
 	if m.pillsExpanded {
-		if todosFocused && hasIncomplete {
-			expandedList = todoList(m.session.Todos, inProgressIcon, t, contentWidth)
-		} else if queueFocused && hasQueue {
-			// Render from the memoized queue (fetched off-thread, see
-			// workspace_cache.go): renderPills runs on the Update/View
-			// path and must never block on a workspace round-trip.
-			if len(m.promptQueueItems) > 0 {
-				expandedList = queueList(m.promptQueueItems, t)
-			}
-		} else if cronFocused && hasCron {
-			expandedList = cronList(m.cronTasks, t)
+		if hasIncomplete {
+			expandedSections = append(expandedSections, todoList(m.session.Todos, inProgressIcon, t, contentWidth))
+		}
+		// Render from the memoized queue (fetched off-thread, see
+		// workspace_cache.go): renderPills runs on the Update/View
+		// path and must never block on a workspace round-trip.
+		if hasQueue && len(m.promptQueueItems) > 0 {
+			expandedSections = append(expandedSections, queueList(m.promptQueueItems, t))
+		}
+		if hasCron {
+			expandedSections = append(expandedSections, cronList(m.cronTasks, t))
 		}
 	}
+	expandedList := lipgloss.JoinVertical(lipgloss.Left, expandedSections...)
 
 	if len(pills) == 0 {
 		return

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -369,9 +369,8 @@ type UI struct {
 	detailsOpen bool
 
 	// pills state
-	pillsExpanded      bool
-	pillsAutoExpanded  bool
-	focusedPillSection pillSection
+	pillsExpanded     bool
+	pillsAutoExpanded bool
 	// promptQueue / promptQueueItems mirror the session's queued prompts.
 	// They are event-driven with a TTL backstop, fetched off-thread by
 	// dispatchPromptQueueRefresh (see workspace_cache.go); promptQueue is
@@ -2475,20 +2474,6 @@ func (m *UI) handleKeyPressMsg(msg tea.KeyPressMsg) tea.Cmd {
 				}
 				return true
 			}
-		case key.Matches(msg, m.keyMap.Chat.PillLeft):
-			if m.state == uiChat && m.hasSession() && m.pillsExpanded && m.focus != uiFocusEditor {
-				if cmd := m.switchPillSection(-1); cmd != nil {
-					cmds = append(cmds, cmd)
-				}
-				return true
-			}
-		case key.Matches(msg, m.keyMap.Chat.PillRight):
-			if m.state == uiChat && m.hasSession() && m.pillsExpanded && m.focus != uiFocusEditor {
-				if cmd := m.switchPillSection(1); cmd != nil {
-					cmds = append(cmds, cmd)
-				}
-				return true
-			}
 		case key.Matches(msg, m.keyMap.Suspend):
 			if m.isAgentBusy() {
 				cmds = append(cmds, util.ReportWarn("Agent is busy, please wait..."))
@@ -3352,9 +3337,6 @@ func (m *UI) ShortHelp() []key.Binding {
 				k.Chat.PageDown,
 				k.Chat.Copy,
 			)
-			if m.pillsExpanded && hasIncompleteTodos(m.session.Todos) && m.promptQueue > 0 {
-				binds = append(binds, k.Chat.PillLeft)
-			}
 		case uiFocusSidebar:
 			esc := k.Editor.Escape
 			esc.SetHelp("esc", "back to editor")
@@ -3503,9 +3485,6 @@ func (m *UI) FullHelp() [][]key.Binding {
 					k.Chat.ClearHighlight,
 				},
 			)
-			if m.pillsExpanded && hasIncompleteTodos(m.session.Todos) && m.promptQueue > 0 {
-				binds = append(binds, []key.Binding{k.Chat.PillLeft})
-			}
 		}
 	default:
 		if m.session == nil {
@@ -5502,8 +5481,9 @@ func (m *UI) openCommandsDialog() tea.Cmd {
 	}
 	hasTodos := hasSession && hasIncompleteTodos(m.session.Todos)
 	hasQueue := m.promptQueue > 0
+	hasCron := len(m.cronTasks) > 0
 
-	commands, err := dialog.NewCommands(m.com, sessionID, hasSession, hasTodos, hasQueue, m.customCommands, m.mcpPrompts)
+	commands, err := dialog.NewCommands(m.com, sessionID, hasSession, hasTodos, hasQueue, hasCron, m.customCommands, m.mcpPrompts)
 	if err != nil {
 		return util.ReportError(err)
 	}

--- a/internal/ui/styles/quickstyle.go
+++ b/internal/ui/styles/quickstyle.go
@@ -1073,8 +1073,10 @@ func quickStyle(o quickStyleOpts) Styles {
 	// Pills styles
 	s.Pills.Base = base.Padding(0, 1)
 	s.Pills.Focused = base.Padding(0, 1).BorderStyle(lipgloss.RoundedBorder()).BorderForeground(o.bgMostVisible)
-	s.Pills.QueueItemPrefix = lipgloss.NewStyle().Foreground(o.fgMoreSubtle).SetString("  •")
-	s.Pills.CronItemPrefix = lipgloss.NewStyle().Foreground(o.fgMoreSubtle).SetString("  ⏰")
+	// No leading pad: these lists stack under the same pills row as the todo
+	// list, which starts at column 0.
+	s.Pills.QueueItemPrefix = lipgloss.NewStyle().Foreground(o.fgMoreSubtle).SetString("•")
+	s.Pills.CronItemPrefix = lipgloss.NewStyle().Foreground(o.fgMoreSubtle).SetString("⏰")
 	s.Pills.QueueItemText = lipgloss.NewStyle().Foreground(o.fgMoreSubtle)
 	s.Pills.QueueLabel = lipgloss.NewStyle().Foreground(o.fgBase)
 	s.Pills.QueueIconBase = lipgloss.NewStyle().Foreground(o.fgBase)

--- a/internal/ui/styles/quickstyle.go
+++ b/internal/ui/styles/quickstyle.go
@@ -1074,6 +1074,7 @@ func quickStyle(o quickStyleOpts) Styles {
 	s.Pills.Base = base.Padding(0, 1)
 	s.Pills.Focused = base.Padding(0, 1).BorderStyle(lipgloss.RoundedBorder()).BorderForeground(o.bgMostVisible)
 	s.Pills.QueueItemPrefix = lipgloss.NewStyle().Foreground(o.fgMoreSubtle).SetString("  •")
+	s.Pills.CronItemPrefix = lipgloss.NewStyle().Foreground(o.fgMoreSubtle).SetString("  ⏰")
 	s.Pills.QueueItemText = lipgloss.NewStyle().Foreground(o.fgMoreSubtle)
 	s.Pills.QueueLabel = lipgloss.NewStyle().Foreground(o.fgBase)
 	s.Pills.QueueIconBase = lipgloss.NewStyle().Foreground(o.fgBase)

--- a/internal/ui/styles/styles.go
+++ b/internal/ui/styles/styles.go
@@ -615,6 +615,7 @@ type Styles struct {
 		Base               lipgloss.Style // Base pill style with padding
 		Focused            lipgloss.Style // Pill with visible rounded border
 		QueueItemPrefix    lipgloss.Style // Prefix for queue list items
+		CronItemPrefix     lipgloss.Style // Prefix for scheduled-task list items
 		QueueItemText      lipgloss.Style // Queue list item body text
 		QueueLabel         lipgloss.Style // "N Queued" label text
 		QueueIconBase      lipgloss.Style // Base style for queue gradient triangles


### PR DESCRIPTION
## Problem

With both **To-Dos** and **Scheduled** pills showing, `ctrl+t` only expanded the to-do list — the scheduled tasks stayed hidden.

The pills panel rendered exactly one section's list at a time: a stored `focusedPillSection` picked a winner (to-dos first) and `renderPills` used an `if/else if` chain. The `←/→` section switcher that made the other sections reachable was undiscoverable, and its help hint was only appended for the to-dos+queue combination — never for scheduled tasks, so with to-dos + cron there was no visible way to reach the second list at all.

## Change

Expanding now shows **every** section that has content, stacked in the same order as the pills advertise them:

```
╭───────────╮╭─────────────╮╭────────────────╮
│ To-Do 1/3 ││ ▶▶ 2 Queued ││ ⏰ 1 Scheduled │ ctrl+t close
╰───────────╯╰─────────────╯╰────────────────╯
✓ Rebase + merge config series
‖ Rebasing TUI bug series
• Update docs PR #54
  • look at the renovate PRs
  • then summarize
  ⏰ a1b2c3d4 09:34 ↻ — nightly sweep
```

- `renderPills` builds one list per populated section and joins them; `pillsAreaHeight` sums all expanded sections so nothing is clipped.
- Removed the now-vestigial focus machinery: `pillSection`, `focusedPillSection`, `switchPillSection`, `effectiveFocusedSection`, the `PillLeft`/`PillRight` bindings and their help entries.
- Scheduled tasks get a `⏰` prefix (`Pills.CronItemPrefix`) so they don't blend into the queued-prompt list directly above them.
- The command-palette toggle ignored cron entirely — a session with only scheduled tasks had no entry despite `ctrl+t` working. It's now plumbed through `NewCommands` and the label names each present section ("Toggle To-Dos/Queue/Scheduled").

## Trade-off

The expanded panel is taller when several sections have content. The layout already clamps it to the main pane and auto-expand still requires a 40-row terminal, so it's bounded — but a manual toggle with many to-dos leaves less room for chat than before. Happy to add a height cap with per-section truncation if that's preferred.

## Verification

- New `TestExpandedPillsShowEverySection` — with to-dos, queued prompts and scheduled tasks all present, all three lists render.
- New `TestPillsAreaHeightSumsExpandedSections` — reserved height is `pill + todos + queue + cron`.
- Reworked `TestQueuePillAlwaysHasBorder` (CHARM-1678 guard) without the focus dimension; dropped `TestEffectiveFocusedSectionFallsThrough` along with the function it covered.
- `go test ./...` green, `golangci-lint run` reports 0 issues.

🤖 Posted on behalf of `@joestump` by [`claude-opus-5`](https://openrouter.ai/anthropic/claude-opus-5) using [Claude Code](https://claude.ai).