### PR TITLE
fix(mcp): stop the A2UI wrapper defeating the standalone SSE stream

### DIFF
--- a/internal/agent/tools/mcp/a2ui.go
+++ b/internal/agent/tools/mcp/a2ui.go
@@ -219,3 +219,22 @@ func injectA2UICapability(raw json.RawMessage) json.RawMessage {
 // unwrapTransport implements [transportWrapper], so wrapping the transport
 // for A2UI never hides the stdio startup diagnostics maybeStdioErr digs out.
 func (t *a2uiInitTransport) unwrapTransport() mcp.Transport { return t.inner }
+
+// isStreamableHTTP reports whether transport is (or wraps) a streamable-HTTP
+// transport, for which the connection must reach the SDK unwrapped.
+//
+// It looks through transportWrapper so the answer does not depend on the order
+// wrappers were applied — the property being asked about belongs to the
+// underlying transport, not to whoever wrapped it last.
+func isStreamableHTTP(t mcp.Transport) bool {
+	for {
+		if _, ok := t.(*mcp.StreamableClientTransport); ok {
+			return true
+		}
+		w, ok := t.(transportWrapper)
+		if !ok {
+			return false
+		}
+		t = w.unwrapTransport()
+	}
+}

--- a/internal/agent/tools/mcp/init.go
+++ b/internal/agent/tools/mcp/init.go
@@ -1044,7 +1044,26 @@ func createSession(ctx context.Context, cfg *config.ConfigStore, name string, m 
 	// Advertise A2UI support in the initialize handshake so an A2UI-over-MCP
 	// server knows it can send surfaces. A host that won't render A2UI must
 	// not claim the capability.
-	if !a2uiDisabled(cfg) {
+	// A2UI injects its capability by wrapping the CONNECTION, and for
+	// streamable HTTP a wrapped connection is fatal: the SDK starts the
+	// standalone SSE stream (the hanging GET every server-initiated
+	// notification rides) only after type-asserting the connection to its
+	// unexported clientConnection interface, and a wrapper declared in this
+	// package can never satisfy an unexported method. The assert fails
+	// silently — the ok is discarded — so the stream is never opened and every
+	// push is rejected with "stream not connected or already closed".
+	//
+	// channelTransport already avoids that by filtering below the connection
+	// for streamable HTTP. Wrapping again out here put the wrapper straight
+	// back on and undid it, which is why channel doorbells still never
+	// arrived after that fix.
+	//
+	// The capability is not lost: a2uiSDKCapabilities carries the same payload
+	// in the typed Extensions field (see opts.Capabilities below), which is
+	// what a go-sdk server reads. Only the raw top-level "capabilities.a2ui"
+	// key — the spec-conformant-non-go-sdk path — is skipped here, and only
+	// for streamable HTTP, where the alternative is no notifications at all.
+	if !a2uiDisabled(cfg) && !isStreamableHTTP(transport) {
 		transport = &a2uiInitTransport{inner: transport}
 	}
 


### PR DESCRIPTION
Channel doorbells still never arrived after #293. This is why.

#293 stopped `channelTransport` wrapping the connection for streamable HTTP — the SDK opens the standalone SSE stream only after asserting the connection to its **unexported** `clientConnection` interface, which no wrapper in this package can satisfy. Then `createSession` wraps it straight back, one line later:

```go
transport = &channelTransport{inner: transport, ...}   // unwraps for HTTP
if !a2uiDisabled(cfg) {
    transport = &a2uiInitTransport{inner: transport}   // wraps it back
}
```

`a2uiInitTransport.Connect` returns `&a2uiInitConn{Connection: conn}`, so the SDK got a wrapper again and the fix was undone. In production every doorbell was rejected with `stream not connected or already closed` while the session initialized, answered pings, and looked healthy on every other signal.

**The A2UI capability is not lost.** `a2uiSDKCapabilities` carries the same payload in the typed `Extensions` field, which is what a go-sdk server reads. Only the raw top-level `capabilities.a2ui` key is skipped, only for streamable HTTP, where the alternative is no server-initiated notifications at all.

`isStreamableHTTP` looks **through** `transportWrapper` rather than checking the concrete type, so the answer depends on the underlying transport rather than on which wrapper is outermost.

**Why this survived a fix and a test.** The existing standalone-stream test builds `channelTransport` directly, so it never applied the second wrapper — it passed throughout. The new test asserts the property through the stack `createSession` actually builds, in production order, and fails with the production symptom when the fix is neutered:

```
client never opened the standalone SSE GET stream through the production wrapper stack
```

Full `go test ./...` green.

🤖 Posted on behalf of `@joestump` by [`claude-opus-5`](https://openrouter.ai/anthropic/claude-opus-5) using [Claude Code](https://claude.com/claude-code).