### PR TITLE
fix(test): wait for the create event instead of sleeping past it

### DIFF
--- a/internal/message/message_test.go
+++ b/internal/message/message_test.go
@@ -91,6 +91,21 @@ func (c *eventCollector) reset() {
 	c.events = nil
 }
 
+// waitForEvents blocks until the collector has seen at least n events.
+//
+// Use this instead of sleeping before reset(): the publish path is
+// asynchronous, so a fixed sleep is a bet on scheduler latency that a loaded
+// CI runner will eventually lose. When it does, reset() clears an empty slice
+// and the straggler shows up in the next snapshot, so the failure surfaces as
+// a wrong event count in an unrelated assertion.
+func waitForEvents(t *testing.T, c *eventCollector, n int) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		return len(c.snapshot()) >= n
+	}, 5*time.Second, time.Millisecond,
+		"expected at least %d event(s) before continuing", n)
+}
+
 func TestUpdate_DebouncesTextDeltas(t *testing.T) {
 	t.Parallel()
 
@@ -106,8 +121,11 @@ func TestUpdate_DebouncesTextDeltas(t *testing.T) {
 		Role: Assistant,
 	})
 	require.NoError(t, err)
-	// Drop the CreatedEvent emitted by Create.
-	time.Sleep(5 * time.Millisecond)
+	// Drop the CreatedEvent emitted by Create — but wait for it to actually
+	// arrive first. A fixed sleep is a guess about scheduler latency: when it
+	// loses, reset() clears nothing, the create event lands afterwards, and
+	// the assertion below counts it alongside the event under test.
+	waitForEvents(t, collector, 1)
 	collector.reset()
 
 	// Push 5 deltas inside a single debounce window.
@@ -147,7 +165,7 @@ func TestUpdate_TerminalUpdatesFlushSynchronously(t *testing.T) {
 
 	msg, err := svc.Create(t.Context(), sessionID, CreateMessageParams{Role: Assistant})
 	require.NoError(t, err)
-	time.Sleep(5 * time.Millisecond)
+	waitForEvents(t, collector, 1)
 	collector.reset()
 
 	// AddFinish makes the message terminal; Update must flush


### PR DESCRIPTION
Fixes the red `main` that appeared right after #274 merged, in a package #274 does not touch.

## What broke

`build (macos-latest)` on `5403b882f`:

```
--- FAIL: TestUpdate_TerminalUpdatesFlushSynchronously (0.63s)
    "[{created ...} {updated ... [done {end_turn ...}]}]" should have 1 item(s), but has 2
```

Both events being present is the whole diagnosis. Two tests in `internal/message` sleep 5ms after `svc.Create`, then `collector.reset()` to drop the `CreatedEvent` before asserting on the event actually under test. The publish path is asynchronous, so that sleep is a bet on scheduler latency. When it loses, `reset()` clears an empty slice, the create event arrives afterwards, and the assertion counts it alongside the real one — which is exactly the pair in the failure output.

`internal/message` is untouched by #274; this is a pre-existing timing dependency that a loaded runner finally hit.

## The fix

Replaces both sleeps with a `waitForEvents` helper that polls until the event has actually landed. Nothing changes about what the tests assert — they just stop racing the thing they are trying to ignore.

## Verification

- `go test -race -failfast ./...` — exit 0, 57 packages
- `golangci-lint` — 0 issues
- 60 runs of both affected tests at `-cpu=1` under `-race` — green

**I could not reproduce the original failure locally.** 40 runs of the old shape at `-cpu=1` under `-race` all passed; this machine wins the race every time. So the diagnosis rests on the CI output above rather than on a local repro. The fix removes the timing dependency regardless of whether I can make the old code lose on demand.

🤖 Posted on behalf of `@joestump` by [`claude-opus-5`](https://openrouter.ai/anthropic/claude-opus-5) using [Claude Code](https://claude.ai).
