### PR TITLE
fix(cmd): make --yolo a persistent flag so subcommands can use it

### DIFF
--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -57,7 +57,12 @@ func init() {
 	rootCmd.PersistentFlags().BoolP("debug", "d", false, "Debug")
 	rootCmd.PersistentFlags().StringVarP(&clientHost, "host", "H", server.DefaultHost(), "Connect to a specific crush server host (for advanced users)")
 	rootCmd.Flags().BoolP("help", "h", false, "Help")
-	rootCmd.Flags().BoolP("yolo", "y", false, "Automatically accept all permissions (dangerous mode)")
+	// yolo must be PERSISTENT: a root-local flag is invisible to subcommands,
+	// so the only position a subcommand-invoking argv can carry it —
+	// `crush --yolo run …` — died with "unknown flag", which crash-looped
+	// every harness-scheduled prompt run. setupLocalWorkspace reads it from
+	// cmd.Flags(), which includes inherited persistent flags.
+	rootCmd.PersistentFlags().BoolP("yolo", "y", false, "Automatically accept all permissions (dangerous mode)")
 	rootCmd.Flags().StringSlice("channels", nil, "MCP servers to enable as channels (repeatable), e.g. --channels server:webhook")
 	rootCmd.Flags().StringP("session", "s", "", "Continue a previous session by ID")
 	rootCmd.Flags().BoolP("continue", "C", false, "Continue the most recent session")


### PR DESCRIPTION
## What

`--yolo` was registered on `rootCmd.Flags()` — a root-**local** flag set that cobra does not propagate to subcommands. Any argv that both selects a subcommand and requests yolo — e.g. `crush --yolo run …`, the exact shape harness synthesizes for scheduled prompt runs (stump.wtf/harness#204 moved the flag BEFORE `run`, which is the correct position but still died) — fails with `unknown flag: --yolo` and crash-loops the supervisor.

## Fix

Register `--yolo` via `PersistentFlags()`. `crush --yolo` (TUI) is unchanged; `setupLocalWorkspace` reads it from `cmd.Flags()`, which includes inherited persistent flags.

## Verification

- Built and executed `crush --yolo run --quiet --model zai/glm-5.3 '<prompt>'` — previously died at flag parsing, now completes the prompt.
- `go vet ./internal/cmd/...` and `go test ./internal/cmd/...` green.

Fork-internal PR only — never to be sent upstream to charmbracelet/crush; upstream submission is a one-click link decision for @joestump.

🤖 This was posted autonomously by [`glm-5.3`](https://openrouter.ai/z-ai/glm-5.3) using [Crush](https://github.com/charmbracelet/crush).