### PR TITLE
fix(run): treat streamed message shrinkage as a cursor reset, not a fatal error

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -417,10 +417,13 @@ func (app *App) RunNonInteractive(ctx context.Context, output io.Writer, prompt,
 
 				content := msg.Content().String()
 				readBytes := messageReadBytes[msg.ID]
-
 				if len(content) < readBytes {
-					slog.Error("Non-interactive: message content is shorter than read bytes", "message_length", len(content), "read_bytes", readBytes)
-					return fmt.Errorf("message content is shorter than read bytes: %d < %d", len(content), readBytes)
+					// The message was rewritten or the stream reset: the
+					// cursor is stale. Re-emit from the start rather than
+					// killing the run.
+					slog.Warn("Non-interactive: message content shrank; resetting stream cursor",
+						"message_length", len(content), "read_bytes", readBytes)
+					readBytes = 0
 				}
 
 				part := content[readBytes:]

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -416,28 +416,13 @@ func (app *App) RunNonInteractive(ctx context.Context, output io.Writer, prompt,
 				stopSpinner()
 
 				content := msg.Content().String()
-				readBytes := messageReadBytes[msg.ID]
-				if len(content) < readBytes {
-					// The message was rewritten or the stream reset: the
-					// cursor is stale. Re-emit from the start rather than
-					// killing the run.
-					slog.Warn("Non-interactive: message content shrank; resetting stream cursor",
-						"message_length", len(content), "read_bytes", readBytes)
-					readBytes = 0
-				}
-
-				part := content[readBytes:]
-				// Trim leading whitespace. Sometimes the LLM includes leading
-				// formatting and intentation, which we don't want here.
-				if readBytes == 0 {
-					part = strings.TrimLeft(part, " \t")
-				}
+				part, next := format.NextStreamChunk(content, messageReadBytes[msg.ID])
 				// Ignore initial whitespace-only messages.
 				if printed || strings.TrimSpace(part) != "" {
 					printed = true
 					fmt.Fprint(output, part)
 				}
-				messageReadBytes[msg.ID] = len(content)
+				messageReadBytes[msg.ID] = next
 			}
 
 		case <-ctx.Done():

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -365,9 +365,12 @@ func (s *runStream) handle(ev any, stopSpinner func()) (done bool, err error) {
 		content := msg.Content().String()
 		readBytes := s.read[msg.ID]
 		if len(content) < readBytes {
-			slog.Error("Non-interactive: message content shorter than read bytes",
+			// The message was rewritten or the stream reset: the
+			// cursor is stale. Re-emit from the start rather than
+			// killing the run.
+			slog.Warn("Non-interactive: message content shrank; resetting stream cursor",
 				"message_length", len(content), "read_bytes", readBytes)
-			return false, fmt.Errorf("message content is shorter than read bytes: %d < %d", len(content), readBytes)
+			readBytes = 0
 		}
 
 		part := content[readBytes:]

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -363,25 +363,12 @@ func (s *runStream) handle(ev any, stopSpinner func()) (done bool, err error) {
 		stop()
 
 		content := msg.Content().String()
-		readBytes := s.read[msg.ID]
-		if len(content) < readBytes {
-			// The message was rewritten or the stream reset: the
-			// cursor is stale. Re-emit from the start rather than
-			// killing the run.
-			slog.Warn("Non-interactive: message content shrank; resetting stream cursor",
-				"message_length", len(content), "read_bytes", readBytes)
-			readBytes = 0
-		}
-
-		part := content[readBytes:]
-		if readBytes == 0 {
-			part = strings.TrimLeft(part, " \t")
-		}
+		part, next := format.NextStreamChunk(content, s.read[msg.ID])
 		if s.printed || strings.TrimSpace(part) != "" {
 			s.printed = true
 			fmt.Fprint(s.out, part)
 		}
-		s.read[msg.ID] = len(content)
+		s.read[msg.ID] = next
 		return false, nil
 
 	case pubsub.Event[proto.RunComplete]:

--- a/internal/cmd/run_stream_test.go
+++ b/internal/cmd/run_stream_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bytes"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -10,6 +11,38 @@ import (
 	"github.com/charmbracelet/crush/internal/pubsub"
 	"github.com/stretchr/testify/require"
 )
+
+// TestRunStream_ContentShrinkResetsCursor is the regression test for
+// the fatal "message content is shorter than read bytes" exit: when a
+// provider stream reset or rewritten content part makes the same
+// message ID come back shorter than the stdout cursor, the stream must
+// reset the cursor and re-emit from the start, not abort the run.
+func TestRunStream_ContentShrinkResetsCursor(t *testing.T) {
+	t.Parallel()
+
+	buf := &bytes.Buffer{}
+	s := &runStream{sessionID: "S", out: buf, read: map[string]int{}}
+
+	long := strings.Repeat("a", 270)
+	done, err := s.handle(pubsub.Event[proto.Message]{Payload: proto.Message{
+		ID: "m1", SessionID: "S", Role: proto.Assistant,
+		Parts: []proto.ContentPart{proto.TextContent{Text: long}},
+	}}, nil)
+	require.NoError(t, err)
+	require.False(t, done)
+	require.Equal(t, 270, s.read["m1"])
+	require.Len(t, buf.String(), 270)
+
+	// Same message ID comes back with 2 bytes of content.
+	done, err = s.handle(pubsub.Event[proto.Message]{Payload: proto.Message{
+		ID: "m1", SessionID: "S", Role: proto.Assistant,
+		Parts: []proto.ContentPart{proto.TextContent{Text: "ok"}},
+	}}, nil)
+	require.NoError(t, err, "shrinking content must not be fatal")
+	require.False(t, done)
+	require.Equal(t, 2, s.read["m1"])
+	require.Equal(t, long+"ok", buf.String(), "cursor reset must re-emit from the start")
+}
 
 // TestRunStream_ToolUseDoesNotTerminate is the regression test for
 // the original bug: a tool-call assistant message has a Finish part

--- a/internal/format/stream.go
+++ b/internal/format/stream.go
@@ -1,0 +1,47 @@
+// Non-Interactive Stream Cursor
+//
+// The non-interactive printers keep a per-message cursor recording how
+// many bytes of an assistant message have already been written to
+// stdout, and emit only the tail on each streamed update. That
+// bookkeeping is shared verbatim by `crush run` (internal/cmd) and
+// App.RunNonInteractive (internal/app); it lives here so a fix cannot
+// land in one copy and miss the other.
+//
+// @joestump 08/25/2026 - Extracted from the two call sites while
+// reviewing the shrink-reset fix (#284), which had to be applied twice
+// because the logic was duplicated.
+
+package format
+
+import (
+	"log/slog"
+	"strings"
+)
+
+// NextStreamChunk returns the not-yet-written tail of an assistant
+// message's content given the cursor position readBytes, together with
+// the cursor position the caller should store afterwards.
+//
+// Content for a given message ID is normally append-only, but a
+// provider stream reset, a retried request, or a rewritten content part
+// can make the same message come back shorter than the cursor. Slicing
+// on a stale cursor would panic, so that case resets the cursor to zero
+// and re-emits from the start: duplicating a little output is always
+// preferable to aborting a run that may already have minutes of tool
+// work behind it.
+//
+// Leading horizontal whitespace is trimmed whenever the chunk starts at
+// the beginning of the message, since models frequently open with
+// indentation that is meaningless on stdout.
+func NextStreamChunk(content string, readBytes int) (chunk string, next int) {
+	if len(content) < readBytes {
+		slog.Warn("Non-interactive: message content shrank; resetting stream cursor",
+			"message_length", len(content), "read_bytes", readBytes)
+		readBytes = 0
+	}
+	chunk = content[readBytes:]
+	if readBytes == 0 {
+		chunk = strings.TrimLeft(chunk, " \t")
+	}
+	return chunk, len(content)
+}

--- a/internal/format/stream_test.go
+++ b/internal/format/stream_test.go
@@ -1,0 +1,58 @@
+package format
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNextStreamChunk(t *testing.T) {
+	t.Parallel()
+
+	t.Run("first chunk trims leading horizontal whitespace", func(t *testing.T) {
+		t.Parallel()
+		chunk, next := NextStreamChunk("  \thello", 0)
+		require.Equal(t, "hello", chunk)
+		require.Equal(t, len("  \thello"), next, "cursor tracks raw content length, not the trimmed chunk")
+	})
+
+	t.Run("append-only growth emits only the tail", func(t *testing.T) {
+		t.Parallel()
+		chunk, next := NextStreamChunk("hello world", 5)
+		require.Equal(t, " world", chunk)
+		require.Equal(t, 11, next)
+	})
+
+	t.Run("mid-message chunk keeps leading whitespace", func(t *testing.T) {
+		t.Parallel()
+		chunk, _ := NextStreamChunk("a  b", 1)
+		require.Equal(t, "  b", chunk, "only the start of a message is trimmed")
+	})
+
+	t.Run("shrunken content resets the cursor and re-emits", func(t *testing.T) {
+		t.Parallel()
+		// The 270 -> 2 shrink observed in the wild (#283).
+		long := strings.Repeat("a", 270)
+		_, next := NextStreamChunk(long, 0)
+		require.Equal(t, 270, next)
+
+		chunk, next := NextStreamChunk("ok", next)
+		require.Equal(t, "ok", chunk, "re-emit from the start rather than slicing on a stale cursor")
+		require.Equal(t, 2, next)
+	})
+
+	t.Run("empty content after a reset is not fatal", func(t *testing.T) {
+		t.Parallel()
+		chunk, next := NextStreamChunk("", 42)
+		require.Empty(t, chunk)
+		require.Equal(t, 0, next)
+	})
+
+	t.Run("unchanged content emits nothing", func(t *testing.T) {
+		t.Parallel()
+		chunk, next := NextStreamChunk("hello", 5)
+		require.Empty(t, chunk)
+		require.Equal(t, 5, next)
+	})
+}


### PR DESCRIPTION
<summary>
Fixes #283

`crush run` and `RunNonInteractive` aborted the whole run when a streamed assistant message's content came back shorter than the bytes already written to stdout (`message content is shorter than read bytes: 2 < 270`). That condition is a transient stream reset / rewritten content part, not a run failure — and it killed multi-minute unattended runs mid-flight, producing silence indistinguishable from success.

## What changed
- Both call sites (`internal/cmd/run.go` live `crush run` path, `internal/app/app.go` `RunNonInteractive`) now log a warning, reset the per-message stdout cursor to 0, and re-emit the message content from the start instead of returning a fatal error.
- Added regression test `TestRunStream_ContentShrinkResetsCursor` covering the 270-byte → 2-byte shrink from the issue, asserting the run survives and the cursor resets.

## Verification
- `go test ./internal/cmd/ ./internal/app/` — green, including the new test.
- `go vet` on both packages — clean.

🤖 This was posted autonomously by [`glm-5.3`](https://openrouter.ai/z-ai/glm-5.3) using [Crush](https://github.com/charmbracelet/crush).