### PR TITLE
feat(mcp): advertise capabilities.a2ui at MCP initialize

### DIFF
--- a/internal/agent/channelreply.go
+++ b/internal/agent/channelreply.go
@@ -148,6 +148,9 @@ func (a *sessionAgent) sendChannelReply(ctx context.Context, call SessionAgentCa
 	// racing this send must not lose the reply.
 	sendCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), channelReplyTimeout)
 	defer cancel()
+	// A channel reply goes back out over the channel, not to a chat UI, so
+	// crush cannot render a surface for it and must not claim it can.
+	sendCtx = mcp.WithA2UICapable(sendCtx, false)
 	if _, err := mcp.RunTool(sendCtx, a.cfg, call.Channel, tool, string(input)); err != nil {
 		slog.Error("Channel reply failed", "channel", call.Channel, "tool", tool, "error", err)
 		return

--- a/internal/agent/tools/mcp-tools.go
+++ b/internal/agent/tools/mcp-tools.go
@@ -129,20 +129,26 @@ func (m *Tool) Run(ctx context.Context, params fantasy.ToolCall) (fantasy.ToolRe
 		}
 	}
 
-	result, err := mcp.RunTool(ctx, m.cfg, m.mcpName, m.tool.Name, params.Input)
-	if err != nil {
-		return fantasy.NewTextErrorResponse(err.Error()), nil
-	}
-
 	// Divert A2UI surface payloads to UI-only metadata only when a chat UI
 	// will actually render them: on channel-originated turns the reply
 	// travels back over the channel and the model needs the payload to
 	// relay it, disable_a2ui deployments opted out of surfaces entirely,
 	// and a zero content width means no interactive UI tagged this turn.
 	// Mirrors the diversion rule in read_mcp_resource.go.
+	//
+	// Computed BEFORE the call so the same answer gates the A2UI capability
+	// crush claims in the call's _meta. Advertising a2ui on a turn that will
+	// not divert invites a surface payload we then fold into model-facing
+	// content as raw JSON.
 	divert := GetChannelFromContext(ctx) == "" &&
 		!m.cfg.Config().Options.DisableA2UI &&
 		GetContentWidthFromContext(ctx) > 0
+
+	result, err := mcp.RunTool(mcp.WithA2UICapable(ctx, divert), m.cfg, m.mcpName, m.tool.Name, params.Input)
+	if err != nil {
+		return fantasy.NewTextErrorResponse(err.Error()), nil
+	}
+
 	content, metadata := splitMCPToolResult(result, m.mcpName, divert)
 
 	switch result.Type {

--- a/internal/agent/tools/mcp/a2ui.go
+++ b/internal/agent/tools/mcp/a2ui.go
@@ -6,6 +6,8 @@ import (
 	"log/slog"
 	"strings"
 
+	"github.com/charmbracelet/crush/internal/config"
+
 	"github.com/modelcontextprotocol/go-sdk/jsonrpc"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	a2ui "github.com/tmc/a2ui"
@@ -19,6 +21,26 @@ import (
 var A2UIBasicCatalogID = "https://a2ui.org/specification/" +
 	strings.ReplaceAll(a2ui.Version, ".", "_") +
 	"/catalogs/basic/catalog.json"
+
+// a2uiDisabled reports whether this host has opted out of rendering A2UI
+// surfaces, and is the only way this package should read that option.
+//
+// Config.Options is a pointer and the config may not be loaded at all on
+// every path that opens a session — the OAuth re-auth flow reaches
+// createSession through BeginAuth, and a store built for a test carries a
+// Config with no Options at all. A bare cfg.Config().Options.DisableA2UI
+// panics on both. Absent configuration means "not disabled", matching the
+// zero value the option has once a config is loaded.
+func a2uiDisabled(cfg *config.ConfigStore) bool {
+	if cfg == nil {
+		return false
+	}
+	c := cfg.Config()
+	if c == nil || c.Options == nil {
+		return false
+	}
+	return c.Options.DisableA2UI
+}
 
 // a2uiClientCapabilities builds the A2UI capability payload a client
 // declares to an A2UI-over-MCP server, per the spec's capability negotiation:

--- a/internal/agent/tools/mcp/a2ui.go
+++ b/internal/agent/tools/mcp/a2ui.go
@@ -3,6 +3,8 @@ package mcp
 import (
 	"context"
 	"encoding/json"
+	"log/slog"
+	"strings"
 
 	"github.com/modelcontextprotocol/go-sdk/jsonrpc"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -10,10 +12,13 @@ import (
 )
 
 // A2UIBasicCatalogID is the catalog the client advertises support for when
-// negotiating A2UI over MCP. It matches the embedded basic catalog for the
-// a2ui version crush compiles in (tmc/a2ui's a2uischema/schemas), so the
-// advertised ID and the rendered catalog never drift apart.
-const A2UIBasicCatalogID = "https://a2ui.org/specification/v0_9/catalogs/basic/catalog.json"
+// negotiating A2UI over MCP. The version segment is derived from a2ui.Version
+// rather than hardcoded, so bumping the a2ui dependency cannot leave crush
+// advertising a v0_9 catalog under a newer version key.
+// TestA2UIBasicCatalogIDTracksVersion pins the relationship.
+var A2UIBasicCatalogID = "https://a2ui.org/specification/" +
+	strings.ReplaceAll(a2ui.Version, ".", "_") +
+	"/catalogs/basic/catalog.json"
 
 // a2uiClientCapabilities builds the A2UI capability payload a client
 // declares to an A2UI-over-MCP server, per the spec's capability negotiation:
@@ -24,12 +29,17 @@ const A2UIBasicCatalogID = "https://a2ui.org/specification/v0_9/catalogs/basic/c
 // prompt uses), and the catalog list holds the compiled-in basic catalog, so
 // this payload, the prompt, and the renderer share one source of truth.
 func a2uiClientCapabilities() map[string]any {
+	return map[string]any{"a2ui": a2uiCapabilityPayload()}
+}
+
+// a2uiCapabilityPayload is the capability body itself, without the "a2ui"
+// wrapper key — the form the go-sdk's Extensions map wants, since the key
+// there is the extension ID.
+func a2uiCapabilityPayload() map[string]any {
 	return map[string]any{
-		"a2ui": map[string]any{
-			"clientCapabilities": map[string]any{
-				a2ui.Version: map[string]any{
-					"supportedCatalogIds": []string{A2UIBasicCatalogID},
-				},
+		"clientCapabilities": map[string]any{
+			a2ui.Version: map[string]any{
+				"supportedCatalogIds": []string{A2UIBasicCatalogID},
 			},
 		},
 	}
@@ -37,19 +47,81 @@ func a2uiClientCapabilities() map[string]any {
 
 // a2uiMetaCapabilities returns the A2UI capability payload for the `_meta`
 // field of an individual tools/call, the variant stateless servers expect
-// when they cannot carry initialize-time state. The shape is the same as the
-// initialize capability, hoisted under a single "a2ui" key.
+// when they cannot carry initialize-time state. It is byte-identical to the
+// initialize capability — same key, same shape — so the two can never drift.
 func a2uiMetaCapabilities() map[string]any {
 	return a2uiClientCapabilities()
 }
 
+// a2uiCapableKey marks a turn as one whose results crush will actually render
+// as surfaces. The initialize handshake is a session-level statement ("this
+// client CAN render A2UI"); this is the per-turn one ("this call will"). They
+// differ because a single session serves both chat turns and headless or
+// channel-originated turns, and only the former renders.
+type a2uiCapableKey struct{}
+
+// WithA2UICapable records whether the current turn will render A2UI surfaces.
+// Callers that drive a real chat UI leave it unset (the default is capable);
+// headless and channel-originated turns must set it false so crush does not
+// claim a capability it will not honor and get a surface it cannot draw.
+func WithA2UICapable(ctx context.Context, capable bool) context.Context {
+	return context.WithValue(ctx, a2uiCapableKey{}, capable)
+}
+
+// a2uiCapable reports whether this turn renders A2UI. Unset means capable, so
+// direct UI-initiated calls (the a2ui_action round-trip) keep working.
+func a2uiCapable(ctx context.Context) bool {
+	capable, ok := ctx.Value(a2uiCapableKey{}).(bool)
+	return !ok || capable
+}
+
+// a2uiRequestMeta returns the `_meta` an outgoing request should carry, or
+// nil when crush must not claim A2UI for it. Every RPC that can return a
+// surface goes through here — tools/call and resources/read alike — so a
+// stateless server keying off the per-request capability cannot see crush
+// claim A2UI on one RPC and stay silent on the other.
+func a2uiRequestMeta(ctx context.Context, disableA2UI bool) mcp.Meta {
+	if disableA2UI || !a2uiCapable(ctx) {
+		return nil
+	}
+	return mcp.Meta(a2uiMetaCapabilities())
+}
+
+// A2UIExtensionID is the extensions key carrying the A2UI capability, in the
+// go-sdk's required "{vendor-prefix}/{extension-name}" form.
+const A2UIExtensionID = "a2ui.org/a2ui"
+
+// a2uiSDKCapabilities returns the typed client capabilities to hand the SDK,
+// or nil when A2UI is disabled.
+//
+// This is deliberately belt-and-braces with the wire-level injection below.
+// The spec puts A2UI at a top-level "capabilities.a2ui" key, but the go-sdk
+// deserializes a peer's capabilities into a typed ClientCapabilities struct
+// that has no such field and no catch-all — so a go-sdk SERVER silently drops
+// the top-level key and never sees the claim. Extensions is the SDK's
+// sanctioned slot for exactly this and survives the round-trip intact.
+// Sending both means spec-conformant servers read the top-level key and
+// go-sdk servers read the extension; neither path alone reaches everyone.
+func a2uiSDKCapabilities(disableA2UI bool) *mcp.ClientCapabilities {
+	if disableA2UI {
+		return nil
+	}
+	caps := &mcp.ClientCapabilities{}
+	caps.AddExtension(A2UIExtensionID, a2uiCapabilityPayload())
+	return caps
+}
+
 // a2uiInitTransport wraps an mcp.Transport so the connection it yields
-// injects the A2UI client capability into the outgoing initialize request.
-// The go-sdk's typed ClientCapabilities has no slot for the spec's top-level
-// "a2ui" capabilities key (its Experimental/Extensions maps nest under their
-// own keys, which well-behaved servers do not read), so the capability is
-// merged into the serialized initialize params at the connection layer — the
-// same seam the channel transport uses to intercept the stream.
+// injects the A2UI client capability into the outgoing initialize request at
+// the spec's top-level "capabilities.a2ui" key. The go-sdk's typed
+// ClientCapabilities has no slot for that key, so it is merged into the
+// serialized params at the connection layer — the same seam the channel
+// transport uses to intercept the stream.
+//
+// This covers spec-conformant servers that read the raw capabilities object.
+// It does NOT reach a go-sdk server, which unmarshals into the typed struct
+// and drops the unknown key; a2uiSDKCapabilities carries the same payload in
+// Extensions for those. Both are sent, on purpose.
 type a2uiInitTransport struct {
 	inner mcp.Transport
 }
@@ -94,10 +166,12 @@ func (c *a2uiInitConn) Write(ctx context.Context, msg jsonrpc.Message) error {
 // "a2ui" key is respected, never overwritten.
 func injectA2UICapability(raw json.RawMessage) json.RawMessage {
 	if len(raw) == 0 {
+		slog.Warn("A2UI capability not advertised: initialize params were empty")
 		return nil
 	}
 	var params map[string]any
 	if err := json.Unmarshal(raw, &params); err != nil || params == nil {
+		slog.Warn("A2UI capability not advertised: initialize params did not decode as an object", "error", err)
 		return nil
 	}
 	caps, ok := params["capabilities"].(map[string]any)
@@ -105,6 +179,7 @@ func injectA2UICapability(raw json.RawMessage) json.RawMessage {
 		caps = map[string]any{}
 	}
 	if _, present := caps["a2ui"]; present {
+		// Already advertised by something upstream; leave it alone.
 		return nil
 	}
 	for k, v := range a2uiClientCapabilities() {
@@ -113,7 +188,12 @@ func injectA2UICapability(raw json.RawMessage) json.RawMessage {
 	params["capabilities"] = caps
 	out, err := json.Marshal(params)
 	if err != nil {
+		slog.Warn("A2UI capability not advertised: re-encoding initialize params failed", "error", err)
 		return nil
 	}
 	return out
 }
+
+// unwrapTransport implements [transportWrapper], so wrapping the transport
+// for A2UI never hides the stdio startup diagnostics maybeStdioErr digs out.
+func (t *a2uiInitTransport) unwrapTransport() mcp.Transport { return t.inner }

--- a/internal/agent/tools/mcp/a2ui.go
+++ b/internal/agent/tools/mcp/a2ui.go
@@ -1,0 +1,119 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/modelcontextprotocol/go-sdk/jsonrpc"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	a2ui "github.com/tmc/a2ui"
+)
+
+// A2UIBasicCatalogID is the catalog the client advertises support for when
+// negotiating A2UI over MCP. It matches the embedded basic catalog for the
+// a2ui version crush compiles in (tmc/a2ui's a2uischema/schemas), so the
+// advertised ID and the rendered catalog never drift apart.
+const A2UIBasicCatalogID = "https://a2ui.org/specification/v0_9/catalogs/basic/catalog.json"
+
+// a2uiClientCapabilities builds the A2UI capability payload a client
+// declares to an A2UI-over-MCP server, per the spec's capability negotiation:
+//
+//	"a2ui": {"clientCapabilities": {"v0.9": {"supportedCatalogIds": [...]}}}
+//
+// The version key comes from a2ui.Version (the same constant the coder
+// prompt uses), and the catalog list holds the compiled-in basic catalog, so
+// this payload, the prompt, and the renderer share one source of truth.
+func a2uiClientCapabilities() map[string]any {
+	return map[string]any{
+		"a2ui": map[string]any{
+			"clientCapabilities": map[string]any{
+				a2ui.Version: map[string]any{
+					"supportedCatalogIds": []string{A2UIBasicCatalogID},
+				},
+			},
+		},
+	}
+}
+
+// a2uiMetaCapabilities returns the A2UI capability payload for the `_meta`
+// field of an individual tools/call, the variant stateless servers expect
+// when they cannot carry initialize-time state. The shape is the same as the
+// initialize capability, hoisted under a single "a2ui" key.
+func a2uiMetaCapabilities() map[string]any {
+	return a2uiClientCapabilities()
+}
+
+// a2uiInitTransport wraps an mcp.Transport so the connection it yields
+// injects the A2UI client capability into the outgoing initialize request.
+// The go-sdk's typed ClientCapabilities has no slot for the spec's top-level
+// "a2ui" capabilities key (its Experimental/Extensions maps nest under their
+// own keys, which well-behaved servers do not read), so the capability is
+// merged into the serialized initialize params at the connection layer — the
+// same seam the channel transport uses to intercept the stream.
+type a2uiInitTransport struct {
+	inner mcp.Transport
+}
+
+// Connect implements mcp.Transport.
+func (t *a2uiInitTransport) Connect(ctx context.Context) (mcp.Connection, error) {
+	conn, err := t.inner.Connect(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &a2uiInitConn{Connection: conn}, nil
+}
+
+// a2uiInitConn injects the A2UI capability into the initialize request's
+// params before they go on the wire.
+type a2uiInitConn struct {
+	mcp.Connection
+}
+
+// initializeMethod is the JSON-RPC method carrying the client's capabilities.
+const initializeMethod = "initialize"
+
+// Write intercepts the initialize request and merges the A2UI capability
+// into its params.capabilities before it goes on the wire. Any other message
+// passes through untouched; a params payload that does not decode as an
+// object is left alone rather than failing the handshake.
+func (c *a2uiInitConn) Write(ctx context.Context, msg jsonrpc.Message) error {
+	req, ok := msg.(*jsonrpc.Request)
+	if !ok || req.Method != initializeMethod {
+		return c.Connection.Write(ctx, msg)
+	}
+	params := injectA2UICapability(req.Params)
+	if params != nil {
+		req.Params = params
+	}
+	return c.Connection.Write(ctx, msg)
+}
+
+// injectA2UICapability merges the A2UI capability into an initialize
+// request's params JSON, returning the rewritten params or nil when no
+// rewrite was possible (params absent or not an object). A pre-existing
+// "a2ui" key is respected, never overwritten.
+func injectA2UICapability(raw json.RawMessage) json.RawMessage {
+	if len(raw) == 0 {
+		return nil
+	}
+	var params map[string]any
+	if err := json.Unmarshal(raw, &params); err != nil || params == nil {
+		return nil
+	}
+	caps, ok := params["capabilities"].(map[string]any)
+	if !ok {
+		caps = map[string]any{}
+	}
+	if _, present := caps["a2ui"]; present {
+		return nil
+	}
+	for k, v := range a2uiClientCapabilities() {
+		caps[k] = v
+	}
+	params["capabilities"] = caps
+	out, err := json.Marshal(params)
+	if err != nil {
+		return nil
+	}
+	return out
+}

--- a/internal/agent/tools/mcp/a2ui_test.go
+++ b/internal/agent/tools/mcp/a2ui_test.go
@@ -1,0 +1,139 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/jsonrpc"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/require"
+)
+
+// a2uiFakeConn records written messages instead of sending them anywhere, so a
+// test can drive a2uiInitConn.Write directly and inspect what would go on
+// the wire.
+type a2uiFakeConn struct {
+	mcp.Connection
+	written []*jsonrpc.Request
+}
+
+func (c *a2uiFakeConn) Write(_ context.Context, msg jsonrpc.Message) error {
+	if req, ok := msg.(*jsonrpc.Request); ok {
+		c.written = append(c.written, req)
+	}
+	return nil
+}
+
+// TestA2UIInitConnRewritesInitialize drives the injection against a
+// representative initialize request and asserts the advertised capability
+// shape — top-level a2ui key, version namespaced, compiled-in catalog — while
+// leaving the rest of the params (roots, clientInfo) intact.
+func TestA2UIInitConnRewritesInitialize(t *testing.T) {
+	t.Parallel()
+
+	fc := &a2uiFakeConn{}
+	conn := &a2uiInitConn{Connection: fc}
+
+	initParams, err := json.Marshal(map[string]any{
+		"protocolVersion": "2025-11-25",
+		"capabilities":    map[string]any{"roots": map[string]any{"listChanged": true}},
+		"clientInfo":      map[string]any{"name": "crush", "version": "1.0.0"},
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, conn.Write(context.Background(), &jsonrpc.Request{
+		Method: "initialize",
+		Params: initParams,
+	}))
+	require.Len(t, fc.written, 1)
+
+	var params map[string]any
+	require.NoError(t, json.Unmarshal(fc.written[0].Params, &params))
+
+	caps, ok := params["capabilities"].(map[string]any)
+	require.True(t, ok, "initialize must carry a capabilities object")
+
+	// The A2UI capability is a top-level key, per the spec's negotiation.
+	a2uiCap, ok := caps["a2ui"].(map[string]any)
+	require.True(t, ok, "capabilities must carry a top-level a2ui key, got: %v", caps)
+	clientCaps, ok := a2uiCap["clientCapabilities"].(map[string]any)
+	require.True(t, ok, "a2ui must carry clientCapabilities")
+	v09, ok := clientCaps["v0.9"].(map[string]any)
+	require.True(t, ok, "clientCapabilities must carry the a2ui version key")
+	ids, ok := v09["supportedCatalogIds"].([]any)
+	require.True(t, ok, "v0.9 must carry supportedCatalogIds")
+	require.Len(t, ids, 1)
+	require.Equal(t, A2UIBasicCatalogID, ids[0])
+
+	// Existing capabilities and the rest of the handshake are preserved.
+	roots, ok := caps["roots"].(map[string]any)
+	require.True(t, ok, "roots must survive the merge")
+	require.Equal(t, true, roots["listChanged"])
+	require.Equal(t, "2025-11-25", params["protocolVersion"])
+}
+
+// TestA2UIInitConnPassesOtherMethods confirms non-initialize writes are not
+// rewritten.
+func TestA2UIInitConnPassesOtherMethods(t *testing.T) {
+	t.Parallel()
+
+	fc := &a2uiFakeConn{}
+	conn := &a2uiInitConn{Connection: fc}
+	require.NoError(t, conn.Write(context.Background(), &jsonrpc.Request{
+		Method: "notifications/initialized",
+		Params: json.RawMessage(`{}`),
+	}))
+	require.Len(t, fc.written, 1)
+	require.JSONEq(t, `{}`, string(fc.written[0].Params))
+}
+
+func TestInjectA2UICapability(t *testing.T) {
+	t.Parallel()
+
+	t.Run("merges into an empty capabilities object", func(t *testing.T) {
+		t.Parallel()
+		raw := json.RawMessage(`{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"x"}}`)
+		out := injectA2UICapability(raw)
+		require.NotNil(t, out)
+		var params map[string]any
+		require.NoError(t, json.Unmarshal(out, &params))
+		caps := params["capabilities"].(map[string]any)
+		require.Contains(t, caps, "a2ui")
+	})
+
+	t.Run("creates capabilities when absent", func(t *testing.T) {
+		t.Parallel()
+		raw := json.RawMessage(`{"protocolVersion":"2025-11-25"}`)
+		out := injectA2UICapability(raw)
+		require.NotNil(t, out)
+		var params map[string]any
+		require.NoError(t, json.Unmarshal(out, &params))
+		caps := params["capabilities"].(map[string]any)
+		require.Contains(t, caps, "a2ui")
+	})
+
+	t.Run("respects a pre-existing a2ui key", func(t *testing.T) {
+		t.Parallel()
+		raw := json.RawMessage(`{"capabilities":{"a2ui":{"custom":true}}}`)
+		require.Nil(t, injectA2UICapability(raw), "an explicit a2ui capability is never overwritten")
+	})
+
+	t.Run("leaves non-object params alone", func(t *testing.T) {
+		t.Parallel()
+		require.Nil(t, injectA2UICapability(json.RawMessage(`null`)))
+		require.Nil(t, injectA2UICapability(json.RawMessage(`"string"`)))
+		require.Nil(t, injectA2UICapability(nil))
+	})
+}
+
+func TestA2UIMetaCapabilitiesShape(t *testing.T) {
+	t.Parallel()
+
+	meta := a2uiMetaCapabilities()
+	a2uiCap, ok := meta["a2ui"].(map[string]any)
+	require.True(t, ok)
+	clientCaps, ok := a2uiCap["clientCapabilities"].(map[string]any)
+	require.True(t, ok)
+	require.Contains(t, clientCaps, "v0.9")
+}

--- a/internal/agent/tools/mcp/a2ui_test.go
+++ b/internal/agent/tools/mcp/a2ui_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/charmbracelet/crush/internal/config"
 	"github.com/modelcontextprotocol/go-sdk/jsonrpc"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/require"
@@ -238,4 +239,28 @@ func TestA2UIBasicCatalogIDTracksVersion(t *testing.T) {
 	slug := strings.ReplaceAll(a2ui.Version, ".", "_")
 	require.Contains(t, A2UIBasicCatalogID, "/"+slug+"/",
 		"catalog ID must carry the compiled-in a2ui version %q", a2ui.Version)
+}
+
+// TestA2UIDisabledToleratesAbsentOptions pins that reading the A2UI opt-out
+// never panics on a partially-populated config.
+//
+// Config.Options is a pointer, and createSession is reached from the OAuth
+// re-auth flow (BeginAuth -> runAuthFlow -> connectAndRegister) with whatever
+// store the caller held. A bare cfg.Config().Options.DisableA2UI crashed
+// TestBeginAuth_Concurrent outright, taking the process down with it rather
+// than failing one test.
+func TestA2UIDisabledToleratesAbsentOptions(t *testing.T) {
+	t.Parallel()
+
+	require.False(t, a2uiDisabled(nil), "a nil store must read as not-disabled")
+	require.False(t, a2uiDisabled(config.NewTestStore(nil)),
+		"a store with no config must read as not-disabled")
+	require.False(t, a2uiDisabled(config.NewTestStore(&config.Config{})),
+		"a config with no Options must read as not-disabled")
+	require.False(t, a2uiDisabled(config.NewTestStore(&config.Config{
+		Options: &config.Options{},
+	})), "an explicit zero Options means A2UI stays enabled")
+	require.True(t, a2uiDisabled(config.NewTestStore(&config.Config{
+		Options: &config.Options{DisableA2UI: true},
+	})), "the opt-out must still be honored")
 }

--- a/internal/agent/tools/mcp/a2ui_test.go
+++ b/internal/agent/tools/mcp/a2ui_test.go
@@ -3,11 +3,14 @@ package mcp
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/jsonrpc"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/require"
+	a2ui "github.com/tmc/a2ui"
 )
 
 // a2uiFakeConn records written messages instead of sending them anywhere, so a
@@ -136,4 +139,103 @@ func TestA2UIMetaCapabilitiesShape(t *testing.T) {
 	clientCaps, ok := a2uiCap["clientCapabilities"].(map[string]any)
 	require.True(t, ok)
 	require.Contains(t, clientCaps, "v0.9")
+}
+
+// TestA2UIHandshakeReachesRealServer drives a real client/server initialize
+// over the SDK's in-memory transport, wrapped the way createSession wraps it,
+// and asserts what the SERVER actually observes — not what crush wrote.
+//
+// This is the gap the unit tests above cannot cover: they hand-build params
+// and call Write directly, so they pass even when the capability never
+// survives to the peer. It does not survive at the spec's top-level key,
+// because the go-sdk unmarshals capabilities into a typed struct with no such
+// field and no catch-all, which is exactly why the Extensions payload exists.
+func TestA2UIHandshakeReachesRealServer(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	t.Cleanup(cancel)
+
+	clientTransport, serverTransport := mcp.NewInMemoryTransports()
+	srv := mcp.NewServer(&mcp.Implementation{Name: "probe", Version: "1"}, nil)
+	go func() { _, _ = srv.Connect(ctx, serverTransport, nil) }()
+
+	client := mcp.NewClient(
+		&mcp.Implementation{Name: "crush", Version: "1"},
+		&mcp.ClientOptions{Capabilities: a2uiSDKCapabilities(false)},
+	)
+	sess, err := client.Connect(ctx, &a2uiInitTransport{inner: clientTransport}, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sess.Close() })
+
+	var seen int
+	for ss := range srv.Sessions() {
+		seen++
+		params := ss.InitializeParams()
+		require.NotNil(t, params.Capabilities, "server must see client capabilities")
+		ext, ok := params.Capabilities.Extensions[A2UIExtensionID]
+		require.True(t, ok,
+			"server must observe the A2UI capability under %q; extensions=%v",
+			A2UIExtensionID, params.Capabilities.Extensions)
+
+		// The payload survives intact, version key and catalog included.
+		raw, err := json.Marshal(ext)
+		require.NoError(t, err)
+		var payload map[string]any
+		require.NoError(t, json.Unmarshal(raw, &payload))
+		clientCaps, ok := payload["clientCapabilities"].(map[string]any)
+		require.True(t, ok, "extension payload must carry clientCapabilities, got %v", payload)
+		_, ok = clientCaps[a2ui.Version]
+		require.True(t, ok, "clientCapabilities must be keyed by %q, got %v", a2ui.Version, clientCaps)
+	}
+	require.Equal(t, 1, seen, "expected exactly one server session")
+}
+
+// TestA2UISDKCapabilitiesDisabled pins the opt-out: a deployment that set
+// disable_a2ui must not advertise the capability at all.
+func TestA2UISDKCapabilitiesDisabled(t *testing.T) {
+	t.Parallel()
+	require.Nil(t, a2uiSDKCapabilities(true))
+}
+
+// TestA2UIRequestMetaGates pins both halves of the per-request claim: the
+// deployment opt-out (disable_a2ui) and the per-turn render check. Before
+// these gates existed, a headless `crush run` advertised a2ui and got back a
+// surface payload it folded into model-facing content as raw JSON.
+func TestA2UIRequestMetaGates(t *testing.T) {
+	t.Parallel()
+
+	const enabled, disabled = false, true
+
+	t.Run("enabled and capable claims a2ui", func(t *testing.T) {
+		t.Parallel()
+		meta := a2uiRequestMeta(context.Background(), enabled)
+		require.NotNil(t, meta)
+		require.Contains(t, map[string]any(meta), "a2ui")
+	})
+	t.Run("disable_a2ui suppresses the claim", func(t *testing.T) {
+		t.Parallel()
+		require.Nil(t, a2uiRequestMeta(context.Background(), disabled))
+	})
+	t.Run("a turn that will not render suppresses the claim", func(t *testing.T) {
+		t.Parallel()
+		ctx := WithA2UICapable(context.Background(), false)
+		require.Nil(t, a2uiRequestMeta(ctx, enabled),
+			"headless and channel turns must not claim a capability crush will not honor")
+	})
+	t.Run("explicitly capable claims a2ui", func(t *testing.T) {
+		t.Parallel()
+		ctx := WithA2UICapable(context.Background(), true)
+		require.NotNil(t, a2uiRequestMeta(ctx, enabled))
+	})
+}
+
+// TestA2UIBasicCatalogIDTracksVersion pins the catalog ID to the compiled-in
+// a2ui version. A dependency bump that moves a2ui.Version must move the
+// advertised catalog with it, or crush advertises a stale catalog under a
+// newer version key and a server negotiates against components it will not
+// receive.
+func TestA2UIBasicCatalogIDTracksVersion(t *testing.T) {
+	t.Parallel()
+	slug := strings.ReplaceAll(a2ui.Version, ".", "_")
+	require.Contains(t, A2UIBasicCatalogID, "/"+slug+"/",
+		"catalog ID must carry the compiled-in a2ui version %q", a2ui.Version)
 }

--- a/internal/agent/tools/mcp/channel.go
+++ b/internal/agent/tools/mcp/channel.go
@@ -345,3 +345,6 @@ func (c *channelConn) Read(ctx context.Context) (jsonrpc.Message, error) {
 		}
 	}
 }
+
+// unwrapTransport implements [transportWrapper].
+func (t *channelTransport) unwrapTransport() mcp.Transport { return t.inner }

--- a/internal/agent/tools/mcp/init.go
+++ b/internal/agent/tools/mcp/init.go
@@ -997,7 +997,7 @@ func createSession(ctx context.Context, cfg *config.ConfigStore, name string, m 
 	// Advertise A2UI support in the initialize handshake so an A2UI-over-MCP
 	// server knows it can send surfaces. A host that won't render A2UI must
 	// not claim the capability.
-	if !cfg.Config().Options.DisableA2UI {
+	if !a2uiDisabled(cfg) {
 		transport = &a2uiInitTransport{inner: transport}
 	}
 
@@ -1030,7 +1030,7 @@ func createSession(ctx context.Context, cfg *config.ConfigStore, name string, m 
 				level := parseLevel(string(req.Params.Level))
 				slog.Log(ctx, level, "MCP log", "name", name, "logger", req.Params.Logger, "data", req.Params.Data)
 			},
-			Capabilities: a2uiSDKCapabilities(cfg.Config().Options.DisableA2UI),
+			Capabilities: a2uiSDKCapabilities(a2uiDisabled(cfg)),
 		},
 	)
 

--- a/internal/agent/tools/mcp/init.go
+++ b/internal/agent/tools/mcp/init.go
@@ -1030,6 +1030,7 @@ func createSession(ctx context.Context, cfg *config.ConfigStore, name string, m 
 				level := parseLevel(string(req.Params.Level))
 				slog.Log(ctx, level, "MCP log", "name", name, "logger", req.Params.Logger, "data", req.Params.Data)
 			},
+			Capabilities: a2uiSDKCapabilities(cfg.Config().Options.DisableA2UI),
 		},
 	)
 
@@ -1077,16 +1078,40 @@ func createSession(ctx context.Context, cfg *config.ConfigStore, name string, m 
 // error.
 // this happens particularly when starting things with npx, e.g. if node can't
 // be found or some other error like that.
+// transportWrapper is implemented by every transport decorator crush layers
+// around the real transport, so diagnostics that need the underlying
+// transport (see maybeStdioErr) can reach it regardless of wrapping order.
+type transportWrapper interface {
+	unwrapTransport() mcp.Transport
+}
+
+// unwrapTransport peels every crush-owned decorator off a transport and
+// returns the innermost one.
+func unwrapTransport(transport mcp.Transport) mcp.Transport {
+	for {
+		w, ok := transport.(transportWrapper)
+		if !ok {
+			return transport
+		}
+		inner := w.unwrapTransport()
+		if inner == nil {
+			return transport
+		}
+		transport = inner
+	}
+}
+
 func maybeStdioErr(err error, transport mcp.Transport) error {
 	if !errors.Is(err, io.EOF) {
 		return err
 	}
-	// Unwrap a channelTransport to reach the stdio command it wraps: a channel
-	// stdio server surfaces its child's stderr diagnostics through the inner
-	// CommandTransport, not through the channel wrapper's own type.
-	if cw, ok := transport.(*channelTransport); ok {
-		transport = cw.inner
-	}
+	// Transports are wrapped in one or more decorators before Connect (the
+	// channel gate, the A2UI capability injector); the stdio transport we're
+	// probing for is the innermost one. Unwrap all of them — without this the
+	// assertion below never matches and stdio startup failures report a bare
+	// EOF instead of the child's actual output. Every wrapper must implement
+	// unwrapTransport or it will hide this diagnostic again.
+	transport = unwrapTransport(transport)
 	ct, ok := transport.(*mcp.CommandTransport)
 	if !ok {
 		return err

--- a/internal/agent/tools/mcp/init.go
+++ b/internal/agent/tools/mcp/init.go
@@ -994,6 +994,13 @@ func createSession(ctx context.Context, cfg *config.ConfigStore, name string, m 
 	channelGate := newChannelGate()
 	transport = &channelTransport{inner: transport, name: name, gate: channelGate}
 
+	// Advertise A2UI support in the initialize handshake so an A2UI-over-MCP
+	// server knows it can send surfaces. A host that won't render A2UI must
+	// not claim the capability.
+	if !cfg.Config().Options.DisableA2UI {
+		transport = &a2uiInitTransport{inner: transport}
+	}
+
 	client := mcp.NewClient(
 		&mcp.Implementation{
 			Name:    "crush",

--- a/internal/agent/tools/mcp/lifecycle_test.go
+++ b/internal/agent/tools/mcp/lifecycle_test.go
@@ -416,11 +416,56 @@ func TestMaybeStdioErr_UnwrapsChannelTransport(t *testing.T) {
 		"the re-executed child's stderr must surface in the error")
 }
 
-// TestUpdateState_ErrorClearsResources pins that StateError teardown clears the
-// resources and resource-template registries alongside tools and prompts — a
-// dead server must not keep advertising resources (or templates) it can no
-// longer serve. Both entry shapes are covered: the registered session itself
-// erroring, and an error with no session at all (connect failed).
+// TestMaybeStdioErr_UnwrapsEveryWrapper pins the diagnostics fix against the
+// ACTUAL wrapper stack createSession builds, not a hand-rolled single layer.
+// A new decorator added on top (the A2UI capability injector was the first)
+// must not hide the child's stderr behind a bare EOF — which is exactly what
+// happened when a2uiInitTransport was layered outside channelTransport and
+// the old single-level unwrap stopped matching.
+func TestMaybeStdioErr_UnwrapsEveryWrapper(t *testing.T) {
+	cmd := exec.CommandContext(t.Context(), "sh", "-c", "echo boom-diagnostic >&2; exit 3")
+	var transport mcp.Transport = &mcp.CommandTransport{Command: cmd}
+	// Same order as createSession: channel gate first, then A2UI.
+	transport = &channelTransport{inner: transport, name: "t", gate: newChannelGate()}
+	transport = &a2uiInitTransport{inner: transport}
+
+	got := maybeStdioErr(io.EOF, transport)
+	require.ErrorContains(t, got, "boom-diagnostic",
+		"stdio diagnostics must survive every transport decorator")
+}
+
+// TestNameLock_ConcurrentFirstUseReturnsOneMutex pins that the per-name
+// lifecycle lock is minted atomically: racing first-use callers must all
+// receive the same mutex, or the serialization the whole lifecycle relies
+// on silently degrades to per-caller locks.
+func TestNameLock_ConcurrentFirstUseReturnsOneMutex(t *testing.T) {
+	const name = "test-name-lock-race"
+	t.Cleanup(func() { delete(renewMus, name) })
+
+	const n = 32
+	locks := make([]*sync.Mutex, n)
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	for i := range n {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			locks[i] = renewLock(name)
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	for i := 1; i < n; i++ {
+		require.Same(t, locks[0], locks[i], "all callers must share one lifecycle mutex")
+	}
+}
+
+// TestUpdateState_ErrorClearsResources pins that both StateError teardown
+// branches clear the resources and resource-template registries alongside
+// tools and prompts — a dead server must not keep advertising resources
+// (or templates) it can no longer serve.
 func TestUpdateState_ErrorClearsResources(t *testing.T) {
 	const name = "test-error-clears-resources"
 	t.Cleanup(func() {

--- a/internal/agent/tools/mcp/resources.go
+++ b/internal/agent/tools/mcp/resources.go
@@ -64,7 +64,7 @@ func ReadResource(ctx context.Context, cfg *config.ConfigStore, name, uri string
 	// Resource templates are how most A2UI surfaces are served, so this RPC
 	// carries the same capability claim as tools/call.
 	result, err := session.ReadResource(ctx, &mcp.ReadResourceParams{
-		Meta: a2uiRequestMeta(ctx, cfg.Config().Options.DisableA2UI),
+		Meta: a2uiRequestMeta(ctx, a2uiDisabled(cfg)),
 		URI:  uri,
 	})
 	if err != nil {

--- a/internal/agent/tools/mcp/resources.go
+++ b/internal/agent/tools/mcp/resources.go
@@ -61,7 +61,12 @@ func ReadResource(ctx context.Context, cfg *config.ConfigStore, name, uri string
 	if err != nil {
 		return nil, err
 	}
-	result, err := session.ReadResource(ctx, &mcp.ReadResourceParams{URI: uri})
+	// Resource templates are how most A2UI surfaces are served, so this RPC
+	// carries the same capability claim as tools/call.
+	result, err := session.ReadResource(ctx, &mcp.ReadResourceParams{
+		Meta: a2uiRequestMeta(ctx, cfg.Config().Options.DisableA2UI),
+		URI:  uri,
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/internal/agent/tools/mcp/tools.go
+++ b/internal/agent/tools/mcp/tools.go
@@ -98,10 +98,22 @@ func RunTool(ctx context.Context, cfg *config.ConfigStore, name, toolName string
 	if err != nil {
 		return ToolResult{}, err
 	}
-	result, err := c.CallTool(ctx, &mcp.CallToolParams{
-		Name:      toolName,
-		Arguments: args,
-	})
+
+	// Attach the A2UI capability to the call's _meta for stateless servers
+	// that cannot carry initialize-time state. Gated the same way as the
+	// handshake advertisement: a host that won't render A2UI must not claim
+	// it.
+	var params *mcp.CallToolParams
+	if cfg.Config().Options.DisableA2UI {
+		params = &mcp.CallToolParams{Name: toolName, Arguments: args}
+	} else {
+		params = &mcp.CallToolParams{
+			Meta:      mcp.Meta(a2uiMetaCapabilities()),
+			Name:      toolName,
+			Arguments: args,
+		}
+	}
+	result, err := c.CallTool(ctx, params)
 	if err != nil {
 		return ToolResult{}, err
 	}

--- a/internal/agent/tools/mcp/tools.go
+++ b/internal/agent/tools/mcp/tools.go
@@ -107,7 +107,7 @@ func RunTool(ctx context.Context, cfg *config.ConfigStore, name, toolName string
 	// a2ui there earns a surface payload that gets folded into model-facing
 	// content as raw JSON instead of an answer.
 	result, err := c.CallTool(ctx, &mcp.CallToolParams{
-		Meta:      a2uiRequestMeta(ctx, cfg.Config().Options.DisableA2UI),
+		Meta:      a2uiRequestMeta(ctx, a2uiDisabled(cfg)),
 		Name:      toolName,
 		Arguments: args,
 	})

--- a/internal/agent/tools/mcp/tools.go
+++ b/internal/agent/tools/mcp/tools.go
@@ -100,20 +100,17 @@ func RunTool(ctx context.Context, cfg *config.ConfigStore, name, toolName string
 	}
 
 	// Attach the A2UI capability to the call's _meta for stateless servers
-	// that cannot carry initialize-time state. Gated the same way as the
-	// handshake advertisement: a host that won't render A2UI must not claim
-	// it.
-	var params *mcp.CallToolParams
-	if cfg.Config().Options.DisableA2UI {
-		params = &mcp.CallToolParams{Name: toolName, Arguments: args}
-	} else {
-		params = &mcp.CallToolParams{
-			Meta:      mcp.Meta(a2uiMetaCapabilities()),
-			Name:      toolName,
-			Arguments: args,
-		}
-	}
-	result, err := c.CallTool(ctx, params)
+	// that cannot carry initialize-time state. This is the per-turn claim, so
+	// it tracks whether THIS turn will actually render — not just whether the
+	// deployment allows surfaces. A headless `crush run` or a
+	// channel-originated turn does not divert surfaces to a UI, so claiming
+	// a2ui there earns a surface payload that gets folded into model-facing
+	// content as raw JSON instead of an answer.
+	result, err := c.CallTool(ctx, &mcp.CallToolParams{
+		Meta:      a2uiRequestMeta(ctx, cfg.Config().Options.DisableA2UI),
+		Name:      toolName,
+		Arguments: args,
+	})
 	if err != nil {
 		return ToolResult{}, err
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -381,7 +381,7 @@ type Options struct {
 	Progress                  *bool        `json:"progress,omitempty" jsonschema:"description=Show indeterminate progress updates during long operations,default=true"`
 	Notifications             string       `json:"notifications,omitempty" jsonschema:"description=Notification style to use. Options: auto (default)\\, native\\, osc\\, bell\\, disabled. Auto selects based on environment: native for local sessions\\, osc for SSH (with automatic OSC 99/777 detection).,enum=auto,enum=native,enum=osc,enum=bell,enum=disabled,default=auto"`
 	DisabledSkills            []string     `json:"disabled_skills,omitempty" jsonschema:"description=List of skill names to disable and hide from the agent,example=crush-config"`
-	DisableA2UI               bool         `json:"disable_a2ui,omitempty" jsonschema:"description=Disable the A2UI prompt section that invites the model to emit renderable <a2ui-json> UI surfaces in chat,default=false"`
+	DisableA2UI               bool         `json:"disable_a2ui,omitempty" jsonschema:"description=Disable A2UI entirely: drops the prompt section inviting the model to emit renderable <a2ui-json> surfaces and stops advertising the a2ui capability to MCP servers,default=false"`
 	// AllowedCommands specifies commands that should be removed from the default
 	// banned commands list, allowing the agent to execute them via the bash tool.
 	// This provides a way to selectively enable commands like "ssh" or "curl"

--- a/schema.json
+++ b/schema.json
@@ -640,7 +640,24 @@
         },
         "disable_a2ui": {
           "type": "boolean",
-          "description": "Disable the A2UI prompt section that invites the model to emit renderable \u003ca2ui-json\u003e UI surfaces in chat",
+          "description": "Disable A2UI entirely: drops the prompt section inviting the model to emit renderable \u003ca2ui-json\u003e surfaces and stops advertising the a2ui capability to MCP servers",
+          "default": false
+        },
+        "allowed_commands": {
+          "items": {
+            "type": "string",
+            "examples": [
+              "ssh",
+              "curl",
+              "scp"
+            ]
+          },
+          "type": "array",
+          "description": "List of commands to allow that are normally banned. Only affects the exact-command block list; package-manager argument blocks (e.g. 'apt install') are unaffected. Allowed commands still require permission approval."
+        },
+        "allow_all_commands": {
+          "type": "boolean",
+          "description": "Remove all command restrictions from the bash tool",
           "default": false
         },
         "allowed_commands": {


### PR DESCRIPTION
Re-lands the A2UI capability advertisement on `main`. Supersedes #243, which was closed after being cherry-picked to `feat/a2ui` (`ca63e14bc` + `0e1adbb3a`) — that landed the code on the A2UI staging branch and nowhere else, so `main` has never advertised the capability.

## Why it matters

Per the [A2UI-over-MCP capability negotiation](https://a2ui.org/guides/a2ui_over_mcp/), a server checks the client's declared `capabilities.a2ui` before sending surfaces. Crush renders A2UI but never says so, so a spec-compliant server has no way to know and is entitled to withhold surfaces entirely.

Nothing is broken *today*: neither cairn nor switchboard gates on the capability — both serve A2UI unconditionally. This is forward-compatibility with third-party servers that do gate, plus the other half of the contract — a host that **cannot** render A2UI (`options.disable_a2ui`) must not claim it, and today it makes no statement either way.

## What's here

The first two commits are #243 verbatim, cherry-picked clean:

- **`feat(mcp): advertise capabilities.a2ui at MCP initialize`** — an `a2uiInitTransport` connection wrapper merges the capability into the serialized initialize params, because the go-sdk's typed `ClientCapabilities` has no slot for the spec's top-level `a2ui` key. Same seam `channelTransport` already uses. Stateless servers get it per-call in `_meta` instead. Both gated on `options.disable_a2ui`.
- **`fix(mcp): make the a2ui capability reach servers and match what crush renders`** — the review round on the above: the capability was being dropped on receipt by go-sdk servers (so it now sends both the top-level key *and* the Extensions map), the transport wrapper had broken stdio error diagnostics, and the claim was made on turns crush will not actually render.

## New in this PR

**`fix(mcp): read the A2UI opt-out without assuming Options is populated`** — #243's code as-merged **crashes on current `main`**. `Config.Options` is a pointer, and `createSession`'s `cfg.Config().Options.DisableA2UI` dereferences it on every connect. `TestBeginAuth_Concurrent` builds its store as `&config.Config{MCP: ...}` with no `Options`, so the OAuth re-auth path (`BeginAuth` → `runAuthFlow` → `connectAndRegister` → `createSession`) took the entire test binary down with a nil dereference — a panic, not a failure.

Every A2UI opt-out read in the package now goes through one `a2uiDisabled` helper that tolerates a nil store, nil config, and nil `Options`, all meaning "not disabled" — the value the option has once a config is loaded. Covered by `TestA2UIDisabledToleratesAbsentOptions`.

## Verification

- `go test -race ./...` — green, with one exception below.
- `golangci-lint run` — 0 issues.
- `TestSidekickDashboardSubscribeDeliversToolPushes` fails, **but it fails identically on a clean `main` at 00d83afa8** (`should have 1 item(s), but has 129` — the dashboard broker subscription picks up every other test's events). Pre-existing, from #172, and out of scope here.

🤖 Posted on behalf of `@joestump` by [`claude-opus-5`](https://openrouter.ai/anthropic/claude-opus-5) using [Claude Code](https://claude.ai).
