### PR TITLE
fix(tools): return tool error responses for recoverable cron failures

### DIFF
--- a/internal/agent/tools/cron.go
+++ b/internal/agent/tools/cron.go
@@ -83,7 +83,10 @@ func NewCronCreateTool(store *scheduler.Store) fantasy.AgentTool {
 
 			task, err := store.Create(sessionID, params.Cron, params.Prompt, recurring, params.Durable)
 			if err != nil {
-				return fantasy.ToolResponse{}, err
+				// Invalid cron expressions, missing prompts, and per-session
+				// task limits are all recoverable by the model; returning a
+				// Go error here would abort the whole agent stream.
+				return fantasy.NewTextErrorResponse(err.Error()), nil
 			}
 
 			kind := "recurring"
@@ -160,12 +163,13 @@ func NewCronDeleteTool(store *scheduler.Store) fantasy.AgentTool {
 				return fantasy.ToolResponse{}, err
 			}
 			if params.ID == "" {
-				return fantasy.ToolResponse{}, errors.New("id is required")
+				return fantasy.NewTextErrorResponse("id is required"), nil
 			}
 
 			task, err := store.Delete(sessionID, params.ID)
 			if errors.Is(err, scheduler.ErrTaskNotFound) {
-				return fantasy.ToolResponse{}, fmt.Errorf("no scheduled task with ID %q in this session", params.ID)
+				return fantasy.NewTextErrorResponse(
+					fmt.Sprintf("no scheduled task with ID %q in this session", params.ID)), nil
 			}
 			if err != nil {
 				return fantasy.ToolResponse{}, err

--- a/internal/agent/tools/cron_test.go
+++ b/internal/agent/tools/cron_test.go
@@ -78,11 +78,29 @@ func TestCronCreateValidatesExpression(t *testing.T) {
 	store := scheduler.NewStore("")
 	ctx := cronTestContext("test-session")
 
-	_, err := runCronTool(t, NewCronCreateTool(store), CronCreateToolName, ctx, CronCreateParams{
+	resp, err := runCronTool(t, NewCronCreateTool(store), CronCreateToolName, ctx, CronCreateParams{
 		Cron:   "not cron",
 		Prompt: "hello",
 	})
-	require.Error(t, err)
+	require.NoError(t, err)
+	require.True(t, resp.IsError)
+	require.Contains(t, resp.Content, "not cron")
+	require.Len(t, store.List("test-session"), 0)
+}
+
+func TestCronCreateMissingPromptIsError(t *testing.T) {
+	t.Parallel()
+
+	store := scheduler.NewStore("")
+	ctx := cronTestContext("test-session")
+
+	resp, err := runCronTool(t, NewCronCreateTool(store), CronCreateToolName, ctx, CronCreateParams{
+		Cron:   "* * * * *",
+		Prompt: "",
+	})
+	require.NoError(t, err)
+	require.True(t, resp.IsError)
+	require.Contains(t, resp.Content, "prompt is required")
 }
 
 func TestCronCreateDefaultsRecurring(t *testing.T) {
@@ -182,9 +200,22 @@ func TestCronDeleteUnknownID(t *testing.T) {
 	store := scheduler.NewStore("")
 	ctx := cronTestContext("test-session")
 
-	_, err := runCronTool(t, NewCronDeleteTool(store), CronDeleteToolName, ctx, CronDeleteParams{ID: "deadbeef"})
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "deadbeef")
+	resp, err := runCronTool(t, NewCronDeleteTool(store), CronDeleteToolName, ctx, CronDeleteParams{ID: "deadbeef"})
+	require.NoError(t, err)
+	require.True(t, resp.IsError)
+	require.Contains(t, resp.Content, "deadbeef")
+}
+
+func TestCronDeleteMissingID(t *testing.T) {
+	t.Parallel()
+
+	store := scheduler.NewStore("")
+	ctx := cronTestContext("test-session")
+
+	resp, err := runCronTool(t, NewCronDeleteTool(store), CronDeleteToolName, ctx, CronDeleteParams{ID: ""})
+	require.NoError(t, err)
+	require.True(t, resp.IsError)
+	require.Contains(t, resp.Content, "id is required")
 }
 
 func TestCronDeleteOtherSessionsTask(t *testing.T) {
@@ -194,8 +225,10 @@ func TestCronDeleteOtherSessionsTask(t *testing.T) {
 	task, err := store.Create("other-session", "* * * * *", "not yours", true, false)
 	require.NoError(t, err)
 
-	_, err = runCronTool(t, NewCronDeleteTool(store), CronDeleteToolName, cronTestContext("test-session"), CronDeleteParams{ID: task.ID})
-	require.Error(t, err)
+	resp, err := runCronTool(t, NewCronDeleteTool(store), CronDeleteToolName, cronTestContext("test-session"), CronDeleteParams{ID: task.ID})
+	require.NoError(t, err)
+	require.True(t, resp.IsError)
+	require.Contains(t, resp.Content, task.ID)
 }
 
 func TestCronCreateEnforcesSessionLimit(t *testing.T) {
@@ -213,10 +246,11 @@ func TestCronCreateEnforcesSessionLimit(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	_, err := runCronTool(t, tool, CronCreateToolName, ctx, CronCreateParams{
+	resp, err := runCronTool(t, tool, CronCreateToolName, ctx, CronCreateParams{
 		Cron:   "* * * * *",
 		Prompt: "one too many",
 	})
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "50")
+	require.NoError(t, err)
+	require.True(t, resp.IsError)
+	require.Contains(t, resp.Content, "50")
 }


### PR DESCRIPTION
## Summary
Closes #289.

Every cron tool returned a Go error for model-recoverable conditions, which aborts the agent stream and destroys the whole turn. This switches those cases to the package's existing `fantasy.NewTextErrorResponse` convention so the model gets a message it can act on:

- CronDelete: missing `id`, and unknown task ID (`ErrTaskNotFound`)
- CronCreate: `store.Create` validation failures (bad cron expression, missing prompt, durable without persistence path, per-session task limit)

`cronSessionID` failures (no session, sub-agent session) remain real errors — those are not the model's to fix.

## Testing
- `go test ./internal/agent/tools/ ./internal/scheduler/` green, including updated tests for invalid-expression, unknown-ID, missing-ID, and session-limit cases (now asserting `resp.IsError` + message content instead of a Go error) and new coverage for missing prompt.

🤖 This was posted autonomously by [`glm-5.3-flash`](https://openrouter.ai/z-ai/glm-5.3-flash) using [Crush](https://github.com/charmbracelet/crush).