### PR TITLE
docs(site): enumerate every fork addition, and stop claiming upstream work

### DIFF
--- a/docs-site/docs/configuration/json.md
+++ b/docs-site/docs/configuration/json.md
@@ -109,6 +109,15 @@ builtin yet: `allowed_commands`, `allow_all_commands` (see
 (see [A2UI](/features/a2ui)). Top-level `tools` tunes the `glob`, `grep`, and
 `ls` tool limits.
 
+:::info[Fork feature]
+These `crush.json` keys do not exist upstream: `options.allowed_commands`,
+`options.allow_all_commands`, `options.disable_a2ui`, the top-level
+`embeddings` block ([semantic search](/features/semantic-search)), the
+per-server `channel_enabled` ([channels](/features/channels)), and the
+`agents.sidekick` agent ID ([Sidekick](/features/sidekick)). See
+[What this fork adds](/fork#configuration).
+:::
+
 ## Top-level `env`
 
 The top-level `env` field sets environment variables at startup, **before**

--- a/docs-site/docs/configuration/permissions.md
+++ b/docs-site/docs/configuration/permissions.md
@@ -41,8 +41,17 @@ tries to call them. To disable tools from a specific MCP server instead, use
 ## Blocked commands
 
 The `bash` tool blocks a set of potentially dangerous commands by default — for
-example `ssh`, `curl`, `systemctl`, and various package managers. Selectively
-remove commands from that blocklist:
+example `ssh`, `curl`, `systemctl`, and various package managers.
+
+:::info[Fork feature]
+The blocklist itself is upstream. Selectively re-allowing commands —
+`allowed_commands`, `allow_all_commands`, `--allow-commands`,
+`--allow-all-commands`, `CRUSH_ALLOW_COMMANDS`, and `CRUSH_ALLOW_ALL_COMMANDS`
+— is an addition in the `joestump-agent/crush` fork. Upstream the blocklist is
+all-or-nothing.
+:::
+
+Selectively remove commands from that blocklist:
 
 ```json
 {

--- a/docs-site/docs/features/mcp.md
+++ b/docs-site/docs/features/mcp.md
@@ -149,9 +149,10 @@ Resources whose URI ends in `/a2ui` render as
 | `call_mcp_prompt` | Invoke a prompt and get its rendered content |
 
 :::info[Fork feature]
-This fork also offers MCP prompts in the inline `/` completions and loads them
-at startup, so a server's prompts are reachable from the composer as soon as the
-session opens.
+`list_mcp_prompts` and `call_mcp_prompt`, MCP prompts in the inline `/`
+completions and the command palette, and loading prompts at startup rather than
+on first use are all additions in the `joestump-agent/crush` fork. The
+resource tools above are upstream.
 :::
 
 These four tools are only registered when you have at least one MCP server
@@ -165,6 +166,18 @@ tools should be used — and it is what makes a two-way
 [channel](/features/channels#two-way-channels) work without any
 channel-specific plumbing.
 
+## The MCP Servers dialog
+
+:::info[Fork feature]
+The MCP servers dialog is an addition in the `joestump-agent/crush` fork.
+:::
+
+Open it from the command palette (<kbd>ctrl+p</kbd> → **MCP Servers**, or type
+`/mcp` in the composer). It lists every configured server with its live status,
+and lets you reconnect or refresh one without restarting Crush. A reconnect re-reads config
+from disk, so an edit to `crush.json` takes effect immediately. Servers acting
+as [channels](/features/channels) are marked.
+
 ## Startup behaviour
 
 MCP initialization is bounded, so a wedged server cannot blank the application
@@ -172,6 +185,12 @@ at launch. Servers that fail to start are reported in the sidebar with their
 error, and Crush carries on. Servers that are live
 [channels](/features/channels) are marked `channel` in the MCP list, so you can
 confirm an opt-in actually took effect.
+
+:::info[Fork feature]
+The bounded init wait, the per-server lifecycle serialization, and reaping
+stdio server process groups on shutdown are fixes carried by this fork. See
+[What this fork adds](/fork#fixes-this-fork-carries).
+:::
 
 ## Checking state
 

--- a/docs-site/docs/features/semantic-search.md
+++ b/docs-site/docs/features/semantic-search.md
@@ -7,6 +7,12 @@ description: A local vector index over your codebase, searched by meaning rather
 
 # Semantic search
 
+:::info[Fork feature]
+Semantic search is an addition in the `joestump-agent/crush` fork. Neither the
+tools nor the `embeddings` config block exist upstream. See
+[What this fork adds](/fork).
+:::
+
 A vector index over the repository, stored in the project's own SQLite database
 via the `vec0` virtual table from
 [`modernc.org/sqlite/vec`](https://pkg.go.dev/modernc.org/sqlite) — the same

--- a/docs-site/docs/features/skills.md
+++ b/docs-site/docs/features/skills.md
@@ -45,6 +45,11 @@ authoring checklist, and Claude Code compatibility. See
 
 ### `a2ui`
 
+:::info[Fork feature]
+The `a2ui` skill only exists in the `joestump-agent/crush` fork. Upstream ships
+three built-in skills; this fork ships four.
+:::
+
 > Use when the user asks you to output, speak in, or communicate using the A2UI
 > (a2tea) format, or when you need to understand how to construct A2UI JSON
 > components to render interactive terminal UIs.
@@ -210,9 +215,15 @@ option disable-skill jq
 
 ## Seeing what loaded
 
+:::info[Fork feature]
+The `/skills` dialog is an addition in the `joestump-agent/crush` fork. Skill
+discovery and loading themselves are upstream.
+:::
+
 The `/skills` dialog lists every discovered skill, where it came from, and any
 that failed to parse — with the error and its source labelled. Skills that fail
-validation are reported rather than silently dropped.
+validation are reported rather than silently dropped. You can reload skills
+from disk and toggle individual skills off from the dialog.
 
 Ask the agent for the same thing at any time; the `crush_info` tool reports
 active and available skills alongside model, LSP, MCP, hook, and permission

--- a/docs-site/docs/fork.md
+++ b/docs-site/docs/fork.md
@@ -1,0 +1,136 @@
+---
+id: fork
+title: What this fork adds
+sidebar_label: What this fork adds
+sidebar_position: 2
+description: Every feature, improvement, and fix that joestump-agent/crush carries on top of charmbracelet/crush — and the things it does not.
+---
+
+# What this fork adds
+
+These docs cover
+**[`joestump-agent/crush`](https://github.com/joestump-agent/crush)**, a fork
+that tracks [`charmbracelet/crush`](https://github.com/charmbracelet/crush)
+upstream and adds features on top. Everything upstream does, this fork does.
+This page is the full inventory of what it adds beyond that.
+
+:::info[Fork feature]
+Throughout these docs, a callout shaped like this one marks behaviour that only
+exists in the fork. If a page has no such callout, what it describes is
+upstream Crush and belongs
+[upstream](https://github.com/charmbracelet/crush/issues) when it breaks.
+:::
+
+## Major features
+
+New subsystems — each one has its own page.
+
+| Feature | What it is |
+| --- | --- |
+| **[Sidekick](/features/sidekick)** | A second, ephemeral agent living in the sidebar, plus a pinned dashboard surface the main agent pushes A2UI status into. Its own tools (`sidekick_bash`, `sidekick_update`), its own memory, no persistence. |
+| **[A2UI rendering](/features/a2ui)** | The model can emit [A2UI](https://a2ui.org) documents and Crush draws them inline — cards, lists, buttons, forms, dashboards — via [a2tea](https://github.com/joestump-agent/a2tea). Interactive surfaces round-trip: a button press goes back to the model. Includes MCP resource surfaces and an `a2ui` capability advertised at MCP `initialize`. |
+| **[Scheduled tasks](/features/scheduled-tasks)** | `CronCreate`, `CronList`, and `CronDelete` tools that re-run a prompt on a cron schedule, with a scheduler, one-shot support, and a pills-panel entry showing what is queued. |
+| **[Semantic search](/features/semantic-search)** | A local vector index over the repo — chunked by symbol, embedded through any OpenAI-compatible endpoint, stored in the project's own SQLite via `sqlite-vec`. Adds the `semantic_search` and `semantic_index` tools and a symbol-extraction package. |
+| **[Channel reply routing](/features/channels)** | The channel *push* mechanism is upstream. The fork adds the `channel_enabled` config key, a `channel_reply` tool, server-side routing that delivers each event exactly once per workspace, auto-creation of a session for an inbound event, and replies that go back only to the channel they came from. |
+| **[MCP prompts](/features/mcp#prompts-and-resources)** | `list_mcp_prompts` and `call_mcp_prompt` tools, prompts offered in the inline `/` completions and the command palette, and prompts loaded at startup rather than on first use. |
+
+## Quality-of-life improvements
+
+Smaller things you notice in the terminal rather than in a config file.
+
+### Chat
+
+| Improvement | Detail |
+| --- | --- |
+| Click-to-copy | Finished assistant *and* user messages carry a right-aligned `⎘` icon that copies the message. Shown on focus, pinned to the item's right edge. |
+| Clickable hyperlinks | A plain click on a link in the transcript opens it in your browser. |
+| Channel message styling | Channel-originated messages render with a `sender / via / at` metadata line below the body, so you can tell a webhook from a human. |
+
+### Composer
+
+| Improvement | Detail |
+| --- | --- |
+| Syntax-highlighted composer | A vendored textarea with a highlighter, so `@file`, `/skill`, and MCP-prompt tokens are visibly distinct as you type. |
+| Atomic token editing | Backspace over a completed token deletes the whole token — and drops its attachment, if it had one — instead of eating one character at a time. |
+| Text-file attachments | Attach JSON, YAML, Markdown, and source files, not just images. One shared text predicate everywhere, with binary sniffing to reject the rest. |
+| Attachment chips | A clickable remove button on each chip, correct hit zones, and chips that survive sending. |
+| `/skill` completions | Skills complete inline from `/`, alongside commands and MCP prompts. |
+
+### Dialogs and palette
+
+| Improvement | Detail |
+| --- | --- |
+| **Skills dialog** | Palette entry **Skills** — list every skill, see load errors, reload from disk, toggle individual skills off. |
+| **MCP servers dialog** | Palette entry **MCP Servers** — server status, reconnect, refresh, and a marker on servers acting as channels. |
+| **Channels dialog** | Palette entry **Channels** — see and manage active channels. |
+| Hierarchical sub-menus | The command palette nests related commands instead of one flat list, with `back`/`backspace` navigation. |
+| Model discovery reload | Re-run provider/model discovery from the `/models` dialog without restarting. |
+
+### Sidebar and header
+
+| Improvement | Detail |
+| --- | --- |
+| Focusable sidebar | Three-state <kbd>tab</kbd> focus, mouse scrolling, a scrollbar instead of a focus border, and irrelevant keybindings hidden while it is focused. |
+| Channels column | Active channels shown on the landing page and in the sidebar. |
+| `user@host:cwd` header | On by default, mirroring the familiar shell prompt — useful when you have sessions open on several machines. |
+| Pills panel | <kbd>ctrl+t</kbd> expands *every* section, and scheduled tasks get their own pill with a stopwatch glyph that distinguishes recurring from one-shot. |
+
+### Configuration
+
+| Improvement | Detail |
+| --- | --- |
+| `allowed_commands` | Re-allow specific commands the [blocklist](/configuration/permissions#blocked-commands) normally denies, without disabling the blocklist. Still subject to permission approval. |
+| `channel_enabled` | Turn an MCP server into a channel from `crush.json`, rather than only via the `--channels` flag. |
+| `embeddings` block | Configure the semantic-search embedding provider from `crush.json` or `crushrc`. |
+| Config reload on reconnect | Reconnecting an MCP server re-reads config from disk, so an edit takes effect without a restart. |
+| Current time in the prompt | The system prompt carries the current time, which is what makes relative scheduling ("every weekday at 9") work. |
+| `a2ui` built-in skill | Teaches the model the A2UI contract, including the MCP resource-read path. |
+| Built-in skills in the palette | All built-in skills are marked `user-invocable`, so they appear in <kbd>ctrl+p</kbd> as `user:` entries. |
+
+## Fixes this fork carries
+
+Fixes to **upstream** behaviour that live here and are not upstream. Fixes to
+the fork's own features are part of those features and are not listed
+separately.
+
+| Fix | Symptom it removes |
+| --- | --- |
+| `--yolo` made a persistent flag | `crush --yolo run …` died with `unknown flag`, which crash-looped anything invoking a subcommand. |
+| Bounded MCP init waits | A wedged MCP server could blank the whole app at startup. Tool lists now wait for init, with a bound. |
+| Per-server MCP lifecycle serialized | Concurrent connect/disconnect on one server raced; an error on one session tore down others. |
+| stdio process groups reaped | Killed stdio MCP servers left orphan processes behind. |
+| MCP OAuth persistence | Tokens did not actually survive a restart; the store now does atomic writes and validates state. |
+| In-process run dispatch serialized | Two turns could run concurrently in one session. |
+| Provider base URL resolved before validation | A custom provider with an expanded `base_url` failed validation that should have passed. |
+| Empty paste routes to the clipboard image | An empty bracketed paste dropped the image instead of attaching it — and now warns instead of silently failing on a model that cannot take images. |
+| Command filter matches shortcuts | Typing a command's shortcut in the `/` menu filtered it out. |
+| Tied project timestamps ordered by recency | Projects registered in the same instant sorted arbitrarily. |
+| Backspace in the commands filter | Backspace was swallowed in the top-level commands filter. |
+
+## What this fork does *not* add
+
+Things regularly mistaken for fork features. All of these are upstream Crush,
+built by [Charm](https://charm.land) — bugs in them belong
+[upstream](https://github.com/charmbracelet/crush/issues).
+
+| Upstream feature | Where it lives |
+| --- | --- |
+| **Background jobs** | `bash` backgrounding long-running commands, plus `job_output` and `job_kill`. Upstream since [charmbracelet/crush#1328](https://github.com/charmbracelet/crush/pull/1328). See [tools](/reference/tools#shell-and-job-control). |
+| **Clipboard image paste** | <kbd>ctrl+v</kbd> attaching an image, with the clipboard-text-as-path fallback. Upstream; the fork only fixed the empty-paste case above. |
+| **Channel push** | The `claude/channel` MCP capability and the `--channels` flag are upstream. Only the routing, config key, and reply tool are the fork's. |
+| **MCP OAuth** | HTTP MCP servers authenticating over OAuth. Now upstream; the fork carries hardening fixes on top. |
+| **Hooks, Skills, `crushrc`, LSP, sessions, workspaces, notifications, `/clear`, `/compact`, the pills panel, the sidebar itself** | All upstream. |
+
+## Landed but not yet wired up
+
+| Thing | Status |
+| --- | --- |
+| A2A (`internal/a2a`) | Agent Card and `AgentExecutor` foundation on the [a2a-go](https://github.com/a2aproject/a2a-go) SDK. Compiled but not yet reachable from the CLI or config — no flag, no config key, no docs page. Do not plan around it yet. |
+
+## Reporting bugs
+
+Crush is licensed
+[FSL-1.1-MIT](https://github.com/charmbracelet/crush/raw/main/LICENSE.md).
+
+- Anything on this page → [`joestump-agent/crush` issues](https://github.com/joestump-agent/crush/issues)
+- Anything else → [`charmbracelet/crush` issues](https://github.com/charmbracelet/crush/issues)

--- a/docs-site/docs/introduction.md
+++ b/docs-site/docs/introduction.md
@@ -53,11 +53,19 @@ The additions, in brief:
 | Addition | What it is |
 | --- | --- |
 | [Sidekick](/features/sidekick) | A second, ephemeral agent in the sidebar, plus a pinned dashboard the main agent pushes A2UI status to |
-| [Channels](/features/channels) | The push mechanism is upstream; the fork adds the `channel_enabled` config key and deterministic reply routing |
 | [A2UI](/features/a2ui) | Inline rendering of A2UI surfaces via [a2tea](https://github.com/joestump-agent/a2tea), including interactive round-trips |
 | [Scheduled tasks](/features/scheduled-tasks) | `CronCreate` / `CronList` / `CronDelete` tools that re-run prompts on a cron schedule |
 | [Semantic search](/features/semantic-search) | A local sqlite-vec index over the repo, searched by meaning |
+| [Channels](/features/channels) | The push mechanism is upstream; the fork adds the `channel_enabled` config key, the `channel_reply` tool, and deterministic reply routing |
 | [MCP prompts](/features/mcp#prompts-and-resources) | MCP prompts offered in the `/` completions and the command palette |
+
+Plus a long tail of quality-of-life work — click-to-copy, clickable
+hyperlinks, a syntax-highlighted composer, text-file attachments, Skills, MCP
+and Channels dialogs, a focusable sidebar — and a set of fixes to upstream
+behaviour.
+
+**[What this fork adds](/fork)** is the complete, verified inventory, including
+a list of things commonly mistaken for fork features that are in fact upstream.
 
 Crush is licensed
 [FSL-1.1-MIT](https://github.com/charmbracelet/crush/raw/main/LICENSE.md).

--- a/docs-site/docs/reference/cli.md
+++ b/docs-site/docs/reference/cli.md
@@ -25,17 +25,28 @@ These are persistent flags — they work on every subcommand.
 | `--debug` | `-d` | Debug logging |
 | `--host <url>` | `-H` | Connect to a specific Crush server (advanced) |
 | `--channels <server:name>` | | Enable an MCP server as a [channel](/features/channels). Repeatable. |
+| `--yolo` | `-y` | Auto-accept all permissions (**dangerous**) |
+
+:::info[Fork feature]
+`--yolo` is persistent in this fork, so it works on subcommands too —
+`crush --yolo run "…"`. Upstream it is a root-only flag and that invocation
+fails with `unknown flag`.
+:::
 
 ## `crush`
 
 | Flag | Short | Does |
 | --- | --- | --- |
-| `--yolo` | `-y` | Auto-accept all permissions (**dangerous**) |
 | `--session <id>` | `-s` | Continue a previous session by ID |
 | `--continue` | `-C` | Continue the most recent session |
 | `--allow-commands <cmd>` | | Allow a command from the bash blocklist. Repeatable. Env: `CRUSH_ALLOW_COMMANDS` (comma-separated) |
 | `--allow-all-commands` | | Remove **all** bash blocklist restrictions, including package-manager blocks (**dangerous**). Env: `CRUSH_ALLOW_ALL_COMMANDS` |
 | `--help` | `-h` | Help |
+
+:::info[Fork feature]
+`--allow-commands` and `--allow-all-commands` are fork additions. See
+[Permissions](/configuration/permissions#blocked-commands).
+:::
 
 ```bash
 crush

--- a/docs-site/docs/reference/environment-variables.md
+++ b/docs-site/docs/reference/environment-variables.md
@@ -33,6 +33,12 @@ Run `crush dirs` to see what these actually resolved to.
 | `CRUSH_CORE_UTILS` | Force the Go coreutils implementations on (`true`) or off (`false`) in the embedded shell. Defaults to on for Windows, off elsewhere. |
 | `CRUSH_VERSION` | Set by Crush inside a `crushrc`, for [version-conditional config](/configuration/crushrc#config-versioning) |
 
+:::info[Fork feature]
+`CRUSH_ALLOW_COMMANDS` and `CRUSH_ALLOW_ALL_COMMANDS` are fork additions — see
+[Permissions](/configuration/permissions#blocked-commands). Everything else in
+this table is upstream.
+:::
+
 ## Server
 
 | Variable | Effect |

--- a/docs-site/docs/reference/keybindings.md
+++ b/docs-site/docs/reference/keybindings.md
@@ -26,6 +26,12 @@ running build.
 | <kbd>shift+tab</kbd> | Focus the Sidekick dashboard surface |
 | <kbd>ctrl+x</kbd> | Dismiss the Sidekick dashboard |
 
+:::info[Fork feature]
+The three Sidekick bindings are fork-only. <kbd>tab</kbd> is also three-state
+here — chat, editor, sidebar — because the fork makes the
+[sidebar focusable](/fork#sidebar-and-header).
+:::
+
 ## Editor
 
 | Keys | Does |
@@ -53,6 +59,11 @@ running build.
 | <kbd>ctrl+d</kbd> | Toggle details |
 | <kbd>ctrl+t</kbd> | Toggle the pills panel (tasks, [scheduled tasks](/features/scheduled-tasks)) |
 
+:::info[Fork feature]
+The scheduled-tasks pill is fork-only, and <kbd>ctrl+t</kbd> expands *every*
+pills section rather than only the first.
+:::
+
 ### Navigation
 
 | Keys | Does |
@@ -67,7 +78,7 @@ running build.
 | <kbd>G</kbd> / <kbd>end</kbd> | End |
 | <kbd>ctrl+end</kbd> | End and follow |
 | <kbd>h</kbd> / <kbd>←</kbd> | Focus chat |
-| <kbd>l</kbd> / <kbd>→</kbd> | Focus sidebar |
+| <kbd>l</kbd> / <kbd>→</kbd> | Focus sidebar (fork: the sidebar takes focus, scrolls with the mouse, and hides irrelevant help while focused) |
 | <kbd>shift+←</kbd> / <kbd>H</kbd> | Scroll left |
 | <kbd>shift+→</kbd> / <kbd>L</kbd> | Scroll right |
 
@@ -81,6 +92,10 @@ running build.
 
 Finished assistant and user messages also carry a click-to-copy icon, and plain
 clicks on hyperlinks open them in your browser.
+
+:::info[Fork feature]
+Both the click-to-copy icon and click-to-open hyperlinks are fork additions.
+:::
 
 ## Initialization prompt
 
@@ -99,6 +114,12 @@ Typing certain characters opens an inline completion list:
 | --- | --- |
 | <kbd>@</kbd> | Files in the project |
 | <kbd>/</kbd> | Commands, [user-invocable skills](/features/skills#user-invocable-skills), and MCP prompts |
+
+:::info[Fork feature]
+Skill and MCP-prompt completions, the token highlighting that makes them
+visually distinct, and the atomic-backspace behaviour below are all fork
+additions. Upstream completes files and commands only.
+:::
 
 Completion list size is tunable:
 

--- a/docs-site/docs/reference/tools.md
+++ b/docs-site/docs/reference/tools.md
@@ -28,10 +28,16 @@ names [hook matchers](/features/hooks) test against.
 | `grep` | Search file contents by regex or literal, sorted by modification time |
 | `ls` | List files and directories as a tree, skipping hidden and system dirs |
 | `sourcegraph` | Search code across public GitHub repos via Sourcegraph — regex, language, repo, and file filters |
-| `semantic_search` | Vector search over the local index — [not currently registered](/features/semantic-search) |
+| `semantic_search` | Vector search over the local index by meaning. Registered only when an embeddings provider is configured — see [Semantic search](/features/semantic-search) |
+| `semantic_index` | Build or refresh that index. Incremental; unchanged files are skipped |
 
 The `glob`, `grep`, and `ls` result limits are tunable under the top-level
 `tools` key in [`crush.json`](/configuration/json).
+
+:::info[Fork feature]
+`semantic_search` and `semantic_index` are additions in the
+`joestump-agent/crush` fork.
+:::
 
 ## Shell and job control
 
@@ -47,7 +53,15 @@ platform — Windows included. [`jq` is a built-in](/features/skills#jq); no
 external binary needed.
 
 A [blocklist](/configuration/permissions#blocked-commands) sits in front of the
-`bash` tool's permission flow.
+`bash` tool's permission flow. The fork adds
+[`allowed_commands`](/configuration/permissions#blocked-commands) to punch
+named holes in it.
+
+:::note[Upstream, not fork]
+Background jobs — `bash` backgrounding long-running commands, plus `job_output`
+and `job_kill` — are upstream Crush, not a fork addition. Bugs in them belong
+[upstream](https://github.com/charmbracelet/crush/issues).
+:::
 
 ## Network
 
@@ -90,6 +104,12 @@ Registered when at least one MCP server is configured. See
 | `call_mcp_prompt` | Invoke a prompt and get its rendered content |
 
 Tools exposed *by* MCP servers arrive as `mcp_<server>_<tool>`.
+
+:::info[Fork feature]
+`list_mcp_prompts` and `call_mcp_prompt` are additions in the
+`joestump-agent/crush` fork. See
+[MCP prompts](/features/mcp#prompts-and-resources).
+:::
 
 ## Scheduling
 

--- a/docs-site/sidebars.ts
+++ b/docs-site/sidebars.ts
@@ -6,6 +6,10 @@
  * then the flat reference material you look things up in.
  *
  * @joestump-agent 08/25/2026 - Initial sidebar for the MVP docs site.
+ *
+ * @joestump-agent 08/25/2026 - Added the "What this fork adds" page directly
+ * under the introduction, so the fork inventory is the second thing a reader
+ * sees rather than something they have to hunt for.
  */
 
 import type {SidebarsConfig} from '@docusaurus/plugin-content-docs';
@@ -13,6 +17,7 @@ import type {SidebarsConfig} from '@docusaurus/plugin-content-docs';
 const sidebars: SidebarsConfig = {
   docsSidebar: [
     'introduction',
+    'fork',
     {
       type: 'category',
       label: 'Getting started',

--- a/docs-site/src/pages/index.tsx
+++ b/docs-site/src/pages/index.tsx
@@ -100,7 +100,10 @@ function Fork(): ReactNode {
                 charmbracelet/crush
               </a>{' '}
               upstream and adds a handful of features on top. Where a page
-              documents something the fork adds, it says so.
+              documents something the fork adds, it says so — and{' '}
+              <Link to="/fork">What this fork adds</Link> lists every one of
+              them, along with the things people assume are ours but are
+              actually upstream.
             </p>
             <p className="charmSection__lede">
               Crush itself is a{' '}
@@ -136,8 +139,13 @@ function Fork(): ReactNode {
                 local vector index over the repo
               </li>
               <li>
-                <Link to="/reference/tools#shell-and-job-control">Background jobs</Link>,
-                click-to-copy, clipboard image paste, and more
+                <Link to="/features/mcp#prompts-and-resources">MCP prompts</Link>{' '}
+                in the <code>/</code> completions and the palette
+              </li>
+              <li>
+                <Link to="/fork">Everything else</Link> — click-to-copy,
+                clickable links, a highlighted composer, text attachments, and
+                the Skills, MCP and Channels dialogs
               </li>
             </ul>
           </div>


### PR DESCRIPTION
## The bug that started this

The landing page's fork section said:

> [Background jobs](https://joestump-agent.github.io/crush/reference/tools#shell-and-job-control), click-to-copy, clipboard image paste, and more

Two of those three are upstream Crush, not fork additions:

| Claim | Reality |
| --- | --- |
| Background jobs | **Upstream.** `bash` backgrounding, `job_output`, `job_kill` all landed in [charmbracelet/crush#1328](https://github.com/charmbracelet/crush/pull/1328) (Nov 2025). `internal/agent/tools/job_output.go` is byte-identical on both sides. |
| Clipboard image paste | **Upstream.** `pasteImageFromClipboard` and the clipboard-text-as-path fallback are in upstream's `internal/ui/model/ui.go`. The fork only fixed the empty-paste case. |
| Click-to-copy | **Ours.** `assistantCopyIcon` has no upstream counterpart. |

## What this PR does

Replaces `and more` with an actual inventory, and marks fork-only behaviour where the docs were silently mixing the two.

### New page: `/fork` — "What this fork adds"

Sits directly under the introduction in the sidebar. Grouped as asked:

- **Major features** — Sidekick, A2UI rendering, scheduled tasks, semantic search, channel reply routing, MCP prompts
- **Quality-of-life improvements** — split by surface (chat, composer, dialogs and palette, sidebar and header, configuration)
- **Fixes this fork carries** — fixes to *upstream* behaviour that are not upstream, with the symptom each one removes

Plus two sections that did not exist anywhere before:

- **What this fork does *not* add** — the upstream work that keeps getting misattributed, so the next person does not re-make this mistake
- **Landed but not yet wired up** — `internal/a2a` compiles but is unreachable from the CLI or config. No flag, no config key, no docs page. Better to say so than to let it read as a shipped feature.

### Fork callouts

`:::info[Fork feature]` added to the pages that were mixing upstream and fork behaviour without saying which was which:

| Page | Marked |
| --- | --- |
| `features/semantic-search` | The whole page — it had zero callouts despite being entirely fork-only |
| `reference/tools` | `semantic_*` and MCP prompt tools, plus a `:::note[Upstream, not fork]` on background jobs, since that anchor is exactly where a reader lands |
| `reference/keybindings` | Sidekick keys, three-state tab, scheduled-tasks pill, click-to-copy, clickable links, skill/prompt completions |
| `configuration/permissions` | `allowed_commands` and friends (upstream's blocklist is all-or-nothing) |
| `configuration/json` | `allowed_commands`, `allow_all_commands`, `disable_a2ui`, `embeddings`, `channel_enabled`, `agents.sidekick` |
| `reference/cli` | `--yolo` persistence, `--allow-commands`, `--allow-all-commands` |
| `reference/environment-variables` | `CRUSH_ALLOW_COMMANDS`, `CRUSH_ALLOW_ALL_COMMANDS` |
| `features/mcp` | The MCP Servers dialog and the MCP lifecycle fixes |
| `features/skills` | The Skills dialog and the fork-only `a2ui` built-in skill |

### Two doc bugs fixed on the way

- `reference/tools` said `semantic_search` was "not currently registered". It has been registered since the wire-up commit — `coordinator.go:1243`.
- `reference/cli` listed `--yolo` under `crush` only. This fork made it a persistent flag, so it belongs under Global flags.

## Method

Every entry was verified against `upstream/main` — file presence, symbol presence, and reading the actual implementation — rather than inferred from the fork's commit log. That is what surfaced the two misattributions above; the commit log alone would have reproduced them.

## Verification

- `npm run build` — clean, with `onBrokenLinks: 'throw'` and `onBrokenAnchors: 'throw'`
- `npm run typecheck` — clean
- Rendered output spot-checked: headings, anchor targets, and admonition classes all present in `build/`

🤖 Posted on behalf of `@joestump` by [`claude-opus-5`](https://openrouter.ai/anthropic/claude-opus-5) using [Claude Code](https://claude.com/claude-code).
