### PR TITLE
fix(projects): order tied registration timestamps by recency

### DIFF
--- a/internal/projects/projects.go
+++ b/internal/projects/projects.go
@@ -27,6 +27,10 @@ type ProjectList struct {
 
 var mu sync.Mutex
 
+// nowFunc returns the current time. Overridden in tests so that ordering
+// assertions do not depend on the host clock's resolution.
+var nowFunc = func() time.Time { return time.Now().UTC() }
+
 // projectsFilePath returns the path to the projects.json file.
 func projectsFilePath() string {
 	return filepath.Join(filepath.Dir(config.GlobalConfigData()), projectsFileName)
@@ -81,36 +85,24 @@ func Register(workingDir, dataDir string) error {
 		return err
 	}
 
-	now := time.Now().UTC()
+	// Drop any existing entry for this path, then put the freshly registered one
+	// at the front. Position, not the timestamp alone, is what makes this project
+	// the most recent: coarse system clocks (Windows ticks roughly every 15ms)
+	// hand out identical timestamps to back-to-back registrations.
+	list.Projects = slices.DeleteFunc(list.Projects, func(p Project) bool {
+		return p.Path == workingDir
+	})
+	list.Projects = append([]Project{{
+		Path:         workingDir,
+		DataDir:      dataDir,
+		LastAccessed: nowFunc(),
+	}}, list.Projects...)
 
-	// Check if project already exists
-	found := false
-	for i, p := range list.Projects {
-		if p.Path == workingDir {
-			list.Projects[i].DataDir = dataDir
-			list.Projects[i].LastAccessed = now
-			found = true
-			break
-		}
-	}
-
-	if !found {
-		list.Projects = append(list.Projects, Project{
-			Path:         workingDir,
-			DataDir:      dataDir,
-			LastAccessed: now,
-		})
-	}
-
-	// Sort by last accessed (most recent first)
-	slices.SortFunc(list.Projects, func(a, b Project) int {
-		if a.LastAccessed.After(b.LastAccessed) {
-			return -1
-		}
-		if a.LastAccessed.Before(b.LastAccessed) {
-			return 1
-		}
-		return 0
+	// Sort by last accessed (most recent first). Stable, so projects sharing a
+	// timestamp keep the order established above instead of being reordered
+	// arbitrarily.
+	slices.SortStableFunc(list.Projects, func(a, b Project) int {
+		return b.LastAccessed.Compare(a.LastAccessed)
 	})
 
 	return Save(list)

--- a/internal/projects/projects_test.go
+++ b/internal/projects/projects_test.go
@@ -2,9 +2,29 @@ package projects
 
 import (
 	"path/filepath"
+	"slices"
 	"testing"
 	"time"
 )
+
+// Paths in these tests are opaque identifiers: Register only stores and
+// compares them as strings, so the Unix-style spelling is portable and reads
+// the same on every platform.
+
+// fakeClock pins the package clock and returns a function that advances it, so
+// ordering assertions do not depend on the host clock's resolution. Left at the
+// pinned instant, every registration shares a timestamp — the case a coarse
+// clock (Windows ticks roughly every 15ms) produces on its own.
+func fakeClock(t *testing.T) func(time.Duration) {
+	t.Helper()
+
+	current := time.Date(2026, 8, 16, 12, 0, 0, 0, time.UTC)
+	restore := nowFunc
+	nowFunc = func() time.Time { return current }
+	t.Cleanup(func() { nowFunc = restore })
+
+	return func(d time.Duration) { current = current.Add(d) }
+}
 
 func TestRegisterAndList(t *testing.T) {
 	// Create a temporary directory for the test
@@ -13,6 +33,10 @@ func TestRegisterAndList(t *testing.T) {
 	// Override the projects file path for testing
 	t.Setenv("XDG_DATA_HOME", tmpDir)
 	t.Setenv("CRUSH_GLOBAL_DATA", filepath.Join(tmpDir, "crush"))
+
+	// Both registrations land on the same timestamp, so ordering has to come
+	// from recency of registration rather than from the clock.
+	fakeClock(t)
 
 	// Test registering a project
 	err := Register("/home/user/project1", "/home/user/project1/.crush")
@@ -64,6 +88,8 @@ func TestRegisterUpdatesExisting(t *testing.T) {
 	t.Setenv("XDG_DATA_HOME", tmpDir)
 	t.Setenv("CRUSH_GLOBAL_DATA", filepath.Join(tmpDir, "crush"))
 
+	advance := fakeClock(t)
+
 	// Register a project
 	err := Register("/home/user/project1", "/home/user/project1/.crush")
 	if err != nil {
@@ -73,8 +99,8 @@ func TestRegisterUpdatesExisting(t *testing.T) {
 	projects, _ := List()
 	firstAccess := projects[0].LastAccessed
 
-	// Wait a bit and re-register
-	time.Sleep(10 * time.Millisecond)
+	// Move the clock forward and re-register
+	advance(time.Second)
 
 	err = Register("/home/user/project1", "/home/user/project1/.crush-new")
 	if err != nil {
@@ -93,6 +119,68 @@ func TestRegisterUpdatesExisting(t *testing.T) {
 
 	if !projects[0].LastAccessed.After(firstAccess) {
 		t.Error("Expected LastAccessed to be updated")
+	}
+}
+
+func TestRegisterOrdersTiedTimestampsByRecency(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", tmpDir)
+	t.Setenv("CRUSH_GLOBAL_DATA", filepath.Join(tmpDir, "crush"))
+
+	// The clock never advances, so all three projects record the same
+	// LastAccessed and only registration order can break the tie.
+	fakeClock(t)
+
+	for _, path := range []string{"/home/user/a", "/home/user/b", "/home/user/c"} {
+		if err := Register(path, path+"/.crush"); err != nil {
+			t.Fatalf("Register(%s) failed: %v", path, err)
+		}
+	}
+
+	assertOrder(t, "/home/user/c", "/home/user/b", "/home/user/a")
+
+	// Re-registering the oldest project moves it back to the front, still
+	// without any help from the clock.
+	if err := Register("/home/user/a", "/home/user/a/.crush"); err != nil {
+		t.Fatalf("Register failed: %v", err)
+	}
+
+	assertOrder(t, "/home/user/a", "/home/user/c", "/home/user/b")
+}
+
+func TestRegisterOrdersDistinctTimestampsByTime(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", tmpDir)
+	t.Setenv("CRUSH_GLOBAL_DATA", filepath.Join(tmpDir, "crush"))
+
+	advance := fakeClock(t)
+
+	for _, path := range []string{"/home/user/a", "/home/user/b", "/home/user/c"} {
+		if err := Register(path, path+"/.crush"); err != nil {
+			t.Fatalf("Register(%s) failed: %v", path, err)
+		}
+		advance(time.Minute)
+	}
+
+	assertOrder(t, "/home/user/c", "/home/user/b", "/home/user/a")
+}
+
+// assertOrder checks that List returns exactly the given paths, in order.
+func assertOrder(t *testing.T, want ...string) {
+	t.Helper()
+
+	projects, err := List()
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+
+	got := make([]string, len(projects))
+	for i, p := range projects {
+		got[i] = p.Path
+	}
+
+	if !slices.Equal(got, want) {
+		t.Errorf("Expected order %v, got %v", want, got)
 	}
 }
 


### PR DESCRIPTION
## What

`TestRegisterAndList` in `internal/projects` was flaky on the `windows-latest` build job — e.g. https://github.com/joestump-agent/crush/actions/runs/31929699885:

```
projects_test.go:58: Expected most recent project first, got /home/user/project1
```

Fixes the ordering bug in `Register` that the flake was surfacing, and makes the test deterministic on every platform.

## Why

`Register` records `LastAccessed` from `time.Now()`. Windows' system clock ticks roughly every 15ms, so two back-to-back `Register` calls frequently land on the identical instant and the sort has nothing left to order by.

It was not merely *unstable* under a tie — it was reliably **wrong**. The new project is `append`ed to the **end** of the slice, and the comparison returned `0` for equal timestamps, so the sort left it there and the **older** project came out first. Reproduced with a fixed timestamp:

```go
// two registrations, same instant
first = /home/user/project1   // wrong — project2 was registered later
```

Linux and macOS have a finer clock that usually separates the two timestamps, which is why this only showed up on Windows.

So the flake was a real ordering defect in the production path, visible to users any time two projects are registered inside one clock tick — not just a test-timing artifact. A `time.Sleep` between registrations would have hidden it while leaving the behaviour in place.

## How

**`internal/projects/projects.go`**

- Put the freshly registered project at the **front** of the slice before sorting, and switch `slices.SortFunc` → `slices.SortStableFunc`. A tie now resolves in favour of the most recent registration rather than depending on clock resolution. Registrations with distinct timestamps are unaffected.
- Add an injectable clock (`nowFunc`), matching the existing `now func() time.Time` idiom in `internal/scheduler`, `internal/lsp`, and `internal/ui/model`.

**`internal/projects/projects_test.go`**

- `fakeClock(t)` helper pins the clock and returns an `advance` function; restored via `t.Cleanup`.
- `TestRegisterAndList` now **freezes** the clock, so it exercises the tie on every platform on every run instead of only when a coarse clock happens to produce one. It fails against the old `Register` with the exact CI message.
- `TestRegisterUpdatesExisting` advances the clock instead of `time.Sleep(10 * time.Millisecond)` — that sleep was itself shorter than a Windows clock tick, so it was a second latent flake in the same file.
- New `TestRegisterOrdersTiedTimestampsByRecency` (three projects, clock frozen, plus a re-registration that must jump back to the front) and `TestRegisterOrdersDistinctTimestampsByTime` (guards that the ordinary time-ordered path still works).

## On the Unix-style paths

Checked, and this is **not** a portability problem. `Register` only stores and string-compares these paths — nothing in `internal/projects` passes them to the filesystem or to `filepath` (the only filesystem path is `projectsFilePath()`, which is built with `filepath.Join` from `t.TempDir()`). They are opaque identifiers, so `/home/user/project1` round-trips identically on Windows. Added a comment saying so, since it is a fair thing to wonder about.

## Verification

Against the **old** `Register` (new tests, unfixed production code) — reproduces the CI failure verbatim:

```
--- FAIL: TestRegisterAndList
    Expected most recent project first, got /home/user/project1
--- FAIL: TestRegisterOrdersTiedTimestampsByRecency
    Expected order [c b a], got [a b c]
```

With the fix:

- `go test ./internal/projects/ -count=200 -race` — pass
- `go test ./internal/cmd/ -run Projects` — pass (only other consumer of this package)
- `GOOS=windows GOARCH=amd64 go vet ./internal/projects/` and `go test -c` — clean
- `golangci-lint run --config=.golangci.yml` (v2.11.4, matching CI's v2.11) — 0 issues
- `go mod tidy` — no diff; `go build ./...` — clean; `./scripts/check_log_capitalization.sh` — clean

Ordering behaviour is now deterministic and clock-resolution independent, so the three-platform `build` matrix is the real check.

### Unrelated pre-existing failure

`go test -race ./...` locally also fails `TestSidekickDashboardSubscribeDeliversToolPushes` in `internal/agent` (`should have 1 item(s), but has 129`). That reproduces identically on a clean checkout of `main` at 00d83afa8 — the test picks up the developer's real `crush.json` MCP servers instead of an isolated config. It is a local-environment leak, not something this branch touches, and I have left it alone rather than widening this PR.

🤖 Posted on behalf of `@joestump` by [`claude-opus-5`](https://openrouter.ai/anthropic/claude-opus-5) using [Claude Code](https://claude.ai).
