### PR TITLE
fix(mcp): rebuild a stream-down channel session instead of destroying it

### DIFF
--- a/internal/agent/tools/mcp/healthcheck.go
+++ b/internal/agent/tools/mcp/healthcheck.go
@@ -61,12 +61,19 @@ func checkChannelSessions(ctx context.Context, cfg *config.ConfigStore) {
 		if !sess.IsChannel() {
 			continue
 		}
+		// A channel session whose notification stream is down pings fine, so the
+		// ordinary ping-gated renewal would keep it forever. Force the rebuild
+		// instead — and force it THROUGH the renewal path rather than tearing the
+		// session down here first. updateState(StateError) deletes the registry
+		// entry, and renewClient's post-lock guard then finds nothing and bails
+		// with "not available" without ever rebuilding, which turned this health
+		// check into a once-a-minute outage.
+		renew := getOrRenewClient
 		if health, ok := channelStreamStates.Get(name); ok && !health.healthy(channelStreamClosedGrace) {
 			channelStreamReportable(name, health)
-			state, _ := states.Get(name)
-			updateState(name, StateError, errChannelStreamDown, sess, state.Counts)
+			renew = forceRenewClient
 		}
-		if _, err := getOrRenewClient(ctx, cfg, name); err != nil {
+		if _, err := renew(ctx, cfg, name); err != nil {
 			slog.Warn("MCP channel health check failed to renew session", "name", name, "error", err)
 		}
 	}

--- a/internal/agent/tools/mcp/healthcheck_test.go
+++ b/internal/agent/tools/mcp/healthcheck_test.go
@@ -142,3 +142,85 @@ func TestChannelHealthCheckLoop_StopsOnContextCancel(t *testing.T) {
 		t.Fatal("health check loop did not stop after context cancellation")
 	}
 }
+
+// The regression this fix exists for.
+//
+// A channel session whose notification stream is down still answers pings — ping rides ordinary
+// POSTs and says nothing about the stream. The first version of this health check handled that by
+// calling updateState(StateError) itself and then getOrRenewClient. StateError DELETES the registry
+// entry, so the renewal's post-lock guard found nothing and returned "mcp '<name>' not available"
+// without ever rebuilding. The health check became a once-a-minute outage: it destroyed a working
+// session every tick and never replaced it.
+//
+// The session must come back, and it must still be registered afterwards.
+func TestChannelHealthCheckRebuildsAStreamDownSessionThatPingsFine(t *testing.T) {
+	const name = "test-stream-down"
+	t.Cleanup(cleanupSession(name))
+
+	cfg := config.NewTestStore(&config.Config{MCP: config.MCPs{name: {Type: config.MCPStdio}}})
+
+	// A LIVE session — it pings fine, which is the whole point.
+	live, _ := liveSession(t, "send_message")
+	live.channel = true
+	sessions.Set(name, live)
+	require.NoError(t, pingSession(context.Background(), live, time.Second),
+		"precondition: the session must be pingable, or this test proves nothing")
+
+	// ...whose notification stream never opened.
+	health := &channelStreamHealth{}
+	channelStreamStates.Set(name, health)
+	t.Cleanup(func() { channelStreamStates.Del(name) })
+	require.False(t, health.healthy(channelStreamClosedGrace),
+		"precondition: an unopened stream must read as unhealthy")
+
+	var created int
+	orig := newSession
+	newSession = func(context.Context, *config.ConfigStore, string, config.MCPConfig, config.VariableResolver, bool) (*ClientSession, error) {
+		created++
+		sess, _ := liveSession(t, "send_message")
+		sess.channel = true
+		return sess, nil
+	}
+	t.Cleanup(func() { newSession = orig })
+
+	checkChannelSessions(context.Background(), cfg)
+
+	require.Equal(t, 1, created, "a stream-down session must be rebuilt, not merely torn down")
+	got, ok := sessions.Get(name)
+	require.True(t, ok, "the rebuilt session must be registered — the bug left the registry empty")
+	require.NotSame(t, live, got, "the dead session must have been replaced")
+	require.NoError(t, pingSession(context.Background(), got, time.Second))
+}
+
+// A channel session with a healthy stream must be left alone: forcing a rebuild every minute
+// would churn every working consumer.
+func TestChannelHealthCheckLeavesAHealthyStreamAlone(t *testing.T) {
+	const name = "test-stream-ok"
+	t.Cleanup(cleanupSession(name))
+
+	cfg := config.NewTestStore(&config.Config{MCP: config.MCPs{name: {Type: config.MCPStdio}}})
+	live, _ := liveSession(t, "send_message")
+	live.channel = true
+	sessions.Set(name, live)
+
+	health := &channelStreamHealth{}
+	health.opened.Store(true)
+	health.active.Store(true)
+	channelStreamStates.Set(name, health)
+	t.Cleanup(func() { channelStreamStates.Del(name) })
+
+	var created int
+	orig := newSession
+	newSession = func(context.Context, *config.ConfigStore, string, config.MCPConfig, config.VariableResolver, bool) (*ClientSession, error) {
+		created++
+		s, _ := liveSession(t, "send_message")
+		return s, nil
+	}
+	t.Cleanup(func() { newSession = orig })
+
+	checkChannelSessions(context.Background(), cfg)
+
+	require.Zero(t, created, "a healthy channel session must not be rebuilt")
+	got, _ := sessions.Get(name)
+	require.Same(t, live, got, "the healthy session must be the same object afterwards")
+}

--- a/internal/agent/tools/mcp/init.go
+++ b/internal/agent/tools/mcp/init.go
@@ -733,12 +733,35 @@ func teardown(name string) {
 	clearMCPData(name)
 }
 
+// errForcedRenewal is the reason recorded when a session is rebuilt despite
+// answering pings — the caller had evidence ping cannot see, such as a channel
+// notification stream that is not connected.
+var errForcedRenewal = errors.New("forced renewal: session healthy to ping but unusable")
+
 func getOrRenewClient(ctx context.Context, cfg *config.ConfigStore, name string) (*ClientSession, error) {
+	return renewClient(ctx, cfg, name, false)
+}
+
+// forceRenewClient rebuilds name's session even when it answers pings.
+//
+// A channel session whose standalone notification stream is down still pings
+// fine — ping rides ordinary POSTs and says nothing about the stream — so the
+// ping-gated path above would keep a session that can never receive another
+// doorbell. Callers that have out-of-band evidence the session is unusable use
+// this instead of tearing the session down themselves: the teardown belongs
+// inside the renewal, under the same lock that rebuilds, because a caller that
+// deletes the session first leaves renewClient's registry guard with nothing to
+// find and it bails with "not available" without ever rebuilding.
+func forceRenewClient(ctx context.Context, cfg *config.ConfigStore, name string) (*ClientSession, error) {
+	return renewClient(ctx, cfg, name, true)
+}
+
+func renewClient(ctx context.Context, cfg *config.ConfigStore, name string, force bool) (*ClientSession, error) {
 	m := cfg.Config().MCP[name]
 	timeout := mcpTimeout(m)
 
 	// Fast path: reuse a healthy session without taking the renewal lock.
-	if sess, ok := sessions.Get(name); ok {
+	if sess, ok := sessions.Get(name); ok && !force {
 		if err := pingSession(ctx, sess, timeout); err == nil {
 			return sess, nil
 		}
@@ -765,10 +788,15 @@ func getOrRenewClient(ctx context.Context, cfg *config.ConfigStore, name string)
 	}
 
 	// A concurrent goroutine may have already renewed the session while we
-	// waited for the lock. Reuse it if it is now healthy.
+	// waited for the lock. Reuse it if it is now healthy — unless the caller
+	// forced a rebuild, in which case a healthy ping is exactly the signal that
+	// must NOT short-circuit us.
 	pingErr := pingSession(ctx, sess, timeout)
-	if pingErr == nil {
+	if pingErr == nil && !force {
 		return sess, nil
+	}
+	if pingErr == nil {
+		pingErr = errForcedRenewal
 	}
 
 	state, _ := states.Get(name)


### PR DESCRIPTION
The channel health check added in #293 — which I reviewed and merged — was a **once-a-minute outage**. Owning that: I checked #293's iteration safety and churn behaviour but never traced what `updateState(StateError)` does to the registry, and that is the bug.

## What went wrong

A channel session whose standalone notification stream is down still answers pings (ping rides ordinary POSTs), so the ping-gated renewal keeps it forever. #293 worked around that by tearing down first:

```go
updateState(name, StateError, errChannelStreamDown, sess, state.Counts)  // deletes the registry entry
if _, err := getOrRenewClient(ctx, cfg, name); err != nil {              // now finds nothing
```

`StateError` calls `sessions.Del(name)`. `getOrRenewClient`'s post-lock guard then does `sessions.Get`, finds nothing, and returns `mcp '<name>' not available` **without ever rebuilding**.

Observed on two hosts — a consumer that had just logged `MCP channel enabled` was dead 59 seconds later, every tick, with its workers' sockets decaying to zero:

```
19:40:30 INFO MCP channel enabled
19:41:29 WARN MCP channel notification stream not connected
19:41:29 WARN MCP channel health check failed to renew session | mcp 'switchboard' not available
```

## The fix

The teardown belongs **inside** the renewal, under the same lock that rebuilds — which is exactly where `getOrRenewClient` already does it. `forceRenewClient` skips the two ping fast paths and takes that existing route, so the session is replaced and re-registered just as a ping failure would have done. A healthy channel session is still left completely alone.

## Verified

`TestChannelHealthCheckRebuildsAStreamDownSessionThatPingsFine` seeds a session that is **genuinely pingable** — asserted as a precondition, or the test proves nothing — whose stream never opened, and requires it be rebuilt *and still registered* afterwards. With the old teardown restored it fails with the exact production error:

```
WARN MCP channel health check failed to renew session error="mcp 'test-stream-down' not available"
```

`TestChannelHealthCheckLeavesAHealthyStreamAlone` pins the other side.

Full `go test ./...` green. The two `gofmt` hits in `internal/agent/coordinator.go` and `internal/cmd/session.go` are pre-existing on `main` and untouched here.

🤖 Posted on behalf of `@joestump` by [`claude-opus-5`](https://openrouter.ai/anthropic/claude-opus-5) using [Claude Code](https://claude.com/claude-code).