### PR TITLE
feat(a2ui): render semantic tool results as live A2UI surfaces

### DIFF
--- a/docs-site/docs/features/semantic-search.md
+++ b/docs-site/docs/features/semantic-search.md
@@ -104,6 +104,14 @@ run, so repeat runs only pay for what moved.
 It returns file locations, symbol names, line ranges, and relevance scores —
 not full file contents; follow up with `view` for the authoritative text.
 
+In the interactive TUI, both tools render their results as an A2UI surface
+under the tool call — a card with per-result location, score, and snippet
+for `semantic_search`, and an index summary card for `semantic_index`. The
+surface travels in tool-result metadata and never enters the model's
+context; the model still receives a compact text digest it can act on.
+Headless runs, channel-originated turns, and `disable_a2ui` deployments get
+the original plain-text output unchanged.
+
 ## Checking state
 
 `crush_info` reports the semantic index alongside LSP and MCP:

--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -1240,8 +1240,8 @@ func (c *coordinator) buildTools(ctx context.Context, agent config.Agent, isSubA
 	if c.semanticStore != nil && c.semanticClient != nil {
 		allTools = append(
 			allTools,
-			tools.NewSemanticSearchTool(c.semanticStore, c.semanticClient),
-			tools.NewSemanticIndexTool(c.semanticStore, c.semanticSymbols, c.cfg.WorkingDir()),
+			tools.NewSemanticSearchTool(c.cfg, c.semanticStore, c.semanticClient),
+			tools.NewSemanticIndexTool(c.cfg, c.semanticStore, c.semanticSymbols, c.cfg.WorkingDir()),
 		)
 	}
 

--- a/internal/agent/tools/read_mcp_resource.go
+++ b/internal/agent/tools/read_mcp_resource.go
@@ -42,6 +42,12 @@ const a2uiMIMEType = mcp.A2UIJSONMIMEType
 type ReadMCPResourceResponseMetadata struct {
 	A2UISurfaces         []string `json:"a2ui_surfaces,omitempty"`
 	MCPSurfaceProvenance []string `json:"mcp_surface_provenance,omitempty"`
+	// TextIsModelOnly marks the tool's text content as written for the
+	// model alone, so the chat renderer draws the surfaces and stops —
+	// rather than repeating a digest of the same results underneath them.
+	// Resource reads leave this false: their text is the resource's own
+	// content and belongs to the user as much as the surface does.
+	TextIsModelOnly bool `json:"a2ui_text_model_only,omitempty"`
 }
 
 // A2UISurfacePlaceholderPrefix starts every model-facing placeholder that

--- a/internal/agent/tools/semantic_a2ui.go
+++ b/internal/agent/tools/semantic_a2ui.go
@@ -1,0 +1,214 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"charm.land/fantasy"
+	"github.com/charmbracelet/crush/internal/config"
+	a2ui "github.com/tmc/a2ui"
+)
+
+// This file renders the semantic tools' results as A2UI surfaces alongside
+// their model-facing text. The payloads travel in response metadata (the
+// same channel read_mcp_resource uses), so the chat UI draws a live,
+// theme-styled surface under the tool call while the model keeps a compact
+// text digest it can act on. When no chat UI will render metadata
+// (channel-originated turns, disable_a2ui deployments, headless runs) the
+// tools fall back to their original plain-text output, so behavior off the
+// interactive UI is unchanged.
+//
+// @joestump-agent 08/25/2026 - Initial version for semantic_search and
+// semantic_index.
+
+// a2uiSurfaceIDPrefix namespaces the semantic tools' surface IDs so they
+// cannot collide with MCP-served surfaces sharing an ID.
+const a2uiSurfaceIDPrefix = "semantic-"
+
+// semanticDivert reports whether this turn carries an interactive chat UI
+// that will render tool-result metadata as a live A2UI surface. Mirrors the
+// gating in read_mcp_resource: channel turns need the model to relay the
+// data, disable_a2ui opts out of surfaces, and a zero content width means
+// no UI tagged the turn.
+func semanticDivert(ctx context.Context, cfg *config.ConfigStore) bool {
+	return GetChannelFromContext(ctx) == "" &&
+		cfg != nil &&
+		!cfg.Config().Options.DisableA2UI &&
+		GetContentWidthFromContext(ctx) > 0
+}
+
+// withSemanticSurface returns resp with the given components attached as a
+// UI-only A2UI surface in response metadata. The model never sees the
+// payload, so it cannot echo the JSON back and double-render the surface.
+func withSemanticSurface(resp fantasy.ToolResponse, surfaceID string, components []a2ui.Component) fantasy.ToolResponse {
+	msg := a2ui.ServerMessage{
+		Version: a2ui.Version,
+		UpdateComponents: &a2ui.UpdateComponents{
+			SurfaceID:  surfaceID,
+			Components: components,
+		},
+	}
+	payload, err := json.Marshal(msg)
+	if err != nil {
+		return resp
+	}
+	metadata := ReadMCPResourceResponseMetadata{
+		A2UISurfaces: []string{"<a2ui-json>" + string(payload) + "</a2ui-json>"},
+	}
+	return fantasy.WithResponseMetadata(resp, metadata)
+}
+
+// semanticSearchSurface builds the results card for a semantic_search call:
+// a header with the query and hit count, then one block per result with the
+// location line, relevance score, and a code snippet. Components form a
+// flat id-linked tree per the A2UI wire format.
+func semanticSearchSurface(query string, results []semanticSearchHit) []a2ui.Component {
+	text := func(id, s string) a2ui.Component {
+		return a2ui.Component{ID: id, Text: &a2ui.TextComponent{Text: a2ui.StringLiteral(s)}}
+	}
+	caption := func(id, s string) a2ui.Component {
+		return a2ui.Component{ID: id, Text: &a2ui.TextComponent{
+			Text:    a2ui.StringLiteral(s),
+			Variant: a2ui.TextVariantCaption,
+		}}
+	}
+
+	ids := newA2UIIDGen()
+	titleID := ids.next()
+	subID := ids.next()
+
+	var blockIDs []string
+	var extra []a2ui.Component
+	for _, r := range results {
+		loc := r.Path
+		if r.Symbol != "" {
+			loc += " :: " + r.Symbol
+		}
+		block := ids.next()
+		line := ids.next()
+		score := ids.next()
+		snippet := ids.next()
+		blockIDs = append(blockIDs, block)
+		extra = append(extra,
+			a2ui.Component{ID: block, Column: &a2ui.ColumnComponent{
+				Children: a2ui.ChildList{IDs: []string{line, score, snippet}},
+			}},
+			text(line, loc),
+			caption(score, fmt.Sprintf("lines %d-%d · score %.3f", r.StartLine+1, r.EndLine+1, r.Score)),
+			caption(snippet, firstLines(r.Snippet, 4)),
+		)
+	}
+
+	return append([]a2ui.Component{
+		{ID: "root", Card: &a2ui.CardComponent{Child: "col"}},
+		{ID: "col", Column: &a2ui.ColumnComponent{
+			Children: a2ui.ChildList{IDs: append([]string{titleID, subID}, blockIDs...)},
+		}},
+		{ID: titleID, Text: &a2ui.TextComponent{
+			Text:    a2ui.StringLiteral(fmt.Sprintf("Semantic search: %q", query)),
+			Variant: a2ui.TextVariantH3,
+		}},
+		caption(subID, fmt.Sprintf("%d results", len(results))),
+	}, extra...)
+}
+
+// semanticIndexSurface builds the summary card for a semantic_index run:
+// chunk totals plus any per-file errors.
+func semanticIndexSurface(indexed, skipped, failed, total int, errs []string) []a2ui.Component {
+	caption := func(id, s string) a2ui.Component {
+		return a2ui.Component{ID: id, Text: &a2ui.TextComponent{
+			Text:    a2ui.StringLiteral(s),
+			Variant: a2ui.TextVariantCaption,
+		}}
+	}
+
+	ids := newA2UIIDGen()
+	titleID := ids.next()
+	statsID := ids.next()
+	totalID := ids.next()
+
+	childIDs := []string{titleID, statsID, totalID}
+	var extra []a2ui.Component
+	for _, e := range errs {
+		id := ids.next()
+		childIDs = append(childIDs, id)
+		extra = append(extra, caption(id, "error: "+e))
+	}
+
+	failedPart := ""
+	if failed > 0 {
+		failedPart = fmt.Sprintf(" · %d failed", failed)
+	}
+
+	return append([]a2ui.Component{
+		{ID: "root", Card: &a2ui.CardComponent{Child: "col"}},
+		{ID: "col", Column: &a2ui.ColumnComponent{
+			Children: a2ui.ChildList{IDs: childIDs},
+		}},
+		{ID: titleID, Text: &a2ui.TextComponent{
+			Text:    a2ui.StringLiteral("Semantic index updated"),
+			Variant: a2ui.TextVariantH3,
+		}},
+		caption(statsID, fmt.Sprintf("%d chunks indexed · %d files unchanged%s", indexed, skipped, failedPart)),
+		caption(totalID, fmt.Sprintf("Index holds %d chunks", total)),
+	}, extra...)
+}
+
+// semanticSearchHit is the subset of semantic.SearchResult the surface and
+// the model-facing digest are built from.
+type semanticSearchHit struct {
+	Path      string
+	Symbol    string
+	StartLine int
+	EndLine   int
+	Score     float64
+	Snippet   string
+}
+
+// semanticSearchDigest renders the compact model-facing result list. It
+// deliberately omits snippets when a surface shows them to the user — the
+// tool description already steers the model to view for authoritative
+// content, and dropping the snippets saves the corresponding tokens.
+func semanticSearchDigest(results []semanticSearchHit, withSnippets bool) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "Found %d results:\n\n", len(results))
+	for i, r := range results {
+		fmt.Fprintf(&b, "%d. %s", i+1, r.Path)
+		if r.Symbol != "" {
+			fmt.Fprintf(&b, " :: %s", r.Symbol)
+		}
+		fmt.Fprintf(&b, " (lines %d-%d, score %.3f)\n", r.StartLine+1, r.EndLine+1, r.Score)
+		if withSnippets {
+			snippet := firstLines(r.Snippet, 5)
+			fmt.Fprintf(&b, "   %s\n", strings.ReplaceAll(snippet, "\n", "\n   "))
+		}
+	}
+	return b.String()
+}
+
+// firstLines truncates s to at most n lines, marking the cut.
+func firstLines(s string, n int) string {
+	lines := strings.Split(strings.TrimRight(s, "\n"), "\n")
+	if len(lines) <= n {
+		return strings.Join(lines, "\n")
+	}
+	return strings.Join(lines[:n], "\n") + "\n..."
+}
+
+// a2uiIDGen mints unique component ids for one surface. Ids only need to be
+// unique within the surface, but a stable scheme keeps output deterministic
+// for tests.
+type a2uiIDGen struct {
+	n int
+}
+
+func newA2UIIDGen() *a2uiIDGen {
+	return &a2uiIDGen{}
+}
+
+func (g *a2uiIDGen) next() string {
+	g.n++
+	return fmt.Sprintf("c%d", g.n)
+}

--- a/internal/agent/tools/semantic_a2ui.go
+++ b/internal/agent/tools/semantic_a2ui.go
@@ -22,6 +22,10 @@ import (
 //
 // @joestump-agent 08/25/2026 - Initial version for semantic_search and
 // semantic_index.
+//
+// @joestump 08/25/2026 - Marked the diverted text model-only so the chat
+// stops drawing the digest underneath the card, restored the blank line
+// between headless results, and pluralized the surface's result count.
 
 // a2uiSurfaceIDPrefix namespaces the semantic tools' surface IDs so they
 // cannot collide with MCP-served surfaces sharing an ID.
@@ -56,6 +60,10 @@ func withSemanticSurface(resp fantasy.ToolResponse, surfaceID string, components
 	}
 	metadata := ReadMCPResourceResponseMetadata{
 		A2UISurfaces: []string{"<a2ui-json>" + string(payload) + "</a2ui-json>"},
+		// resp's text is the model's digest of the same results the surface
+		// draws. Without this the chat would render the card and then repeat
+		// the digest underneath it.
+		TextIsModelOnly: true,
 	}
 	return fantasy.WithResponseMetadata(resp, metadata)
 }
@@ -110,7 +118,7 @@ func semanticSearchSurface(query string, results []semanticSearchHit) []a2ui.Com
 			Text:    a2ui.StringLiteral(fmt.Sprintf("Semantic search: %q", query)),
 			Variant: a2ui.TextVariantH3,
 		}},
-		caption(subID, fmt.Sprintf("%d results", len(results))),
+		caption(subID, fmt.Sprintf("%d %s", len(results), pluralize(len(results), "result"))),
 	}, extra...)
 }
 
@@ -182,10 +190,22 @@ func semanticSearchDigest(results []semanticSearchHit, withSnippets bool) string
 		fmt.Fprintf(&b, " (lines %d-%d, score %.3f)\n", r.StartLine+1, r.EndLine+1, r.Score)
 		if withSnippets {
 			snippet := firstLines(r.Snippet, 5)
-			fmt.Fprintf(&b, "   %s\n", strings.ReplaceAll(snippet, "\n", "\n   "))
+			// The trailing blank line is part of the pre-A2UI format this
+			// path must reproduce byte for byte on headless runs.
+			fmt.Fprintf(&b, "   %s\n\n", strings.ReplaceAll(snippet, "\n", "\n   "))
 		}
 	}
 	return b.String()
+}
+
+// pluralize appends an s to word unless n is exactly 1. The surface is the
+// user-facing copy, so "1 results" would read as a bug there; the
+// model-facing digest keeps its original wording.
+func pluralize(n int, word string) string {
+	if n == 1 {
+		return word
+	}
+	return word + "s"
 }
 
 // firstLines truncates s to at most n lines, marking the cut.

--- a/internal/agent/tools/semantic_a2ui_test.go
+++ b/internal/agent/tools/semantic_a2ui_test.go
@@ -1,0 +1,167 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"charm.land/fantasy"
+	a2tea "github.com/joestump-agent/a2tea"
+	a2ui "github.com/tmc/a2ui"
+
+	"github.com/charmbracelet/crush/internal/config"
+	"github.com/charmbracelet/crush/internal/csync"
+	"github.com/charmbracelet/crush/internal/semantic"
+	"github.com/charmbracelet/crush/internal/symbols"
+	"github.com/stretchr/testify/require"
+)
+
+// uiTurnContext mimics a turn tagged by the interactive chat UI: no channel
+// origin and a positive content width, the two signals semanticDivert keys
+// on.
+func uiTurnContext(t *testing.T) context.Context {
+	t.Helper()
+	ctx := context.WithValue(t.Context(), ChannelContextKey, "")
+	return context.WithValue(ctx, ContentWidthContextKey, 120)
+}
+
+// semanticTestConfig returns a config store with A2UI left at its default
+// (enabled).
+func semanticTestConfig(t *testing.T) *config.ConfigStore {
+	t.Helper()
+	return config.NewTestStore(&config.Config{
+		Providers: csync.NewMap[string, config.ProviderConfig](),
+		Options:   &config.Options{},
+	})
+}
+
+// validateSurfaceComponents asserts the invariants the chat renderer relies
+// on: every component has an id, ids are unique, and every child/children
+// reference resolves to a component in the same flat list.
+func validateSurfaceComponents(t *testing.T, components []a2ui.Component) {
+	t.Helper()
+	ids := map[string]bool{}
+	for _, c := range components {
+		require.NotEmpty(t, c.ID, "component must have an id")
+		require.False(t, ids[c.ID], "duplicate component id %q", c.ID)
+		ids[c.ID] = true
+	}
+	refs := []string{}
+	for _, c := range components {
+		if c.Card != nil {
+			refs = append(refs, c.Card.Child)
+		}
+		if c.Column != nil {
+			refs = append(refs, c.Column.Children.IDs...)
+		}
+		if c.Row != nil {
+			refs = append(refs, c.Row.Children.IDs...)
+		}
+		if c.List != nil {
+			refs = append(refs, c.List.Children.IDs...)
+		}
+	}
+	for _, ref := range refs {
+		require.True(t, ids[ref], "dangling child reference %q", ref)
+	}
+}
+
+func TestSemanticSearchSurfaceLinks(t *testing.T) {
+	hits := []semanticSearchHit{
+		{Path: "a.go", Symbol: "Foo", StartLine: 9, EndLine: 20, Score: 0.912, Snippet: "func Foo() {\n\treturn\n}"},
+		{Path: "b.go", StartLine: 0, EndLine: 3, Score: 0.734, Snippet: strings.Repeat("line\n", 10)},
+	}
+	components := semanticSearchSurface("where is auth handled", hits)
+	validateSurfaceComponents(t, components)
+	require.Len(t, components, 4+4*len(hits))
+}
+
+func TestSemanticIndexSurfaceLinks(t *testing.T) {
+	components := semanticIndexSurface(3, 5, 1, 9, []string{"x.go: boom"})
+	validateSurfaceComponents(t, components)
+}
+
+// TestSemanticSurfacesRender guards the surfaces against drifting from what
+// the pinned a2tea actually renders: a surface that only draws placeholders
+// would fail silently in chat, since the model-facing text still looks fine.
+func TestSemanticSurfacesRender(t *testing.T) {
+	t.Parallel()
+	for name, comps := range map[string][]a2ui.Component{
+		"search": semanticSearchSurface("where is auth handled", []semanticSearchHit{
+			{Path: "a.go", Symbol: "Foo", StartLine: 9, EndLine: 20, Score: 0.912, Snippet: "func Foo() {\n\treturn\n}"},
+		}),
+		"index": semanticIndexSurface(3, 5, 0, 9, nil),
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			m, err := a2tea.Render([]a2ui.ServerMessage{{
+				Version:          a2ui.Version,
+				UpdateComponents: &a2ui.UpdateComponents{SurfaceID: "s", Components: comps},
+			}})
+			require.NoError(t, err)
+			out := m.View().Content
+			require.NotContains(t, out, "[a2tea:")
+			require.NotEmpty(t, strings.TrimSpace(out))
+		})
+	}
+}
+
+// TestSemanticSearchDivert pins the split: on a UI-tagged turn the model
+// gets the snippet-free digest and the pretty card rides in response
+// metadata; on a plain turn the text keeps its snippets and no metadata is
+// attached.
+func TestSemanticSearchDivert(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "main.go"),
+		[]byte("package main\n\nfunc Hello() string { return \"hi\" }\n"), 0o644))
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, err := w.Write([]byte(`{"data":[{"embedding":[0.1,0.2,0.3],"index":0}]}`))
+		require.NoError(t, err)
+	}))
+	t.Cleanup(srv.Close)
+
+	store := newSemanticTestStore(t, srv.URL)
+	client := semantic.NewClient(semantic.EmbeddingConfig{
+		BaseURL: srv.URL, Model: "test-model", Dimension: 3,
+	})
+
+	indexTool := NewSemanticIndexTool(semanticTestConfig(t), store, symbols.NewExtractor(), dir)
+	_, runErr := runTool(t, indexTool, SemanticIndexParams{})
+	require.NoError(t, runErr)
+
+	run := func(ctx context.Context, cfg *config.ConfigStore) fantasy.ToolResponse {
+		tool := NewSemanticSearchTool(cfg, store, client)
+		input, err := json.Marshal(SemanticSearchParams{Query: "hello"})
+		require.NoError(t, err)
+		resp, err := tool.Run(ctx, fantasy.ToolCall{ID: "c", Name: SemanticSearchToolName, Input: string(input)})
+		require.NoError(t, err)
+		return resp
+	}
+
+	uiResp := run(uiTurnContext(t), semanticTestConfig(t))
+	require.Contains(t, uiResp.Content, "main.go :: Hello")
+	require.NotContains(t, uiResp.Content, "return \"hi\"")
+	var meta ReadMCPResourceResponseMetadata
+	require.NoError(t, json.Unmarshal([]byte(uiResp.Metadata), &meta))
+	require.Len(t, meta.A2UISurfaces, 1)
+	require.True(t, strings.HasPrefix(meta.A2UISurfaces[0], "<a2ui-json>"))
+	var msg a2ui.ServerMessage
+	payload := strings.TrimSuffix(strings.TrimPrefix(meta.A2UISurfaces[0], "<a2ui-json>"), "</a2ui-json>")
+	require.NoError(t, json.Unmarshal([]byte(payload), &msg))
+	require.Equal(t, a2ui.Version, msg.Version)
+	require.NotNil(t, msg.UpdateComponents)
+	require.Equal(t, "semantic-search", msg.UpdateComponents.SurfaceID)
+	validateSurfaceComponents(t, msg.UpdateComponents.Components)
+
+	// Plain (headless) turn: snippets stay in the text, no surface metadata.
+	plainResp := run(t.Context(), semanticTestConfig(t))
+	require.Contains(t, plainResp.Content, "return")
+	require.Empty(t, plainResp.Metadata)
+}

--- a/internal/agent/tools/semantic_a2ui_test.go
+++ b/internal/agent/tools/semantic_a2ui_test.go
@@ -165,3 +165,60 @@ func TestSemanticSearchDivert(t *testing.T) {
 	require.Contains(t, plainResp.Content, "return")
 	require.Empty(t, plainResp.Metadata)
 }
+
+// The diverted text is a digest of the same hits the surface draws, so it
+// must be flagged model-only — otherwise the chat renders the card and then
+// repeats the digest as flat text underneath it.
+func TestSemanticSurfaceMarksTextModelOnly(t *testing.T) {
+	t.Parallel()
+	resp := withSemanticSurface(fantasy.NewTextResponse("digest"), a2uiSurfaceIDPrefix+"search",
+		semanticSearchSurface("q", []semanticSearchHit{{Path: "a.go", Score: 0.5, Snippet: "x"}}))
+	var meta ReadMCPResourceResponseMetadata
+	require.NoError(t, json.Unmarshal([]byte(resp.Metadata), &meta))
+	require.True(t, meta.TextIsModelOnly)
+}
+
+// The headless path must reproduce the pre-A2UI text byte for byte: the
+// blank line between results was part of it, and dropping it silently
+// changed every non-interactive semantic_search result.
+func TestSemanticSearchDigestHeadlessFormat(t *testing.T) {
+	t.Parallel()
+	hits := []semanticSearchHit{
+		{Path: "a.go", Symbol: "Foo", StartLine: 0, EndLine: 1, Score: 0.5, Snippet: "one\ntwo"},
+		{Path: "b.go", StartLine: 4, EndLine: 4, Score: 0.25, Snippet: "solo"},
+	}
+	require.Equal(t, "Found 2 results:\n\n"+
+		"1. a.go :: Foo (lines 1-2, score 0.500)\n   one\n   two\n\n"+
+		"2. b.go (lines 5-5, score 0.250)\n   solo\n\n",
+		semanticSearchDigest(hits, true))
+
+	require.Equal(t, "Found 2 results:\n\n"+
+		"1. a.go :: Foo (lines 1-2, score 0.500)\n"+
+		"2. b.go (lines 5-5, score 0.250)\n",
+		semanticSearchDigest(hits, false))
+}
+
+// The surface is user-facing copy, so a single hit reads "1 result".
+func TestSemanticSearchSurfacePluralizesCount(t *testing.T) {
+	t.Parallel()
+	one := semanticSearchSurface("q", []semanticSearchHit{{Path: "a.go", Score: 0.5, Snippet: "x"}})
+	require.Contains(t, surfaceText(t, one), "1 result")
+	require.NotContains(t, surfaceText(t, one), "1 results")
+	two := semanticSearchSurface("q", []semanticSearchHit{
+		{Path: "a.go", Score: 0.5, Snippet: "x"},
+		{Path: "b.go", Score: 0.4, Snippet: "y"},
+	})
+	require.Contains(t, surfaceText(t, two), "2 results")
+}
+
+// surfaceText joins every Text component's literal in a surface.
+func surfaceText(t *testing.T, components []a2ui.Component) string {
+	t.Helper()
+	var parts []string
+	for _, c := range components {
+		if c.Text != nil && c.Text.Text.Literal != nil {
+			parts = append(parts, *c.Text.Text.Literal)
+		}
+	}
+	return strings.Join(parts, "\n")
+}

--- a/internal/agent/tools/semantic_index.go
+++ b/internal/agent/tools/semantic_index.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 
 	"charm.land/fantasy"
-
+	"github.com/charmbracelet/crush/internal/config"
 	"github.com/charmbracelet/crush/internal/fsext"
 	"github.com/charmbracelet/crush/internal/semantic"
 	"github.com/charmbracelet/crush/internal/symbols"
@@ -41,7 +41,7 @@ var indexableExtensions = map[string]bool{
 // semantic search index. Files whose contents and embedding model have
 // not changed since the last index are skipped, so repeated runs are
 // incremental.
-func NewSemanticIndexTool(store *semantic.Store, extractor *symbols.Extractor, workingDir string) fantasy.AgentTool {
+func NewSemanticIndexTool(cfg *config.ConfigStore, store *semantic.Store, extractor *symbols.Extractor, workingDir string) fantasy.AgentTool {
 	return fantasy.NewAgentTool(
 		SemanticIndexToolName,
 		semanticIndexDescription(),
@@ -110,7 +110,13 @@ func NewSemanticIndexTool(store *semantic.Store, extractor *symbols.Extractor, w
 			for _, e := range errs {
 				fmt.Fprintf(&b, "error: %s\n", e)
 			}
-			return fantasy.NewTextResponse(b.String()), nil
+			resp := fantasy.NewTextResponse(b.String())
+			// The summary card renders as a live A2UI surface when a chat UI
+			// is attached; the text above stays model-facing either way.
+			if semanticDivert(ctx, cfg) {
+				resp = withSemanticSurface(resp, a2uiSurfaceIDPrefix+"index", semanticIndexSurface(indexed, skipped, failed, int(total), errs))
+			}
+			return resp, nil
 		},
 	)
 }

--- a/internal/agent/tools/semantic_search.go
+++ b/internal/agent/tools/semantic_search.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	"charm.land/fantasy"
-
+	"github.com/charmbracelet/crush/internal/config"
 	"github.com/charmbracelet/crush/internal/semantic"
 )
 
@@ -21,7 +21,7 @@ type SemanticSearchParams struct {
 // NewSemanticSearchTool creates a semantic search tool backed by the
 // given semantic store. If store is nil the tool returns an error
 // indicating the index is not available.
-func NewSemanticSearchTool(store *semantic.Store, client *semantic.Client) fantasy.AgentTool {
+func NewSemanticSearchTool(cfg *config.ConfigStore, store *semantic.Store, client *semantic.Client) fantasy.AgentTool {
 	return fantasy.NewAgentTool(
 		SemanticSearchToolName,
 		semanticSearchDescription(),
@@ -63,24 +63,26 @@ func NewSemanticSearchTool(store *semantic.Store, client *semantic.Client) fanta
 				return fantasy.NewTextResponse("No results found for this query."), nil
 			}
 
-			var b strings.Builder
-			fmt.Fprintf(&b, "Found %d results:\n\n", len(results))
+			hits := make([]semanticSearchHit, len(results))
 			for i, r := range results {
-				fmt.Fprintf(&b, "%d. %s", i+1, r.Path)
-				if r.Symbol != "" {
-					fmt.Fprintf(&b, " :: %s", r.Symbol)
+				hits[i] = semanticSearchHit{
+					Path:      r.Path,
+					Symbol:    r.Symbol,
+					StartLine: r.StartLine,
+					EndLine:   r.EndLine,
+					Score:     r.Score,
+					Snippet:   r.Content,
 				}
-				fmt.Fprintf(&b, " (lines %d-%d, score %.3f)\n", r.StartLine+1, r.EndLine+1, r.Score)
-
-				snippet := r.Content
-				lines := strings.Split(snippet, "\n")
-				if len(lines) > 5 {
-					snippet = strings.Join(lines[:5], "\n") + "\n..."
-				}
-				fmt.Fprintf(&b, "   %s\n\n", strings.ReplaceAll(snippet, "\n", "\n   "))
 			}
 
-			return fantasy.NewTextResponse(b.String()), nil
+			// With a chat UI attached, the result card renders as a live
+			// A2UI surface in the tool bubble and the model gets the snippet-
+			// free digest; otherwise the tool behaves exactly as before.
+			if semanticDivert(ctx, cfg) {
+				resp := fantasy.NewTextResponse(semanticSearchDigest(hits, false))
+				return withSemanticSurface(resp, a2uiSurfaceIDPrefix+"search", semanticSearchSurface(params.Query, hits)), nil
+			}
+			return fantasy.NewTextResponse(semanticSearchDigest(hits, true)), nil
 		},
 	)
 }

--- a/internal/agent/tools/semantic_wiring_test.go
+++ b/internal/agent/tools/semantic_wiring_test.go
@@ -95,7 +95,7 @@ func TestSemanticIndexToolIndexesFiles(t *testing.T) {
 	srv := embeddingServer(t)
 	store := newSemanticTestStore(t, srv.URL)
 
-	tool := NewSemanticIndexTool(store, symbols.NewExtractor(), dir)
+	tool := NewSemanticIndexTool(nil, store, symbols.NewExtractor(), dir)
 	resp, err := runTool(t, tool, SemanticIndexParams{})
 	require.NoError(t, err)
 	require.Contains(t, resp, "Index now holds 1 chunks")
@@ -115,7 +115,7 @@ func TestSemanticIndexToolIsIncremental(t *testing.T) {
 
 	srv := embeddingServer(t)
 	store := newSemanticTestStore(t, srv.URL)
-	tool := NewSemanticIndexTool(store, symbols.NewExtractor(), dir)
+	tool := NewSemanticIndexTool(nil, store, symbols.NewExtractor(), dir)
 
 	first, err := runTool(t, tool, SemanticIndexParams{})
 	require.NoError(t, err)
@@ -145,14 +145,14 @@ func TestSemanticIndexToolIsIncremental(t *testing.T) {
 }
 
 func TestSemanticIndexToolUnconfigured(t *testing.T) {
-	tool := NewSemanticIndexTool(nil, nil, t.TempDir())
+	tool := NewSemanticIndexTool(nil, nil, nil, t.TempDir())
 	resp, err := runTool(t, tool, SemanticIndexParams{})
 	require.NoError(t, err)
 	require.Contains(t, resp, "not configured")
 }
 
 func TestSemanticSearchToolUnconfigured(t *testing.T) {
-	tool := NewSemanticSearchTool(nil, nil)
+	tool := NewSemanticSearchTool(nil, nil, nil)
 	resp, err := runTool(t, tool, SemanticSearchParams{Query: "anything"})
 	require.NoError(t, err)
 	require.Contains(t, resp, "not configured")

--- a/internal/ui/chat/generic.go
+++ b/internal/ui/chat/generic.go
@@ -87,7 +87,7 @@ func (g *GenericToolRenderContext) RenderTool(sty *styles.Styles, width int, opt
 	if opts.Result.Metadata != "" {
 		var meta tools.ReadMCPResourceResponseMetadata
 		if err := json.Unmarshal([]byte(opts.Result.Metadata), &meta); err == nil && len(meta.A2UISurfaces) > 0 {
-			return joinToolParts(header, renderToolA2UIResultBody(sty, meta.A2UISurfaces, opts, widths))
+			return joinToolParts(header, renderToolA2UIResultBody(sty, meta, opts, widths))
 		}
 	}
 	// Pre-change read_mcp_resource results persisted the raw payload in the
@@ -113,7 +113,8 @@ func (g *GenericToolRenderContext) RenderTool(sty *styles.Styles, width int, opt
 // When every surface fails to render, an alert replaces the body — the
 // model-facing placeholder claims the user can already see the surface,
 // which would be false here.
-func renderToolA2UIResultBody(sty *styles.Styles, surfaces []string, opts *ToolRenderOpts, widths toolResultContentWidths) string {
+func renderToolA2UIResultBody(sty *styles.Styles, meta tools.ReadMCPResourceResponseMetadata, opts *ToolRenderOpts, widths toolResultContentWidths) string {
+	surfaces := meta.A2UISurfaces
 	var b strings.Builder
 	failed := 0
 	if opts.LiveSurfaces != nil {
@@ -146,8 +147,10 @@ func renderToolA2UIResultBody(sty *styles.Styles, surfaces []string, opts *ToolR
 	}
 	// Show any real text the resource returned alongside its surfaces — the
 	// model-facing placeholder lines are stripped, the rest belongs to the
-	// user just as much as the surfaces do.
-	if text := stripA2UIPlaceholders(opts.Result.Content); text != "" {
+	// user just as much as the surfaces do. Tools that flag their text as
+	// model-only (a digest of the very results the surface draws) show
+	// nothing here, so the card is not shadowed by a flat copy of itself.
+	if text := stripA2UIPlaceholders(opts.Result.Content); text != "" && !meta.TextIsModelOnly {
 		chunks = append(chunks, renderToolResultTextContent(sty, text, widths, opts.ExpandedContent))
 	}
 	return strings.Join(chunks, "\n")

--- a/internal/ui/chat/generic_test.go
+++ b/internal/ui/chat/generic_test.go
@@ -242,3 +242,51 @@ func TestGenericToolA2UICollapse(t *testing.T) {
 	require.NotContains(t, outExpanded, "lines hidden")
 	require.Contains(t, outExpanded, "row a0")
 }
+
+// A tool whose text is a model-facing digest of the very results its
+// surface draws (semantic_search, semantic_index) must not have that digest
+// rendered underneath the card — the user would read the same hits twice,
+// once styled and once flat.
+func TestGenericToolModelOnlyTextIsHidden(t *testing.T) {
+	t.Parallel()
+
+	meta, err := json.Marshal(tools.ReadMCPResourceResponseMetadata{
+		A2UISurfaces:    []string{a2uiSurface},
+		TextIsModelOnly: true,
+	})
+	require.NoError(t, err)
+
+	sty := styles.CharmtonePantera()
+	ctx := &GenericToolRenderContext{}
+	out := ctx.RenderTool(&sty, 100, genericToolOptsFor(t, tools.SemanticSearchToolName, &message.ToolResult{
+		Content:  "Found 1 results:\n\n1. main.go :: Hello (lines 1-3, score 0.912)\n",
+		Metadata: string(meta),
+	}))
+	plain := ansi.Strip(out)
+
+	require.Contains(t, plain, "Hello from A2UI")
+	require.NotContains(t, plain, "Found 1 results")
+	require.NotContains(t, plain, "score 0.912")
+}
+
+// The flag is opt-in: a resource read leaves it unset, and its text still
+// belongs to the user alongside the surface.
+func TestGenericToolTextShownWhenNotModelOnly(t *testing.T) {
+	t.Parallel()
+
+	meta, err := json.Marshal(tools.ReadMCPResourceResponseMetadata{
+		A2UISurfaces: []string{a2uiSurface},
+	})
+	require.NoError(t, err)
+
+	sty := styles.CharmtonePantera()
+	ctx := &GenericToolRenderContext{}
+	out := ctx.RenderTool(&sty, 100, genericToolOpts(t, &message.ToolResult{
+		Content:  a2uiTestPlaceholder + "\nreal resource prose",
+		Metadata: string(meta),
+	}))
+	plain := ansi.Strip(out)
+
+	require.Contains(t, plain, "Hello from A2UI")
+	require.Contains(t, plain, "real resource prose")
+}

--- a/internal/ui/chat/mcp.go
+++ b/internal/ui/chat/mcp.go
@@ -83,7 +83,7 @@ func (b *MCPToolRenderContext) RenderTool(sty *styles.Styles, width int, opts *T
 	if opts.Result.Metadata != "" {
 		var meta tools.ReadMCPResourceResponseMetadata
 		if err := json.Unmarshal([]byte(opts.Result.Metadata), &meta); err == nil && len(meta.A2UISurfaces) > 0 {
-			return joinToolParts(header, renderToolA2UIResultBody(sty, meta.A2UISurfaces, opts, widths))
+			return joinToolParts(header, renderToolA2UIResultBody(sty, meta, opts, widths))
 		}
 	}
 


### PR DESCRIPTION
## Summary
- `semantic_search` and `semantic_index` now emit A2UI surfaces via tool-result metadata (the same UI-only channel `read_mcp_resource` uses), so the interactive TUI draws a live, theme-styled results card under the tool call instead of flat markdown-ish text.
- `semantic_search` card: query header + one block per hit with location line, `lines a-b · score` caption, and a 4-line snippet. `semantic_index` card: chunks indexed / unchanged / failed totals plus per-file errors.
- The surface never enters the model's context — the model gets a compact snippet-free digest (paths, symbols, lines, scores), saving the snippet tokens; on headless runs, channel-originated turns, and `disable_a2ui` deployments the tools return the original plain-text output unchanged.
- Surface IDs are namespaced (`semantic-search`, `semantic-index`) to avoid collisions with MCP-served surfaces.

## Verification
- `go test ./internal/agent/...` green, including new tests: component-id link integrity for both surfaces, an a2tea render test guarding against placeholder regressions, and an end-to-end divert test (metadata present + snippet-free text on a UI-tagged turn; snippets and no metadata on a plain turn).
- `golangci-lint run ./internal/agent/...` → 0 issues.