### PR TITLE
fix(agent): apply model provider_options to session title generation

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -32,6 +32,7 @@ import (
 	"charm.land/fantasy/providers/bedrock"
 	"charm.land/fantasy/providers/google"
 	"charm.land/fantasy/providers/openai"
+	"charm.land/fantasy/providers/openaicompat"
 	"charm.land/fantasy/providers/openrouter"
 	"charm.land/fantasy/providers/vercel"
 	"charm.land/lipgloss/v2"
@@ -1813,6 +1814,32 @@ func hasUserTextMessage(msgs []message.Message) bool {
 // GenerateTitle generates a session title based on the initial prompt.
 // It is a no-op for ephemeral agents, whose sessions never surface in
 // the session list.
+// titleProviderOptions forwards the model's configured provider_options
+// (e.g. disabling thinking for Qwen models via chat_template_kwargs) to
+// the title call, which otherwise never goes through getProviderOptions.
+// The options are keyed for openai-compat transports; other transports
+// ignore keys that are not theirs.
+func titleProviderOptions(m Model) fantasy.ProviderOptions {
+	if len(m.ModelCfg.ProviderOptions) == 0 {
+		return nil
+	}
+	merged := map[string]any{}
+	data, err := json.Marshal(m.ModelCfg.ProviderOptions)
+	if err == nil {
+		err = json.Unmarshal(data, &merged)
+	}
+	if err != nil {
+		slog.Error("Could not marshal title provider options", "err", err)
+		return nil
+	}
+	parsed, err := openaicompat.ParseOptions(merged)
+	if err != nil {
+		slog.Error("Could not parse title provider options", "err", err)
+		return nil
+	}
+	return fantasy.ProviderOptions{openaicompat.Name: parsed}
+}
+
 func (a *sessionAgent) GenerateTitle(ctx context.Context, sessionID string, userPrompt string) {
 	if a.ephemeral || userPrompt == "" {
 		return
@@ -1877,7 +1904,9 @@ func (a *sessionAgent) GenerateTitle(ctx context.Context, sessionID string, user
 			tok = attempt.model.CatwalkCfg.DefaultMaxTokens
 		}
 		agent := newAgent(attempt.model.Model, titlePrompt, tok)
-		resp, err = agent.Stream(ctx, streamCall)
+		call := streamCall
+		call.ProviderOptions = titleProviderOptions(attempt.model)
+		resp, err = agent.Stream(ctx, call)
 		if err == nil && resp.Response.FinishReason != fantasy.FinishReasonLength {
 			model = attempt.model
 			slog.Debug("Generated title with " + attempt.name + " model")

--- a/internal/agent/title_provider_options_test.go
+++ b/internal/agent/title_provider_options_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"charm.land/catwalk/pkg/catwalk"
-	"charm.land/fantasy"
 	"charm.land/fantasy/providers/openaicompat"
 	"github.com/charmbracelet/crush/internal/config"
 	"github.com/stretchr/testify/require"
@@ -70,6 +69,6 @@ func TestTitleProviderOptions(t *testing.T) {
 				},
 			},
 		}
-		var _ fantasy.ProviderOptions = titleProviderOptions(m)
+		_ = titleProviderOptions(m)
 	})
 }

--- a/internal/agent/title_provider_options_test.go
+++ b/internal/agent/title_provider_options_test.go
@@ -1,0 +1,75 @@
+package agent
+
+import (
+	"encoding/json"
+	"testing"
+
+	"charm.land/catwalk/pkg/catwalk"
+	"charm.land/fantasy"
+	"charm.land/fantasy/providers/openaicompat"
+	"github.com/charmbracelet/crush/internal/config"
+	"github.com/stretchr/testify/require"
+)
+
+// Title generation never goes through getProviderOptions, so a model that
+// needs provider-specific request fields (Qwen's chat_template_kwargs to
+// disable thinking, for example) would lose them on the title call and
+// burn the whole token budget reasoning. These tests pin that the title
+// path forwards model provider_options.
+func TestTitleProviderOptions(t *testing.T) {
+	t.Run("empty options produce no provider options", func(t *testing.T) {
+		m := Model{CatwalkCfg: catwalk.Model{ID: "qwen3.8-27b"}}
+		require.Nil(t, titleProviderOptions(m))
+	})
+
+	t.Run("model provider_options are keyed for openai-compat transports", func(t *testing.T) {
+		m := Model{
+			CatwalkCfg: catwalk.Model{ID: "Qwen3.8-27B"},
+			ModelCfg: config.SelectedModel{
+				ProviderOptions: map[string]any{
+					"extra_body": map[string]any{
+						"chat_template_kwargs": map[string]any{"enable_thinking": false},
+					},
+				},
+			},
+		}
+
+		opts := titleProviderOptions(m)
+		require.Len(t, opts, 1)
+
+		parsed, ok := opts[openaicompat.Name].(*openaicompat.ProviderOptions)
+		require.True(t, ok, "options should parse as openai-compat provider options")
+		require.NotNil(t, parsed.ExtraBody)
+
+		body, err := json.Marshal(parsed.ExtraBody)
+		require.NoError(t, err)
+
+		var extra map[string]any
+		require.NoError(t, json.Unmarshal(body, &extra))
+		kwargs, ok := extra["chat_template_kwargs"].(map[string]any)
+		require.True(t, ok, "chat_template_kwargs should survive the round trip: %v", extra)
+		require.Equal(t, false, kwargs["enable_thinking"])
+	})
+
+	t.Run("options parse failures degrade to none", func(t *testing.T) {
+		m := Model{
+			ModelCfg: config.SelectedModel{
+				ProviderOptions: map[string]any{
+					"extra_body": make(chan int), // not JSON marshalable
+				},
+			},
+		}
+		require.Nil(t, titleProviderOptions(m))
+	})
+
+	t.Run("the generated options fit the fantasy call shape", func(t *testing.T) {
+		m := Model{
+			ModelCfg: config.SelectedModel{
+				ProviderOptions: map[string]any{
+					"extra_body": map[string]any{"k": "v"},
+				},
+			},
+		}
+		var _ fantasy.ProviderOptions = titleProviderOptions(m)
+	})
+}


### PR DESCRIPTION

## Summary

- Title generation built its stream call by hand and never went through `getProviderOptions`, so a model's configured `provider_options` were silently dropped on the title call.
- Concretely: a small model that needs a request field to behave sanely (Qwen's `chat_template_kwargs.enable_thinking=false`) still reasoned during title generation, and when the 40-token non-reasoning cap applied it exhausted the budget on reasoning, finish reason came back `length`, and the session fell back to "Untitled Session".
- The title stream call now forwards the selected model's `provider_options`, keyed for openai-compat transports (other transports ignore keys that are not theirs), with unit tests for the conversion.

## Testing

- `go test ./internal/agent/ -run TestTitleProviderOptions` (new tests).
- Full `go test ./internal/agent/` green; `go build ./...` clean.

🤖 This was posted autonomously by [`glm-5.3-flash`](https://openrouter.ai/z-ai/glm-5.3-flash) using [Crush](https://github.com/charmbracelet/crush).