### PR TITLE
test(backend): isolate global config from the host in TestMain

### DIFF
--- a/internal/backend/main_test.go
+++ b/internal/backend/main_test.go
@@ -1,0 +1,104 @@
+package backend
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/crush/internal/config"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMain(m *testing.M) {
+	cleanup := isolateGlobalConfig()
+	code := m.Run()
+	cleanup()
+	os.Exit(code)
+}
+
+// isolateGlobalConfig points every global Crush lookup at a throwaway
+// directory tree for the lifetime of the test binary, and returns the
+// func that tears it down.
+//
+// config.Init always merges the user-level config locations on top of
+// the working dir, so without this the package loads the developer's
+// real ~/.config/crush/crush.json: their providers, LSPs, global
+// CRUSH.md context, skills, and MCP servers. Several tests here reach
+// config.Init with no isolation of their own — channels_test's
+// insertChannelWorkspace, and agenttest.NewCoordinator by way of
+// accepted_run_integration_test — so on a developer machine they load
+// whatever that config declares, connect to those MCP servers for
+// real, and issue authenticated model-discovery requests to the
+// provider endpoints it names. That is slow, non-deterministic, and
+// dependent on host state a test has no business reading.
+//
+// It is the same trap that made TestSidekickDashboardSubscribeDeliversToolPushes
+// report 129 tools where it expects 1; see isolateGlobalConfig in
+// internal/agent/agent_test.go.
+//
+// This has to happen once, before m.Run: most tests in this package
+// run under t.Parallel(), which forbids t.Setenv.
+func isolateGlobalConfig() func() {
+	root, err := os.MkdirTemp("", "crush-backend-test-*")
+	if err != nil {
+		panic(fmt.Sprintf("isolate global config: %v", err))
+	}
+	// CRUSH_SKILLS_DIR replaces the whole default skills search path.
+	// It is not optional: that path reaches into ~/.agents/skills and
+	// ~/.claude/skills via home.Dir(), which caches os.UserHomeDir() in
+	// a package var at init, so redirecting HOME cannot reach it.
+	// XDG_CONFIG_HOME covers the home.Config() lookups that have no
+	// dedicated override (crush/ignore, git/ignore, commands).
+	//
+	// XDG_DATA_HOME is deliberately left alone: config.cachePathFor
+	// resolves the Catwalk provider catalog cache under it, and
+	// redirecting it would send every config.Init back to the network
+	// for a provider list.
+	for envVar, dir := range map[string]string{
+		"CRUSH_GLOBAL_CONFIG": filepath.Join(root, "config", "crush"),
+		"CRUSH_GLOBAL_DATA":   filepath.Join(root, "data", "crush"),
+		"CRUSH_CACHE_DIR":     filepath.Join(root, "cache"),
+		"CRUSH_SKILLS_DIR":    filepath.Join(root, "skills"),
+		"XDG_CONFIG_HOME":     filepath.Join(root, "config"),
+	} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			panic(fmt.Sprintf("isolate global config: %v", err))
+		}
+		if err := os.Setenv(envVar, dir); err != nil {
+			panic(fmt.Sprintf("isolate global config: %v", err))
+		}
+	}
+	return func() { os.RemoveAll(root) }
+}
+
+// TestGlobalConfigIsolated guards the isolation TestMain installs. It
+// is the assertion the rest of this package leans on implicitly: a
+// bare config.Init here must see nothing from the host.
+//
+// Not parallel — it reads process env that the xdgIsolated tests
+// mutate with t.Setenv.
+func TestGlobalConfigIsolated(t *testing.T) {
+	root := os.Getenv("CRUSH_GLOBAL_CONFIG")
+	require.NotEmpty(t, root, "TestMain must set CRUSH_GLOBAL_CONFIG")
+
+	// The lookups config.Init merges on top of the working dir all
+	// have to land inside the throwaway tree, not the developer's
+	// home. GlobalSkillsDirs is the one that cannot be fixed by
+	// redirecting HOME, since home.Dir caches os.UserHomeDir at init.
+	require.True(t, strings.HasPrefix(config.GlobalConfig(), root),
+		"GlobalConfig %q escaped the test tree", config.GlobalConfig())
+	for _, dir := range config.GlobalSkillsDirs() {
+		require.Equal(t, os.Getenv("CRUSH_SKILLS_DIR"), dir,
+			"GlobalSkillsDirs reached outside the test tree")
+	}
+
+	// An empty working dir plus the isolated globals means an empty
+	// config. A non-zero count here is the host's crush.json leaking
+	// in, which is what makes MCP servers get spawned for real.
+	cfg, err := config.Init(t.TempDir(), "", false)
+	require.NoError(t, err)
+	require.Empty(t, cfg.Config().MCP, "host MCP servers leaked into the test config")
+	require.Empty(t, cfg.Config().LSP, "host LSP servers leaked into the test config")
+}


### PR DESCRIPTION
## What

Adds a `TestMain` to `internal/backend` that redirects the global Crush config lookups at a throwaway temp tree before `m.Run`, plus a `TestGlobalConfigIsolated` guard. Applies the same fix as #263 did for `internal/agent`.

## Why

`internal/backend`'s tests call `config.Init(...)` with no isolation of their own:

- `internal/backend/channels_test.go` — `insertChannelWorkspace`
- `internal/agent/agenttest/coordinator.go` — `NewCoordinator`, reached from `accepted_run_integration_test.go` under `t.Parallel()`

`config.Init` always merges the user-level config locations on top of the working dir, so on a developer machine these load the real `~/.config/crush/crush.json`.

Measured on a live machine with a throwaway probe test in the package, a bare `config.Init` here pulled in:

- **13 MCP servers** and **7 LSP servers** from the host config
- **authenticated model-discovery HTTP requests** to the provider endpoints that config names — `litellm 401`, `gemini 404`, `openai 401`

After the fix the same probe reports `0` MCP, `0` LSP, skills dir inside the temp tree, and a single `WARN No providers configured` with no network calls.

Nothing asserts on exact counts today, so this is **latent rather than failing** — but it is the same trap that made `TestSidekickDashboardSubscribeDeliversToolPushes` report `129` tools where it expects `1`, fixed in #263.

## Notes on the specific env vars

- **`CRUSH_SKILLS_DIR` is not optional.** The default skills search path reaches `~/.agents/skills` and `~/.claude/skills` via `home.Dir()`, which caches `os.UserHomeDir()` in a **package var at init** (`internal/home/home.go:11`). Redirecting `HOME` cannot reach it — the pre-existing `xdgIsolated` helper's `t.Setenv("HOME", ...)` never actually isolated those paths.
- **`XDG_DATA_HOME` is deliberately left alone.** `config.cachePathFor` resolves the Catwalk provider catalog cache under it (`internal/config/provider.go:37`); redirecting it would send every `config.Init` back to the network for a provider list.
- **It has to be `TestMain`, not per-test.** Most tests in this package use `t.Parallel()`, which forbids `t.Setenv`.

## Test

`TestGlobalConfigIsolated` guards the arrangement. It was mutation-checked rather than assumed:

| Mutation | Result |
|---|---|
| `cleanup := func() {}` (isolation removed) | fails — `TestMain must set CRUSH_GLOBAL_CONFIG` |
| `CRUSH_GLOBAL_CONFIG` pointed back at `$HOME/.config/crush` | fails — `host MCP servers leaked into the test config`, listing all 13 |
| unmutated | passes |

## Verification

```
go test -race ./internal/backend/ -count=1                        # ok, green
gofumpt -l internal/backend/                                      # clean
golangci-lint run --config=.golangci.yml ./internal/backend/...   # 0 issues
./scripts/check_log_capitalization.sh                             # clean
```

## On the expected runtime drop — it did not materialize

The issue anticipated the backend test runtime dropping from ~7.0s. **It doesn't.** Measured 3 runs each, warm:

| | baseline | isolated |
|---|---|---|
| `go test` | 5.2–6.3s | 5.1–5.6s |
| `go test -race` | 8.1–8.3s | 8.5–8.8s |

Wall clock is flat (marginally *up* under `-race`, since this adds one more test). These tests run in parallel, so the wall clock is bounded by the deliberate timing waits in `TestPathDedupe_FullCreate`, `TestHoldExpiry_RaceWithAttach` and friends — not by config loading.

What *does* drop is aggregate per-test time, **10.57s → 7.18s (-32%)**, spread across parallel workers and absorbed by the wall clock. Every config-loading test got individually faster — e.g. `TestMCPReconnect_ReloadsConfigFromDisk` 0.16s → 0.06s, `TestPathDedupe_FullCreate` 1.15s → 0.84s, `TestFirstWinsMismatch_LogsOnFlagDifferences` 0.82s → 0.53s.

Run-to-run variance also tightens (baseline had 6.3s / 10.8s / 16.7s outliers; isolated stays 5.1–5.6s) because no run reaches the network anymore. The earlier 7.0s observation was most likely one of those cold, network-bound runs.

**The justification for this change is hermeticity, not speed.** Tests should not read the developer's config or talk to their LLM endpoints.

## Not included

I considered dropping the `XDG_DATA_HOME` line from the existing `xdgIsolated` helper, since `GlobalConfigData` now consults `CRUSH_GLOBAL_DATA` first and that line only blocks the catalog cache. I measured it: **no benefit**, and it makes those tests read a real host path. Reverted — not in this PR.

Also noting for a separate change: this repo has no `Makefile`, so `make test` / `make lint` don't exist; it uses `Taskfile.yaml` (`task test`, `task lint`), which is the upstream convention. Adding a Makefile wrapper would create merge friction on every `charmbracelet/crush` sync, so I left it alone rather than bundling it here.

🤖 Posted on behalf of `@joestump` by [`claude-opus-5`](https://openrouter.ai/anthropic/claude-opus-5) using [Claude Code](https://claude.ai).
