### PR TITLE
fix(agent): isolate tests from the developer's global Crush config

### DIFF
--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -26,30 +26,54 @@ import (
 
 func TestMain(m *testing.M) {
 	slog.SetLogLoggerLevel(slog.LevelError)
-	defer isolateGlobalConfig()()
-	m.Run()
+	cleanup := isolateGlobalConfig()
+	code := m.Run()
+	cleanup()
+	os.Exit(code)
 }
 
-// isolateGlobalConfig points the global config and data JSON paths at a
-// throwaway directory for the whole package.
+// isolateGlobalConfig points every global Crush lookup at a throwaway
+// directory tree for the lifetime of the test binary, and returns the
+// func that tears it down.
 //
-// Tests here call config.Init, which always merges the user-level
-// crush.json on top of the project config. On a developer machine that
-// file carries real MCP servers, so without this the tests spawn the
-// developer's actual MCP processes and count their tools — tool-list
-// assertions then fail with counts nobody can reproduce, and VCR
-// cassettes stop matching. CI only passes because its runners have no
-// user config. Env vars, not t.Setenv: the tests run in parallel.
+// config.Init always merges the user-level config locations on top of
+// the working dir, so without this the package loads the developer's
+// real ~/.config/crush/crush.json: their providers, LSPs, global
+// CRUSH.md context, skills, and — most visibly — their MCP servers,
+// which mcp.Initialize then actually connects to. Those servers'
+// tools land in every buildTools result, because an agent with a nil
+// AllowedMCP means "no MCP restrictions" and so bypasses the
+// AllowedTools filter entirely. A test asserting an exact tool list
+// then fails on a developer machine and passes in CI, which is how
+// TestSidekickDashboardSubscribeDeliversToolPushes came to report 129
+// tools where it expects 1.
 //
-// It returns a cleanup func for the caller to defer.
+// This has to happen once, before m.Run: the tests in this package run
+// under t.Parallel(), which forbids t.Setenv.
 func isolateGlobalConfig() func() {
-	dir, err := os.MkdirTemp("", "crush-agent-test-config")
+	root, err := os.MkdirTemp("", "crush-agent-test-*")
 	if err != nil {
 		panic(fmt.Sprintf("isolate global config: %v", err))
 	}
-	os.Setenv("CRUSH_GLOBAL_CONFIG", dir)
-	os.Setenv("CRUSH_GLOBAL_DATA", dir)
-	return func() { os.RemoveAll(dir) }
+	// CRUSH_SKILLS_DIR replaces the whole default skills search path,
+	// which otherwise reaches into ~/.claude/skills and friends.
+	// XDG_CONFIG_HOME covers the home.Config() lookups that have no
+	// dedicated override (crush/ignore, git/ignore, commands).
+	for envVar, dir := range map[string]string{
+		"CRUSH_GLOBAL_CONFIG": filepath.Join(root, "config", "crush"),
+		"CRUSH_GLOBAL_DATA":   filepath.Join(root, "data", "crush"),
+		"CRUSH_CACHE_DIR":     filepath.Join(root, "cache"),
+		"CRUSH_SKILLS_DIR":    filepath.Join(root, "skills"),
+		"XDG_CONFIG_HOME":     filepath.Join(root, "config"),
+	} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			panic(fmt.Sprintf("isolate global config: %v", err))
+		}
+		if err := os.Setenv(envVar, dir); err != nil {
+			panic(fmt.Sprintf("isolate global config: %v", err))
+		}
+	}
+	return func() { os.RemoveAll(root) }
 }
 
 var modelPairs = []modelPair{

--- a/internal/agent/sidekick_update_test.go
+++ b/internal/agent/sidekick_update_test.go
@@ -88,7 +88,11 @@ func TestSidekickDashboardSubscribeDeliversToolPushes(t *testing.T) {
 	agentCfg := config.Agent{ID: config.AgentCoder, AllowedTools: []string{tools.SidekickUpdateToolName}}
 	built, err := coord.buildTools(t.Context(), agentCfg, false)
 	require.NoError(t, err)
-	require.Len(t, built, 1)
+	// AllowedTools admits exactly one built-in. A longer list means MCP
+	// tools leaked in (AllowedMCP is nil here, so MCP servers bypass the
+	// AllowedTools filter) — see isolateGlobalConfig in agent_test.go.
+	require.Len(t, built, 1, "expected only %s; got %v", tools.SidekickUpdateToolName, toolNames(built))
+	require.Equal(t, tools.SidekickUpdateToolName, built[0].Info().Name)
 
 	const payload = `{"version":"v0.9","updateComponents":{"surfaceId":"s1","components":[{"component":"Text","id":"t","text":"Step 1/3"}]}}`
 	input, err := json.Marshal(map[string]string{"surface": payload})


### PR DESCRIPTION
## The bug

`TestSidekickDashboardSubscribeDeliversToolPushes` fails on a clean checkout of `main` on any machine with a real `~/.config/crush/crush.json`:

```
sidekick_update_test.go:91: "[...129 pointers...]" should have 1 item(s), but has 129
```

It stays green in CI, which is why it landed.

## Root cause — not pubsub cross-talk

The failing assertion is `require.Len(t, built, 1)` on the **tool list**, not on events received from the broker. The `sidekickDashboard` broker is constructed per-coordinator (`coordinator.go:259`) and each test builds its own via `newSidekickTestCoordinator`, so cross-talk between tests is not possible here.

What actually happens:

1. `newSidekickTestCoordinator` calls `config.Init(env.workingDir, "", false)`, and `lookupConfigs` always merges the user-level locations on top of the working dir. So the test loads the developer's real `~/.config/crush/crush.json` — their providers, LSPs, global `CRUSH.md` context, skills, and MCP servers.
2. `mcp.Initialize` then connects to those MCP servers for real. The test run emits their failures:
   ```
   ERROR MCP client failed to initialize name=cairn
   ERROR MCP client failed to initialize name=outline
   ERROR MCP client failed to initialize name=github
   ```
   The comment in `newSidekickTestCoordinator` claiming "no MCP servers are configured" was only true on a machine without a global config.
3. Their tools land in the result because MCP tools are appended **after** the `AllowedTools` filter has already run — a nil `AllowedMCP` means "no MCP restrictions" (`coordinator.go:1229-1233`), so `AllowedTools: []string{sidekick_update}` does not constrain them.

On my machine that is 1 built-in + 128 MCP tools = 129.

## The fix

Redirect the global lookups at a throwaway temp tree in `TestMain`:

| Env var | Covers |
|---|---|
| `CRUSH_GLOBAL_CONFIG` | `crush.json`, `crushrc`, global `CRUSH.md` context |
| `CRUSH_GLOBAL_DATA` | the data-scope config overrides |
| `CRUSH_CACHE_DIR` | global cache |
| `CRUSH_SKILLS_DIR` | replaces the whole default skills search path (otherwise reaches `~/.claude/skills`) |
| `XDG_CONFIG_HOME` | the `home.Config()` lookups with no dedicated override — `crush/ignore`, `git/ignore`, `commands` |

It has to happen in `TestMain` rather than per-test because these tests use `t.Parallel()`, which forbids `t.Setenv`. The rest of the repo already isolates this way (`internal/config`, `internal/workspace`, `internal/projects` all use the same env vars); `internal/agent` had just never adopted it.

`XDG_DATA_HOME` is deliberately left alone so the Catwalk provider catalog cache still resolves — isolating it would push every run into a network fetch with a 45s timeout, and the catalog is machine cache rather than user configuration.

## The assertion

Kept exact, per the intent of the test — the coder agent gets *precisely* the push tool, and an assertion that accepted N items would not catch a regression. Added the tool names to the failure message and an explicit name check, so the next leak reads as a leak instead of as pubsub cross-talk.

## Verification

```
go test -count=1 ./internal/agent/ -run 'TestSidekickDashboardSubscribeDeliversToolPushes'
ok      github.com/charmbracelet/crush/internal/agent   1.412s

go test -race -count=1 ./internal/agent/
ok      github.com/charmbracelet/crush/internal/agent   12.265s

gofumpt -l internal/agent/               # clean
go vet ./internal/agent/                 # clean
golangci-lint run ./internal/agent/...   # 0 issues
go build ./...                           # ok
```

Side effect: the package no longer spawns the developer's MCP servers, cutting the single-test run from 4.9s to 1.4s.

Test-only change — no production code touched.

🤖 Posted on behalf of `@joestump` by [`claude-opus-5`](https://openrouter.ai/anthropic/claude-opus-5) using [Claude Code](https://claude.ai).
