### PR TITLE
feat: wire up semantic_search — tool registration, embedding config surface, index lifecycle

### DIFF
--- a/docs-site/docs/features/semantic-search.md
+++ b/docs-site/docs/features/semantic-search.md
@@ -7,16 +7,6 @@ description: A local vector index over your codebase, searched by meaning rather
 
 # Semantic search
 
-:::info[Fork feature — not yet wired up]
-The storage and search layer has landed in the `joestump-agent/crush` fork, but
-the `semantic_search` tool is **not currently registered** in the agent's tool
-list and there is no `crushrc` or `crush.json` surface for the embedding
-provider yet. This page documents what exists so far. Until it is wired up, use
-`grep`, `glob`, and the [LSP tools](/features/lsp).
-:::
-
-## What it is
-
 A vector index over the repository, stored in the project's own SQLite database
 via the `vec0` virtual table from
 [`modernc.org/sqlite/vec`](https://pkg.go.dev/modernc.org/sqlite) — the same
@@ -40,9 +30,42 @@ is much cheaper.
 3. Vectors go into a `chunk_vectors` virtual table alongside the chunk text.
 4. A query is embedded the same way and matched by K-nearest-neighbour search.
 
-## Embedding configuration
+## Enabling it
 
-The embedding client takes four values, with these defaults:
+Semantic search is **opt-in**: it is disabled unless an embedding provider is
+configured. When it is configured, two tools appear in the agent's palette —
+`semantic_search` and `semantic_index`.
+
+### `crush.json`
+
+Add a top-level `embeddings` block:
+
+```json
+{
+  "embeddings": {
+    "base_url": "https://api.openai.com/v1",
+    "api_key": "${OPENAI_API_KEY:?set OPENAI_API_KEY}",
+    "model": "text-embedding-3-small",
+    "dimension": 768
+  }
+}
+```
+
+`api_key` and `base_url` support the same shell expansion as every other
+credential field: `$VAR`, `${VAR}`, `${VAR:?message}`, and `$(command)`.
+
+### `crushrc`
+
+```bash
+embeddings set --base-url https://api.openai.com/v1 \
+               --api-key ${OPENAI_API_KEY:?set OPENAI_API_KEY} \
+               --model text-embedding-3-small \
+               --dimension 768
+
+embeddings clear   # remove the provider and disable semantic search
+```
+
+### Fields and defaults
 
 | Field | Default |
 | --- | --- |
@@ -55,21 +78,44 @@ Any OpenAI-compatible embeddings endpoint works, including a local one.
 
 **The dimension is baked into the table on first creation.** Changing it later
 is detected and fails with an actionable error rather than silently mismatching
-every insert — a dimension change means reindexing.
+every insert — a dimension change means reindexing (drop the `chunks` and
+`chunk_vectors` tables and run `semantic_index` again).
 
-## The tool
+## The tools
 
-When registered, `semantic_search` takes:
+| Tool | Purpose |
+| --- | --- |
+| `semantic_index` | Build or refresh the index. Unchanged files are skipped, so it is incremental and safe to re-run. |
+| `semantic_search` | Query the index by natural-language description. |
+
+**Indexing lifecycle:** the index is built on demand — the agent (or you, via
+a prompt) runs `semantic_index` before searching, and re-runs it after large
+changes. With no arguments it walks the working directory gitignore-aware and
+skips files whose contents and embedding model have not changed since the last
+run, so repeat runs only pay for what moved.
+
+`semantic_search` takes:
 
 | Parameter | Meaning |
 | --- | --- |
 | `query` | A natural-language description of the code or concept to find |
 | `limit` | Maximum results (default 10) |
 
-It returns an explicit error rather than nothing when no embedding provider is
-configured, or when the index is empty.
+It returns file locations, symbol names, line ranges, and relevance scores —
+not full file contents; follow up with `view` for the authoritative text.
 
-## Tracking this
+## Checking state
 
-Follow [`joestump-agent/crush`](https://github.com/joestump-agent/crush) for
-when the tool is registered and the config surface lands.
+`crush_info` reports the semantic index alongside LSP and MCP:
+
+```
+[semantic_index]
+model = text-embedding-3-small (dim 768)
+chunks = 1337
+```
+
+The section is absent when no embedding provider is configured.
+
+Note that changing the embedding `dimension` against an existing index
+disables the tools for that run with a logged, actionable error, since the
+vector table cannot be resized in place.

--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -40,8 +40,10 @@ import (
 	"github.com/charmbracelet/crush/internal/pubsub"
 	"github.com/charmbracelet/crush/internal/question"
 	"github.com/charmbracelet/crush/internal/scheduler"
+	"github.com/charmbracelet/crush/internal/semantic"
 	"github.com/charmbracelet/crush/internal/session"
 	"github.com/charmbracelet/crush/internal/skills"
+	"github.com/charmbracelet/crush/internal/symbols"
 	"golang.org/x/sync/errgroup"
 
 	"charm.land/fantasy/providers/anthropic"
@@ -173,6 +175,14 @@ type coordinator struct {
 
 	cronStore *scheduler.Store
 
+	// semanticStore and semanticClient back the semantic_search and
+	// semantic_index tools. Both are nil unless an embedding provider is
+	// configured and the store initialised, in which case neither tool
+	// is registered.
+	semanticStore   *semantic.Store
+	semanticClient  *semantic.Client
+	semanticSymbols *symbols.Extractor
+
 	// sidekickAgent is the fully independent Sidekick agent: its own
 	// (ephemeral, in-memory) sessions and messages, its own read-only
 	// tool set, its own model config, and its own activeRequests — so
@@ -219,6 +229,13 @@ type CoordinatorOptions struct {
 	RunComplete pubsub.Publisher[notify.RunComplete]
 	Skills      *skills.Manager
 	Interactive bool
+
+	// SemanticStore/SemanticClient enable the semantic_search and
+	// semantic_index tools. Both must be non-nil for the tools to be
+	// registered; the caller (app) is responsible for constructing them
+	// from the configured embedding provider.
+	SemanticStore  *semantic.Store
+	SemanticClient *semantic.Client
 }
 
 func NewCoordinator(ctx context.Context, opts CoordinatorOptions) (Coordinator, error) {
@@ -258,6 +275,9 @@ func NewCoordinator(ctx context.Context, opts CoordinatorOptions) (Coordinator, 
 		skillTracker:      skillTracker,
 		sidekickDashboard: pubsub.NewBroker[tools.SidekickSurface](),
 		interactive:       opts.Interactive,
+		semanticStore:     opts.SemanticStore,
+		semanticClient:    opts.SemanticClient,
+		semanticSymbols:   symbols.NewExtractor(),
 	}
 
 	agentCfg, ok := opts.Config.Config().Agents[config.AgentCoder]
@@ -1174,7 +1194,7 @@ func (c *coordinator) buildTools(ctx context.Context, agent config.Agent, isSubA
 	allTools = append(
 		allTools,
 		tools.NewBashTool(c.permissions, c.cfg.WorkingDir(), c.cfg.Config().Options.Attribution, modelID, allowedCommands, allowAllCommands),
-		tools.NewCrushInfoTool(c.cfg, c.lspManager, c.allSkills, c.activeSkills, c.skillTracker),
+		tools.NewCrushInfoTool(c.cfg, c.lspManager, c.allSkills, c.activeSkills, c.skillTracker, c.semanticStore),
 		tools.NewCrushLogsTool(logFile),
 		tools.NewCronCreateTool(c.cronStore),
 		tools.NewCronListTool(c.cronStore),
@@ -1211,6 +1231,17 @@ func (c *coordinator) buildTools(ctx context.Context, agent config.Agent, isSubA
 			tools.NewCallHierarchyTool(c.lspManager),
 			tools.NewRenameTool(c.lspManager, c.permissions, c.history, c.filetracker),
 			tools.NewReplaceSymbolTool(c.lspManager, c.permissions, c.history, c.filetracker),
+		)
+	}
+
+	// Semantic search tools are registered only when an embedding
+	// provider is configured and the store initialised — the same
+	// conditional-registration style as the LSP and MCP blocks above.
+	if c.semanticStore != nil && c.semanticClient != nil {
+		allTools = append(
+			allTools,
+			tools.NewSemanticSearchTool(c.semanticStore, c.semanticClient),
+			tools.NewSemanticIndexTool(c.semanticStore, c.semanticSymbols, c.cfg.WorkingDir()),
 		)
 	}
 

--- a/internal/agent/coordinator_semantic_test.go
+++ b/internal/agent/coordinator_semantic_test.go
@@ -1,0 +1,85 @@
+package agent
+
+import (
+	"context"
+	"database/sql"
+	"slices"
+	"testing"
+
+	"github.com/charmbracelet/crush/internal/config"
+	"github.com/charmbracelet/crush/internal/semantic"
+	"github.com/charmbracelet/crush/internal/symbols"
+	"github.com/stretchr/testify/require"
+
+	_ "modernc.org/sqlite"
+)
+
+func coordinatorToolNames(t *testing.T, coord *coordinator) []string {
+	t.Helper()
+	agentCfg := coord.cfg.Config().Agents[config.AgentCoder]
+	built, err := coord.buildTools(context.Background(), agentCfg, false)
+	require.NoError(t, err)
+	names := make([]string, len(built))
+	for i, tool := range built {
+		names[i] = tool.Info().Name
+	}
+	return names
+}
+
+func semanticTestStore(t *testing.T) *semantic.Store {
+	t.Helper()
+	db, err := sql.Open("sqlite", ":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() { db.Close() })
+	_, err = db.Exec(`CREATE TABLE IF NOT EXISTS chunks (
+			chunk_id   INTEGER PRIMARY KEY,
+			session_id TEXT,
+			path       TEXT,
+			symbol     TEXT,
+			start_line INTEGER,
+			end_line   INTEGER,
+			content    TEXT NOT NULL,
+			file_hash  TEXT,
+			model      TEXT NOT NULL,
+			dim        INTEGER NOT NULL
+		) STRICT`)
+	require.NoError(t, err)
+	store, err := semantic.NewStore(context.Background(), db, semantic.EmbeddingConfig{
+		BaseURL: "http://127.0.0.1:9/v1", Model: "test", Dimension: 3,
+	})
+	require.NoError(t, err)
+	return store
+}
+
+// TestSemanticToolsGatedOnStore pins the registration rule: the
+// semantic_search and semantic_index tools exist in the coder's palette
+// only when an embedding provider is configured and the store initialised.
+func TestSemanticToolsGatedOnStore(t *testing.T) {
+	t.Run("absent without store", func(t *testing.T) {
+		coord := newGateTestCoordinator(t, false)
+		names := coordinatorToolNames(t, coord)
+		require.NotContains(t, names, "semantic_search")
+		require.NotContains(t, names, "semantic_index")
+	})
+
+	t.Run("present with store", func(t *testing.T) {
+		coord := newGateTestCoordinator(t, false)
+		emb := semantic.EmbeddingConfig{
+			BaseURL: "http://127.0.0.1:9/v1", Model: "test", Dimension: 3,
+		}
+		coord.semanticStore = semanticTestStore(t)
+		coord.semanticClient = semantic.NewClient(emb)
+		coord.semanticSymbols = symbols.NewExtractor()
+
+		names := coordinatorToolNames(t, coord)
+		require.Contains(t, names, "semantic_search")
+		require.Contains(t, names, "semantic_index")
+	})
+
+	t.Run("default palette allows the tools", func(t *testing.T) {
+		coord := newGateTestCoordinator(t, false)
+		allowed := coord.cfg.Config().Agents[config.AgentCoder].AllowedTools
+		require.True(t, slices.Contains(allowed, "semantic_search"))
+		require.True(t, slices.Contains(allowed, "semantic_index"))
+	})
+}

--- a/internal/agent/coordinator_semantic_test.go
+++ b/internal/agent/coordinator_semantic_test.go
@@ -31,7 +31,7 @@ func semanticTestStore(t *testing.T) *semantic.Store {
 	db, err := sql.Open("sqlite", ":memory:")
 	require.NoError(t, err)
 	t.Cleanup(func() { db.Close() })
-	_, err = db.Exec(`CREATE TABLE IF NOT EXISTS chunks (
+	_, err = db.ExecContext(t.Context(), `CREATE TABLE IF NOT EXISTS chunks (
 			chunk_id   INTEGER PRIMARY KEY,
 			session_id TEXT,
 			path       TEXT,

--- a/internal/agent/tools/crush_info.go
+++ b/internal/agent/tools/crush_info.go
@@ -11,6 +11,7 @@ import (
 	"github.com/charmbracelet/crush/internal/agent/tools/mcp"
 	"github.com/charmbracelet/crush/internal/config"
 	"github.com/charmbracelet/crush/internal/lsp"
+	"github.com/charmbracelet/crush/internal/semantic"
 	"github.com/charmbracelet/crush/internal/skills"
 )
 
@@ -27,17 +28,18 @@ func NewCrushInfoTool(
 	allSkills []*skills.Skill,
 	activeSkills []*skills.Skill,
 	skillTracker *skills.Tracker,
+	semanticStore *semantic.Store,
 ) fantasy.AgentTool {
 	return fantasy.NewAgentTool(
 		CrushInfoToolName,
 		crushInfoDescription,
 		func(ctx context.Context, _ CrushInfoParams, _ fantasy.ToolCall) (fantasy.ToolResponse, error) {
-			return fantasy.NewTextResponse(buildCrushInfo(cfg, lspManager, allSkills, activeSkills, skillTracker)), nil
+			return fantasy.NewTextResponse(buildCrushInfo(cfg, lspManager, allSkills, activeSkills, skillTracker, semanticStore)), nil
 		},
 	)
 }
 
-func buildCrushInfo(cfg *config.ConfigStore, lspManager *lsp.Manager, allSkills []*skills.Skill, activeSkills []*skills.Skill, skillTracker *skills.Tracker) string {
+func buildCrushInfo(cfg *config.ConfigStore, lspManager *lsp.Manager, allSkills []*skills.Skill, activeSkills []*skills.Skill, skillTracker *skills.Tracker, semanticStore *semantic.Store) string {
 	var b strings.Builder
 
 	writeConfigFiles(&b, cfg)
@@ -46,6 +48,7 @@ func buildCrushInfo(cfg *config.ConfigStore, lspManager *lsp.Manager, allSkills 
 	writeProviders(&b, cfg)
 	writeLSP(&b, lspManager, cfg)
 	writeMCP(&b, mcp.GetStates(), cfg)
+	writeSemanticIndex(&b, cfg, semanticStore)
 	writeSkills(&b, allSkills, activeSkills, skillTracker, cfg)
 	writeHooks(&b, cfg)
 	writePermissions(&b, cfg)
@@ -204,6 +207,28 @@ func writeLSP(b *strings.Builder, lspManager *lsp.Manager, cfg *config.ConfigSto
 			b.WriteString("\n")
 		}
 	}
+}
+
+// writeSemanticIndex reports semantic-search state alongside LSP and MCP:
+// the configured embedding model, and how many chunks the index holds.
+// It prints nothing when semantic search is not configured.
+func writeSemanticIndex(b *strings.Builder, cfg *config.ConfigStore, store *semantic.Store) {
+	e, ok := cfg.Config().ResolvedEmbeddings()
+	if !ok {
+		return
+	}
+	b.WriteString("[semantic_index]\n")
+	fmt.Fprintf(b, "model = %s (dim %d)\n", e.Model, e.Dimension)
+	if store == nil {
+		b.WriteString("store = unavailable (initialisation failed)\n")
+	} else {
+		if count, err := store.ChunkCount(context.Background()); err == nil {
+			fmt.Fprintf(b, "chunks = %d\n", count)
+		} else {
+			fmt.Fprintf(b, "chunks = unknown (%v)\n", err)
+		}
+	}
+	b.WriteString("\n")
 }
 
 func writeMCP(b *strings.Builder, states map[string]mcp.ClientInfo, cfg *config.ConfigStore) {

--- a/internal/agent/tools/crush_info_test.go
+++ b/internal/agent/tools/crush_info_test.go
@@ -23,7 +23,7 @@ func TestCrushInfo_MinimalConfig(t *testing.T) {
 	cfg := config.NewTestStore(&config.Config{
 		Providers: csync.NewMap[string, config.ProviderConfig](),
 	})
-	output := buildCrushInfo(cfg, nil, nil, nil, nil)
+	output := buildCrushInfo(cfg, nil, nil, nil, nil, nil)
 	require.NotContains(t, output, "[providers]")
 	require.NotContains(t, output, "[lsp]")
 	require.NotContains(t, output, "[mcp]")
@@ -39,7 +39,7 @@ func TestCrushInfo_ConfigFiles(t *testing.T) {
 		"/home/user/.config/crush/crush.json",
 		"/project/.crush/crush.json",
 	)
-	output := buildCrushInfo(cfg, nil, nil, nil, nil)
+	output := buildCrushInfo(cfg, nil, nil, nil, nil, nil)
 	require.Contains(t, output, "[config_files]")
 	require.Contains(t, output, "/home/user/.config/crush/crush.json")
 	require.Contains(t, output, "/project/.crush/crush.json")
@@ -55,7 +55,7 @@ func TestCrushInfo_Models(t *testing.T) {
 		},
 		Providers: csync.NewMap[string, config.ProviderConfig](),
 	})
-	output := buildCrushInfo(cfg, nil, nil, nil, nil)
+	output := buildCrushInfo(cfg, nil, nil, nil, nil, nil)
 	require.Contains(t, output, "[model]")
 	require.Contains(t, output, "large = claude-sonnet-4-20250514 (anthropic)")
 	require.Contains(t, output, "small = claude-haiku-3-20250307 (anthropic)")
@@ -69,7 +69,7 @@ func TestCrushInfo_Providers(t *testing.T) {
 	providers.Set("anthropic", config.ProviderConfig{Models: make([]catwalk.Model, 12)})
 
 	cfg := config.NewTestStore(&config.Config{Providers: providers})
-	output := buildCrushInfo(cfg, nil, nil, nil, nil)
+	output := buildCrushInfo(cfg, nil, nil, nil, nil, nil)
 	require.Contains(t, output, "[providers]")
 	anthropicIdx := strings.Index(output, "anthropic = enabled")
 	openaiIdx := strings.Index(output, "openai = enabled")
@@ -88,7 +88,7 @@ func TestCrushInfo_DisabledProvidersOmitted(t *testing.T) {
 	providers.Set("anthropic", config.ProviderConfig{Models: make([]catwalk.Model, 12)})
 
 	cfg := config.NewTestStore(&config.Config{Providers: providers})
-	output := buildCrushInfo(cfg, nil, nil, nil, nil)
+	output := buildCrushInfo(cfg, nil, nil, nil, nil, nil)
 	require.Contains(t, output, "anthropic = enabled")
 	require.NotContains(t, output, "openai")
 }
@@ -108,7 +108,7 @@ func TestCrushInfo_LSPStates(t *testing.T) {
 	mgr.Clients().Set("pyright", errorClient)
 
 	cfg := config.NewTestStore(&config.Config{Providers: csync.NewMap[string, config.ProviderConfig]()})
-	output := buildCrushInfo(cfg, mgr, nil, nil, nil)
+	output := buildCrushInfo(cfg, mgr, nil, nil, nil, nil)
 	require.Contains(t, output, "[lsp]")
 	require.Contains(t, output, "gopls = ready")
 	require.Contains(t, output, "pyright = error")
@@ -159,7 +159,7 @@ func TestCrushInfo_YoloMode(t *testing.T) {
 	})
 	cfg.Overrides().SkipPermissionRequests = true
 
-	output := buildCrushInfo(cfg, nil, nil, nil, nil)
+	output := buildCrushInfo(cfg, nil, nil, nil, nil, nil)
 	require.Contains(t, output, "[permissions]")
 	require.Contains(t, output, "mode = yolo")
 }
@@ -172,7 +172,7 @@ func TestCrushInfo_AllowedTools(t *testing.T) {
 		Permissions: &config.Permissions{AllowedTools: []string{"edit:write", "bash"}},
 	})
 
-	output := buildCrushInfo(cfg, nil, nil, nil, nil)
+	output := buildCrushInfo(cfg, nil, nil, nil, nil, nil)
 	require.Contains(t, output, "[permissions]")
 	require.Contains(t, output, "allowed_tools = bash, edit:write")
 }
@@ -185,7 +185,7 @@ func TestCrushInfo_DisabledTools(t *testing.T) {
 		Options:   &config.Options{DisabledTools: []string{"sourcegraph", "agentic_fetch"}},
 	})
 
-	output := buildCrushInfo(cfg, nil, nil, nil, nil)
+	output := buildCrushInfo(cfg, nil, nil, nil, nil, nil)
 	require.Contains(t, output, "[tools]")
 	require.Contains(t, output, "disabled = agentic_fetch, sourcegraph")
 }
@@ -202,7 +202,7 @@ func TestCrushInfo_Options(t *testing.T) {
 		},
 	})
 
-	output := buildCrushInfo(cfg, nil, nil, nil, nil)
+	output := buildCrushInfo(cfg, nil, nil, nil, nil, nil)
 	require.Contains(t, output, "[options]")
 	require.Contains(t, output, "auto_lsp = true")
 	require.Contains(t, output, "auto_summarize = false")
@@ -217,14 +217,14 @@ func TestCrushInfo_AutoSummarizeInversion(t *testing.T) {
 		Providers: csync.NewMap[string, config.ProviderConfig](),
 		Options:   &config.Options{DisableAutoSummarize: true},
 	})
-	outputFalse := buildCrushInfo(cfgFalse, nil, nil, nil, nil)
+	outputFalse := buildCrushInfo(cfgFalse, nil, nil, nil, nil, nil)
 	require.Contains(t, outputFalse, "auto_summarize = false")
 
 	cfgTrue := config.NewTestStore(&config.Config{
 		Providers: csync.NewMap[string, config.ProviderConfig](),
 		Options:   &config.Options{DisableAutoSummarize: false},
 	})
-	outputTrue := buildCrushInfo(cfgTrue, nil, nil, nil, nil)
+	outputTrue := buildCrushInfo(cfgTrue, nil, nil, nil, nil, nil)
 	require.Contains(t, outputTrue, "auto_summarize = true")
 }
 
@@ -238,7 +238,7 @@ func TestCrushInfo_NoSecrets(t *testing.T) {
 	})
 
 	cfg := config.NewTestStore(&config.Config{Providers: providers})
-	output := buildCrushInfo(cfg, nil, nil, nil, nil)
+	output := buildCrushInfo(cfg, nil, nil, nil, nil, nil)
 	require.NotContains(t, output, "sk-super-secret-key-12345")
 	require.NotContains(t, output, "secret")
 	require.Contains(t, output, "openai = enabled (8 models)")
@@ -274,7 +274,7 @@ func TestCrushInfo_DeterministicOrdering(t *testing.T) {
 	zMcpIdx := strings.Index(mcpOutput, "z-mcp = connected")
 	require.Less(t, aMcpIdx, zMcpIdx)
 
-	output := buildCrushInfo(cfg, nil, nil, nil, nil)
+	output := buildCrushInfo(cfg, nil, nil, nil, nil, nil)
 
 	alphaIdx := strings.Index(output, "alpha = enabled")
 	middleIdx := strings.Index(output, "middle = enabled")
@@ -295,7 +295,7 @@ func TestCrushInfo_EmptySectionsOmitted(t *testing.T) {
 		Options:     &config.Options{},
 	})
 
-	output := buildCrushInfo(cfg, nil, nil, nil, nil)
+	output := buildCrushInfo(cfg, nil, nil, nil, nil, nil)
 	require.NotContains(t, output, "[tools]")
 	require.NotContains(t, output, "[permissions]")
 	require.NotContains(t, output, "[lsp]")
@@ -317,7 +317,7 @@ func TestCrushInfo_ConfigStaleness_Clean(t *testing.T) {
 	// Capture snapshot (normally done in Load)
 	store.CaptureStalenessSnapshot([]string{configPath})
 
-	output := buildCrushInfo(store, nil, nil, nil, nil)
+	output := buildCrushInfo(store, nil, nil, nil, nil, nil)
 	require.Contains(t, output, "[config]")
 	require.Contains(t, output, "dirty = false")
 	require.NotContains(t, output, "changed_paths")
@@ -342,7 +342,7 @@ func TestCrushInfo_ConfigStaleness_Dirty(t *testing.T) {
 	time.Sleep(10 * time.Millisecond)
 	require.NoError(t, os.WriteFile(configPath, []byte(`{"debug": true}`), 0o600))
 
-	output := buildCrushInfo(store, nil, nil, nil, nil)
+	output := buildCrushInfo(store, nil, nil, nil, nil, nil)
 	require.Contains(t, output, "[config]")
 	require.Contains(t, output, "dirty = true")
 	require.Contains(t, output, "changed_paths")
@@ -366,7 +366,7 @@ func TestCrushInfo_ConfigStaleness_MissingPath(t *testing.T) {
 	// Delete file to trigger missing state
 	require.NoError(t, os.Remove(configPath))
 
-	output := buildCrushInfo(store, nil, nil, nil, nil)
+	output := buildCrushInfo(store, nil, nil, nil, nil, nil)
 	require.Contains(t, output, "[config]")
 	require.Contains(t, output, "dirty = true")
 	require.Contains(t, output, "missing_paths")
@@ -379,7 +379,7 @@ func TestCrushInfo_Skills_NoSkills(t *testing.T) {
 	cfg := config.NewTestStore(&config.Config{
 		Providers: csync.NewMap[string, config.ProviderConfig](),
 	})
-	output := buildCrushInfo(cfg, nil, nil, nil, nil)
+	output := buildCrushInfo(cfg, nil, nil, nil, nil, nil)
 	require.NotContains(t, output, "[skills]")
 }
 
@@ -400,7 +400,7 @@ func TestCrushInfo_Skills_MixedLoadedUnloaded(t *testing.T) {
 	cfg := config.NewTestStore(&config.Config{
 		Providers: csync.NewMap[string, config.ProviderConfig](),
 	})
-	output := buildCrushInfo(cfg, nil, allSkills, activeSkills, tracker)
+	output := buildCrushInfo(cfg, nil, allSkills, activeSkills, tracker, nil)
 	require.Contains(t, output, "[skills]")
 	require.Contains(t, output, "bash = user, loaded")
 	require.Contains(t, output, "crush-config = builtin, loaded")
@@ -426,7 +426,7 @@ func TestCrushInfo_Skills_DisabledSkills(t *testing.T) {
 		Providers: csync.NewMap[string, config.ProviderConfig](),
 		Options:   &config.Options{DisabledSkills: []string{"image-convert"}},
 	})
-	output := buildCrushInfo(cfg, nil, allSkills, activeSkills, tracker)
+	output := buildCrushInfo(cfg, nil, allSkills, activeSkills, tracker, nil)
 	require.Contains(t, output, "[skills]")
 	require.Contains(t, output, "bash = user, unloaded")
 	require.Contains(t, output, "crush-config = builtin, unloaded")
@@ -447,7 +447,7 @@ func TestCrushInfo_Skills_Ordering(t *testing.T) {
 	cfg := config.NewTestStore(&config.Config{
 		Providers: csync.NewMap[string, config.ProviderConfig](),
 	})
-	output := buildCrushInfo(cfg, nil, allSkills, activeSkills, tracker)
+	output := buildCrushInfo(cfg, nil, allSkills, activeSkills, tracker, nil)
 
 	aIdx := strings.Index(output, "a-skill")
 	mIdx := strings.Index(output, "m-skill")
@@ -469,7 +469,7 @@ func TestCrushInfo_Skills_BuiltinOrigin(t *testing.T) {
 	cfg := config.NewTestStore(&config.Config{
 		Providers: csync.NewMap[string, config.ProviderConfig](),
 	})
-	output := buildCrushInfo(cfg, nil, allSkills, activeSkills, tracker)
+	output := buildCrushInfo(cfg, nil, allSkills, activeSkills, tracker, nil)
 	require.Contains(t, output, "crush-config = builtin, unloaded")
 	require.Contains(t, output, "my-skill = user, unloaded")
 }
@@ -487,7 +487,7 @@ func TestCrushInfo_Hooks(t *testing.T) {
 		},
 	})
 
-	output := buildCrushInfo(cfg, nil, nil, nil, nil)
+	output := buildCrushInfo(cfg, nil, nil, nil, nil, nil)
 	require.Contains(t, output, "[hooks]")
 	require.Contains(t, output, "PreToolUse (matcher: edit|write) = check-privates.sh")
 	require.Contains(t, output, "PreToolUse = audit.sh")
@@ -500,6 +500,6 @@ func TestCrushInfo_Hooks_NoHooks(t *testing.T) {
 		Providers: csync.NewMap[string, config.ProviderConfig](),
 	})
 
-	output := buildCrushInfo(cfg, nil, nil, nil, nil)
+	output := buildCrushInfo(cfg, nil, nil, nil, nil, nil)
 	require.NotContains(t, output, "[hooks]")
 }

--- a/internal/agent/tools/semantic_index.go
+++ b/internal/agent/tools/semantic_index.go
@@ -1,0 +1,122 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"charm.land/fantasy"
+
+	"github.com/charmbracelet/crush/internal/fsext"
+	"github.com/charmbracelet/crush/internal/semantic"
+	"github.com/charmbracelet/crush/internal/symbols"
+)
+
+const SemanticIndexToolName = "semantic_index"
+
+// SemanticIndexParams are the parameters for the semantic_index tool.
+type SemanticIndexParams struct {
+	Paths []string `json:"paths,omitempty" jsonschema:"description=Optional files or directories to index, relative to the working directory. Defaults to the whole working directory."`
+}
+
+// indexableExtensions is the allowlist of file extensions worth embedding.
+// The extractor falls back to whole-file chunking for unknown languages,
+// which is fine for source-adjacent text but worthless (and costly) for
+// binaries, images, and lockfiles.
+var indexableExtensions = map[string]bool{
+	".bash": true, ".c": true, ".cc": true, ".cljc": true, ".clj": true,
+	".cpp": true, ".cs": true, ".css": true, ".cxx": true, ".dart": true,
+	".elixir": true, ".elm": true, ".ex": true, ".exs": true, ".go": true,
+	".groovy": true, ".h": true, ".hpp": true, ".hs": true, ".htm": true,
+	".html": true, ".java": true, ".js": true, ".json": true, ".jsx": true,
+	".kt": true, ".kts": true, ".lua": true, ".md": true, ".mjs": true,
+	".ml": true, ".mts": true, ".php": true, ".py": true, ".rb": true,
+	".rs": true, ".scala": true, ".scm": true, ".sh": true, ".sql": true,
+	".svelte": true, ".swift": true, ".toml": true, ".ts": true, ".tsx": true,
+	".vue": true, ".xml": true, ".yaml": true, ".yml": true, ".zig": true,
+}
+
+// NewSemanticIndexTool creates a tool that builds or refreshes the
+// semantic search index. Files whose contents and embedding model have
+// not changed since the last index are skipped, so repeated runs are
+// incremental.
+func NewSemanticIndexTool(store *semantic.Store, extractor *symbols.Extractor, workingDir string) fantasy.AgentTool {
+	return fantasy.NewAgentTool(
+		SemanticIndexToolName,
+		semanticIndexDescription(),
+		func(ctx context.Context, params SemanticIndexParams, call fantasy.ToolCall) (fantasy.ToolResponse, error) {
+			if store == nil {
+				return fantasy.NewTextErrorResponse("Semantic search index is not configured. Set up an embedding provider in crush.json to enable semantic search."), nil
+			}
+
+			roots := params.Paths
+			if len(roots) == 0 {
+				roots = []string{"."}
+			}
+
+			var (
+				indexed int
+				skipped int
+				failed  int
+				errs    []string
+			)
+			for _, root := range roots {
+				absRoot := root
+				if !filepath.IsAbs(absRoot) {
+					absRoot = filepath.Join(workingDir, root)
+				}
+
+				// The glob walker is gitignore-aware and skips hidden
+				// directories, so vendor trees and .git never reach the
+				// embedding endpoint. The limit keeps a pathological
+				// repository from running away; 10k files is already an
+				// expensive index.
+				files, _, err := fsext.GlobGitignoreAwareCtx(ctx, "**/*", absRoot, 10000)
+				if err != nil {
+					errs = append(errs, fmt.Sprintf("%s: %v", root, err))
+					continue
+				}
+
+				for _, path := range files {
+					if ctx.Err() != nil {
+						return fantasy.NewTextErrorResponse(fmt.Sprintf("Indexing cancelled: %v", ctx.Err())), nil
+					}
+					if indexableExtensions[strings.ToLower(filepath.Ext(path))] {
+						n, skip, err := store.IndexFile(ctx, extractor, path)
+						if err != nil {
+							failed++
+							if len(errs) < 10 {
+								errs = append(errs, fmt.Sprintf("%s: %v", path, err))
+							}
+							continue
+						}
+						if skip {
+							skipped++
+						}
+						indexed += n
+					}
+				}
+			}
+
+			total, _ := store.ChunkCount(ctx)
+
+			var b strings.Builder
+			fmt.Fprintf(&b, "Indexed %d chunks from newly indexed or changed files. %d files unchanged and skipped.", indexed, skipped)
+			if failed > 0 {
+				fmt.Fprintf(&b, " %d files failed.", failed)
+			}
+			fmt.Fprintf(&b, " Index now holds %d chunks.\n", total)
+			for _, e := range errs {
+				fmt.Fprintf(&b, "error: %s\n", e)
+			}
+			return fantasy.NewTextResponse(b.String()), nil
+		},
+	)
+}
+
+func semanticIndexDescription() string {
+	return `Build or refresh the semantic search index for this repository. Files are chunked by symbol, embedded through the configured embedding provider, and stored in the project database. Unchanged files are skipped, so this is incremental and safe to re-run.
+
+Run this before semantic_search when the index is empty or stale (for example after pulling changes or editing many files). With no arguments it indexes the whole working directory (gitignore-aware); pass specific files or directories to narrow the run.`
+}

--- a/internal/agent/tools/semantic_wiring_test.go
+++ b/internal/agent/tools/semantic_wiring_test.go
@@ -29,7 +29,7 @@ func newSemanticTestStore(t *testing.T, baseURL string) *semantic.Store {
 	db, err := sql.Open("sqlite", ":memory:")
 	require.NoError(t, err)
 	t.Cleanup(func() { db.Close() })
-	_, err = db.Exec(`CREATE TABLE IF NOT EXISTS chunks (
+	_, err = db.ExecContext(t.Context(), `CREATE TABLE IF NOT EXISTS chunks (
 			chunk_id   INTEGER PRIMARY KEY,
 			session_id TEXT,
 			path       TEXT,

--- a/internal/agent/tools/semantic_wiring_test.go
+++ b/internal/agent/tools/semantic_wiring_test.go
@@ -105,6 +105,45 @@ func TestSemanticIndexToolIndexesFiles(t *testing.T) {
 	require.Equal(t, int64(1), count)
 }
 
+// TestSemanticIndexToolIsIncremental pins the claim in the tool's own
+// description: a second run over unchanged files re-embeds nothing and
+// reports them as skipped, so re-running is cheap rather than a full
+// re-index at the embedding provider's expense.
+func TestSemanticIndexToolIsIncremental(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "main.go"), []byte("package main\n\nfunc Hello() string { return \"hi\" }\n"), 0o644))
+
+	srv := embeddingServer(t)
+	store := newSemanticTestStore(t, srv.URL)
+	tool := NewSemanticIndexTool(store, symbols.NewExtractor(), dir)
+
+	first, err := runTool(t, tool, SemanticIndexParams{})
+	require.NoError(t, err)
+	require.Contains(t, first, "0 files unchanged and skipped")
+
+	second, err := runTool(t, tool, SemanticIndexParams{})
+	require.NoError(t, err)
+	require.Contains(t, second, "Indexed 0 chunks")
+	require.Contains(t, second, "1 files unchanged and skipped")
+
+	// Idempotent: the second run must not duplicate the chunk.
+	count, err := store.ChunkCount(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, int64(1), count)
+
+	// A changed file is re-indexed rather than skipped.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "main.go"), []byte("package main\n\nfunc Goodbye() string { return \"bye\" }\n"), 0o644))
+	third, err := runTool(t, tool, SemanticIndexParams{})
+	require.NoError(t, err)
+	require.Contains(t, third, "0 files unchanged and skipped")
+
+	// Re-indexing replaces the file's chunks rather than accumulating
+	// stale ones alongside them.
+	count, err = store.ChunkCount(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, int64(1), count)
+}
+
 func TestSemanticIndexToolUnconfigured(t *testing.T) {
 	tool := NewSemanticIndexTool(nil, nil, t.TempDir())
 	resp, err := runTool(t, tool, SemanticIndexParams{})

--- a/internal/agent/tools/semantic_wiring_test.go
+++ b/internal/agent/tools/semantic_wiring_test.go
@@ -1,0 +1,143 @@
+package tools
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"charm.land/fantasy"
+
+	"github.com/charmbracelet/crush/internal/config"
+	"github.com/charmbracelet/crush/internal/csync"
+	"github.com/charmbracelet/crush/internal/semantic"
+	"github.com/charmbracelet/crush/internal/symbols"
+	"github.com/stretchr/testify/require"
+
+	_ "modernc.org/sqlite"
+)
+
+// newSemanticTestStore opens an in-memory store with the chunks table the
+// migrations create, so NewStore only has to add the vec0 table.
+func newSemanticTestStore(t *testing.T, baseURL string) *semantic.Store {
+	t.Helper()
+	db, err := sql.Open("sqlite", ":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() { db.Close() })
+	_, err = db.Exec(`CREATE TABLE IF NOT EXISTS chunks (
+			chunk_id   INTEGER PRIMARY KEY,
+			session_id TEXT,
+			path       TEXT,
+			symbol     TEXT,
+			start_line INTEGER,
+			end_line   INTEGER,
+			content    TEXT NOT NULL,
+			file_hash  TEXT,
+			model      TEXT NOT NULL,
+			dim        INTEGER NOT NULL
+		) STRICT`)
+	require.NoError(t, err)
+	store, err := semantic.NewStore(context.Background(), db, semantic.EmbeddingConfig{
+		BaseURL: baseURL, Model: "test-model", Dimension: 3,
+	})
+	require.NoError(t, err)
+	return store
+}
+
+// embeddingServer serves an /embeddings endpoint returning fixed
+// 3-dimensional vectors, one per input.
+func embeddingServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Input []string `json:"input"`
+		}
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+		out := "{\"data\":["
+		for i := range req.Input {
+			if i > 0 {
+				out += ","
+			}
+			out += "{\"embedding\":[0.1,0.2,0.3],\"index\":" + strconv.Itoa(i) + "}"
+		}
+		out += "]}"
+		w.Header().Set("Content-Type", "application/json")
+		_, err := w.Write([]byte(out))
+		require.NoError(t, err)
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func runTool[T any](t *testing.T, tool fantasy.AgentTool, params T) (string, error) {
+	t.Helper()
+	input, err := json.Marshal(params)
+	require.NoError(t, err)
+	call := fantasy.ToolCall{ID: "test-call", Name: tool.Info().Name, Input: string(input)}
+	resp, err := tool.Run(t.Context(), call)
+	if err != nil {
+		return "", err
+	}
+	return resp.Content, nil
+}
+
+func TestSemanticIndexToolIndexesFiles(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "main.go"), []byte("package main\n\nfunc Hello() string { return \"hi\" }\n"), 0o644))
+	// A binary extension must be skipped by the extension allowlist.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "img.png"), []byte("binary"), 0o644))
+
+	srv := embeddingServer(t)
+	store := newSemanticTestStore(t, srv.URL)
+
+	tool := NewSemanticIndexTool(store, symbols.NewExtractor(), dir)
+	resp, err := runTool(t, tool, SemanticIndexParams{})
+	require.NoError(t, err)
+	require.Contains(t, resp, "Index now holds 1 chunks")
+
+	count, err := store.ChunkCount(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, int64(1), count)
+}
+
+func TestSemanticIndexToolUnconfigured(t *testing.T) {
+	tool := NewSemanticIndexTool(nil, nil, t.TempDir())
+	resp, err := runTool(t, tool, SemanticIndexParams{})
+	require.NoError(t, err)
+	require.Contains(t, resp, "not configured")
+}
+
+func TestSemanticSearchToolUnconfigured(t *testing.T) {
+	tool := NewSemanticSearchTool(nil, nil)
+	resp, err := runTool(t, tool, SemanticSearchParams{Query: "anything"})
+	require.NoError(t, err)
+	require.Contains(t, resp, "not configured")
+}
+
+func TestCrushInfoSemanticSection(t *testing.T) {
+	cfg := config.NewTestStore(&config.Config{
+		Providers:  csync.NewMap[string, config.ProviderConfig](),
+		Embeddings: &config.EmbeddingsConfig{Model: "test-model", Dimension: 512, APIKey: "sk-secret"},
+	})
+	store := newSemanticTestStore(t, "")
+	out := buildCrushInfo(cfg, nil, nil, nil, nil, store)
+	require.Contains(t, out, "[semantic_index]")
+	require.Contains(t, out, "model = test-model (dim 512)")
+	require.Contains(t, out, "chunks = 0")
+	// The API key must never be echoed back.
+	require.NotContains(t, out, "sk-secret")
+
+	out = buildCrushInfo(cfg, nil, nil, nil, nil, nil)
+	require.Contains(t, out, "store = unavailable")
+
+	cfgNone := config.NewTestStore(&config.Config{
+		Providers: csync.NewMap[string, config.ProviderConfig](),
+	})
+	out = buildCrushInfo(cfgNone, nil, nil, nil, nil, nil)
+	require.NotContains(t, out, "[semantic_index]")
+}

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -34,6 +34,7 @@ import (
 	"github.com/charmbracelet/crush/internal/permission"
 	"github.com/charmbracelet/crush/internal/pubsub"
 	"github.com/charmbracelet/crush/internal/question"
+	"github.com/charmbracelet/crush/internal/semantic"
 	"github.com/charmbracelet/crush/internal/session"
 	"github.com/charmbracelet/crush/internal/shell"
 	"github.com/charmbracelet/crush/internal/skills"
@@ -67,6 +68,11 @@ type App struct {
 	Skills *skills.Manager
 
 	config *config.ConfigStore
+
+	// conn is the shared project database handle, retained so the
+	// semantic index store can be (re)built against it when the coder
+	// agent initialises.
+	conn *sql.DB
 
 	serviceEventsWG *sync.WaitGroup
 	eventsCtx       context.Context
@@ -119,6 +125,7 @@ func New(ctx context.Context, conn *sql.DB, store *config.ConfigStore, skillsMgr
 		globalCtx: ctx,
 
 		config: store,
+		conn:   conn,
 
 		events:             pubsub.NewBroker[tea.Msg](),
 		serviceEventsWG:    &sync.WaitGroup{},
@@ -681,7 +688,7 @@ func (app *App) initCoderAgent(ctx context.Context, interactive bool) error {
 		return fmt.Errorf("coder agent configuration is missing")
 	}
 	var err error
-	app.AgentCoordinator, err = agent.NewCoordinator(ctx, agent.CoordinatorOptions{
+	coordinatorOpts := agent.CoordinatorOptions{
 		Config:      app.config,
 		Sessions:    app.Sessions,
 		Messages:    app.Messages,
@@ -694,7 +701,33 @@ func (app *App) initCoderAgent(ctx context.Context, interactive bool) error {
 		RunComplete: app.runCompletions,
 		Skills:      app.Skills,
 		Interactive: interactive,
-	})
+	}
+
+	// Semantic search is opt-in: only wire the store and client when an
+	// embedding provider is configured. A failed store init (e.g. a
+	// dimension change demanding a reindex) disables the tools for this
+	// run with a logged, actionable error rather than killing startup.
+	if emb, ok := app.config.Config().ResolvedEmbeddings(); ok {
+		store, err := semantic.NewStore(ctx, app.conn, semantic.EmbeddingConfig{
+			BaseURL:   emb.BaseURL,
+			APIKey:    emb.APIKey,
+			Model:     emb.Model,
+			Dimension: emb.Dimension,
+		})
+		if err != nil {
+			slog.Error("Semantic search disabled: index store initialisation failed", "error", err)
+		} else {
+			coordinatorOpts.SemanticStore = store
+			coordinatorOpts.SemanticClient = semantic.NewClient(semantic.EmbeddingConfig{
+				BaseURL:   emb.BaseURL,
+				APIKey:    emb.APIKey,
+				Model:     emb.Model,
+				Dimension: emb.Dimension,
+			})
+		}
+	}
+
+	app.AgentCoordinator, err = agent.NewCoordinator(ctx, coordinatorOpts)
 	if err != nil {
 		slog.Error("Failed to create coder agent", "err", err)
 		return err

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -402,6 +402,17 @@ type Options struct {
 
 type MCPs map[string]MCPConfig
 
+// EmbeddingsConfig configures the embedding provider that backs the
+// semantic_search tool. It points at any OpenAI-compatible
+// /v1/embeddings endpoint. A nil config disables semantic search
+// entirely — the tool is not registered.
+type EmbeddingsConfig struct {
+	BaseURL   string `json:"base_url,omitempty" jsonschema:"description=Base URL of an OpenAI-compatible embeddings endpoint,default=https://api.openai.com/v1,example=https://api.openai.com/v1"`
+	APIKey    string `json:"api_key,omitempty" jsonschema:"description=API key for the embeddings endpoint. Supports shell expansion of $VAR and $(command)."`
+	Model     string `json:"model,omitempty" jsonschema:"description=Embedding model name,default=text-embedding-3-small,example=text-embedding-3-small"`
+	Dimension int    `json:"dimension,omitempty" jsonschema:"description=Embedding vector dimension. Baked into the vector table on first creation; changing it requires reindexing.,default=768,example=768"`
+}
+
 type MCP struct {
 	Name string    `json:"name"`
 	MCP  MCPConfig `json:"mcp"`
@@ -700,6 +711,26 @@ func (h *HookConfig) TimeoutDuration() time.Duration {
 	return time.Duration(h.Timeout) * time.Second
 }
 
+// ResolvedEmbeddings returns the effective embedding configuration with
+// defaults applied, and whether semantic search is enabled at all. The
+// second return value is false when no embeddings block is configured.
+func (c *Config) ResolvedEmbeddings() (EmbeddingsConfig, bool) {
+	if c.Embeddings == nil {
+		return EmbeddingsConfig{}, false
+	}
+	e := *c.Embeddings
+	if e.BaseURL == "" {
+		e.BaseURL = "https://api.openai.com/v1"
+	}
+	if e.Model == "" {
+		e.Model = "text-embedding-3-small"
+	}
+	if e.Dimension <= 0 {
+		e.Dimension = 768
+	}
+	return e, true
+}
+
 // Config holds the configuration for crush.
 type Config struct {
 	Schema string `json:"$schema,omitempty"`
@@ -716,6 +747,10 @@ type Config struct {
 	MCP MCPs `json:"mcp,omitempty" jsonschema:"description=Model Context Protocol server configurations"`
 
 	LSP LSPs `json:"lsp,omitempty" jsonschema:"description=Language Server Protocol configurations"`
+
+	// Embeddings enables the semantic_search tool. Nil (the default)
+	// leaves the tool unregistered.
+	Embeddings *EmbeddingsConfig `json:"embeddings,omitempty" jsonschema:"description=Embedding provider configuration for semantic search"`
 
 	Options *Options `json:"options,omitempty" jsonschema:"description=General application options"`
 
@@ -876,6 +911,8 @@ func allToolNames() []string {
 		"grep",
 		"ls",
 		"question",
+		"semantic_search",
+		"semantic_index",
 		"sidekick_update",
 		"sourcegraph",
 		"todos",
@@ -897,7 +934,7 @@ func resolveAllowedTools(allTools []string, disabledTools []string) []string {
 }
 
 func resolveReadOnlyTools(tools []string) []string {
-	readOnlyTools := []string{"glob", "grep", "ls", "lsp_call_hierarchy", "lsp_definition", "lsp_symbols", "sourcegraph", "view"}
+	readOnlyTools := []string{"glob", "grep", "ls", "lsp_call_hierarchy", "lsp_definition", "lsp_symbols", "semantic_search", "sourcegraph", "view"}
 	// filter to only include tools that are in allowedtools (include mode)
 	return filterSlice(tools, readOnlyTools, true)
 }

--- a/internal/config/embeddings_test.go
+++ b/internal/config/embeddings_test.go
@@ -1,0 +1,51 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type fakeResolver struct{}
+
+func (fakeResolver) ResolveValue(v string) (string, error) { return "resolved:" + v, nil }
+
+func TestResolvedEmbeddingsDefaults(t *testing.T) {
+	t.Parallel()
+
+	c := &Config{Embeddings: &EmbeddingsConfig{APIKey: "sk-test"}}
+	e, ok := c.ResolvedEmbeddings()
+	require.True(t, ok)
+	require.Equal(t, "https://api.openai.com/v1", e.BaseURL)
+	require.Equal(t, "text-embedding-3-small", e.Model)
+	require.Equal(t, 768, e.Dimension)
+	require.Equal(t, "sk-test", e.APIKey)
+}
+
+func TestResolvedEmbeddingsUnset(t *testing.T) {
+	t.Parallel()
+
+	c := &Config{}
+	_, ok := c.ResolvedEmbeddings()
+	require.False(t, ok)
+}
+
+func TestResolveEmbeddingsExpandsCredentials(t *testing.T) {
+	t.Parallel()
+
+	c := &Config{Embeddings: &EmbeddingsConfig{
+		BaseURL: "$(printenv EMB_BASE)",
+		APIKey:  "$EMB_KEY",
+	}}
+	c.resolveEmbeddings(fakeResolver{})
+	require.Equal(t, "resolved:$(printenv EMB_BASE)", c.Embeddings.BaseURL)
+	require.Equal(t, "resolved:$EMB_KEY", c.Embeddings.APIKey)
+}
+
+func TestResolveEmbeddingsNilNoop(t *testing.T) {
+	t.Parallel()
+
+	c := &Config{}
+	c.resolveEmbeddings(fakeResolver{})
+	require.Nil(t, c.Embeddings)
+}

--- a/internal/config/embeddings_test.go
+++ b/internal/config/embeddings_test.go
@@ -1,8 +1,13 @@
 package config
 
 import (
+	"bytes"
+	"errors"
+	"log/slog"
+	"strings"
 	"testing"
 
+	"github.com/charmbracelet/crush/internal/env"
 	"github.com/stretchr/testify/require"
 )
 
@@ -48,4 +53,65 @@ func TestResolveEmbeddingsNilNoop(t *testing.T) {
 	c := &Config{}
 	c.resolveEmbeddings(fakeResolver{})
 	require.Nil(t, c.Embeddings)
+}
+
+// failingResolver stands in for the real shell resolver on the error path.
+// Its error embeds the template it was handed, exactly as resolveError does.
+type failingResolver struct{}
+
+func (failingResolver) ResolveValue(v string) (string, error) {
+	return "", errors.New("resolving " + v + ": parse error")
+}
+
+// TestResolveEmbeddingsNeverLogsAPIKey pins the reason api_key is logged
+// without its error: resolveError renders the pre-expansion template, which
+// is the credential itself when the user wrote a literal key.
+func TestResolveEmbeddingsNeverLogsAPIKey(t *testing.T) {
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, nil)))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	c := &Config{Embeddings: &EmbeddingsConfig{APIKey: "sk-live-DEADBEEF"}}
+	c.resolveEmbeddings(failingResolver{})
+
+	require.NotContains(t, buf.String(), "sk-live-DEADBEEF")
+	require.Contains(t, buf.String(), "embeddings API key")
+}
+
+// TestResolveEmbeddingsClearsUnresolvableFields pins that a failed
+// resolution does not leave the raw template behind, which would otherwise
+// be sent verbatim as the bearer token and base URL.
+func TestResolveEmbeddingsClearsUnresolvableFields(t *testing.T) {
+	t.Parallel()
+
+	c := &Config{Embeddings: &EmbeddingsConfig{
+		APIKey:  "$EMB_KEY",
+		BaseURL: "$(broken",
+	}}
+	c.resolveEmbeddings(failingResolver{})
+
+	require.Empty(t, c.Embeddings.APIKey)
+	require.Empty(t, c.Embeddings.BaseURL)
+
+	// The cleared base URL falls back to the documented default.
+	e, ok := c.ResolvedEmbeddings()
+	require.True(t, ok)
+	require.Equal(t, "https://api.openai.com/v1", e.BaseURL)
+}
+
+// TestResolveEmbeddingsRealResolverHidesLiteralKey is the end-to-end version
+// of the above against the real shell resolver: a literal key containing
+// shell metacharacters fails to parse, and must not reach the log.
+func TestResolveEmbeddingsRealResolverHidesLiteralKey(t *testing.T) {
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, nil)))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	c := &Config{Embeddings: &EmbeddingsConfig{APIKey: `sk-live-DEADBEEF$(`}}
+	c.resolveEmbeddings(NewShellVariableResolver(env.New()))
+
+	require.False(t, strings.Contains(buf.String(), "DEADBEEF"), "api key leaked into logs: %s", buf.String())
+	require.Empty(t, c.Embeddings.APIKey)
 }

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -129,6 +129,8 @@ func Load(workingDir, dataDir string, debug bool) (*ConfigStore, error) {
 	// like AWS_PROFILE are visible to the AWS SDK credential chain.
 	cfg.applyEnv(valueResolver)
 
+	cfg.resolveEmbeddings(valueResolver)
+
 	if err := cfg.configureProviders(context.Background(), store, env, valueResolver, store.knownProviders); err != nil {
 		return nil, fmt.Errorf("failed to configure providers: %w", err)
 	}
@@ -502,6 +504,38 @@ func (c *Config) applyEnv(resolver VariableResolver) {
 			continue
 		}
 		os.Setenv(k, resolved)
+	}
+}
+
+// resolveEmbeddings shell-expands the credential-bearing embedding fields
+// in place so $VAR and $(command) templates in api_key and base_url behave
+// like every other credential field in the config.
+func (c *Config) resolveEmbeddings(resolver VariableResolver) {
+	if c.Embeddings == nil {
+		return
+	}
+	for _, field := range []struct {
+		name  string
+		value string
+	}{
+		{"api_key", c.Embeddings.APIKey},
+		{"base_url", c.Embeddings.BaseURL},
+	} {
+		if field.value == "" {
+			continue
+		}
+		resolved, err := resolver.ResolveValue(field.value)
+		if err != nil {
+			slog.Warn("Skipping embeddings field due to resolution failure.",
+				"field", field.name, "error", err)
+			continue
+		}
+		switch field.name {
+		case "api_key":
+			c.Embeddings.APIKey = resolved
+		case "base_url":
+			c.Embeddings.BaseURL = resolved
+		}
 	}
 }
 

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -510,32 +510,43 @@ func (c *Config) applyEnv(resolver VariableResolver) {
 // resolveEmbeddings shell-expands the credential-bearing embedding fields
 // in place so $VAR and $(command) templates in api_key and base_url behave
 // like every other credential field in the config.
+//
+// A field that fails to resolve is cleared rather than left holding its
+// unexpanded template: keeping it would send the literal "$EMB_KEY" as the
+// bearer token (or as the base URL) to the embeddings endpoint, which fails
+// far away from the config mistake that caused it. Clearing lets
+// ResolvedEmbeddings reapply the documented defaults instead.
+//
+// @joestump-agent 08/25/2026 - Initial implementation.
+//
+// @joestump 08/25/2026 - Stopped logging the resolution error for api_key.
+// resolveError renders the pre-expansion template, which is the secret
+// itself when the user wrote a literal key, so the failure path wrote the
+// key to the crush log in clear text (CodeQL go/clear-text-logging, high).
+// The error is still logged for base_url, matching how configureProviders
+// treats API keys versus endpoints. Also clear failed fields, see above.
 func (c *Config) resolveEmbeddings(resolver VariableResolver) {
 	if c.Embeddings == nil {
 		return
 	}
-	for _, field := range []struct {
-		name  string
-		value string
-	}{
-		{"api_key", c.Embeddings.APIKey},
-		{"base_url", c.Embeddings.BaseURL},
-	} {
-		if field.value == "" {
-			continue
-		}
-		resolved, err := resolver.ResolveValue(field.value)
+
+	if v := c.Embeddings.APIKey; v != "" {
+		resolved, err := resolver.ResolveValue(v)
 		if err != nil {
-			slog.Warn("Skipping embeddings field due to resolution failure.",
-				"field", field.name, "error", err)
-			continue
+			// No "error" attribute: it embeds the unresolved template.
+			slog.Warn("Ignoring embeddings API key that failed to resolve.")
+			resolved = ""
 		}
-		switch field.name {
-		case "api_key":
-			c.Embeddings.APIKey = resolved
-		case "base_url":
-			c.Embeddings.BaseURL = resolved
+		c.Embeddings.APIKey = resolved
+	}
+
+	if v := c.Embeddings.BaseURL; v != "" {
+		resolved, err := resolver.ResolveValue(v)
+		if err != nil {
+			slog.Warn("Ignoring embeddings base URL that failed to resolve.", "error", err)
+			resolved = ""
 		}
+		c.Embeddings.BaseURL = resolved
 	}
 }
 

--- a/internal/config/load_test.go
+++ b/internal/config/load_test.go
@@ -789,7 +789,7 @@ func TestConfig_setupAgentsWithNoDisabledTools(t *testing.T) {
 
 	taskAgent, ok := cfg.Agents[AgentTask]
 	require.True(t, ok)
-	assert.Equal(t, []string{"lsp_symbols", "lsp_definition", "lsp_call_hierarchy", "glob", "grep", "ls", "sourcegraph", "view"}, taskAgent.AllowedTools)
+	assert.Equal(t, []string{"lsp_symbols", "lsp_definition", "lsp_call_hierarchy", "glob", "grep", "ls", "semantic_search", "sourcegraph", "view"}, taskAgent.AllowedTools)
 }
 
 func TestConfig_setupAgentsWithDisabledTools(t *testing.T) {
@@ -807,11 +807,11 @@ func TestConfig_setupAgentsWithDisabledTools(t *testing.T) {
 	coderAgent, ok := cfg.Agents[AgentCoder]
 	require.True(t, ok)
 
-	assert.Equal(t, []string{"agent", "bash", "crush_info", "crush_logs", "CronCreate", "CronList", "CronDelete", "job_output", "job_kill", "multiedit", "lsp_diagnostics", "lsp_references", "lsp_restart", "lsp_symbols", "lsp_definition", "lsp_call_hierarchy", "lsp_rename", "lsp_replace_symbol", "fetch", "agentic_fetch", "glob", "ls", "question", "sidekick_update", "sourcegraph", "todos", "view", "write", "list_mcp_resources", "read_mcp_resource", "list_mcp_prompts", "call_mcp_prompt"}, coderAgent.AllowedTools)
+	assert.Equal(t, []string{"agent", "bash", "crush_info", "crush_logs", "CronCreate", "CronList", "CronDelete", "job_output", "job_kill", "multiedit", "lsp_diagnostics", "lsp_references", "lsp_restart", "lsp_symbols", "lsp_definition", "lsp_call_hierarchy", "lsp_rename", "lsp_replace_symbol", "fetch", "agentic_fetch", "glob", "ls", "question", "semantic_search", "semantic_index", "sidekick_update", "sourcegraph", "todos", "view", "write", "list_mcp_resources", "read_mcp_resource", "list_mcp_prompts", "call_mcp_prompt"}, coderAgent.AllowedTools)
 
 	taskAgent, ok := cfg.Agents[AgentTask]
 	require.True(t, ok)
-	assert.Equal(t, []string{"lsp_symbols", "lsp_definition", "lsp_call_hierarchy", "glob", "ls", "sourcegraph", "view"}, taskAgent.AllowedTools)
+	assert.Equal(t, []string{"lsp_symbols", "lsp_definition", "lsp_call_hierarchy", "glob", "ls", "semantic_search", "sourcegraph", "view"}, taskAgent.AllowedTools)
 }
 
 func TestConfig_setupAgentsWithEveryReadOnlyToolDisabled(t *testing.T) {
@@ -824,6 +824,7 @@ func TestConfig_setupAgentsWithEveryReadOnlyToolDisabled(t *testing.T) {
 				"lsp_call_hierarchy",
 				"lsp_definition",
 				"lsp_symbols",
+				"semantic_search",
 				"sourcegraph",
 				"view",
 			},
@@ -833,7 +834,7 @@ func TestConfig_setupAgentsWithEveryReadOnlyToolDisabled(t *testing.T) {
 	cfg.SetupAgents()
 	coderAgent, ok := cfg.Agents[AgentCoder]
 	require.True(t, ok)
-	assert.Equal(t, []string{"agent", "bash", "crush_info", "crush_logs", "CronCreate", "CronList", "CronDelete", "job_output", "job_kill", "download", "edit", "multiedit", "lsp_diagnostics", "lsp_references", "lsp_restart", "lsp_rename", "lsp_replace_symbol", "fetch", "agentic_fetch", "question", "sidekick_update", "todos", "write", "list_mcp_resources", "read_mcp_resource", "list_mcp_prompts", "call_mcp_prompt"}, coderAgent.AllowedTools)
+	assert.Equal(t, []string{"agent", "bash", "crush_info", "crush_logs", "CronCreate", "CronList", "CronDelete", "job_output", "job_kill", "download", "edit", "multiedit", "lsp_diagnostics", "lsp_references", "lsp_restart", "lsp_rename", "lsp_replace_symbol", "fetch", "agentic_fetch", "question", "semantic_index", "sidekick_update", "todos", "write", "list_mcp_resources", "read_mcp_resource", "list_mcp_prompts", "call_mcp_prompt"}, coderAgent.AllowedTools)
 
 	taskAgent, ok := cfg.Agents[AgentTask]
 	require.True(t, ok)

--- a/internal/shellconfig/embeddings.go
+++ b/internal/shellconfig/embeddings.go
@@ -1,0 +1,71 @@
+package shellconfig
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+)
+
+// handleEmbeddings implements the `embeddings` builtin.
+//
+// Usage:
+//
+//	embeddings set [--base-url URL] [--api-key KEY] [--model NAME]
+//	    [--dimension N]
+//	embeddings clear
+//
+// "set" defines or updates the single embedding provider that backs the
+// semantic_search tool; unspecified fields keep their current (or default)
+// values. "clear" removes the configuration entirely, which unregisters the
+// semantic search tools on the next config load.
+func handleEmbeddings(ctx context.Context, args []string, stdin io.Reader, stdout, stderr io.Writer) error {
+	b := configBuilderFromCtx(ctx)
+	if b == nil {
+		return nil
+	}
+	if len(args) < 2 {
+		return usage(stderr, "usage: embeddings set [--base-url URL] [--api-key KEY] [--model NAME] [--dimension N] | embeddings clear")
+	}
+
+	switch args[1] {
+	case "set":
+		return embeddingsSet(b, args, stderr)
+	case "clear", "remove", "rm":
+		return embeddingsClear(b)
+	default:
+		return usage(stderr, fmt.Sprintf("embeddings: unknown subcommand %q (expected set or clear)", args[1]))
+	}
+}
+
+// embeddingsSetFlags is the declarative flag surface for `embeddings set`.
+var embeddingsSetFlags = []flagSpec{
+	{name: "--base-url", jsonKey: "base_url", kind: flagString, op: opSet},
+	{name: "--api-key", jsonKey: "api_key", kind: flagString, op: opSet},
+	{name: "--model", jsonKey: "model", kind: flagString, op: opSet},
+	{name: "--dimension", jsonKey: "dimension", kind: flagInt, op: opSet, validate: positiveDimension},
+}
+
+// positiveDimension rejects non-positive dimensions: a zero or negative
+// dimension would silently default at load, hiding the typo from the user.
+func positiveDimension(v any) error {
+	if d, ok := v.(int64); ok && d <= 0 {
+		return fmt.Errorf("dimension must be positive, got %d", d)
+	}
+	return nil
+}
+
+func embeddingsSet(b *ConfigBuilder, args []string, stderr io.Writer) error {
+	section := b.section("embeddings")
+	if err := applyFlags(embeddingsSetFlags, args, 2, section, "embeddings set", stderr); err != nil {
+		return err
+	}
+	slog.Info("Embedding provider defined in shell config")
+	return nil
+}
+
+func embeddingsClear(b *ConfigBuilder) error {
+	delete(b.root, "embeddings")
+	slog.Info("Embedding provider removed in shell config")
+	return nil
+}

--- a/internal/shellconfig/embeddings_test.go
+++ b/internal/shellconfig/embeddings_test.go
@@ -1,0 +1,67 @@
+package shellconfig
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestEmbeddingsSet(t *testing.T) {
+	t.Parallel()
+
+	result := loadScript(t, `embeddings set --base-url https://emb.example.com/v1 --api-key sk-test --model nomic-embed --dimension 512`)
+
+	emb, ok := result["embeddings"].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "https://emb.example.com/v1", emb["base_url"])
+	require.Equal(t, "sk-test", emb["api_key"])
+	require.Equal(t, "nomic-embed", emb["model"])
+	require.Equal(t, float64(512), emb["dimension"])
+}
+
+func TestEmbeddingsSetPartialKeepsExisting(t *testing.T) {
+	t.Parallel()
+
+	result := loadScript(t, `embeddings set --model m1 --api-key k1
+embeddings set --dimension 256`)
+
+	emb := result["embeddings"].(map[string]any)
+	require.Equal(t, "m1", emb["model"])
+	require.Equal(t, "k1", emb["api_key"])
+	require.Equal(t, float64(256), emb["dimension"])
+}
+
+func TestEmbeddingsSetInvalidDimension(t *testing.T) {
+	t.Parallel()
+
+	path := t.TempDir() + "/crushrc"
+	_, err := LoadShellConfig(t.Context(), path, []byte(`embeddings set --dimension 0`))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "dimension must be positive")
+}
+
+func TestEmbeddingsClear(t *testing.T) {
+	t.Parallel()
+
+	// Clearing the only section leaves the builder empty, which the
+	// loader treats as "no config" and returns no JSON.
+	path := t.TempDir() + "/crushrc"
+	jsonBytes, err := LoadShellConfig(t.Context(), path, []byte(`embeddings set --model m1
+embeddings clear`))
+	require.NoError(t, err)
+	require.Empty(t, string(jsonBytes))
+
+	result := loadScript(t, `provider add openai --api-key k
+embeddings set --model m1
+embeddings clear`)
+	require.NotContains(t, result, "embeddings")
+}
+
+func TestEmbeddingsUnknownSubcommand(t *testing.T) {
+	t.Parallel()
+
+	path := t.TempDir() + "/crushrc"
+	_, err := LoadShellConfig(t.Context(), path, []byte(`embeddings bogus`))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unknown subcommand")
+}

--- a/internal/shellconfig/register.go
+++ b/internal/shellconfig/register.go
@@ -26,6 +26,7 @@ func init() {
 	shell.RegisterBuiltin("permissions", handlePermissions)
 	shell.RegisterBuiltin("hook", handleHook)
 	shell.RegisterBuiltin("option", handleOption)
+	shell.RegisterBuiltin("embeddings", handleEmbeddings)
 }
 
 // usage prints a usage message to stderr and returns an error.

--- a/schema.json
+++ b/schema.json
@@ -78,6 +78,10 @@
           "$ref": "#/$defs/LSPs",
           "description": "Language Server Protocol configurations"
         },
+        "embeddings": {
+          "$ref": "#/$defs/EmbeddingsConfig",
+          "description": "Embedding provider configuration for semantic search"
+        },
         "options": {
           "$ref": "#/$defs/Options",
           "description": "General application options"
@@ -106,6 +110,40 @@
           },
           "type": "object",
           "description": "Environment variables to set on startup"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "EmbeddingsConfig": {
+      "properties": {
+        "base_url": {
+          "type": "string",
+          "description": "Base URL of an OpenAI-compatible embeddings endpoint",
+          "default": "https://api.openai.com/v1",
+          "examples": [
+            "https://api.openai.com/v1"
+          ]
+        },
+        "api_key": {
+          "type": "string",
+          "description": "API key for the embeddings endpoint. Supports shell expansion of $VAR and $(command)."
+        },
+        "model": {
+          "type": "string",
+          "description": "Embedding model name",
+          "default": "text-embedding-3-small",
+          "examples": [
+            "text-embedding-3-small"
+          ]
+        },
+        "dimension": {
+          "type": "integer",
+          "description": "Embedding vector dimension. Baked into the vector table on first creation; changing it requires reindexing.",
+          "default": 768,
+          "examples": [
+            768
+          ]
         }
       },
       "additionalProperties": false,
@@ -641,23 +679,6 @@
         "disable_a2ui": {
           "type": "boolean",
           "description": "Disable A2UI entirely: drops the prompt section inviting the model to emit renderable \u003ca2ui-json\u003e surfaces and stops advertising the a2ui capability to MCP servers",
-          "default": false
-        },
-        "allowed_commands": {
-          "items": {
-            "type": "string",
-            "examples": [
-              "ssh",
-              "curl",
-              "scp"
-            ]
-          },
-          "type": "array",
-          "description": "List of commands to allow that are normally banned. Only affects the exact-command block list; package-manager argument blocks (e.g. 'apt install') are unaffected. Allowed commands still require permission approval."
-        },
-        "allow_all_commands": {
-          "type": "boolean",
-          "description": "Remove all command restrictions from the bash tool",
           "default": false
         },
         "allowed_commands": {


### PR DESCRIPTION
## Summary

Closes #277. The storage/search layer from #249 is now reachable:

- **Config surface**: top-level `embeddings` block in `crush.json` (`base_url`, `api_key`, `model`, `dimension`, defaults applied) and an `embeddings set|clear` crushrc builtin. `api_key` and `base_url` get the same shell expansion (`$VAR`, `$(...)`, `${VAR:?}`) as every other credential field.
- **Tool registration**: `semantic_search` plus a new `semantic_index` tool are registered in `buildTools` only when an embedding provider is configured **and** the store initialises — same conditional style as the LSP/MCP blocks. A failed store init (e.g. dimension change) disables the tools for the run with a logged, actionable error instead of killing startup. Both tools added to the default coder palette; `semantic_search` is also in the read-only (task agent) toolset.
- **Index lifecycle (defined trigger)**: on demand. `semantic_index` walks the working directory gitignore-aware through an extension allowlist, and `Store.IndexFile` already skips files whose hash + model + dimension are unchanged, so runs are incremental and idempotent.
- **crush_info**: new `[semantic_index]` section (model, dimension, chunk count; `store = unavailable` on init failure; absent entirely when unconfigured). Never echoes the API key.
- **Docs**: removed the "not yet wired up" callout from the docs-site page and documented the real config + tools.

## How verified

- `go build ./...`, `go vet ./...`, `gofmt` clean; full `go test ./...` green.
- New tests: shellconfig `embeddings` builtin (set/partial/clear/invalid dimension/unknown subcommand), config `ResolvedEmbeddings` defaults + shell-expansion resolution, coordinator gating (tools absent without store, present with store, in default palette), `semantic_index` end-to-end against an httptest embeddings server (indexes `.go`, skips `.png`), unconfigured-tool error paths, and crush_info section content + no-secret assertion.

🤖 This was posted autonomously by [`glm-5.3`](https://openrouter.ai/z-ai/glm-5.3) using [Crush](https://github.com/charmbracelet/crush).