### PR TITLE
fix(mcp): stop the channel health check rebuilding healthy sessions

### DIFF
--- a/internal/agent/tools/mcp/channel_sse.go
+++ b/internal/agent/tools/mcp/channel_sse.go
@@ -44,7 +44,20 @@ type channelStreamHealth struct {
 // how long a closed stream is given to come back before it counts as down.
 func (h *channelStreamHealth) healthy(closedGrace time.Duration) bool {
 	if !h.opened.Load() {
-		return false
+		// Never observed open. This is ABSENCE OF EVIDENCE, not evidence of
+		// failure, and treating it as unhealthy created a self-sustaining
+		// rebuild loop: installChannelSSEFilter registers a fresh health record
+		// on every Connect, so each forced rebuild reset opened to false, the
+		// next tick read "never opened" and forced another rebuild, once a
+		// minute forever, on hosts whose streams were in fact open and
+		// delivering doorbells.
+		//
+		// A genuinely never-opened stream is not something a rebuild fixes
+		// either: that was the wrapped-connection bug, which is a code defect
+		// repaired in the transport, not a runtime condition. So the forced
+		// rebuild is reserved for the recoverable case below — observed open,
+		// then closed, and not back within the grace.
+		return true
 	}
 	if h.active.Load() {
 		return true
@@ -75,7 +88,14 @@ func installChannelSSEFilter(t *mcp.StreamableClientTransport, name string, gate
 		inner = t.HTTPClient.Transport
 	}
 	health := &channelStreamHealth{}
-	channelStreamStates.Set(name, health)
+	// Reuse the existing record when one is already registered for this server.
+	// Replacing it on every Connect discards what has been observed about the
+	// stream, which is what made the health predicate flap.
+	if existing, ok := channelStreamStates.Get(name); ok {
+		health = existing
+	} else {
+		channelStreamStates.Set(name, health)
+	}
 	t.HTTPClient = &http.Client{Transport: &channelSSEFilter{
 		inner:  inner,
 		name:   name,

--- a/internal/agent/tools/mcp/channel_sse_test.go
+++ b/internal/agent/tools/mcp/channel_sse_test.go
@@ -192,23 +192,6 @@ func TestChannelSSEFilterLeavesNonChannelEventsForSDK(t *testing.T) {
 	}
 }
 
-// TestChannelStreamHealthClosesAfterGrace covers the health predicate: an
-// unopened stream is down, a closed one is healthy within the reconnect
-// grace and down after it.
-func TestChannelStreamHealthClosesAfterGrace(t *testing.T) {
-	t.Parallel()
-	h := &channelStreamHealth{}
-	require.False(t, h.healthy(time.Minute), "never-opened stream must be unhealthy")
-
-	h.opened.Store(true)
-	require.True(t, h.healthy(time.Minute), "open stream is healthy")
-
-	h.active.Store(false)
-	h.closedAt.Store(time.Now().Add(-time.Minute).UnixMilli())
-	require.True(t, h.healthy(2*time.Minute), "stream closed within grace is healthy")
-	require.False(t, h.healthy(time.Second), "stream closed beyond grace is unhealthy")
-}
-
 // TestEventFilterStripsDoorbellAndKeepsKeepalive exercises the SSE event
 // parser directly: the doorbell event is removed, comments (keepalives) and
 // unrelated events pass through, and bytes are delivered in order.
@@ -257,4 +240,67 @@ func TestChannelDoorbellBufferedUntilGateResolves(t *testing.T) {
 	buffered := gate2.resolve(true)
 	require.Len(t, buffered, 1)
 	require.Equal(t, raw, buffered[0])
+}
+
+// The rebuild loop this predicate caused.
+//
+// installChannelSSEFilter registers a fresh health record on every Connect, so a forced rebuild
+// reset opened to false. The next tick read "never opened", forced another rebuild, and the cycle
+// repeated once a minute — on hosts whose streams were open and delivering doorbells the whole
+// time. Absence of evidence must not read as failure.
+func TestChannelStreamHealthNeverOpenedIsNotUnhealthy(t *testing.T) {
+	t.Parallel()
+	h := &channelStreamHealth{}
+	if !h.healthy(channelStreamClosedGrace) {
+		t.Fatal("a never-observed stream must not be reported down; that is what caused the rebuild loop")
+	}
+}
+
+// The recoverable case still forces a rebuild: observed open, then closed, and not back within
+// the grace the SDK's own reconnect loop is given.
+func TestChannelStreamHealthClosedBeyondGraceIsUnhealthy(t *testing.T) {
+	t.Parallel()
+	h := &channelStreamHealth{}
+	h.opened.Store(true)
+
+	h.active.Store(true)
+	if !h.healthy(channelStreamClosedGrace) {
+		t.Error("an active stream is healthy")
+	}
+
+	h.active.Store(false)
+	h.closedAt.Store(time.Now().Add(-time.Second).UnixMilli())
+	if !h.healthy(channelStreamClosedGrace) {
+		t.Error("a stream that closed a second ago is mid-reconnect and still healthy")
+	}
+
+	h.closedAt.Store(time.Now().Add(-2 * channelStreamClosedGrace).UnixMilli())
+	if h.healthy(channelStreamClosedGrace) {
+		t.Error("a stream closed well beyond the grace must read as down")
+	}
+}
+
+// Reconnecting must not discard what has been observed about the stream — that reset is the other
+// half of the loop.
+func TestInstallChannelSSEFilterKeepsAnExistingHealthRecord(t *testing.T) {
+	const name = "test-health-reuse"
+	t.Cleanup(func() { channelStreamStates.Del(name) })
+
+	first := &channelStreamHealth{}
+	first.opened.Store(true)
+	first.active.Store(true)
+	channelStreamStates.Set(name, first)
+
+	installChannelSSEFilter(&mcp.StreamableClientTransport{}, name, newChannelGate())
+
+	got, ok := channelStreamStates.Get(name)
+	if !ok {
+		t.Fatal("health record disappeared on reconnect")
+	}
+	if got != first {
+		t.Fatal("reconnect replaced the health record, discarding the observed stream state")
+	}
+	if !got.healthy(channelStreamClosedGrace) {
+		t.Error("an observed-healthy stream must stay healthy across a reconnect")
+	}
 }

--- a/internal/agent/tools/mcp/healthcheck_test.go
+++ b/internal/agent/tools/mcp/healthcheck_test.go
@@ -166,12 +166,17 @@ func TestChannelHealthCheckRebuildsAStreamDownSessionThatPingsFine(t *testing.T)
 	require.NoError(t, pingSession(context.Background(), live, time.Second),
 		"precondition: the session must be pingable, or this test proves nothing")
 
-	// ...whose notification stream never opened.
+	// ...whose notification stream opened and then died and did not come back.
+	// Observed-open-then-closed is the recoverable case a rebuild is for; a
+	// never-observed stream is absence of evidence and deliberately reads as
+	// healthy, because treating it as down caused a once-a-minute rebuild loop.
 	health := &channelStreamHealth{}
+	health.opened.Store(true)
+	health.closedAt.Store(time.Now().Add(-2 * channelStreamClosedGrace).UnixMilli())
 	channelStreamStates.Set(name, health)
 	t.Cleanup(func() { channelStreamStates.Del(name) })
 	require.False(t, health.healthy(channelStreamClosedGrace),
-		"precondition: an unopened stream must read as unhealthy")
+		"precondition: a stream closed beyond the grace must read as down")
 
 	var created int
 	orig := newSession


### PR DESCRIPTION
The stream-health predicate treated "never observed open" as unhealthy, turning the health check into a **once-a-minute rebuild loop** on hosts whose streams were open and delivering doorbells the whole time.

`installChannelSSEFilter` registered a **fresh** health record on every `Connect`, so each forced rebuild reset `opened` to false; the next tick read "never opened" and forced another. Both hosts cycled every 60s:

```
20:12:47 INFO  MCP channel enabled
20:13:47 WARN  MCP channel notification stream not connected
20:13:47 INFO  MCP channel enabled
```

Two changes, either alone would still flap:

1. **Absence of evidence is not failure.** A never-observed stream reads as healthy. A genuinely never-opened stream is not something a rebuild fixes — that was the wrapped-connection defect, repaired in the transport (#293) — so the forced rebuild is reserved for the recoverable case: observed open, then closed, not back within the grace.
2. **Reconnect reuses the existing health record** instead of replacing it, so observations survive a renewal.

Two tests asserted the old semantics and are **updated, not deleted**: #294's regression test now seeds observed-open-then-closed (the case a rebuild is actually for), and #293's predicate test is superseded by explicit coverage of both halves plus a reconnect-preserves-the-record test.

Full `go test ./...` green.

🤖 Posted on behalf of `@joestump` by [`claude-opus-5`](https://openrouter.ai/anthropic/claude-opus-5) using [Claude Code](https://claude.com/claude-code).