### PR TITLE
test(agent): isolate tests from the developer's user config

### DIFF
--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -26,7 +26,30 @@ import (
 
 func TestMain(m *testing.M) {
 	slog.SetLogLoggerLevel(slog.LevelError)
+	defer isolateGlobalConfig()()
 	m.Run()
+}
+
+// isolateGlobalConfig points the global config and data JSON paths at a
+// throwaway directory for the whole package.
+//
+// Tests here call config.Init, which always merges the user-level
+// crush.json on top of the project config. On a developer machine that
+// file carries real MCP servers, so without this the tests spawn the
+// developer's actual MCP processes and count their tools — tool-list
+// assertions then fail with counts nobody can reproduce, and VCR
+// cassettes stop matching. CI only passes because its runners have no
+// user config. Env vars, not t.Setenv: the tests run in parallel.
+//
+// It returns a cleanup func for the caller to defer.
+func isolateGlobalConfig() func() {
+	dir, err := os.MkdirTemp("", "crush-agent-test-config")
+	if err != nil {
+		panic(fmt.Sprintf("isolate global config: %v", err))
+	}
+	os.Setenv("CRUSH_GLOBAL_CONFIG", dir)
+	os.Setenv("CRUSH_GLOBAL_DATA", dir)
+	return func() { os.RemoveAll(dir) }
 }
 
 var modelPairs = []modelPair{

--- a/internal/agent/config_isolation_test.go
+++ b/internal/agent/config_isolation_test.go
@@ -1,0 +1,25 @@
+package agent
+
+import (
+	"testing"
+
+	"github.com/charmbracelet/crush/internal/config"
+	"github.com/stretchr/testify/require"
+)
+
+// TestConfigInitIsolatedFromUserConfig pins the package-wide isolation set
+// up by TestMain: config.Init must not pick up the developer's own
+// crush.json. Without it, every tool-list assertion in this package counts
+// whatever MCP servers happen to be configured on the machine running the
+// tests, and the suite spawns those servers for real.
+func TestConfigInitIsolatedFromUserConfig(t *testing.T) {
+	t.Parallel()
+	env := testEnv(t)
+
+	cfg, err := config.Init(env.workingDir, "", false)
+	require.NoError(t, err)
+	require.Empty(t, cfg.Config().MCP,
+		"the ambient user config leaked into the test config: TestMain must isolate CRUSH_GLOBAL_CONFIG and CRUSH_GLOBAL_DATA")
+	require.Empty(t, cfg.Config().LSP,
+		"the ambient user config leaked into the test config: TestMain must isolate CRUSH_GLOBAL_CONFIG and CRUSH_GLOBAL_DATA")
+}

--- a/internal/agent/sidekick_test.go
+++ b/internal/agent/sidekick_test.go
@@ -47,8 +47,9 @@ func newSidekickTestCoordinator(t *testing.T, env fakeEnv, baseURL string) *coor
 	coderCfg.AllowedTools = nil
 	cfg.Config().Agents[config.AgentCoder] = coderCfg
 
-	// Close the package-global MCP init gate (no MCP servers are
-	// configured) so the coordinator's readyWg never blocks on it.
+	// Close the package-global MCP init gate so the coordinator's readyWg
+	// never blocks on it. No MCP servers are configured: TestMain isolates
+	// the global config so the ambient user crush.json stays out.
 	mcp.Initialize(t.Context(), env.permissions, cfg)
 
 	coord, err := NewCoordinator(


### PR DESCRIPTION
## What

`TestSidekickDashboardSubscribeDeliversToolPushes` fails on any developer machine that has MCP servers configured in `crush.json`:

```
sidekick_update_test.go:91: "[...]" should have 1 item(s), but has 129
```

`config.Init` always merges the user-level `crush.json` on top of the project config, so `buildTools` returned every MCP tool on the developer's machine instead of the single expected one. The test log confirms it — `ERROR MCP client failed to initialize ... name=signal / name=outline / name=github`.

This is test isolation, not a product bug. CI passes only because its runners have no user config, so the tests silently ran against a different config than any developer sees. It reproduces on clean `main` (00d83afa8) with no local changes.

The blast radius was wider than one assertion: the whole package spawned the developer's real MCP server processes on every run.

## How

Isolate `CRUSH_GLOBAL_CONFIG` and `CRUSH_GLOBAL_DATA` into a throwaway directory in the package `TestMain`. It has to be `os.Setenv` in `TestMain` rather than `t.Setenv` per test — these tests call `t.Parallel()`, which `t.Setenv` refuses to coexist with — and doing it once covers every `config.Init` caller in the package (`sidekick_test.go`, `coordinator_test.go`, `coordinator_cron_test.go`, `coordinator_readiness_test.go`, `coordinator_mcp_gate_test.go`, `common_test.go`) instead of six separate patches.

`TestConfigInitIsolatedFromUserConfig` pins the isolation so a future change that drops it fails with a message naming the cause, rather than as an unreproducible tool count.

Also corrects the now-stale comment in `newSidekickTestCoordinator` that asserted "no MCP servers are configured" — which was only true on CI.

## Verification

Before, on this machine:

```
--- FAIL: TestSidekickDashboardSubscribeDeliversToolPushes (3.67s)
    should have 1 item(s), but has 129
```

After:

```
$ go test -race -count=1 ./internal/agent/...
ok  github.com/charmbracelet/crush/internal/agent            8.971s
ok  github.com/charmbracelet/crush/internal/agent/tools      9.192s
ok  github.com/charmbracelet/crush/internal/agent/tools/mcp  7.552s
```

- Full suite green: `go build -race ./...` and `go test -race -failfast ./...` both pass locally.
- Lint green: `golangci-lint run --path-mode=abs --config=.golangci.yml ./internal/agent/...` → `0 issues.`, plus `scripts/check_log_capitalization.sh`.
- The package no longer spawns MCP servers, which drops its runtime from ~27s to ~9s.

## Out of scope

`internal/backend` has the same latent pattern — `insertChannelWorkspace` and friends call `config.Init` without isolating the global config — but its assertions are `Contains`-style, so it passes today. Worth a follow-up; not bundled here.

🤖 Posted on behalf of `@joestump` by [`claude-opus-5`](https://openrouter.ai/anthropic/claude-opus-5) using [Claude Code](https://claude.ai).
