### PR TITLE
fix(mcp): keep channel doorbell stream alive on streamable-HTTP servers

### DIFF
--- a/internal/agent/tools/mcp/channel.go
+++ b/internal/agent/tools/mcp/channel.go
@@ -308,11 +308,19 @@ type channelTransport struct {
 	gate  *channelGate
 }
 
-// Connect implements mcp.Transport.
 // unwrapTransport implements [transportWrapper].
 func (t *channelTransport) unwrapTransport() mcp.Transport { return t.inner }
 
+// Connect implements mcp.Transport. Streamable-HTTP transports get the
+// notification filter at the HTTP layer instead: the go-sdk only starts the
+// standalone SSE stream by type-asserting the connection it receives to its
+// internal client connection type, so a wrapped connection silently defeats
+// that check and the doorbell stream is never opened. See channel_sse.go.
 func (t *channelTransport) Connect(ctx context.Context) (mcp.Connection, error) {
+	if inner, ok := t.inner.(*mcp.StreamableClientTransport); ok {
+		installChannelSSEFilter(inner, t.name, t.gate)
+		return inner.Connect(ctx)
+	}
 	conn, err := t.inner.Connect(ctx)
 	if err != nil {
 		return nil, err

--- a/internal/agent/tools/mcp/channel_sse.go
+++ b/internal/agent/tools/mcp/channel_sse.go
@@ -1,0 +1,303 @@
+package mcp
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"log/slog"
+	"net/http"
+	"sync/atomic"
+	"time"
+	"unicode/utf8"
+
+	"github.com/charmbracelet/crush/internal/csync"
+	"github.com/modelcontextprotocol/go-sdk/jsonrpc"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// The standalone SSE stream is the hanging GET that a streamable-HTTP MCP
+// server uses to push server-initiated notifications. For channel-enabled
+// servers every doorbell rides on it, so its state is health: a session that
+// initializes fine but never opens (or loses) the stream is dead weight —
+// the SDK answers pings over ordinary POSTs and cannot tell the difference.
+//
+// Interception note: channel notifications must be filtered below the go-sdk
+// connection layer for streamable-HTTP transports. The SDK only starts the
+// standalone SSE stream by type-asserting the connection returned from
+// Transport.Connect to its internal connection type; wrapping the connection
+// (as channelConn does for other transports) silently defeats that assert,
+// so the stream is never opened and every doorbell is rejected server-side
+// with "stream not connected or already closed".
+
+// channelStreamHealth records the observable state of a channel server's
+// standalone SSE stream, maintained by the filter round-tripper.
+type channelStreamHealth struct {
+	opened    atomic.Bool  // a standalone GET ever returned 200 text/event-stream
+	active    atomic.Bool  // the most recent stream body is still being read
+	closedAt  atomic.Int64 // unix milliseconds of the last stream body EOF/error
+	firstOpen atomic.Int64 // unix milliseconds of the first successful stream open
+}
+
+// healthy reports whether the notification stream looks connected. A stream
+// that closed recently is still considered healthy: the go-sdk reconnects it
+// on its own, and health must not flap while that loop runs. closedGrace is
+// how long a closed stream is given to come back before it counts as down.
+func (h *channelStreamHealth) healthy(closedGrace time.Duration) bool {
+	if !h.opened.Load() {
+		return false
+	}
+	if h.active.Load() {
+		return true
+	}
+	closed := h.closedAt.Load()
+	if closed == 0 {
+		return true
+	}
+	return time.Since(time.UnixMilli(closed)) < closedGrace
+}
+
+// channelStreamStates tracks stream health per channel MCP name. Entries are
+// created when the filter is installed and consulted by the channel health
+// check; a session is recreated when the stream has been down too long.
+var channelStreamStates = csync.NewMap[string, *channelStreamHealth]()
+
+// channelStreamClosedGrace is how long a closed stream is presumed to be
+// mid-reconnect before the channel health check treats it as down. The SDK's
+// reconnect loop retries with exponential backoff up to MaxRetries (5), so
+// this comfortably exceeds a normal reconnect cycle.
+const channelStreamClosedGrace = 2 * channelHealthCheckInterval
+
+// installChannelSSEFilter wires the SSE-filtering round-tripper into a
+// streamable-HTTP transport and registers the server's stream health state.
+func installChannelSSEFilter(t *mcp.StreamableClientTransport, name string, gate *channelGate) {
+	inner := http.RoundTripper(http.DefaultTransport)
+	if t.HTTPClient != nil && t.HTTPClient.Transport != nil {
+		inner = t.HTTPClient.Transport
+	}
+	health := &channelStreamHealth{}
+	channelStreamStates.Set(name, health)
+	t.HTTPClient = &http.Client{Transport: &channelSSEFilter{
+		inner:  inner,
+		name:   name,
+		gate:   gate,
+		health: health,
+	}}
+}
+
+// channelSSEFilter is an http.RoundTripper that watches event-stream
+// response bodies. It filters notifications/claude/channel events out of
+// every stream (doorbells may ride any SSE body, in practice the standalone
+// GET) and dispatches them through the channel gate, while recording stream
+// health for the health check.
+type channelSSEFilter struct {
+	inner  http.RoundTripper
+	name   string
+	gate   *channelGate
+	health *channelStreamHealth
+}
+
+func (f *channelSSEFilter) RoundTrip(req *http.Request) (*http.Response, error) {
+	resp, err := f.inner.RoundTrip(req)
+	if err != nil {
+		return resp, err
+	}
+	standalone := req.Method == http.MethodGet &&
+		req.Header.Get("Accept") == "text/event-stream"
+	if resp.StatusCode != http.StatusOK ||
+		!isEventStreamContentType(resp.Header.Get("Content-Type")) {
+		return resp, nil
+	}
+	if standalone {
+		now := time.Now().UnixMilli()
+		f.health.opened.Store(true)
+		f.health.active.Store(true)
+		f.health.firstOpen.CompareAndSwap(0, now)
+	}
+	resp.Body = &channelSSEBody{
+		ctx:        req.Context(),
+		body:       resp.Body,
+		filter:     f,
+		standalone: standalone,
+	}
+	return resp, nil
+}
+
+func isEventStreamContentType(ct string) bool {
+	const prefix = "text/event-stream"
+	if len(ct) < len(prefix) {
+		return false
+	}
+	ct = ct[:len(prefix)]
+	for i := 0; i < len(ct); i++ {
+		c := ct[i]
+		if c >= 'A' && c <= 'Z' {
+			c += 'a' - 'A'
+		}
+		if c != prefix[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// maxUnboundedBuffer caps how many bytes are held waiting for an event
+// boundary. A doorbell is capped far below this (parseChannelParams enforces
+// maxChannelContentBytes), so anything this large is not a channel event and
+// is forwarded to the SDK untouched rather than buffered forever.
+const maxUnboundedBuffer = 1 << 20
+
+// channelSSEBody filters one event-stream body. Complete events are checked
+// for the channel notification method; matching events are dispatched to the
+// gate and stripped, everything else passes through unchanged and in order.
+type channelSSEBody struct {
+	ctx        context.Context
+	body       io.ReadCloser
+	filter     *channelSSEFilter
+	standalone bool
+
+	out     bytes.Buffer // filtered bytes not yet consumed by the reader
+	buf     []byte       // raw bytes awaiting an event boundary
+	eof     bool
+	readErr error
+}
+
+// Read returns filtered stream data, blocking on the underlying body only
+// when no filtered bytes are available.
+func (b *channelSSEBody) Read(p []byte) (int, error) {
+	for b.out.Len() == 0 {
+		if b.eof {
+			if b.readErr != nil {
+				return 0, b.readErr
+			}
+			return 0, io.EOF
+		}
+		if err := b.pump(); err != nil {
+			return 0, err
+		}
+	}
+	return b.out.Read(p)
+}
+
+// pump reads more raw bytes from the stream, extracts any complete events,
+// and appends the filtered result to the output buffer.
+func (b *channelSSEBody) pump() error {
+	chunk := make([]byte, 4096)
+	n, err := b.body.Read(chunk)
+	if n > 0 {
+		b.buf = append(b.buf, chunk[:n]...)
+		b.extractEvents()
+	}
+	if err == nil {
+		return nil
+	}
+	// Stream ended: flush anything left (a trailing event without a final
+	// blank line) before propagating EOF/error to the reader.
+	b.out.Write(b.buf)
+	b.buf = nil
+	b.eof = true
+	b.readErr = err
+	if b.standalone {
+		b.filter.health.active.Store(false)
+		b.filter.health.closedAt.Store(time.Now().UnixMilli())
+	}
+	return nil
+}
+
+// extractEvents drains complete events from buf. An SSE event ends at a
+// blank line; both \n\n and \r\n\r\n are accepted as delimiters. If buf
+// grows past maxUnboundedBuffer without a boundary the data is forwarded
+// as-is: it cannot be a valid doorbell (those are size-capped) and holding
+// it would stall the stream.
+func (b *channelSSEBody) extractEvents() {
+	for len(b.buf) > 0 {
+		end := eventBoundary(b.buf)
+		if end < 0 {
+			if len(b.buf) > maxUnboundedBuffer {
+				b.out.Write(b.buf)
+				b.buf = nil
+			}
+			return
+		}
+		event := b.buf[:end]
+		b.buf = b.buf[end:]
+		b.handleEvent(event)
+	}
+}
+
+// eventBoundary returns the length of the first event in data (including the
+// terminating blank line), or -1 if no complete event is buffered.
+func eventBoundary(data []byte) int {
+	if i := bytes.Index(data, []byte("\r\n\r\n")); i >= 0 {
+		return i + 4
+	}
+	if i := bytes.Index(data, []byte("\n\n")); i >= 0 {
+		return i + 2
+	}
+	return -1
+}
+
+// handleEvent inspects one complete SSE event. Events whose data decodes to
+// a notifications/claude/channel request are dispatched through the channel
+// gate and dropped from the stream; all other events pass through to the
+// SDK untouched.
+func (b *channelSSEBody) handleEvent(event []byte) {
+	raw := eventData(event)
+	if raw == nil || !utf8.Valid(raw) || !bytes.Contains(raw, []byte(channelNotificationMethod)) {
+		b.out.Write(event)
+		return
+	}
+	msg, err := jsonrpc.DecodeMessage(raw)
+	if err != nil {
+		b.out.Write(event)
+		return
+	}
+	req, ok := msg.(*jsonrpc.Request)
+	if !ok || req.IsCall() || req.Method != channelNotificationMethod {
+		b.out.Write(event)
+		return
+	}
+	if parsed := b.filter.gate.accept(req.Params); parsed != nil {
+		publishChannelMessage(b.ctx, b.filter.name, parsed)
+	}
+}
+
+// eventData joins the data lines of an SSE event into the JSON-RPC payload.
+// Returns nil for comments (keepalives) and events without data.
+func eventData(event []byte) []byte {
+	var lines [][]byte
+	for _, line := range bytes.Split(event, []byte("\n")) {
+		line = bytes.TrimSuffix(line, []byte("\r"))
+		if len(line) == 0 || line[0] == ':' {
+			continue
+		}
+		name, value, found := bytes.Cut(line, []byte(":"))
+		if !found || string(name) != "data" {
+			continue
+		}
+		value = bytes.TrimPrefix(value, []byte(" "))
+		lines = append(lines, value)
+	}
+	if len(lines) == 0 {
+		return nil
+	}
+	return bytes.Join(lines, []byte("\n"))
+}
+
+// Close implements io.Closer.
+func (b *channelSSEBody) Close() error {
+	if b.standalone {
+		b.filter.health.active.Store(false)
+		b.filter.health.closedAt.Store(time.Now().UnixMilli())
+	}
+	return b.body.Close()
+}
+
+// channelStreamReportable logs a compact stream-health summary for a channel
+// server, used by the health check when the stream looks down.
+func channelStreamReportable(name string, h *channelStreamHealth) {
+	firstOpen := h.firstOpen.Load()
+	slog.Warn("MCP channel notification stream not connected",
+		"name", name,
+		"everOpened", h.opened.Load(),
+		"firstOpenUnixMilli", firstOpen)
+}

--- a/internal/agent/tools/mcp/channel_sse_test.go
+++ b/internal/agent/tools/mcp/channel_sse_test.go
@@ -1,0 +1,259 @@
+package mcp
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/require"
+)
+
+// newStreamableChannelServer starts a minimal streamable-HTTP MCP server that
+// answers the legacy initialize handshake, advertises the claude/channel
+// capability, and serves a standalone SSE GET stream. The returned record
+// channel reports what the client actually did on the wire.
+type streamableRecord struct {
+	sawGET      chan struct{}
+	sawDiscover chan struct{}
+}
+
+func newStreamableChannelServer(t *testing.T, name string, doorbell func(w http.ResponseWriter)) (*httptest.Server, *streamableRecord) {
+	t.Helper()
+	rec := &streamableRecord{sawGET: make(chan struct{}, 4), sawDiscover: make(chan struct{}, 4)}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/mcp", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			select {
+			case rec.sawGET <- struct{}{}:
+			default:
+			}
+			w.Header().Set("Content-Type", "text/event-stream")
+			w.WriteHeader(http.StatusOK)
+			if f, ok := w.(http.Flusher); ok {
+				f.Flush()
+			}
+			if doorbell != nil {
+				doorbell(w)
+			}
+			<-r.Context().Done()
+		case http.MethodPost:
+			body, err := io.ReadAll(r.Body)
+			require.NoError(t, err)
+			var req struct {
+				ID     json.RawMessage `json:"id"`
+				Method string          `json:"method"`
+			}
+			require.NoError(t, json.Unmarshal(body, &req))
+			id := string(bytes.Trim(req.ID, "null"))
+			if id == "" {
+				id = "1"
+			}
+			if req.Method == "initialize" {
+				w.Header().Set("Content-Type", "application/json")
+				w.Header().Set("Mcp-Session-Id", "test-session")
+				_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":` + id + `,"result":{"protocolVersion":"2025-06-18","capabilities":{"experimental":{"claude/channel":{}}},"serverInfo":{"name":"t","version":"0"}}}`))
+				return
+			}
+			if req.Method == "notifications/initialized" {
+				w.WriteHeader(http.StatusAccepted)
+				return
+			}
+			// Anything else (e.g. server/discover) is refused so the SDK
+			// falls back to the legacy initialize handshake.
+			select {
+			case rec.sawDiscover <- struct{}{}:
+			default:
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":` + id + `,"error":{"code":-32601,"message":"method not found"}}`))
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv, rec
+}
+
+// TestChannelStreamableStandaloneSSEOpens is the regression test for the
+// doorbell deadness: the go-sdk only opens the standalone SSE stream by
+// type-asserting the connection from Transport.Connect to its internal type,
+// so a transport wrapper that wraps the connection silently suppresses the
+// stream and the session stays ping-alive but doorbell-deaf. The filter must
+// live below the connection (see channel_sse.go), leaving the connection
+// unwrapped so the stream opens and doorbells flow.
+func TestChannelStreamableStandaloneSSEOpens(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	doorbell := func(w http.ResponseWriter) {
+		time.Sleep(50 * time.Millisecond)
+		_, _ = w.Write([]byte("event: message\ndata: " +
+			`{"jsonrpc":"2.0","method":"notifications/claude/channel","params":{"content":"knock knock"}}` +
+			"\n\n"))
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+	}
+	const name = "chan-sse"
+	srv, rec := newStreamableChannelServer(t, name, doorbell)
+
+	sub := broker.Subscribe(ctx)
+	gate := newChannelGate()
+	client := mcp.NewClient(&mcp.Implementation{Name: "crush", Version: "test"}, nil)
+	transport := &channelTransport{
+		inner: &mcp.StreamableClientTransport{Endpoint: srv.URL + "/mcp"},
+		name:  name,
+		gate:  gate,
+	}
+	session, err := client.Connect(ctx, transport, nil)
+	require.NoError(t, err)
+	defer session.Close()
+
+	select {
+	case <-rec.sawGET:
+	case <-time.After(5 * time.Second):
+		t.Fatal("client never opened the standalone SSE GET stream")
+	}
+
+	// Mirror createSession: resolve the gate after Connect and publish
+	// anything that arrived during negotiation.
+	for _, raw := range gate.resolve(true) {
+		publishChannelMessage(ctx, name, raw)
+	}
+
+	for {
+		select {
+		case ev := <-sub:
+			// The broker is package-global and other tests publish on it;
+			// only our own doorbell completes the test.
+			if ev.Payload.Type != EventChannelMessage || ev.Payload.Name != name {
+				continue
+			}
+			require.Contains(t, ev.Payload.ChannelMessage, "knock knock")
+			return
+		case <-ctx.Done():
+			t.Fatal("timed out waiting for doorbell over the standalone SSE stream")
+		}
+	}
+}
+
+// TestChannelSSEFilterLeavesNonChannelEventsForSDK verifies the filter is
+// transparent for ordinary notifications: they pass through unchanged and
+// the SDK dispatches them (here: a tools/list_changed-shaped notification
+// would reach the session, and a ping request is answered normally).
+func TestChannelSSEFilterLeavesNonChannelEventsForSDK(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	const name = "chan-pass"
+	ping := func(w http.ResponseWriter) {
+		time.Sleep(50 * time.Millisecond)
+		_, _ = w.Write([]byte("event: message\ndata: " +
+			`{"jsonrpc":"2.0","method":"notifications/message","params":{"level":"info","data":"hi"}}` +
+			"\n\n"))
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+	}
+	srv, _ := newStreamableChannelServer(t, name, ping)
+
+	gate := newChannelGate()
+	gotLogging := make(chan struct{}, 1)
+	client := mcp.NewClient(&mcp.Implementation{Name: "crush", Version: "test"}, &mcp.ClientOptions{
+		LoggingMessageHandler: func(context.Context, *mcp.LoggingMessageRequest) {
+			gotLogging <- struct{}{}
+		},
+	})
+	transport := &channelTransport{
+		inner: &mcp.StreamableClientTransport{Endpoint: srv.URL + "/mcp"},
+		name:  name,
+		gate:  gate,
+	}
+	session, err := client.Connect(ctx, transport, nil)
+	require.NoError(t, err)
+	defer session.Close()
+	gate.resolve(false) // closed: channel events would be dropped, others pass
+
+	select {
+	case <-gotLogging:
+	case <-time.After(5 * time.Second):
+		t.Fatal("non-channel notification did not reach the SDK handler")
+	}
+}
+
+// TestChannelStreamHealthClosesAfterGrace covers the health predicate: an
+// unopened stream is down, a closed one is healthy within the reconnect
+// grace and down after it.
+func TestChannelStreamHealthClosesAfterGrace(t *testing.T) {
+	t.Parallel()
+	h := &channelStreamHealth{}
+	require.False(t, h.healthy(time.Minute), "never-opened stream must be unhealthy")
+
+	h.opened.Store(true)
+	require.True(t, h.healthy(time.Minute), "open stream is healthy")
+
+	h.active.Store(false)
+	h.closedAt.Store(time.Now().Add(-time.Minute).UnixMilli())
+	require.True(t, h.healthy(2*time.Minute), "stream closed within grace is healthy")
+	require.False(t, h.healthy(time.Second), "stream closed beyond grace is unhealthy")
+}
+
+// TestEventFilterStripsDoorbellAndKeepsKeepalive exercises the SSE event
+// parser directly: the doorbell event is removed, comments (keepalives) and
+// unrelated events pass through, and bytes are delivered in order.
+func TestEventFilterStripsDoorbellAndKeepsKeepalive(t *testing.T) {
+	t.Parallel()
+	gate := newChannelGate()
+	// Resolve closed so the stripped doorbell is dropped instead of
+	// published to the package-global broker other tests subscribe to.
+	gate.resolve(false)
+	health := &channelStreamHealth{}
+	ctx := context.Background()
+	body := io.NopCloser(bytes.NewReader([]byte(
+		": ok\n\n" +
+			"event: message\ndata: {\"jsonrpc\":\"2.0\",\"method\":\"other/notification\"}\n\n" +
+			"event: message\ndata: {\"jsonrpc\":\"2.0\",\"method\":\"notifications/claude/channel\",\"params\":{\"content\":\"hi\"}}\n\n" +
+			": ping\n\n",
+	)))
+	b := &channelSSEBody{
+		ctx:        ctx,
+		body:       body,
+		filter:     &channelSSEFilter{name: "chan-filter", gate: gate, health: health},
+		standalone: true,
+	}
+	health.opened.Store(true)
+	health.active.Store(true)
+	out, err := io.ReadAll(b)
+	require.NoError(t, err)
+	require.NotContains(t, string(out), "claude/channel", "doorbell must be stripped")
+	require.Contains(t, string(out), "other/notification")
+	require.Contains(t, string(out), ": ok")
+}
+
+// TestChannelDoorbellBufferedUntilGateResolves verifies undecided-gate
+// buffering survives the HTTP-layer path: a doorbell arriving before the
+// gate resolves is published once it opens.
+func TestChannelDoorbellBufferedUntilGateResolves(t *testing.T) {
+	t.Parallel()
+	gate := newChannelGate()
+	raw := json.RawMessage(`{"content":"buffered"}`)
+	require.Nil(t, gate.accept(raw), "undecided gate must buffer")
+	require.Empty(t, gate.resolve(false))
+	require.Nil(t, gate.accept(raw), "resolved-closed gate must drop")
+
+	gate2 := newChannelGate()
+	require.Nil(t, gate2.accept(raw))
+	buffered := gate2.resolve(true)
+	require.Len(t, buffered, 1)
+	require.Equal(t, raw, buffered[0])
+}

--- a/internal/agent/tools/mcp/channel_sse_test.go
+++ b/internal/agent/tools/mcp/channel_sse_test.go
@@ -170,6 +170,7 @@ func TestChannelSSEFilterLeavesNonChannelEventsForSDK(t *testing.T) {
 	gate := newChannelGate()
 	gotLogging := make(chan struct{}, 1)
 	client := mcp.NewClient(&mcp.Implementation{Name: "crush", Version: "test"}, &mcp.ClientOptions{
+		//nolint:staticcheck // SA1019: only non-channel notification the SDK dispatches without extra capability negotiation
 		LoggingMessageHandler: func(context.Context, *mcp.LoggingMessageRequest) {
 			gotLogging <- struct{}{}
 		},

--- a/internal/agent/tools/mcp/healthcheck.go
+++ b/internal/agent/tools/mcp/healthcheck.go
@@ -2,6 +2,7 @@ package mcp
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"time"
 
@@ -47,13 +48,30 @@ func runChannelHealthCheck(ctx context.Context, cfg *config.ConfigStore, interva
 // fails. Only channel sessions are checked: ordinary servers have their
 // sessions renewed lazily by tool calls, so proactively pinging them would
 // add traffic for no benefit.
+//
+// A ping alone cannot see the failure mode that matters most: on a
+// streamable-HTTP channel server, doorbells arrive on the standalone SSE
+// stream, and a session whose stream is gone keeps answering pings over
+// ordinary request/response. So a channel session on a streamable transport
+// is only healthy when its notification stream is connected too; when the
+// stream has stayed down past the reconnect grace the session is forced
+// through the same rebuild path a failed ping takes.
 func checkChannelSessions(ctx context.Context, cfg *config.ConfigStore) {
 	for name, sess := range sessions.Seq2() {
 		if !sess.IsChannel() {
 			continue
+		}
+		if health, ok := channelStreamStates.Get(name); ok && !health.healthy(channelStreamClosedGrace) {
+			channelStreamReportable(name, health)
+			state, _ := states.Get(name)
+			updateState(name, StateError, errChannelStreamDown, sess, state.Counts)
 		}
 		if _, err := getOrRenewClient(ctx, cfg, name); err != nil {
 			slog.Warn("MCP channel health check failed to renew session", "name", name, "error", err)
 		}
 	}
 }
+
+// errChannelStreamDown forces a channel session rebuild when the standalone
+// SSE notification stream has been down longer than the reconnect grace.
+var errChannelStreamDown = errors.New("standalone SSE notification stream not connected")


### PR DESCRIPTION
## Summary

- **Root cause of dead channel doorbells:** the go-sdk (v1.7.0) only opens the standalone SSE notification stream inside `sessionUpdated`, which it invokes via a type assertion on the connection returned from `Transport.Connect` (`client.go` legacy-init path, `streamable.go` `connectStandaloneSSE`). `channelTransport` returned a wrapped `*channelConn`, the assertion failed, and the stream was **never opened**. The session still initialized and answered pings over ordinary POSTs — which is why #292's health check saw nothing wrong while switchboard rejected every push with `undelivered message: stream not connected or already closed`.
- **Fix:** for streamable-HTTP transports the channel notification filter now lives below the connection: an `http.RoundTripper` that watches event-stream bodies, strips `notifications/claude/channel` events (gate buffering/open/closed semantics preserved), and records per-server stream health. The connection is returned unwrapped, so the SDK opens and reconnects the standalone stream normally. Other transport types keep the existing connection wrapper (no standalone-stream semantics there).
- **Health check extended:** `checkChannelSessions` now treats a channel session as unhealthy when its notification stream has been down longer than the SDK's reconnect grace (never opened, or closed and not back), and forces the same rebuild path a failed ping takes. Pings alone cannot see this failure mode.

## Verification

- New regression test `TestChannelStreamableStandaloneSSEOpens` runs the real go-sdk client against a minimal streamable-HTTP test server: on the old code it fails ("client never opened the standalone SSE GET stream"); with the fix the GET opens and the doorbell is dispatched to the channel broker. Confirmed red→green.
- Additional tests: filter transparency for non-channel notifications, event parser (keepalives pass, doorbells stripped), gate buffering semantics, stream-health predicate.
- `go test ./...`, `go build ./...` clean; `go vet` shows only a pre-existing warning in `internal/csync`.

🤖 This was posted autonomously by [`glm-5.3-flash`](https://openrouter.ai/z-ai/glm-5.3-flash) using [Crush](https://github.com/charmbracelet/crush).