### PR TITLE
feat(mcp): periodic health check renews dropped channel sessions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,17 @@
+.PHONY: test lint check
+
+# Thin wrapper over the Taskfile targets so `make test` and `make lint` work
+# from a clean checkout without task installed. The commands mirror the
+# Taskfile's test and lint tasks exactly; CI runs the same commands.
+#
+# @joestump-agent 09/05/2026 - Added so the repo exposes the uniform
+# make test / make lint entry points.
+
+test:
+	go test -race -failfast ./...
+
+lint:
+	./scripts/check_log_capitalization.sh
+	GOEXPERIMENT= golangci-lint run --path-mode=abs --config=".golangci.yml" --timeout=5m
+
+check: test lint

--- a/internal/agent/tools/mcp/healthcheck.go
+++ b/internal/agent/tools/mcp/healthcheck.go
@@ -1,0 +1,59 @@
+package mcp
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/charmbracelet/crush/internal/config"
+)
+
+// channelHealthCheckInterval is how often the health check pings each
+// channel-enabled MCP session.
+const channelHealthCheckInterval = time.Minute
+
+// StartChannelHealthCheck launches the periodic channel session health
+// check. It runs for the lifetime of ctx.
+func StartChannelHealthCheck(ctx context.Context, cfg *config.ConfigStore) {
+	go runChannelHealthCheck(ctx, cfg, channelHealthCheckInterval)
+}
+
+// runChannelHealthCheck periodically renews channel sessions that no other
+// traffic would renew.
+//
+// A channel-enabled MCP connection carries no traffic of its own: the
+// consumer never calls its tools, so the lazy getOrRenewClient path behind
+// every tool call never runs, and pingSession is never reached. When such a
+// connection's stream drops, nothing surfaces the failure — the session
+// looks established from the client's side, the server keeps writing
+// notifications into a dead stream, and only a restart clears it. This loop
+// closes that gap: it pings every registered channel session on a fixed
+// interval and renews the dead ones through the same serialized renewal path
+// tool calls use, without waiting for traffic that will never come.
+func runChannelHealthCheck(ctx context.Context, cfg *config.ConfigStore, interval time.Duration) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			checkChannelSessions(ctx, cfg)
+		}
+	}
+}
+
+// checkChannelSessions pings every channel session and renews any whose ping
+// fails. Only channel sessions are checked: ordinary servers have their
+// sessions renewed lazily by tool calls, so proactively pinging them would
+// add traffic for no benefit.
+func checkChannelSessions(ctx context.Context, cfg *config.ConfigStore) {
+	for name, sess := range sessions.Seq2() {
+		if !sess.IsChannel() {
+			continue
+		}
+		if _, err := getOrRenewClient(ctx, cfg, name); err != nil {
+			slog.Warn("MCP channel health check failed to renew session", "name", name, "error", err)
+		}
+	}
+}

--- a/internal/agent/tools/mcp/healthcheck_test.go
+++ b/internal/agent/tools/mcp/healthcheck_test.go
@@ -1,0 +1,144 @@
+package mcp
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/charmbracelet/crush/internal/config"
+	"github.com/stretchr/testify/require"
+)
+
+// seedDeadSession registers a closed (dead) session under name. Ping on it
+// always fails, which is what drives the renewal path.
+func seedDeadSession(t *testing.T, name string, channel bool) {
+	t.Helper()
+	dead, _ := liveSession(t, "send_message")
+	dead.channel = channel
+	require.NoError(t, dead.Close())
+	sessions.Set(name, dead)
+}
+
+// cleanupSession removes a server's session and state from the package-level
+// registries after a test.
+func cleanupSession(name string) func() {
+	return func() {
+		if s, ok := sessions.Take(name); ok {
+			_ = s.Close()
+		}
+		states.Del(name)
+		allTools.Del(name)
+		allPrompts.Del(name)
+		allResources.Del(name)
+	}
+}
+
+// TestChannelHealthCheck_RenewsDeadChannelSession is the regression test for
+// the channel-only MCP failure mode: a channel consumer never calls tools, so
+// nothing pings its session and a dropped stream is never renewed. The health
+// check must renew a dead channel session (and only channel sessions) without
+// any tool call happening. Without the fix, the dead channel session stays
+// registered forever and this test fails on the ping assertion.
+func TestChannelHealthCheck_RenewsDeadChannelSession(t *testing.T) {
+	const channelName = "test-health-channel"
+	const plainName = "test-health-plain"
+	t.Cleanup(cleanupSession(channelName))
+	t.Cleanup(cleanupSession(plainName))
+
+	cfg := config.NewTestStore(&config.Config{MCP: config.MCPs{
+		channelName: {Type: config.MCPStdio},
+		plainName:   {Type: config.MCPStdio},
+	}})
+
+	seedDeadSession(t, channelName, true)
+	// A dead non-channel session must be left alone: ordinary servers renew
+	// lazily via tool calls, so the health check must not touch them.
+	seedDeadSession(t, plainName, false)
+
+	var created int
+	origNewSession := newSession
+	newSession = func(context.Context, *config.ConfigStore, string, config.MCPConfig, config.VariableResolver, bool) (*ClientSession, error) {
+		created++
+		sess, _ := liveSession(t, "send_message")
+		sess.channel = true
+		return sess, nil
+	}
+	t.Cleanup(func() { newSession = origNewSession })
+
+	checkChannelSessions(context.Background(), cfg)
+
+	require.Equal(t, 1, created, "exactly the dead channel session must be renewed")
+
+	renewed, ok := sessions.Get(channelName)
+	require.True(t, ok, "a live session must be registered after the health check renews it")
+	require.NoError(t, pingSession(context.Background(), renewed, time.Second))
+
+	untouched, ok := sessions.Get(plainName)
+	require.True(t, ok, "the non-channel session must be left untouched by the health check")
+	require.Error(t, pingSession(context.Background(), untouched, time.Second),
+		"the non-channel session must still be the dead one, not a renewal")
+
+	info, ok := GetState(channelName)
+	require.True(t, ok)
+	require.Equal(t, StateConnected, info.State)
+}
+
+// TestChannelHealthCheckLoop_TickerRenewsDeadSession pins the loop itself:
+// left running with a short interval, it must detect and renew a dead channel
+// session on its own, with no tool call ever made. This is the property the
+// production deployment depends on — the loop is the only thing standing
+// between a dropped channel stream and a deaf consumer.
+func TestChannelHealthCheckLoop_TickerRenewsDeadSession(t *testing.T) {
+	const name = "test-health-loop"
+	t.Cleanup(cleanupSession(name))
+
+	cfg := config.NewTestStore(&config.Config{MCP: config.MCPs{name: {Type: config.MCPStdio}}})
+
+	seedDeadSession(t, name, true)
+
+	origNewSession := newSession
+	newSession = func(context.Context, *config.ConfigStore, string, config.MCPConfig, config.VariableResolver, bool) (*ClientSession, error) {
+		sess, _ := liveSession(t, "send_message")
+		sess.channel = true
+		return sess, nil
+	}
+	t.Cleanup(func() { newSession = origNewSession })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go runChannelHealthCheck(ctx, cfg, 10*time.Millisecond)
+
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		sess, ok := sessions.Get(name)
+		if ok {
+			if err := pingSession(context.Background(), sess, time.Second); err == nil {
+				return
+			}
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("health check loop never renewed the dead channel session")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+// TestChannelHealthCheckLoop_StopsOnContextCancel pins that the loop exits
+// when its context is canceled rather than leaking a goroutine per app start.
+func TestChannelHealthCheckLoop_StopsOnContextCancel(t *testing.T) {
+	cfg := config.NewTestStore(&config.Config{MCP: config.MCPs{}})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		runChannelHealthCheck(ctx, cfg, 10*time.Millisecond)
+		close(done)
+	}()
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("health check loop did not stop after context cancellation")
+	}
+}

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -151,6 +151,12 @@ func New(ctx context.Context, conn *sql.DB, store *config.ConfigStore, skillsMgr
 	mcp.ArmInit()
 	go mcp.Initialize(ctx, app.Permissions, store)
 
+	// Keep channel MCP sessions healthy: a channel-only connection carries no
+	// traffic of its own, so a dropped stream is never surfaced by the lazy
+	// tool-call renewal path. The health check pings channel sessions
+	// periodically and renews the dead ones.
+	mcp.StartChannelHealthCheck(ctx, store)
+
 	// Start herdr integration when running inside a herdr pane.
 	app.herdrClient = herdr.Init()
 	herdr.BridgeLocal(ctx, app.herdrClient, herdr.BridgeSources{


### PR DESCRIPTION
## Summary

A channel-enabled MCP connection carries no traffic of its own: the consumer never calls its tools, so the lazy `getOrRenewClient` renewal path (which runs behind every tool call and pings the session) is never reached. When such a connection's stream drops, nothing surfaces the failure. The session looks established from the client's side, the server keeps writing notifications into a dead stream, and the consumer stays deaf until restart — matching the hours-long silences observed with the Switchboard doorbell consumer (stump.wtf/switchboard#161, "Option C").

This PR adds a periodic health check for channel sessions:

- `internal/agent/tools/mcp/healthcheck.go` — a loop started from app startup that ticks every minute, pings every registered channel session (`ClientSession.IsChannel()`), and renews any whose ping fails through the same serialized `getOrRenewClient` path tool calls use. Non-channel sessions are untouched; they already renew lazily via tool calls.
- `internal/app/app.go` — starts the loop with the app's context.
- `Makefile` — thin wrapper exposing `make test` / `make lint`, mirroring the Taskfile's `test` and `lint` commands exactly.

## Failure mode and how the test reproduces it

`TestChannelHealthCheck_RenewsDeadChannelSession` seeds a closed (dead) channel session and a dead non-channel session, runs one health-check pass with no tool calls, and asserts the channel session was renewed (exactly one new session created, live and pingable, state `StateConnected`) while the non-channel session is left untouched. With the fix neutered, the dead channel session stays registered forever and the test fails on the ping assertion. `TestChannelHealthCheckLoop_TickerRenewsDeadSession` runs the real loop with a 10ms interval and fails after a 5s deadline if the loop never renews the dead session on its own. Both were verified to fail with the health check disabled.

## Verification

- `go test -race ./...` green (full suite).
- `gofmt` clean, `go vet` clean on touched packages. Note: the locally installed golangci-lint binary is built with go1.26 and refuses this repo's go 1.27 module ("Go language version ... lower than the targeted Go version"), so it could not run in this environment; the Makefile lint target runs the same commands CI runs.

🤖 This was posted autonomously by [`glm-5.3-flash`](https://openrouter.ai/z-ai/glm-5.3-flash) using [Crush](https://github.com/charmbracelet/crush).