### PR TITLE
fix(scheduler): reject one-shots pinned to a date that has already passed

### DIFF
--- a/internal/agent/tools/croncreate.md
+++ b/internal/agent/tools/croncreate.md
@@ -16,6 +16,11 @@ To schedule N minutes from now, add N to the current minute (handling hour/day r
 
 Expressions that are syntactically valid but can never match — "0 0 30 2 *", February 30th — are rejected rather than accepted as a task that silently never runs.
 
-A one-shot (recurring: false) whose pinned time has already passed today is also rejected: its next match would jump to tomorrow or next year, which is never what a one-shot means. Recompute the cron fields against the current time and try again. Recurring schedules are unaffected — a daily 9am task created at 10:30 legitimately fires tomorrow.
+A one-shot (recurring: false) whose pinned moment has already gone by is also rejected: its next match would jump to next month or next year, which is never what a one-shot means. The rejection names both the match that slipped by and the next one, and comes in two flavours:
+
+- The pinned **time** passed earlier today — recompute the minute/hour and try again.
+- The pinned **date** is on an earlier day, which happens when a long session crosses midnight — recompute day-of-month and month too, not just the minute. Call `date` first: this is exactly the case where the stale `<env>` time bites.
+
+A one-shot that still fires within the next 24 hours is always accepted, even if the same expression matched a moment ago — "*/5 * * * *" created at 06:29 fires at 06:30. Recurring schedules are unaffected — a daily 9am task created at 10:30 legitimately fires tomorrow.
 
 Set recurring to false for a one-shot reminder that fires once and deletes itself (pin minute/hour/day-of-month/month to specific values). Set durable to true to persist the task to disk so it survives restarts; otherwise it lives only in this session. A session can hold up to 50 scheduled tasks. Returns a task ID you can pass to CronDelete.

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -63,14 +63,27 @@ var ErrTooManyTasks = errors.New("session already has the maximum of 50 schedule
 var ErrNeverFires = errors.New("cron expression is valid but will never fire")
 
 // ErrOneShotInPast is returned when a one-shot (non-recurring) task's
-// schedule already matched at an earlier minute today. The intended
-// fire time is then unrecoverable: the schedule's next match has jumped
-// to tomorrow, next month, or next year, which is never what a one-shot
-// means. The usual cause is an agent computing the cron fields against
-// a stale clock (e.g. the session-start time in its prompt rather than
-// the actual current time), so the error names the next match to make
-// the discrepancy visible.
-var ErrOneShotInPast = errors.New("one-shot schedule's fire time has already passed today")
+// schedule matched within the last day and does not match again within
+// the next one. The intended fire time is then unrecoverable: the
+// schedule's next match has jumped to tomorrow, next month, or next
+// year, which is never what a one-shot means. The usual cause is an
+// agent computing the cron fields against a stale clock (e.g. the
+// session-start time in its prompt rather than the actual current
+// time), so the error names both the match that slipped by and the
+// next one.
+var ErrOneShotInPast = errors.New("one-shot schedule's fire time has already passed")
+
+// ErrOneShotDateInPast is the same rejection for a one-shot whose
+// slipped match was on an EARLIER DAY: the cron fields name a calendar
+// date that is already behind us, so the next match is a month or a
+// year out. It is a distinct sentinel because the remedy differs — the
+// caller must recompute the day-of-month/month fields, not just the
+// minute — and because the two are easy to confuse from the message
+// alone (both report a far-future next match).
+//
+// It wraps ErrOneShotInPast, so callers that only care that a one-shot
+// was rejected as stale can keep matching the single sentinel.
+var ErrOneShotDateInPast = fmt.Errorf("%w: its day-of-month/month name a date that is already behind us", ErrOneShotInPast)
 
 // Store keeps scheduled tasks for all sessions. Session tasks live only
 // in memory; durable tasks are additionally persisted to a JSON file so
@@ -184,11 +197,19 @@ func (s *Store) Create(sessionID, cronExpr, prompt string, recurring, durable bo
 	// that so users are not confused by sub-minute firing.
 	nextRun = nextRun.Truncate(time.Minute)
 
-	// A one-shot whose schedule already matched earlier today pinned a
-	// fire time that has passed; accepting it would store a task firing
-	// tomorrow or next year when the caller meant "in a few minutes".
-	if !recurring && matchedEarlierToday(sched, now) {
-		return Task{}, fmt.Errorf("%w: %q next matches %s", ErrOneShotInPast, cronExpr, nextRun.Format(time.RFC3339))
+	// A one-shot whose intended moment has already slipped by pinned a
+	// fire time that is now unrecoverable; accepting it would store a
+	// task firing next month or next year when the caller meant "in a
+	// few minutes".
+	if !recurring {
+		if slipped, ok := oneShotSlipped(sched, now, nextRun); ok {
+			kind := ErrOneShotInPast
+			if !sameDay(slipped, now) {
+				kind = ErrOneShotDateInPast
+			}
+			return Task{}, fmt.Errorf("%w: %q matched %s, which has passed, and does not match again until %s",
+				kind, cronExpr, slipped.Format(time.RFC3339), nextRun.Format(time.RFC3339))
+		}
 	}
 
 	id, err := NewTaskID()
@@ -213,20 +234,68 @@ func (s *Store) Create(sessionID, cronExpr, prompt string, recurring, durable bo
 	return *task, nil
 }
 
-// matchedEarlierToday reports whether the schedule's most recent match
-// is at or before the current minute today. A one-shot created after
-// such a match can only fire on a later day than its fields suggest —
-// the signature of cron fields computed against a stale clock. The
-// current minute counts as "already passed": robfig treats it as
-// consumed, so a schedule matching it next fires tomorrow or beyond.
-// Next returns the first match strictly after its argument, so the
-// cursor starts a second before midnight to include a "0 0 ..."
-// schedule firing exactly at midnight.
-func matchedEarlierToday(sched *Schedule, now time.Time) bool {
-	midnight := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
-	today := now.Truncate(time.Minute)
-	next := sched.Next(midnight.Add(-time.Second))
-	return !next.IsZero() && !next.After(today)
+// oneShotWindow is how far back a slipped match still counts as the
+// moment the caller meant, and how far ahead the next match may be
+// before the schedule is treated as unrecoverable. A one-shot is a
+// pinned instant, so both sides ask the same question: is there a
+// matching moment in the last day, and is the next one further off
+// than a day?
+const oneShotWindow = 24 * time.Hour
+
+// oneShotSlipped reports whether a one-shot's intended fire time has
+// already gone by, returning the match that slipped.
+//
+// Both halves are required, and each rules out a different false
+// positive:
+//
+//   - A match within the last day. Without it, "0 9 25 12 *" created in
+//     August — a legitimate one-shot four months out — looks identical
+//     to a stale one.
+//   - A next match more than a day out. Without it, "*/5 * * * *"
+//     created at 06:29 is rejected even though it fires at 06:30: a
+//     match did just slip by, but the caller loses nothing.
+//
+// Together they say: the fields describe a moment that just passed, and
+// the schedule will not come back around in time to be what the caller
+// asked for. That is the signature of cron fields computed against a
+// stale clock, and it holds across midnight — the previous form of this
+// check looked back only to midnight, so a schedule pinned to
+// yesterday's date sailed through and was stored to fire a year later
+// (issue #272).
+//
+// Next returns the first match strictly after its argument, so a match
+// landing exactly on the current minute counts as slipped: robfig
+// treats the current minute as consumed, and the stored next run would
+// jump a full period.
+func oneShotSlipped(sched *Schedule, now, next time.Time) (time.Time, bool) {
+	if next.IsZero() || next.Sub(now) <= oneShotWindow {
+		return time.Time{}, false
+	}
+	minute := now.Truncate(time.Minute)
+	slipped := sched.Next(now.Add(-oneShotWindow))
+	if slipped.IsZero() || slipped.After(minute) {
+		return time.Time{}, false
+	}
+	// Next walks forward, so land on the LAST match in the window rather
+	// than the first: "0 22,23 19 8 *" matched twice yesterday, and the
+	// message should name 23:00, the moment the caller most likely meant.
+	// Bounded by construction — the loop only advances through matches
+	// inside a 24h window that the schedule has already left behind.
+	for {
+		after := sched.Next(slipped)
+		if after.IsZero() || after.After(minute) {
+			return slipped, true
+		}
+		slipped = after
+	}
+}
+
+// sameDay reports whether a and b fall on the same calendar day. Both
+// come from the same clock, so they share a location.
+func sameDay(a, b time.Time) bool {
+	ay, am, ad := a.Date()
+	by, bm, bd := b.Date()
+	return ay == by && am == bm && ad == bd
 }
 
 // List returns the tasks belonging to sessionID, ordered by next run.

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -348,18 +348,18 @@ func TestCreateRejectsScheduleThatNeverFires(t *testing.T) {
 	require.Empty(t, store.ListAll(), "a rejected task must not be stored")
 }
 
-// A one-shot pinned to a minute that already passed today must be
-// rejected: its next match has jumped to tomorrow or next year, which
-// is never what "remind me in 3 minutes" means. This is the signature
-// of cron fields computed against a stale clock. Recurring tasks are
-// exempt — "0 9 * * *" created at 10:30 legitimately fires tomorrow.
+// A one-shot pinned to a minute that already passed must be rejected:
+// its next match has jumped to tomorrow or next year, which is never
+// what "remind me in 3 minutes" means. This is the signature of cron
+// fields computed against a stale clock. Recurring tasks are exempt —
+// "0 9 * * *" created at 10:30 legitimately fires tomorrow.
 func TestCreateRejectsOneShotInPast(t *testing.T) {
 	t.Parallel()
 
 	// testStore's clock is 2026-07-27 10:30 local.
 	store := testStore(t)
 
-	// 09:15 today already passed: the next match is tomorrow.
+	// 09:15 today already passed: the next match is a year out.
 	_, err := store.Create("s1", "15 9 27 7 *", "stale-clock one-shot", false, false)
 	require.ErrorIs(t, err, ErrOneShotInPast)
 	require.Empty(t, store.ListAll(), "a rejected task must not be stored")
@@ -378,6 +378,94 @@ func TestCreateRejectsOneShotInPast(t *testing.T) {
 	// A daily recurring schedule whose time passed today is fine.
 	_, err = store.Create("s1", "0 9 * * *", "recurring 9am", true, false)
 	require.NoError(t, err)
+}
+
+// The guard has to survive midnight. A one-shot pinned to YESTERDAY's
+// date used to sail through, because the old check only looked back as
+// far as this morning's midnight: the next match was next year, which
+// is trivially "not earlier today", so the task was accepted and stored
+// to fire in 2027 (issue #272). The rejection now carries the more
+// specific ErrOneShotDateInPast, because the fix is to recompute the
+// date fields rather than just the minute.
+func TestCreateRejectsOneShotPinnedToAnEarlierDate(t *testing.T) {
+	t.Parallel()
+
+	store := testStore(t)
+	// One minute past midnight, 2026-07-28 — the reported scenario: a
+	// session that crossed midnight while the agent was computing.
+	store.now = func() time.Time {
+		return time.Date(2026, 7, 28, 0, 1, 0, 0, time.Local)
+	}
+
+	_, err := store.Create("s1", "22 22 27 7 *", "yesterday's date", false, false)
+	require.ErrorIs(t, err, ErrOneShotDateInPast)
+	require.ErrorIs(t, err, ErrOneShotInPast, "the specific error must still satisfy the general one")
+	require.Empty(t, store.ListAll(), "a rejected task must not be stored")
+
+	// The message must name BOTH the match that slipped and the next
+	// one. Reporting only the next match reads as the scheduler jumping
+	// a year for no reason, which is how issue #272 got misdiagnosed as
+	// a timezone bug.
+	require.Contains(t, err.Error(), "2026-07-27T22:22:00")
+	require.Contains(t, err.Error(), "2027-07-27T22:22:00")
+
+	// When several matches slipped inside the window, the message names
+	// the last one — the moment the caller most likely meant.
+	_, err = store.Create("s1", "0 22,23 27 7 *", "twice yesterday", false, false)
+	require.ErrorIs(t, err, ErrOneShotDateInPast)
+	require.Contains(t, err.Error(), "2026-07-27T23:00:00")
+	require.NotContains(t, err.Error(), "2026-07-27T22:00:00")
+
+	// Same clock, but the slip was earlier the same day: the general
+	// error, not the date-specific one.
+	store.now = func() time.Time {
+		return time.Date(2026, 7, 28, 23, 0, 0, 0, time.Local)
+	}
+	_, err = store.Create("s1", "22 22 28 7 *", "earlier today", false, false)
+	require.ErrorIs(t, err, ErrOneShotInPast)
+	require.NotErrorIs(t, err, ErrOneShotDateInPast)
+}
+
+// The guard must not reject a one-shot the caller can still use. Both
+// halves of the check earn their place here: a schedule that comes back
+// around within the day loses nothing to a slipped match, and a date
+// months out has no recent match to be confused by.
+func TestCreateAcceptsOneShotsThatStillFireSoon(t *testing.T) {
+	t.Parallel()
+
+	// testStore's clock is 2026-07-27 10:30 local.
+	store := testStore(t)
+
+	// Matched a minute ago AND matches again in a minute: the caller
+	// wanted "the next one", and gets it. The midnight-based guard used
+	// to reject this outright.
+	task, err := store.Create("s1", "*/5 * * * *", "next five-minute boundary", false, false)
+	require.NoError(t, err)
+	require.Equal(t, time.Date(2026, 7, 27, 10, 35, 0, 0, time.Local), task.NextRunAt)
+
+	// Matched at 20:00 yesterday, matches again at 20:00 tonight —
+	// inside the day, so "8pm" still means tonight.
+	task, err = store.Create("s1", "0 20 * * *", "8pm tonight", false, false)
+	require.NoError(t, err)
+	require.Equal(t, time.Date(2026, 7, 27, 20, 0, 0, 0, time.Local), task.NextRunAt)
+
+	// A legitimate far-future one-shot: no match in the last day, so
+	// nothing slipped. Christmas is four months out, not stale.
+	task, err = store.Create("s1", "0 9 25 12 *", "christmas morning", false, false)
+	require.NoError(t, err)
+	require.Equal(t, time.Date(2026, 12, 25, 9, 0, 0, 0, time.Local), task.NextRunAt)
+}
+
+// Store.Create takes no caller-supplied timestamp: the only clock is
+// s.now, which NewStore wires to time.Now. Issue #272 suspected a
+// prompt-derived time leaking in through a caller; this pins that there
+// is no seam for one to enter through, so the suspicion cannot silently
+// become true later.
+func TestStoreClockIsTimeNow(t *testing.T) {
+	t.Parallel()
+
+	store := NewStore("")
+	require.WithinDuration(t, time.Now(), store.now(), time.Minute)
 }
 
 // The same guard has to hold on the rescheduling path. A recurring task


### PR DESCRIPTION
Closes #272.

## What actually happened

I reproduced the reported scenario against `matchedEarlierToday` before changing anything, and the diagnosis in the issue is off in an interesting way — the real bug is worse than the reported symptom.

**The reported rejection was correct.** The wall clock was not 06:29 on Aug 20; it was **22:23 on Aug 19**, one minute after the requested `22 22 19 8 *` had fired. Feeding that clock to the current code reproduces the error string byte for byte:

```
now=2026-08-19T22:23:00+01:00  expr="22 22 19 8 *"
  -> REJECTED: one-shot schedule's fire time has already passed today: "22 22 19 8 *" next matches 2027-08-19T22:22:00+01:00
```

So the guard did its job. What misled the report is the **message**: it names only the *next* match, which reads as the scheduler inexplicably jumping a year, rather than "the moment you asked for went by 60 seconds ago."

**The genuine bug is the opposite of the report.** At the time the issue *describes* — 06:29 on Aug 20, one-shot pinned to Aug 19 — the current guard does not reject at all:

```
now=2026-08-20T06:29:00+01:00  expr="22 22 19 8 *"  guard=false
  -> accepted next=2027-08-19T22:22:00+01:00
```

The task is silently stored to fire **in 2027**. That is precisely the failure the guard exists to prevent, and it slips through because "did this match earlier *today*?" is trivially false once the session crosses midnight.

**And there is a false rejection.** A one-shot `*/5 * * * *` created at 06:29 was rejected as "already passed today" even though its next match is 06:30 — sixty seconds away.

## The fix

Replace the midnight-anchored question with the one that actually separates stale from legitimate: **did a match slip by within the last 24 hours, and is the next one more than 24 hours out?**

Both halves are load-bearing:

| Without | False result |
|---|---|
| the recent-match half | `0 9 25 12 *` created in August — a legitimate one-shot four months out — looks identical to a stale one |
| the far-next-match half | `*/5 * * * *` at 06:29 is rejected even though it fires at 06:30 |

Verified behavior after the change:

| now | expression | before | after |
|---|---|---|---|
| Aug 20 06:29 | `22 22 19 8 *` | ❌ accepted, fires 2027 | ✅ rejected (`ErrOneShotDateInPast`) |
| Aug 19 22:23 | `22 22 19 8 *` | ✅ rejected, misleading message | ✅ rejected, message names both matches |
| Aug 20 06:29 | `*/5 * * * *` | ❌ rejected, fires in 60s | ✅ accepted → 06:30 |
| Aug 20 06:29 | `0 20 * * *` | ✅ accepted → 20:00 today | ✅ unchanged |
| Aug 20 06:29 | `0 9 25 12 *` | ✅ accepted → Dec 25 | ✅ unchanged |

### Distinct error, per the issue's suggestion #2

`ErrOneShotDateInPast` is returned when the slipped match was on an earlier **day**. It wraps `ErrOneShotInPast`, so any `errors.Is` check against the general sentinel keeps working. It is worth a separate sentinel because the remedy differs — recompute day-of-month and month, not just the minute — and because the two are indistinguishable from the message alone.

The message now names the match that slipped *and* the next one:

```
one-shot schedule's fire time has already passed: its day-of-month/month name a date
that is already behind us: "22 22 19 8 *" matched 2026-08-19T22:22:00+01:00, which has
passed, and does not match again until 2027-08-19T22:22:00+01:00
```

When several matches slipped inside the window, it names the last one — the moment the caller most likely meant.

### Clock audit, per the issue's suggestion #1

Hypothesis (a) — a prompt-derived timestamp reaching `Store.Create` — **is false**. `Create` takes no timestamp parameter at all; the only clock is `s.now`, which `NewStore` wires to `time.Now`, and the sole override is in `scheduler_test.go`. `TestStoreClockIsTimeNow` pins that so it cannot quietly become true later.

### Suggestion #3 (an explicit `at` RFC 3339 parameter)

Not done here — it is an agent-facing tool-schema change rather than a bug fix, and it deserves its own PR. Happy to file it as a follow-up issue if you want it.

## Also

`croncreate.md` is updated, since that description is what the agent reads when it hits this error: it now documents both flavours of rejection and the "fires within 24 hours is always fine" rule.

## Verification

- `go build ./...`, `golangci-lint run` on the touched packages (0 issues), `go test -race -failfast`, `scripts/check_log_capitalization.sh`, and `go mod tidy` + `git diff --exit-code` all clean.
- Scheduler suite re-run uncached under `UTC`, `America/Los_Angeles`, `Asia/Kolkata`, `Australia/Lord_Howe`, `Pacific/Chatham`, and `America/Sao_Paulo` — the guard arithmetic is local-time-sensitive, so half-hour and 45-minute offsets are worth the extra runs.
- Both new tests were run against the **old** implementation to confirm they fail: the earlier-date one-shot came back `nil` (the silent-2027 bug) and the `*/5` one-shot came back rejected (the false rejection).

🤖 This was posted autonomously by [`claude-opus-5`](https://openrouter.ai/anthropic/claude-opus-5) using [Claude Code](https://claude.ai).