### PR TITLE
feat(a2ui): rebuild the semantic result cards, and highlight code in surfaces

### DIFF
--- a/docs-site/docs/features/a2ui.md
+++ b/docs-site/docs/features/a2ui.md
@@ -126,6 +126,57 @@ When a surface comes from a server, the
 Crush advertises `capabilities.a2ui` at MCP `initialize`, so a server can detect
 that it is talking to an A2UI-capable host before offering surfaces.
 
+## Code, Markdown, and syntax highlighting
+
+Body-variant `Text` — a `Text` with no `variant` — is passed through Crush's
+Markdown renderer (glamour, with chroma for code). So a surface is not limited
+to flat strings: tables, lists, bold, inline code, and **syntax-highlighted
+fenced code blocks** all render inside a card.
+
+```json
+{"component": "Text", "id": "snippet", "text": "```go\n42  func Verify() error {\n43      return nil\n44  }\n```"}
+```
+
+The fence's language tag selects the lexer, so tag it. Line numbers are simply
+part of the block's text — the gutter is lexed along with the code and reads as
+a distinct color. Long lines word-wrap to column zero, which breaks that gutter,
+so a producer drawing one should truncate instead.
+
+The heading and caption variants deliberately skip the Markdown renderer: they
+are short labels, and their variant style already handles them.
+
+## Semantic search results
+
+`semantic_search` and `semantic_index` use all of this. When a chat UI is
+attached, their results divert into a surface and the model keeps a compact
+text digest — so the snippets cost the user nothing in context:
+
+```text
+╭───────────────────────────────────────────────────────╮
+│ Semantic search                                       │
+│ "where is auth handled" · 3 results                   │
+│ 1. internal/auth/token.go:42                          │
+│ Verify · lines 42–89 · ███████░░░ 0.734               │
+│                                                       │
+│   42  func Verify() error {                           │
+│   43      return nil                                  │
+│   44  }                                               │
+│       …                                               │
+│                                                       │
+│ ───────────────────────────────────────────────────── │
+│ 2. …                                                  │
+╰───────────────────────────────────────────────────────╯
+```
+
+Each hit carries a rank, a `path:line` jump target relativized to the working
+directory, the symbol, the chunk's line range, a fixed-width relevance meter
+beside the score, and the chunk's opening lines with a line-number gutter and
+syntax highlighting. Snippet lines are sized from the pane's width hint so the
+gutter survives.
+
+Headless and channel-originated runs are unaffected — with no chat UI to render
+metadata, both tools emit their original plain text.
+
 ## Where surfaces render
 
 | Location | Behaviour |
@@ -149,8 +200,8 @@ With A2UI disabled, `<a2ui-json>` blocks are left as text and the
 - A block that fails to parse shows an alert rather than silently disappearing.
 - Every `child` / `children` id must exist — a dangling id renders
   `[a2tea: missing component …]`.
-- Keep surfaces compact. Code and long logs belong in fenced code blocks, not in
-  a surface.
+- Keep surfaces compact. A surface is a summary, not a viewer — show a handful
+  of lines of code and point at the file for the rest.
 
 ## The built-in skill
 

--- a/internal/agent/tools/semantic_a2ui.go
+++ b/internal/agent/tools/semantic_a2ui.go
@@ -476,14 +476,16 @@ var fenceLanguage = func() func(path string) string {
 }()
 
 // splitIndexError pulls the path off a per-file index error, which the index
-// tool formats as "<path>: <err>", and condenses the message. An error with
-// no recognizable path prefix returns an empty path and the whole condensed
-// string.
+// tool formats as "<path>: <err>", and condenses the message. The prefix only
+// counts as a path when it ends in an extension the indexer accepts — a
+// message like "indexing cancelled: context deadline exceeded" would
+// otherwise lose its first clause to the path column, and a heuristic on
+// spaces or separators would drop a real path under a directory with a space
+// in its name. An error with no path prefix returns an empty path and the
+// whole condensed string.
 func splitIndexError(workingDir, e string) (path, msg string) {
-	if i := strings.Index(e, ": "); i > 0 {
-		if p := relativizePath(workingDir, e[:i]); !strings.Contains(p, " ") {
-			return p, condenseError(e[i+2:])
-		}
+	if i := strings.Index(e, ": "); i > 0 && indexableExtensions[strings.ToLower(filepath.Ext(e[:i]))] {
+		return relativizePath(workingDir, e[:i]), condenseError(e[i+2:])
 	}
 	return "", condenseError(e)
 }

--- a/internal/agent/tools/semantic_a2ui.go
+++ b/internal/agent/tools/semantic_a2ui.go
@@ -4,13 +4,19 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math"
+	"path/filepath"
+	"strconv"
 	"strings"
 
 	"charm.land/fantasy"
 	"github.com/charmbracelet/crush/internal/config"
+	"github.com/charmbracelet/x/ansi"
 	a2ui "github.com/tmc/a2ui"
 )
 
+// Semantic Tool Result Surfaces
+//
 // This file renders the semantic tools' results as A2UI surfaces alongside
 // their model-facing text. The payloads travel in response metadata (the
 // same channel read_mcp_resource uses), so the chat UI draws a live,
@@ -20,16 +26,88 @@ import (
 // tools fall back to their original plain-text output, so behavior off the
 // interactive UI is unchanged.
 //
+// Snippets ride in a body-variant Text as a fenced code block. a2tea routes
+// body Text that looks like Markdown through the host's MarkdownRenderer,
+// which in Crush is glamour + chroma — so the fence language is what buys
+// the surface real syntax highlighting. Nothing here reaches into the UI
+// packages to do it: any A2UI host with a Markdown renderer gets the same
+// result from the same payload.
+//
 // @joestump-agent 08/25/2026 - Initial version for semantic_search and
 // semantic_index.
 //
 // @joestump 08/25/2026 - Marked the diverted text model-only so the chat
 // stops drawing the digest underneath the card, restored the blank line
 // between headless results, and pluralized the surface's result count.
+//
+// @joestump-agent 08/25/2026 - Reworked both cards: search hits are now
+// ranked blocks with a workdir-relative path, a jump target, a line range, a
+// score meter and a line-numbered, syntax-highlighted snippet; the index card
+// splits its per-file errors into path + condensed message and stops
+// silently dropping the ones past the tool's cap.
 
 // a2uiSurfaceIDPrefix namespaces the semantic tools' surface IDs so they
 // cannot collide with MCP-served surfaces sharing an ID.
 const a2uiSurfaceIDPrefix = "semantic-"
+
+const (
+	// snippetLines is how many lines of a hit's chunk the card shows before
+	// eliding. The card is a scanning aid, not a viewer — the model is told
+	// to open the file for authoritative content.
+	snippetLines = 6
+	// scoreMeterCells is the width of the relevance meter drawn beside each
+	// score, so neighboring hits can be compared at a glance.
+	scoreMeterCells = 10
+	// gutterTabWidth expands tabs in snippets. Terminal tab stops interact
+	// badly with the code block's own indentation, and a fixed expansion
+	// keeps the line-number gutter aligned.
+	gutterTabWidth = 4
+	// errorMessageLimit caps a per-file index error. Provider errors nest
+	// escaped JSON several layers deep; the leading clause is the part that
+	// says what actually went wrong.
+	errorMessageLimit = 160
+	// defaultSnippetWidth sizes snippet lines when the turn carries no width
+	// hint, and minSnippetWidth floors the computed one so a very narrow pane
+	// cannot truncate every line down to its gutter.
+	defaultSnippetWidth = 100
+	minSnippetWidth     = 40
+)
+
+// Snippet line widths
+//
+// A code block whose lines overflow the pane is word-wrapped by the host's
+// Markdown renderer, and the continuation lands in column zero — which breaks
+// the line-number gutter the block exists to provide. Truncating instead
+// keeps the grid readable, and a search hit is a scanning aid: the model is
+// told to open the file for the authoritative content.
+//
+// The chat pane's width reaches the tool through the same content-width hint
+// MCP surfaces get, so the payload can be sized to it. The arithmetic mirrors
+// how the chat nests a surface — message padding, then tool-body padding,
+// then the card's border and padding — and being a cell or two off only costs
+// an occasional wrap, so it is a hint, not a contract.
+//
+// @joestump-agent 08/25/2026 - Added with the reworked search card.
+func snippetWidth(contentWidth int) int {
+	if contentWidth <= 0 {
+		return defaultSnippetWidth
+	}
+	w := min(contentWidth-messageLeftPadding, maxMessageWidth) - toolBodyLeftPadding - cardChrome - codeBlockMargin
+	return max(w, minSnippetWidth)
+}
+
+// The chat layout constants the width hint has to be walked through. They are
+// duplicated rather than imported because internal/ui must not be a
+// dependency of the tool layer; a drift here degrades to a wrapped line.
+const (
+	messageLeftPadding  = 2
+	maxMessageWidth     = 120
+	toolBodyLeftPadding = 2
+	cardChrome          = 4
+	// codeBlockMargin is the Markdown renderer's own indent on a fenced
+	// block, on both sides.
+	codeBlockMargin = 4
+)
 
 // semanticDivert reports whether this turn carries an interactive chat UI
 // that will render tool-result metadata as a live A2UI surface. Mirrors the
@@ -68,86 +146,73 @@ func withSemanticSurface(resp fantasy.ToolResponse, surfaceID string, components
 	return fantasy.WithResponseMetadata(resp, metadata)
 }
 
-// semanticSearchSurface builds the results card for a semantic_search call:
-// a header with the query and hit count, then one block per result with the
-// location line, relevance score, and a code snippet. Components form a
-// flat id-linked tree per the A2UI wire format.
-func semanticSearchSurface(query string, results []semanticSearchHit) []a2ui.Component {
-	text := func(id, s string) a2ui.Component {
-		return a2ui.Component{ID: id, Text: &a2ui.TextComponent{Text: a2ui.StringLiteral(s)}}
-	}
-	caption := func(id, s string) a2ui.Component {
-		return a2ui.Component{ID: id, Text: &a2ui.TextComponent{
-			Text:    a2ui.StringLiteral(s),
-			Variant: a2ui.TextVariantCaption,
-		}}
-	}
+// a2uiText builds a body-variant Text component. Body text is the only
+// variant a2tea routes through the host's Markdown renderer, so this is what
+// carries fenced code.
+func a2uiText(id, s string) a2ui.Component {
+	return a2ui.Component{ID: id, Text: &a2ui.TextComponent{Text: a2ui.StringLiteral(s)}}
+}
 
+// a2uiCaption builds a caption-variant Text component — the muted secondary
+// line under a heading.
+func a2uiCaption(id, s string) a2ui.Component {
+	return a2ui.Component{ID: id, Text: &a2ui.TextComponent{
+		Text:    a2ui.StringLiteral(s),
+		Variant: a2ui.TextVariantCaption,
+	}}
+}
+
+// a2uiHeading builds a Text component at the given heading variant.
+func a2uiHeading(id, s string, v a2ui.TextVariant) a2ui.Component {
+	return a2ui.Component{ID: id, Text: &a2ui.TextComponent{
+		Text:    a2ui.StringLiteral(s),
+		Variant: v,
+	}}
+}
+
+// semanticSearchSurface builds the results card for a semantic_search call.
+// The header names the query and the hit count; each hit below it is a block
+// of three lines — a ranked jump target (path:line), a metadata line
+// carrying the symbol, the line range and a relevance meter, and the chunk's
+// opening lines as a line-numbered, syntax-highlighted code block. Blocks are
+// separated by dividers. Components form a flat id-linked tree per the A2UI
+// wire format.
+func semanticSearchSurface(query, workingDir string, contentWidth int, results []semanticSearchHit) []a2ui.Component {
 	ids := newA2UIIDGen()
 	titleID := ids.next()
 	subID := ids.next()
+	lineWidth := snippetWidth(contentWidth)
 
-	var blockIDs []string
+	childIDs := []string{titleID, subID}
 	var extra []a2ui.Component
-	for _, r := range results {
-		loc := r.Path
-		if r.Symbol != "" {
-			loc += " :: " + r.Symbol
+	for i, r := range results {
+		if i > 0 {
+			divID := ids.next()
+			childIDs = append(childIDs, divID)
+			extra = append(extra, a2ui.Component{ID: divID, Divider: &a2ui.DividerComponent{}})
 		}
-		block := ids.next()
-		line := ids.next()
-		score := ids.next()
-		snippet := ids.next()
-		blockIDs = append(blockIDs, block)
-		extra = append(extra,
-			a2ui.Component{ID: block, Column: &a2ui.ColumnComponent{
-				Children: a2ui.ChildList{IDs: []string{line, score, snippet}},
-			}},
-			text(line, loc),
-			caption(score, fmt.Sprintf("lines %d-%d · score %.3f", r.StartLine+1, r.EndLine+1, r.Score)),
-			caption(snippet, firstLines(r.Snippet, 4)),
-		)
-	}
 
-	return append([]a2ui.Component{
-		{ID: "root", Card: &a2ui.CardComponent{Child: "col"}},
-		{ID: "col", Column: &a2ui.ColumnComponent{
-			Children: a2ui.ChildList{IDs: append([]string{titleID, subID}, blockIDs...)},
-		}},
-		{ID: titleID, Text: &a2ui.TextComponent{
-			Text:    a2ui.StringLiteral(fmt.Sprintf("Semantic search: %q", query)),
-			Variant: a2ui.TextVariantH3,
-		}},
-		caption(subID, fmt.Sprintf("%d %s", len(results), pluralize(len(results), "result"))),
-	}, extra...)
-}
+		path := relativizePath(workingDir, r.Path)
+		blockID := ids.next()
+		headID := ids.next()
+		metaID := ids.next()
+		blockChildren := []string{headID, metaID}
 
-// semanticIndexSurface builds the summary card for a semantic_index run:
-// chunk totals plus any per-file errors.
-func semanticIndexSurface(indexed, skipped, failed, total int, errs []string) []a2ui.Component {
-	caption := func(id, s string) a2ui.Component {
-		return a2ui.Component{ID: id, Text: &a2ui.TextComponent{
-			Text:    a2ui.StringLiteral(s),
-			Variant: a2ui.TextVariantCaption,
-		}}
-	}
+		block := []a2ui.Component{
+			a2uiHeading(headID, fmt.Sprintf("%d. %s:%d", i+1, path, r.StartLine+1), a2ui.TextVariantH5),
+			a2uiCaption(metaID, searchHitMeta(r)),
+		}
+		if snippet := numberedSnippet(r.Snippet, r.StartLine+1, snippetLines, lineWidth); snippet != "" {
+			codeID := ids.next()
+			blockChildren = append(blockChildren, codeID)
+			block = append(block, a2uiText(codeID, fenceCode(snippet, fenceLanguage(path))))
+		}
 
-	ids := newA2UIIDGen()
-	titleID := ids.next()
-	statsID := ids.next()
-	totalID := ids.next()
-
-	childIDs := []string{titleID, statsID, totalID}
-	var extra []a2ui.Component
-	for _, e := range errs {
-		id := ids.next()
-		childIDs = append(childIDs, id)
-		extra = append(extra, caption(id, "error: "+e))
-	}
-
-	failedPart := ""
-	if failed > 0 {
-		failedPart = fmt.Sprintf(" · %d failed", failed)
+		childIDs = append(childIDs, blockID)
+		extra = append(extra, a2ui.Component{ID: blockID, Column: &a2ui.ColumnComponent{
+			Children: a2ui.ChildList{IDs: blockChildren},
+		}})
+		extra = append(extra, block...)
 	}
 
 	return append([]a2ui.Component{
@@ -155,12 +220,101 @@ func semanticIndexSurface(indexed, skipped, failed, total int, errs []string) []
 		{ID: "col", Column: &a2ui.ColumnComponent{
 			Children: a2ui.ChildList{IDs: childIDs},
 		}},
-		{ID: titleID, Text: &a2ui.TextComponent{
-			Text:    a2ui.StringLiteral("Semantic index updated"),
-			Variant: a2ui.TextVariantH3,
+		a2uiHeading(titleID, "Semantic search", a2ui.TextVariantH3),
+		a2uiCaption(subID, fmt.Sprintf("%q · %d %s", query, len(results), pluralize(len(results), "result"))),
+	}, extra...)
+}
+
+// searchHitMeta renders a hit's secondary line: the symbol when the chunk has
+// one, the line range, and the relevance score behind a meter so neighboring
+// hits compare at a glance.
+func searchHitMeta(r semanticSearchHit) string {
+	parts := make([]string, 0, 3)
+	if r.Symbol != "" {
+		parts = append(parts, r.Symbol)
+	}
+	parts = append(parts,
+		fmt.Sprintf("lines %d–%d", r.StartLine+1, r.EndLine+1),
+		fmt.Sprintf("%s %.3f", scoreMeter(r.Score), r.Score),
+	)
+	return strings.Join(parts, " · ")
+}
+
+// semanticIndexSurface builds the summary card for a semantic_index run:
+// the chunk totals, then any per-file errors as a list of path + condensed
+// message. errs is capped by the caller, so failed is what says how many
+// files actually broke.
+func semanticIndexSurface(workingDir string, indexed, skipped, failed, total int, errs []string) []a2ui.Component {
+	ids := newA2UIIDGen()
+	titleID := ids.next()
+	statsID := ids.next()
+	totalID := ids.next()
+
+	childIDs := []string{titleID, statsID, totalID}
+	var extra []a2ui.Component
+	if len(errs) > 0 {
+		divID := ids.next()
+		errHeadID := ids.next()
+		listID := ids.next()
+		childIDs = append(childIDs, divID, errHeadID, listID)
+
+		var errIDs []string
+		for _, e := range errs {
+			path, msg := splitIndexError(workingDir, e)
+			entryID := ids.next()
+			msgID := ids.next()
+			entryChildren := []string{}
+			var entry []a2ui.Component
+			if path != "" {
+				pathID := ids.next()
+				entryChildren = append(entryChildren, pathID)
+				entry = append(entry, a2uiText(pathID, path))
+			}
+			entryChildren = append(entryChildren, msgID)
+			entry = append(entry, a2uiCaption(msgID, msg))
+
+			errIDs = append(errIDs, entryID)
+			extra = append(extra, a2ui.Component{ID: entryID, Column: &a2ui.ColumnComponent{
+				Children: a2ui.ChildList{IDs: entryChildren},
+			}})
+			extra = append(extra, entry...)
+		}
+
+		// A root that could not be walked produces an error without a failed
+		// file, so the heading counts errors when nothing was charged to a
+		// file.
+		head := fmt.Sprintf("%d %s", len(errs), pluralize(len(errs), "error"))
+		if failed > 0 {
+			head = fmt.Sprintf("%d %s failed to index", failed, pluralize(failed, "file"))
+			if failed > len(errs) {
+				// The tool stops collecting after a handful of errors. Saying
+				// so beats a list that silently reads as the complete story.
+				head += fmt.Sprintf(" — first %d shown", len(errs))
+			}
+		}
+		extra = append(extra,
+			a2ui.Component{ID: divID, Divider: &a2ui.DividerComponent{}},
+			a2uiHeading(errHeadID, head, a2ui.TextVariantH5),
+			a2ui.Component{ID: listID, List: &a2ui.ListComponent{
+				Children: a2ui.ChildList{IDs: errIDs},
+			}},
+		)
+	}
+
+	stats := fmt.Sprintf("%d %s indexed · %d %s unchanged",
+		indexed, pluralize(indexed, "chunk"), skipped, pluralize(skipped, "file"))
+	if failed > 0 {
+		stats += fmt.Sprintf(" · %d failed", failed)
+	}
+
+	return append([]a2ui.Component{
+		{ID: "root", Card: &a2ui.CardComponent{Child: "col"}},
+		{ID: "col", Column: &a2ui.ColumnComponent{
+			Children: a2ui.ChildList{IDs: childIDs},
 		}},
-		caption(statsID, fmt.Sprintf("%d chunks indexed · %d files unchanged%s", indexed, skipped, failedPart)),
-		caption(totalID, fmt.Sprintf("Index holds %d chunks", total)),
+		a2uiHeading(titleID, "Semantic index updated", a2ui.TextVariantH3),
+		a2uiCaption(statsID, stats),
+		a2uiCaption(totalID, fmt.Sprintf("Index holds %d %s", total, pluralize(total, "chunk"))),
 	}, extra...)
 }
 
@@ -196,6 +350,153 @@ func semanticSearchDigest(results []semanticSearchHit, withSnippets bool) string
 		}
 	}
 	return b.String()
+}
+
+// relativizePath renders an indexed path relative to the working directory
+// so the card shows repository-shaped paths instead of the absolute ones the
+// store holds. Paths outside the working directory (and any path when the
+// directory is unknown) are left alone rather than rendered as a pile of
+// "../".
+func relativizePath(workingDir, path string) string {
+	if workingDir == "" || path == "" || !filepath.IsAbs(path) {
+		return path
+	}
+	rel, err := filepath.Rel(workingDir, path)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return path
+	}
+	return rel
+}
+
+// scoreMeter draws a fixed-width bar for a similarity score. Scores are
+// 1 - cosine distance, so they nominally land in [0,1]; the bar clamps
+// rather than overflowing on an out-of-range value.
+func scoreMeter(score float64) string {
+	filled := int(math.Round(math.Max(0, math.Min(1, score)) * scoreMeterCells))
+	return strings.Repeat("█", filled) + strings.Repeat("░", scoreMeterCells-filled)
+}
+
+// numberedSnippet renders at most maxLines lines of a chunk with a right-aligned
+// line-number gutter starting at startLine (1-based), marking an elision with
+// a gutter-aligned ellipsis. Tabs are expanded and the block's common
+// indentation is stripped so a deeply nested chunk spends its width on code
+// rather than leading space, and each line is truncated to width so the
+// gutter survives (see snippetWidth).
+func numberedSnippet(snippet string, startLine, maxLines, width int) string {
+	snippet = strings.TrimRight(snippet, "\n")
+	if strings.TrimSpace(snippet) == "" {
+		return ""
+	}
+	lines := strings.Split(snippet, "\n")
+	elided := false
+	if len(lines) > maxLines {
+		lines, elided = lines[:maxLines], true
+	}
+	for i, ln := range lines {
+		lines[i] = strings.TrimRight(strings.ReplaceAll(ln, "\t", strings.Repeat(" ", gutterTabWidth)), " ")
+	}
+	lines = dedent(lines)
+
+	gutter := len(strconv.Itoa(startLine + len(lines) - 1))
+	var b strings.Builder
+	for i, ln := range lines {
+		fmt.Fprintf(&b, "%*d  %s\n", gutter, startLine+i, ansi.Truncate(ln, max(width-gutter-2, 1), "…"))
+	}
+	if elided {
+		fmt.Fprintf(&b, "%*s  …", gutter, "")
+	}
+	return strings.TrimRight(b.String(), "\n")
+}
+
+// dedent strips the indentation common to every non-blank line.
+func dedent(lines []string) []string {
+	common := -1
+	for _, ln := range lines {
+		if strings.TrimSpace(ln) == "" {
+			continue
+		}
+		n := len(ln) - len(strings.TrimLeft(ln, " "))
+		if common < 0 || n < common {
+			common = n
+		}
+	}
+	if common <= 0 {
+		return lines
+	}
+	for i, ln := range lines {
+		if len(ln) >= common {
+			lines[i] = ln[common:]
+		} else {
+			lines[i] = strings.TrimLeft(ln, " ")
+		}
+	}
+	return lines
+}
+
+// fenceCode wraps code in a Markdown fence tagged with lang. The fence is
+// grown past the longest backtick run in the code so an indexed Markdown file
+// — which can hold fences of its own — cannot break out of the block.
+func fenceCode(code, lang string) string {
+	longest, run := 0, 0
+	for _, r := range code {
+		if r == '`' {
+			run++
+			longest = max(longest, run)
+			continue
+		}
+		run = 0
+	}
+	fence := strings.Repeat("`", max(3, longest+1))
+	return fence + lang + "\n" + code + "\n" + fence
+}
+
+// fenceLanguage maps a path to the Markdown fence tag the host's Markdown
+// renderer highlights it with. Every extension the indexer accepts (see
+// indexableExtensions) has an entry, so a hit can always be tagged; unknown
+// extensions fall back to an untagged fence, which still renders as code.
+var fenceLanguage = func() func(path string) string {
+	byExt := map[string]string{
+		".bash": "bash", ".c": "c", ".cc": "cpp", ".cljc": "clojure",
+		".clj": "clojure", ".cpp": "cpp", ".cs": "csharp", ".css": "css",
+		".cxx": "cpp", ".dart": "dart", ".elixir": "elixir", ".elm": "elm",
+		".ex": "elixir", ".exs": "elixir", ".go": "go", ".groovy": "groovy",
+		".h": "c", ".hpp": "cpp", ".hs": "haskell", ".htm": "html",
+		".html": "html", ".java": "java", ".js": "javascript", ".json": "json",
+		".jsx": "jsx", ".kt": "kotlin", ".kts": "kotlin", ".lua": "lua",
+		".md": "markdown", ".mjs": "javascript", ".ml": "ocaml",
+		".mts": "typescript", ".php": "php", ".py": "python", ".rb": "ruby",
+		".rs": "rust", ".scala": "scala", ".scm": "scheme", ".sh": "bash",
+		".sql": "sql", ".svelte": "svelte", ".swift": "swift", ".toml": "toml",
+		".ts": "typescript", ".tsx": "tsx", ".vue": "vue", ".xml": "xml",
+		".yaml": "yaml", ".yml": "yaml", ".zig": "zig",
+	}
+	return func(path string) string {
+		return byExt[strings.ToLower(filepath.Ext(path))]
+	}
+}()
+
+// splitIndexError pulls the path off a per-file index error, which the index
+// tool formats as "<path>: <err>", and condenses the message. An error with
+// no recognizable path prefix returns an empty path and the whole condensed
+// string.
+func splitIndexError(workingDir, e string) (path, msg string) {
+	if i := strings.Index(e, ": "); i > 0 {
+		if p := relativizePath(workingDir, e[:i]); !strings.Contains(p, " ") {
+			return p, condenseError(e[i+2:])
+		}
+	}
+	return "", condenseError(e)
+}
+
+// condenseError flattens an error onto one line and truncates it. Provider
+// errors arrive as several layers of escaped JSON, which wraps into an
+// unreadable wall inside a card; the leading clause carries the cause.
+func condenseError(s string) string {
+	s = strings.TrimSpace(strings.Join(strings.Fields(s), " "))
+	if r := []rune(s); len(r) > errorMessageLimit {
+		return strings.TrimRight(string(r[:errorMessageLimit]), " ") + "…"
+	}
+	return s
 }
 
 // pluralize appends an s to word unless n is exactly 1. The surface is the

--- a/internal/agent/tools/semantic_a2ui_test.go
+++ b/internal/agent/tools/semantic_a2ui_test.go
@@ -120,9 +120,12 @@ func TestScoreMeter(t *testing.T) {
 // card's width on the part every hit shares.
 func TestSemanticSearchSurfaceRelativizesPaths(t *testing.T) {
 	t.Parallel()
-	wd := filepath.Join(string(filepath.Separator), "src", "repo")
+	// t.TempDir is absolute on every platform. A hand-built "/src/repo" is
+	// not absolute on Windows, so relativizePath would decline it and the
+	// test would pass everywhere the separator happens to be "/".
+	wd := t.TempDir()
 	inside := filepath.Join(wd, "internal", "auth.go")
-	outside := filepath.Join(string(filepath.Separator), "etc", "elsewhere.go")
+	outside := filepath.Join(filepath.Dir(wd), "elsewhere.go")
 
 	text := surfaceText(t, semanticSearchSurface("q", wd, 0, []semanticSearchHit{
 		{Path: inside, Score: 0.5, Snippet: "x"},
@@ -207,7 +210,7 @@ func TestSemanticIndexSurfaceLinks(t *testing.T) {
 // provider JSON, which wraps into an unreadable wall inside a card.
 func TestSemanticIndexSurfaceErrors(t *testing.T) {
 	t.Parallel()
-	wd := filepath.Join(string(filepath.Separator), "src", "repo")
+	wd := t.TempDir()
 	errs := []string{
 		filepath.Join(wd, "a.go") + ": generate embeddings: embedding API returned 422:\n" + strings.Repeat("{\"error\": \"deep\"}", 40),
 	}

--- a/internal/agent/tools/semantic_a2ui_test.go
+++ b/internal/agent/tools/semantic_a2ui_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"charm.land/fantasy"
+	"github.com/alecthomas/chroma/v2/lexers"
 	a2tea "github.com/joestump-agent/a2tea"
 	a2ui "github.com/tmc/a2ui"
 
@@ -76,14 +77,175 @@ func TestSemanticSearchSurfaceLinks(t *testing.T) {
 		{Path: "a.go", Symbol: "Foo", StartLine: 9, EndLine: 20, Score: 0.912, Snippet: "func Foo() {\n\treturn\n}"},
 		{Path: "b.go", StartLine: 0, EndLine: 3, Score: 0.734, Snippet: strings.Repeat("line\n", 10)},
 	}
-	components := semanticSearchSurface("where is auth handled", hits)
+	components := semanticSearchSurface("where is auth handled", "", 0, hits)
 	validateSurfaceComponents(t, components)
-	require.Len(t, components, 4+4*len(hits))
+	// Card, column, title, subtitle, then per hit: a block column, a head, a
+	// meta line and a snippet — with a divider between consecutive hits.
+	require.Len(t, components, 4+4*len(hits)+(len(hits)-1))
+}
+
+// The card is where the user reads a hit, so it has to carry the things the
+// digest only names: which lines the chunk spans, where to jump, how relevant
+// it is, and what the code looks like.
+func TestSemanticSearchSurfaceHitDetail(t *testing.T) {
+	t.Parallel()
+	components := semanticSearchSurface("q", "", 0, []semanticSearchHit{
+		{Path: "internal/auth/token.go", Symbol: "Verify", StartLine: 41, EndLine: 88, Score: 0.734, Snippet: "func Verify() error {\n\treturn nil\n}"},
+	})
+	text := surfaceText(t, components)
+
+	// Rank plus a path:line jump target, and the range and score below it.
+	require.Contains(t, text, "1. internal/auth/token.go:42")
+	require.Contains(t, text, "Verify · lines 42–89 · ")
+	require.Contains(t, text, "0.734")
+	// A meter beside the score, so neighboring hits compare at a glance.
+	require.Contains(t, text, scoreMeter(0.734))
+	// The snippet is a Go-tagged fence with a line-number gutter starting at
+	// the chunk's own first line.
+	require.Contains(t, text, "```go\n42  func Verify() error {\n43      return nil\n44  }\n```")
+}
+
+// Scores are 1 - cosine distance; the meter clamps rather than repeating a
+// negative count of blocks or overflowing its width.
+func TestScoreMeter(t *testing.T) {
+	t.Parallel()
+	require.Equal(t, strings.Repeat("░", scoreMeterCells), scoreMeter(0))
+	require.Equal(t, strings.Repeat("█", scoreMeterCells), scoreMeter(1))
+	require.Equal(t, strings.Repeat("░", scoreMeterCells), scoreMeter(-2))
+	require.Equal(t, strings.Repeat("█", scoreMeterCells), scoreMeter(9))
+	require.Equal(t, strings.Repeat("█", 5)+strings.Repeat("░", 5), scoreMeter(0.5))
+}
+
+// The store holds absolute paths. Showing them verbatim spends most of a
+// card's width on the part every hit shares.
+func TestSemanticSearchSurfaceRelativizesPaths(t *testing.T) {
+	t.Parallel()
+	wd := filepath.Join(string(filepath.Separator), "src", "repo")
+	inside := filepath.Join(wd, "internal", "auth.go")
+	outside := filepath.Join(string(filepath.Separator), "etc", "elsewhere.go")
+
+	text := surfaceText(t, semanticSearchSurface("q", wd, 0, []semanticSearchHit{
+		{Path: inside, Score: 0.5, Snippet: "x"},
+		{Path: outside, Score: 0.4, Snippet: "y"},
+	}))
+	require.Contains(t, text, "1. "+filepath.Join("internal", "auth.go")+":1")
+	// A path outside the working directory stays absolute rather than
+	// becoming a pile of "../".
+	require.Contains(t, text, "2. "+outside+":1")
+}
+
+// A long line wrapped by the host's Markdown renderer restarts in column
+// zero, which breaks the gutter the block exists to provide.
+func TestNumberedSnippetTruncatesToWidth(t *testing.T) {
+	t.Parallel()
+	out := numberedSnippet(strings.Repeat("x", 200), 1, 6, 20)
+	require.Equal(t, "1  "+strings.Repeat("x", 16)+"…", out)
+	for _, line := range strings.Split(out, "\n") {
+		require.LessOrEqual(t, len([]rune(line)), 20)
+	}
+}
+
+// Chunks arrive indented at their nesting depth; spending a card's width on
+// leading space is the one thing a preview cannot afford.
+func TestNumberedSnippetDedentsAndElides(t *testing.T) {
+	t.Parallel()
+	snippet := "\t\tif err != nil {\n\t\t\treturn err\n\t\t}\n\t\tmore()"
+	require.Equal(t,
+		"1  if err != nil {\n2      return err\n3  }\n   …",
+		numberedSnippet(snippet, 1, 3, 60))
+}
+
+// An empty or whitespace-only chunk gets no code block at all — an empty
+// fence renders as a stray box.
+func TestNumberedSnippetSkipsEmpty(t *testing.T) {
+	t.Parallel()
+	require.Empty(t, numberedSnippet("", 1, 6, 80))
+	require.Empty(t, numberedSnippet("  \n\t\n", 1, 6, 80))
+	require.Len(t, semanticSearchSurface("q", "", 0, []semanticSearchHit{
+		{Path: "a.go", Score: 0.5},
+	}), 4+3)
+}
+
+// The fence language is what buys the surface real syntax highlighting from
+// the host's Markdown renderer, so every extension the indexer accepts needs
+// one — and it has to name a lexer that actually exists.
+func TestFenceLanguageCoversIndexableExtensions(t *testing.T) {
+	t.Parallel()
+	for ext := range indexableExtensions {
+		lang := fenceLanguage("file" + ext)
+		require.NotEmpty(t, lang, "no fence language for %s", ext)
+		lexer := lexers.Get(lang)
+		require.NotNil(t, lexer, "fence language %q for %s is not a chroma lexer", lang, ext)
+		require.NotEqual(t, lexers.Fallback.Config().Name, lexer.Config().Name,
+			"fence language %q for %s resolves to the fallback lexer", lang, ext)
+	}
+	// An extension the indexer never produces still fences, just untagged.
+	require.Empty(t, fenceLanguage("a.bin"))
+	require.True(t, strings.HasPrefix(fenceCode("x", fenceLanguage("a.bin")), "```\n"))
+}
+
+// Markdown is indexable, so a chunk can carry fences of its own. A
+// three-backtick wrapper would end at the chunk's first fence and dump the
+// rest of the snippet into the card as prose.
+func TestFenceCodeEscapesNestedFences(t *testing.T) {
+	t.Parallel()
+	code := "Example:\n```go\nx := 1\n```"
+	out := fenceCode(code, "markdown")
+	require.True(t, strings.HasPrefix(out, "````markdown\n"), out)
+	require.True(t, strings.HasSuffix(out, "\n````"), out)
+	require.Contains(t, out, code)
 }
 
 func TestSemanticIndexSurfaceLinks(t *testing.T) {
-	components := semanticIndexSurface(3, 5, 1, 9, []string{"x.go: boom"})
+	components := semanticIndexSurface("", 3, 5, 1, 9, []string{"x.go: boom"})
 	validateSurfaceComponents(t, components)
+}
+
+// The index tool stops collecting errors after a handful, so a list that
+// reads as the complete story is a lie. It also formats them as
+// "<path>: <err>" with an absolute path and several layers of escaped
+// provider JSON, which wraps into an unreadable wall inside a card.
+func TestSemanticIndexSurfaceErrors(t *testing.T) {
+	t.Parallel()
+	wd := filepath.Join(string(filepath.Separator), "src", "repo")
+	errs := []string{
+		filepath.Join(wd, "a.go") + ": generate embeddings: embedding API returned 422:\n" + strings.Repeat("{\"error\": \"deep\"}", 40),
+	}
+	components := semanticIndexSurface(wd, 3, 5, 12, 9, errs)
+	validateSurfaceComponents(t, components)
+	text := surfaceText(t, components)
+
+	require.Contains(t, text, "12 files failed to index — first 1 shown")
+	// The path is split off and relativized; the message is flattened onto
+	// one line and capped.
+	require.Contains(t, text, "\na.go\n")
+	require.Contains(t, text, "generate embeddings: embedding API returned 422: {\"error\"")
+	require.NotContains(t, text, "422:\n")
+	for _, line := range strings.Split(text, "\n") {
+		require.LessOrEqual(t, len([]rune(line)), errorMessageLimit+1)
+	}
+
+	// No "— first N shown" when the list is complete.
+	require.NotContains(t, surfaceText(t, semanticIndexSurface(wd, 3, 5, 1, 9, errs)), "first")
+
+	// A root that could not be walked produces an error charged to no file;
+	// "0 files failed to index" over a populated list would read as a bug.
+	require.Contains(t,
+		surfaceText(t, semanticIndexSurface(wd, 0, 0, 0, 0, []string{"docs: lstat docs: no such file or directory"})),
+		"1 error")
+}
+
+// An error with no "<path>: " prefix keeps its whole text rather than losing
+// its first clause to a path column.
+func TestSplitIndexError(t *testing.T) {
+	t.Parallel()
+	path, msg := splitIndexError("", "x.go: boom")
+	require.Equal(t, "x.go", path)
+	require.Equal(t, "boom", msg)
+
+	path, msg = splitIndexError("", "indexing cancelled: context deadline exceeded")
+	require.Empty(t, path)
+	require.Equal(t, "indexing cancelled: context deadline exceeded", msg)
 }
 
 // TestSemanticSurfacesRender guards the surfaces against drifting from what
@@ -92,10 +254,10 @@ func TestSemanticIndexSurfaceLinks(t *testing.T) {
 func TestSemanticSurfacesRender(t *testing.T) {
 	t.Parallel()
 	for name, comps := range map[string][]a2ui.Component{
-		"search": semanticSearchSurface("where is auth handled", []semanticSearchHit{
+		"search": semanticSearchSurface("where is auth handled", "", 0, []semanticSearchHit{
 			{Path: "a.go", Symbol: "Foo", StartLine: 9, EndLine: 20, Score: 0.912, Snippet: "func Foo() {\n\treturn\n}"},
 		}),
-		"index": semanticIndexSurface(3, 5, 0, 9, nil),
+		"index": semanticIndexSurface("", 3, 5, 0, 9, nil),
 	} {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -172,7 +334,7 @@ func TestSemanticSearchDivert(t *testing.T) {
 func TestSemanticSurfaceMarksTextModelOnly(t *testing.T) {
 	t.Parallel()
 	resp := withSemanticSurface(fantasy.NewTextResponse("digest"), a2uiSurfaceIDPrefix+"search",
-		semanticSearchSurface("q", []semanticSearchHit{{Path: "a.go", Score: 0.5, Snippet: "x"}}))
+		semanticSearchSurface("q", "", 0, []semanticSearchHit{{Path: "a.go", Score: 0.5, Snippet: "x"}}))
 	var meta ReadMCPResourceResponseMetadata
 	require.NoError(t, json.Unmarshal([]byte(resp.Metadata), &meta))
 	require.True(t, meta.TextIsModelOnly)
@@ -201,10 +363,10 @@ func TestSemanticSearchDigestHeadlessFormat(t *testing.T) {
 // The surface is user-facing copy, so a single hit reads "1 result".
 func TestSemanticSearchSurfacePluralizesCount(t *testing.T) {
 	t.Parallel()
-	one := semanticSearchSurface("q", []semanticSearchHit{{Path: "a.go", Score: 0.5, Snippet: "x"}})
+	one := semanticSearchSurface("q", "", 0, []semanticSearchHit{{Path: "a.go", Score: 0.5, Snippet: "x"}})
 	require.Contains(t, surfaceText(t, one), "1 result")
 	require.NotContains(t, surfaceText(t, one), "1 results")
-	two := semanticSearchSurface("q", []semanticSearchHit{
+	two := semanticSearchSurface("q", "", 0, []semanticSearchHit{
 		{Path: "a.go", Score: 0.5, Snippet: "x"},
 		{Path: "b.go", Score: 0.4, Snippet: "y"},
 	})

--- a/internal/agent/tools/semantic_index.go
+++ b/internal/agent/tools/semantic_index.go
@@ -114,7 +114,7 @@ func NewSemanticIndexTool(cfg *config.ConfigStore, store *semantic.Store, extrac
 			// The summary card renders as a live A2UI surface when a chat UI
 			// is attached; the text above stays model-facing either way.
 			if semanticDivert(ctx, cfg) {
-				resp = withSemanticSurface(resp, a2uiSurfaceIDPrefix+"index", semanticIndexSurface(indexed, skipped, failed, int(total), errs))
+				resp = withSemanticSurface(resp, a2uiSurfaceIDPrefix+"index", semanticIndexSurface(workingDir, indexed, skipped, failed, int(total), errs))
 			}
 			return resp, nil
 		},

--- a/internal/agent/tools/semantic_search.go
+++ b/internal/agent/tools/semantic_search.go
@@ -80,7 +80,7 @@ func NewSemanticSearchTool(cfg *config.ConfigStore, store *semantic.Store, clien
 			// free digest; otherwise the tool behaves exactly as before.
 			if semanticDivert(ctx, cfg) {
 				resp := fantasy.NewTextResponse(semanticSearchDigest(hits, false))
-				return withSemanticSurface(resp, a2uiSurfaceIDPrefix+"search", semanticSearchSurface(params.Query, hits)), nil
+				return withSemanticSurface(resp, a2uiSurfaceIDPrefix+"search", semanticSearchSurface(params.Query, cfg.WorkingDir(), GetContentWidthFromContext(ctx), hits)), nil
 			}
 			return fantasy.NewTextResponse(semanticSearchDigest(hits, true)), nil
 		},

--- a/internal/skills/builtin/a2ui/SKILL.md
+++ b/internal/skills/builtin/a2ui/SKILL.md
@@ -114,11 +114,58 @@ You normally only *consume* server surfaces (path 1). Build them only when you a
 
 ## Best practices
 
-1. **Keep it compact.** Surfaces are concise summaries, controls, or dashboards. Use fenced code blocks for code or long logs.
+1. **Keep it compact.** Surfaces are concise summaries, controls, or dashboards — not viewers. Show a handful of lines and point at the file for the rest.
 2. **One surface per block.** All components inside the `components` array of a single `updateComponents` message.
 3. **Link correctly.** Every `child`/`children` id must exist in your array — a dangling id renders `[a2tea: missing component ...]`.
 4. **Mix with Markdown.** Prose before and after the `<a2ui-json>` block is fine.
 5. **Don't re-emit server surfaces.** If you read an `/a2ui` resource, the user already sees it — move on in prose.
+
+## Code and syntax highlighting in a surface
+
+**Yes — a surface can show syntax-highlighted code.** Body-variant `Text` (a `Text` with no `variant`) is routed through the host's Markdown renderer, which in Crush is glamour + chroma. So a body `Text` whose content is a fenced code block renders with real highlighting, and the same path gives you tables, lists, bold, and inline code.
+
+```json
+{"component": "Text", "id": "snippet", "text": "```go\n42  func Verify() error {\n43      return nil\n44  }\n```"}
+```
+
+Three things to get right:
+
+- **Tag the fence with a language.** The tag is what selects the lexer — an untagged fence renders as plain code. Use the language's usual Markdown tag (`go`, `python`, `typescript`, `bash`, `json`, `yaml`).
+- **Escape the newlines and quotes.** The fence lives inside a JSON string, so it is `` "```go\nx := 1\n```" ``, not a literal multi-line value.
+- **Grow the fence if the code contains one.** Markdown content can carry its own `` ``` ``; wrap it in four backticks (or one more than the longest run inside) or the block ends early and the rest spills out as prose.
+
+Line numbers are just part of the code: prefix each line with a right-aligned number and two spaces, as above. The gutter is lexed as part of the block, which reads as a distinct color rather than as source.
+
+Long lines are word-wrapped by the renderer and the continuation restarts at column zero, which breaks that gutter — so **truncate lines rather than letting them wrap** when you are drawing one.
+
+## Recipe: a result card
+
+The shape Crush's own `semantic_search` card uses — a heading, a caption of metadata, and a code snippet per result, separated by dividers. Copy it for anything list-shaped with a payload per row:
+
+```json
+<a2ui-json>{
+  "version": "v0.9",
+  "updateComponents": {
+    "surfaceId": "results",
+    "components": [
+      {"component": "Card", "id": "root", "child": "col"},
+      {"component": "Column", "id": "col", "children": ["title", "sub", "hit1", "div", "hit2"]},
+      {"component": "Text", "id": "title", "variant": "h3", "text": "Semantic search"},
+      {"component": "Text", "id": "sub", "variant": "caption", "text": "\"where is auth handled\" · 2 results"},
+      {"component": "Column", "id": "hit1", "children": ["h1-head", "h1-meta", "h1-code"]},
+      {"component": "Text", "id": "h1-head", "variant": "h5", "text": "1. internal/auth/token.go:42"},
+      {"component": "Text", "id": "h1-meta", "variant": "caption", "text": "Verify · lines 42–89 · ███████░░░ 0.734"},
+      {"component": "Text", "id": "h1-code", "text": "```go\n42  func Verify() error {\n43      return nil\n44  }\n```"},
+      {"component": "Divider", "id": "div"},
+      {"component": "Column", "id": "hit2", "children": ["h2-head", "h2-meta"]},
+      {"component": "Text", "id": "h2-head", "variant": "h5", "text": "2. internal/auth/session.go:8"},
+      {"component": "Text", "id": "h2-meta", "variant": "caption", "text": "newSession · lines 8–31 · ████░░░░░░ 0.412"}
+    ]
+  }
+}</a2ui-json>
+```
+
+A fixed-width meter (`█` filled, `░` empty) beside a score lets neighboring rows be compared at a glance — cheaper to read than the number alone, and it costs no components.
 
 ## Common mistakes (anti-patterns)
 
@@ -160,6 +207,16 @@ Components are a **flat list**; `child` is a **string id**, not an object.
 {"component": "Text", "id": "body", "text": "Hello"}
 ```
 
-### Do not put code in a surface
+### Only body `Text` renders Markdown
 
-A2UI surfaces are for compact visual structure. Use fenced code blocks (`` ``` ``) for code, command output, or logs — a `Text` component will not syntax-highlight.
+The heading and caption variants are short labels — they render with their variant style and nothing else. Markdown in an `h3` or a `caption` shows up as literal `**asterisks**` and unrendered fences.
+
+**Wrong — the fence renders as three literal backticks:**
+```json
+{"component": "Text", "id": "snippet", "variant": "caption", "text": "```go\nx := 1\n```"}
+```
+
+**Correct — omit `variant` so it is body text:**
+```json
+{"component": "Text", "id": "snippet", "text": "```go\nx := 1\n```"}
+```

--- a/internal/ui/chat/a2ui_test.go
+++ b/internal/ui/chat/a2ui_test.go
@@ -30,6 +30,60 @@ func TestContentHasA2UI(t *testing.T) {
 	require.False(t, contentHasA2UI("plain prose"))
 }
 
+// --- Syntax highlighting inside a surface ---
+
+// A body-variant Text is the one variant a2tea routes through the host's
+// Markdown renderer, which in Crush is glamour + chroma. That is what lets a
+// surface show code with real highlighting — the semantic_search result card
+// depends on it, and the a2ui skill tells the model it works.
+func TestA2UIBodyTextCodeFenceSyntaxHighlights(t *testing.T) {
+	t.Parallel()
+
+	const code = "func Verify() error {\n\treturn nil\n}"
+	surface := func(text string) string {
+		body, err := json.Marshal(text)
+		require.NoError(t, err)
+		return `<a2ui-json>{"version":"v0.9","updateComponents":{"surfaceId":"s","components":[` +
+			`{"component":"Card","id":"root","child":"t"},` +
+			`{"component":"Text","id":"t","text":` + string(body) + `}` +
+			`]}}</a2ui-json>`
+	}
+
+	sty := styles.CharmtonePantera()
+	renderSurface := func(payload string) string {
+		out, err := renderToolA2UI(&sty, payload, 60)
+		require.NoError(t, err)
+		return out
+	}
+
+	fenced := renderSurface(surface("```go\n" + code + "\n```"))
+	plain := renderSurface(surface(code))
+
+	// Both show the code; only the fenced one is colored, and its keyword
+	// carries a different color than its identifier.
+	require.Contains(t, ansi.Strip(fenced), "func Verify() error {")
+	require.Contains(t, ansi.Strip(plain), "func Verify() error {")
+	require.Greater(t, countSGR(fenced), countSGR(plain))
+	require.NotEqual(t, colorOfWord(t, fenced, "func"), colorOfWord(t, fenced, "Verify"))
+}
+
+// countSGR counts the SGR escape sequences in s — a proxy for "was this
+// styled at all".
+func countSGR(s string) int {
+	return strings.Count(s, "\x1b[")
+}
+
+// colorOfWord returns the SGR sequence immediately preceding word in s.
+func colorOfWord(t *testing.T, s, word string) string {
+	t.Helper()
+	idx := strings.Index(s, word)
+	require.GreaterOrEqual(t, idx, 0, "%q not found", word)
+	prefix := s[:idx]
+	start := strings.LastIndex(prefix, "\x1b[")
+	require.GreaterOrEqual(t, start, 0, "no SGR before %q", word)
+	return prefix[start:]
+}
+
 // --- Issue #6: fenced code blocks should not render as live surfaces ---
 
 func TestContentHasA2UIIgnoresFencedCode(t *testing.T) {


### PR DESCRIPTION
Rebuilds the two semantic tool cards and documents the capability that makes them possible: **A2UI surfaces can show syntax-highlighted code.**

## The highlighting answer

a2tea routes **body-variant `Text`** (a `Text` with no `variant`) through the host's Markdown renderer, which in Crush is glamour + chroma. So a body `Text` whose content is a fenced code block renders with real highlighting — tables, lists, and bold come along for free. Nothing in `internal/agent/tools` reaches into `internal/ui` to colorize; any A2UI host with a Markdown renderer draws the same payload the same way.

The skill and the docs both claimed the opposite ("a `Text` component will not syntax-highlight"). Both are corrected.

## `semantic_search`

Before, each hit was three lines of muted caption text — an absolute path, `lines N-M · score`, and a flat grey snippet. Every hit looked identical and the path spent most of the card's width on the prefix they all shared.

Now each hit is a block:

```text
╭───────────────────────────────────────────────────────╮
│ Semantic search                                       │
│ "where is auth handled" · 3 results                   │
│ 1. internal/auth/token.go:42                          │
│ Verify · lines 42–89 · ███████░░░ 0.734               │
│                                                       │
│   42  func Verify() error {                           │
│   43      return nil                                  │
│   44  }                                               │
│       …                                               │
│                                                       │
│ ───────────────────────────────────────────────────── │
│ 2. …                                                  │
╰───────────────────────────────────────────────────────╯
```

- **Rank + jump target** — `1. path:line`, relativized to the working directory (paths outside it stay absolute rather than becoming a pile of `../`).
- **Metadata line** — symbol, line range, and a fixed-width relevance meter beside the score so neighbouring hits compare at a glance.
- **Snippet** — dedented, tabs expanded, line-numbered gutter starting at the chunk's own first line, fenced with the language for the file's extension.
- **Dividers** between hits.

Two things the code block needs to survive:

- **Line width.** A long line is word-wrapped by the renderer and the continuation restarts in column zero, which destroys the gutter. Lines are truncated to a width derived from the turn's content-width hint — the same hint MCP `?w=N` surfaces get.
- **Fence length.** `.md` is indexable, so a chunk can carry its own fences. The wrapper grows past the longest backtick run inside, or the block ends early and the rest of the snippet spills into the card as prose.

## `semantic_index`

The error list was raw `absolute/path: <300 chars of nested escaped provider JSON>` captions that wrapped into a wall. Now each error is a bulleted entry: relativized path on its own line, message flattened onto one line and capped. It also stops presenting the tool's first-ten cap as the complete list — `12 files failed to index — first 10 shown` — and counts errors rather than files when a failure was charged to no file (an unwalkable root).

## Unchanged

Headless and channel-originated runs. With no chat UI to render metadata, both tools emit their original plain text, byte for byte.

## Verification

- `go test -race ./...` — green.
- `golangci-lint run` on the touched packages — 0 issues; `gofumpt` clean.
- `npm run build` in `docs-site` (strict) — green.
- New tests cover the hit detail (rank, jump target, range, meter, fenced gutter), meter clamping, path relativization, line truncation, dedent + elision, fence escaping, index error splitting and the first-N-shown copy, plus a table test asserting every extension in `indexableExtensions` maps to a fence language that resolves to a real chroma lexer.
- `internal/ui/chat` gets the end-to-end guard: the same code rendered with and without a fence, asserting the fenced one is colored and that its keyword and identifier get different colors.

Not done here: this repo has no `make test` / `make lint` (it is Taskfile-driven, inherited from upstream). Adding the wrappers is its own change, not this one.

🤖 Posted on behalf of `@joestump` by [`claude-opus-5`](https://openrouter.ai/anthropic/claude-opus-5) using [Claude Code](https://claude.ai).
